### PR TITLE
Remove length restrictions from remaining ScriptName and Name object properties

### DIFF
--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -20,9 +20,9 @@
 using namespace AGS::Common;
 
 
-void CharacterInfo::ReadFromFileImpl(Stream *in, GameDataVersion data_ver, int save_ver)
+void CharacterInfo::ReadFromFileImpl(Stream *in, bool is_save)
 {
-    const bool do_align_pad = data_ver != kGameVersion_Undefined;
+    const bool do_align_pad = !is_save;
     defview = in->ReadInt32();
     talkview = in->ReadInt32();
     view = in->ReadInt32();
@@ -71,15 +71,6 @@ void CharacterInfo::ReadFromFileImpl(Stream *in, GameDataVersion data_ver, int s
     on = in->ReadInt8();
     if (do_align_pad)
         in->ReadInt8(); // alignment padding to int32
-
-    // Upgrade data
-    name = legacy_name;
-    scrname = legacy_scrname;
-    if ((data_ver > kGameVersion_Undefined && data_ver < kGameVersion_360_16) ||
-        ((data_ver == kGameVersion_Undefined) && save_ver >= 0 && save_ver < 2))
-    {
-        idle_anim_speed = animspeed + 5;
-    }
 }
 
 void CharacterInfo::WriteToFileImpl(Stream *out, bool is_save) const
@@ -137,7 +128,17 @@ void CharacterInfo::WriteToFileImpl(Stream *out, bool is_save) const
 
 void CharacterInfo::ReadFromFile(Stream *in, GameDataVersion data_ver)
 {
-    ReadFromFileImpl(in, data_ver, -1);
+    ReadFromFileImpl(in, false);
+
+    // Assign names from legacy fields
+    name = legacy_name;
+    scrname = legacy_scrname;
+
+    // Upgrade data
+    if (data_ver < kGameVersion_360_16)
+    {
+        idle_anim_speed = animspeed + 5;
+    }
 }
 
 void CharacterInfo::WriteToFile(Stream *out) const
@@ -145,9 +146,9 @@ void CharacterInfo::WriteToFile(Stream *out) const
     WriteToFileImpl(out, false);
 }
 
-void CharacterInfo::ReadFromSavegame(Stream *in, int save_ver)
+void CharacterInfo::ReadFromSavegame(Stream *in)
 {
-    ReadFromFileImpl(in, kGameVersion_Undefined, save_ver);
+    ReadFromFileImpl(in, true);
 }
 
 void CharacterInfo::WriteToSavegame(Stream *out) const

--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -66,13 +66,15 @@ void CharacterInfo::ReadFromFileImpl(Stream *in, GameDataVersion data_ver, int s
     in->ReadArrayOfInt16(inv, MAX_INV);
     actx = in->ReadInt16();
     acty = in->ReadInt16();
-    StrUtil::ReadCStrCount(name, in, MAX_CHAR_NAME_LEN);
-    StrUtil::ReadCStrCount(scrname, in, MAX_SCRIPT_NAME_LEN);
+    StrUtil::ReadCStrCount(legacy_name, in, LEGACY_MAX_CHAR_NAME_LEN);
+    StrUtil::ReadCStrCount(legacy_scrname, in, LEGACY_MAX_SCRIPT_NAME_LEN);
     on = in->ReadInt8();
     if (do_align_pad)
         in->ReadInt8(); // alignment padding to int32
 
     // Upgrade data
+    name = legacy_name;
+    scrname = legacy_scrname;
     if ((data_ver > kGameVersion_Undefined && data_ver < kGameVersion_360_16) ||
         ((data_ver == kGameVersion_Undefined) && save_ver >= 0 && save_ver < 2))
     {
@@ -126,8 +128,8 @@ void CharacterInfo::WriteToFileImpl(Stream *out, bool is_save) const
     out->WriteArrayOfInt16(inv, MAX_INV);
     out->WriteInt16(actx);
     out->WriteInt16(acty);
-    out->Write(name, 40);
-    out->Write(scrname, MAX_SCRIPT_NAME_LEN);
+    out->Write(legacy_name, LEGACY_MAX_CHAR_NAME_LEN);
+    out->Write(legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
     out->WriteInt8(on);
     if (do_align_pad)
         out->WriteInt8(0); // alignment padding to int32

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -162,12 +162,12 @@ struct CharacterInfo {
     void ReadFromFile(Common::Stream *in, GameDataVersion data_ver);
     void WriteToFile(Common::Stream *out) const;
     // TODO: move to runtime-only class (?)
-    void ReadFromSavegame(Common::Stream *in, int save_ver);
+    void ReadFromSavegame(Common::Stream *in);
     void WriteToSavegame(Common::Stream *out) const;
 
 private:
     // TODO: this is likely temp here until runtime class is factored out
-    void ReadFromFileImpl(Common::Stream *in, GameDataVersion data_ver, int save_ver);
+    void ReadFromFileImpl(Common::Stream *in, bool is_save);
     void WriteToFileImpl(Common::Stream *out, bool is_save) const;
 };
 

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -52,7 +52,7 @@ using namespace AGS; // FIXME later
 #define FOLLOW_ALWAYSONTOP  0x7ffe
 
 // Length of deprecated character name field, in bytes
-#define MAX_CHAR_NAME_LEN 40
+#define LEGACY_MAX_CHAR_NAME_LEN 40
 
 // Character's internal flags, packed in CharacterInfo::animating
 #define CHANIM_MASK         0xFF
@@ -78,6 +78,7 @@ inline int CharFlagsToObjFlags(int chflags)
 
 
 struct CharacterExtras; // forward declaration
+
 // IMPORTANT: exposed to script API, and plugin API as AGSCharacter!
 // For older script compatibility the struct also has to maintain its size;
 // do not extend or change existing fields, unless planning breaking compatibility.
@@ -115,9 +116,14 @@ struct CharacterInfo {
     short walkspeed, animspeed;
     short inv[MAX_INV];
     short actx, acty;
-    char  name[MAX_CHAR_NAME_LEN];
-    char  scrname[MAX_SCRIPT_NAME_LEN];
+    // These two name fields are deprecated, but must stay here
+    // for compatibility with the plugin API (unless the plugin interface is reworked)
+    char  legacy_name[LEGACY_MAX_CHAR_NAME_LEN];
+    char  legacy_scrname[LEGACY_MAX_SCRIPT_NAME_LEN];
     char  on;
+
+    AGS::Common::String scrname;
+    AGS::Common::String name;
 
     int get_baseline() const;        // return baseline, or Y if not set
     int get_blocking_top() const;    // return Y - BlockingHeight/2

--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -82,7 +82,7 @@
 #endif
 
 // Script name length limit for some game objects
-#define MAX_SCRIPT_NAME_LEN 20
+#define LEGACY_MAX_SCRIPT_NAME_LEN 20
 // Number of state-saved rooms
 #define MAX_ROOMS 300
 // Some obsolete room data, likely pre-2.5

--- a/Common/ac/dynobj/scriptaudioclip.cpp
+++ b/Common/ac/dynobj/scriptaudioclip.cpp
@@ -20,8 +20,8 @@ using namespace AGS::Common;
 void ScriptAudioClip::ReadFromFile(Stream *in)
 {
     id = in->ReadInt32();
-    scriptName.ReadCount(in, SCRIPTAUDIOCLIP_SCRIPTNAMELENGTH);
-    fileName.ReadCount(in, SCRIPTAUDIOCLIP_FILENAMELENGTH);
+    scriptName.ReadCount(in, LEGACY_AUDIOCLIP_SCRIPTNAMELENGTH);
+    fileName.ReadCount(in, LEGACY_AUDIOCLIP_FILENAMELENGTH);
     bundlingType = static_cast<uint8_t>(in->ReadInt8());
     type = static_cast<uint8_t>(in->ReadInt8());
     fileType = static_cast<AudioFileType>(in->ReadInt8());

--- a/Common/ac/dynobj/scriptaudioclip.h
+++ b/Common/ac/dynobj/scriptaudioclip.h
@@ -35,8 +35,9 @@ enum AudioFileType {
 #define AUCL_BUNDLE_EXE 1
 #define AUCL_BUNDLE_VOX 2
 
-#define SCRIPTAUDIOCLIP_SCRIPTNAMELENGTH    30
-#define SCRIPTAUDIOCLIP_FILENAMELENGTH      15
+#define LEGACY_AUDIOCLIP_SCRIPTNAMELENGTH    30
+#define LEGACY_AUDIOCLIP_FILENAMELENGTH      15
+
 struct ScriptAudioClip {
     int id = 0;
     Common::String scriptName;

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -116,6 +116,8 @@ Some adjustments to gui text alignment.
 In RTL mode all text is reversed, not only wrappable (labels etc).
 3.6.1.10:
 Disabled automatic SetRestartPoint.
+3.6.1.14:
+Extended game object names, resolving hard length limits.
 
 */
 
@@ -156,7 +158,8 @@ enum GameDataVersion
     kGameVersion_360_21         = 3060021,
     kGameVersion_361            = 3060100,
     kGameVersion_361_10         = 3060110,
-    kGameVersion_Current        = kGameVersion_361_10
+    kGameVersion_361_14         = 3060114,
+    kGameVersion_Current        = kGameVersion_361_14
 };
 
 // Data format version of the loaded game

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -29,7 +29,6 @@ GameSetupStruct::GameSetupStruct()
     memset(lipSyncFrameLetters, 0, sizeof(lipSyncFrameLetters));
     memset(guid, 0, sizeof(guid));
     memset(saveGameFileExtension, 0, sizeof(saveGameFileExtension));
-    memset(saveGameFolderName, 0, sizeof(saveGameFolderName));
 }
 
 GameSetupStruct::~GameSetupStruct()
@@ -103,7 +102,7 @@ void GameSetupStruct::read_savegame_info(Common::Stream *in, GameDataVersion dat
     {
         StrUtil::ReadCStrCount(guid, in, MAX_GUID_LENGTH);
         StrUtil::ReadCStrCount(saveGameFileExtension, in, MAX_SG_EXT_LENGTH);
-        StrUtil::ReadCStrCount(saveGameFolderName, in, MAX_SG_FOLDER_LEN);
+        saveGameFolderName.ReadCount(in, LEGACY_MAX_SG_FOLDER_LEN);
     }
 }
 

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -75,7 +75,7 @@ struct GameSetupStruct : public GameSetupStructBase
     char              guid[MAX_GUID_LENGTH];
     char              saveGameFileExtension[MAX_SG_EXT_LENGTH];
     // NOTE: saveGameFolderName is generally used to create game subdirs in common user directories
-    char              saveGameFolderName[MAX_SG_FOLDER_LEN];
+    Common::String    saveGameFolderName;
     int               roomCount;
     std::vector<int>  roomNumbers;
     std::vector<Common::String> roomNames;

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -44,7 +44,6 @@ GameSetupStructBase::GameSetupStructBase()
     , _dataUpscaleMult(1)
     , _screenUpscaleMult(1)
 {
-    memset(gamename, 0, sizeof(gamename));
     memset(options, 0, sizeof(options));
     memset(paluses, 0, sizeof(paluses));
     memset(defpal, 0, sizeof(defpal));
@@ -139,7 +138,7 @@ void GameSetupStructBase::ReadFromFile(Stream *in, GameDataVersion game_ver, Ser
     // NOTE: historically the struct was saved by dumping whole memory
     // into the file stream, which added padding from memory alignment;
     // here we mark the padding bytes, as they do not belong to actual data.
-    StrUtil::ReadCStrCount(gamename, in, GAME_NAME_LENGTH);
+    gamename.ReadCount(in, LEGACY_GAME_NAME_LENGTH);
     in->ReadInt16(); // alignment padding to int32 (gamename: 50 -> 52 bytes)
     in->ReadArrayOfInt32(options, MAX_OPTIONS);
     if (game_ver < kGameVersion_340_4)
@@ -193,7 +192,7 @@ void GameSetupStructBase::WriteToFile(Stream *out, const SerializeInfo &info) co
     // NOTE: historically the struct was saved by dumping whole memory
     // into the file stream, which added padding from memory alignment;
     // here we mark the padding bytes, as they do not belong to actual data.
-    out->Write(gamename, GAME_NAME_LENGTH);
+    gamename.WriteCount(out, LEGACY_GAME_NAME_LENGTH);
     out->WriteInt16(0); // alignment padding to int32
     out->WriteArrayOfInt32(options, MAX_OPTIONS);
     out->Write(&paluses[0], sizeof(paluses));

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -179,6 +179,8 @@ void GameSetupStructBase::ReadFromFile(Stream *in, GameDataVersion game_ver, Ser
     default_lipsync_frame = in->ReadInt32();
     invhotdotsprite = in->ReadInt32();
     in->ReadArrayOfInt32(reserved, NUM_INTS_RESERVED);
+
+    info.ExtensionOffset = static_cast<uint32_t>(in->ReadInt32());
     in->ReadArrayOfInt32(&info.HasMessages.front(), MAXGLOBALMES);
 
     info.HasWordsDict = in->ReadInt32() != 0;

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -38,7 +38,7 @@ struct GameSetupStructBase
 {
     static const int  LEGACY_GAME_NAME_LENGTH = 50;
     static const int  MAX_OPTIONS = 100;
-    static const int  NUM_INTS_RESERVED = 17;
+    static const int  NUM_INTS_RESERVED = 16;
 
     Common::String    gamename;
     int               options[MAX_OPTIONS];
@@ -83,6 +83,8 @@ struct GameSetupStructBase
         bool HasCCScript = false;
         bool HasWordsDict = false;
         std::array<int, MAXGLOBALMES> HasMessages{};
+        // File offset at which game data extensions begin
+        uint32_t ExtensionOffset = 0u;
     };
 
     void ReadFromFile(Common::Stream *in, GameDataVersion game_ver, SerializeInfo &info);

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -36,11 +36,11 @@ struct ccScript;
 
 struct GameSetupStructBase
 {
-    static const int  GAME_NAME_LENGTH = 50;
+    static const int  LEGACY_GAME_NAME_LENGTH = 50;
     static const int  MAX_OPTIONS = 100;
     static const int  NUM_INTS_RESERVED = 17;
 
-    char              gamename[GAME_NAME_LENGTH];
+    Common::String    gamename;
     int               options[MAX_OPTIONS];
     unsigned char     paluses[256];
     RGB               defpal[256];

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -130,11 +130,12 @@
 
 #define DIALOG_OPTIONS_HIGHLIGHT_COLOR_DEFAULT  14 // Yellow
 
-#define MAXVIEWNAMELENGTH 15
+// MAXVIEWNAMELENGTH comes from unknown old engine version
+#define LEGACY_MAXVIEWNAMELENGTH 15
 #define MAXLIPSYNCFRAMES  20
 #define MAX_GUID_LENGTH   40
 #define MAX_SG_EXT_LENGTH 20
-#define MAX_SG_FOLDER_LEN 50
+#define LEGACY_MAX_SG_FOLDER_LEN 50
 
 enum GameResolutionType
 {

--- a/Common/ac/inventoryiteminfo.cpp
+++ b/Common/ac/inventoryiteminfo.cpp
@@ -19,7 +19,7 @@ using namespace AGS::Common;
 
 void InventoryItemInfo::ReadFromFile(Stream *in)
 {
-    StrUtil::ReadCStrCount(name, in, MAX_INVENTORY_NAME_LENGTH);
+    name.ReadCount(in, LEGACY_MAX_INVENTORY_NAME_LENGTH);
     in->Seek(3); // alignment padding to int32
     pic = in->ReadInt32();
     cursorPic = in->ReadInt32();
@@ -32,7 +32,7 @@ void InventoryItemInfo::ReadFromFile(Stream *in)
 
 void InventoryItemInfo::WriteToFile(Stream *out)
 {
-    out->Write(name, MAX_INVENTORY_NAME_LENGTH);
+    name.WriteCount(out, LEGACY_MAX_INVENTORY_NAME_LENGTH);
     out->WriteByteCount(0, 3); // alignment padding to int32
     out->WriteInt32(pic);
     out->WriteInt32(cursorPic);
@@ -45,7 +45,7 @@ void InventoryItemInfo::WriteToFile(Stream *out)
 
 void InventoryItemInfo::ReadFromSavegame(Stream *in)
 {
-    StrUtil::ReadString(name, in, 25);
+    name = StrUtil::ReadString(in);
     pic = in->ReadInt32();
     cursorPic = in->ReadInt32();
 }

--- a/Common/ac/inventoryiteminfo.h
+++ b/Common/ac/inventoryiteminfo.h
@@ -11,27 +11,26 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_INVENTORYITEMINFO_H
 #define __AC_INVENTORYITEMINFO_H
 
-namespace AGS { namespace Common { class Stream; } }
-using namespace AGS; // FIXME later
+#include "util/stream.h"
+#include "util/string.h"
 
 #define IFLG_STARTWITH 1
-#define MAX_INVENTORY_NAME_LENGTH 25
+#define LEGACY_MAX_INVENTORY_NAME_LENGTH 25
 
 struct InventoryItemInfo {
-    char name[MAX_INVENTORY_NAME_LENGTH];
+    AGS::Common::String name;
     int  pic;
     int  cursorPic, hotx, hoty;
     int  reserved[5];
-    char flags;
+    uint8_t flags; // IFLG_STARTWITH
 
-    void ReadFromFile(Common::Stream *in);
-    void WriteToFile(Common::Stream *out);
-    void ReadFromSavegame(Common::Stream *in);
-    void WriteToSavegame(Common::Stream *out) const;
+    void ReadFromFile(AGS::Common::Stream *in);
+    void WriteToFile(AGS::Common::Stream *out);
+    void ReadFromSavegame(AGS::Common::Stream *in);
+    void WriteToSavegame(AGS::Common::Stream *out) const;
 };
 
 #endif // __AC_INVENTORYITEMINFO_H

--- a/Common/ac/mousecursor.cpp
+++ b/Common/ac/mousecursor.cpp
@@ -23,9 +23,11 @@ void MouseCursor::ReadFromFile(Stream *in)
     hotx = in->ReadInt16();
     hoty = in->ReadInt16();
     view = in->ReadInt16();
-    StrUtil::ReadCStrCount(name, in, MAX_CURSOR_NAME_LENGTH);
+    StrUtil::ReadCStrCount(legacy_name, in, LEGACY_MAX_CURSOR_NAME_LENGTH);
     flags = in->ReadInt8();
     in->Seek(3); // alignment padding to int32
+
+    name = legacy_name;
 }
 
 void MouseCursor::WriteToFile(Stream *out)
@@ -34,7 +36,7 @@ void MouseCursor::WriteToFile(Stream *out)
     out->WriteInt16(hotx);
     out->WriteInt16(hoty);
     out->WriteInt16(view);
-    out->Write(name, MAX_CURSOR_NAME_LENGTH);
+    out->Write(legacy_name, LEGACY_MAX_CURSOR_NAME_LENGTH);
     out->WriteInt8(flags);
     out->WriteByteCount(0, 3); // alignment padding to int32
 }

--- a/Common/ac/mousecursor.h
+++ b/Common/ac/mousecursor.h
@@ -11,19 +11,18 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_MOUSECURSOR_H
 #define __AC_MOUSECURSOR_H
 
-namespace AGS { namespace Common { class Stream; } }
-using namespace AGS; // FIXME later
+#include "util/stream.h"
+#include "util/string.h"
 
 #define MCF_ANIMMOVE 1
 #define MCF_DISABLED 2
 #define MCF_STANDARD 4
 #define MCF_HOTSPOT  8  // only animate when over hotspot
 
-#define MAX_CURSOR_NAME_LENGTH 10
+#define LEGACY_MAX_CURSOR_NAME_LENGTH 10
 
 enum CursorSvgVersion
 {
@@ -31,25 +30,27 @@ enum CursorSvgVersion
     kCursorSvgVersion_36016   = 1, // animation delay
 };
 
-
 // IMPORTANT: exposed to plugin API as AGSCursor!
 // do not change topmost fields, unless planning breaking compatibility.
 struct MouseCursor {
     int   pic = 0;
     short hotx = 0, hoty = 0;
     short view = -1;
-    char  name[MAX_CURSOR_NAME_LENGTH]{};
+    // This is a deprecated name field, but must stay here for compatibility
+    // with the plugin API (unless the plugin interface is reworked)
+    char  legacy_name[LEGACY_MAX_CURSOR_NAME_LENGTH]{};
     char  flags = 0;
 
-    // up to here is a part of plugin API
+    // Following fields are not part of the plugin API
+    AGS::Common::String name;
     int   animdelay = 5;
 
     MouseCursor() = default;
 
-    void ReadFromFile(Common::Stream *in);
-    void WriteToFile(Common::Stream *out);
-    void ReadFromSavegame(Common::Stream *in, int cmp_ver);
-    void WriteToSavegame(Common::Stream *out) const;
+    void ReadFromFile(AGS::Common::Stream *in);
+    void WriteToFile(AGS::Common::Stream *out);
+    void ReadFromSavegame(AGS::Common::Stream *in, int cmp_ver);
+    void WriteToSavegame(AGS::Common::Stream *out) const;
 };
 
 #endif // __AC_MOUSECURSOR_H

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -853,6 +853,32 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
     return HError::None();
 }
 
+// Search and read only data belonging to the general game info
+class GameDataExtPreloader : public GameDataExtReader
+{
+public:
+    GameDataExtPreloader(LoadedGameEntities &ents, GameDataVersion data_ver, Stream *in)
+        : GameDataExtReader(ents, data_ver, in) {}
+
+protected:
+    HError ReadBlock(int block_id, const String &ext_id,
+        soff_t block_len, bool &read_next) override;
+};
+
+HError GameDataExtPreloader::ReadBlock(int /*block_id*/, const String &ext_id,
+    soff_t /*block_len*/, bool &read_next)
+{
+    // Try reading only data which belongs to the general game info
+    read_next = true;
+    if (ext_id.CompareNoCase("v361_objnames") == 0)
+    {
+        _ents.Game.gamename = StrUtil::ReadString(_in);
+        _ents.Game.saveGameFolderName = StrUtil::ReadString(_in);
+        read_next = false; // we're done
+    }
+    return HError::None();
+}
+
 
 HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver)
 {
@@ -983,6 +1009,16 @@ void PreReadGameData(GameSetupStruct &game, Stream *in, GameDataVersion data_ver
     GameSetupStruct::SerializeInfo sinfo;
     game.ReadFromFile(in, data_ver, sinfo);
     game.read_savegame_info(in, data_ver);
+
+    // Check for particular expansions that might have data necessary
+    // for "preload" purposes
+    if (sinfo.ExtensionOffset == 0u)
+        return; // either no extensions, or data version is too early
+
+    in->Seek(sinfo.ExtensionOffset, kSeekBegin);
+    LoadedGameEntities ents(game);
+    GameDataExtPreloader reader(ents, data_ver, in);
+    reader.Read();
 }
 
 } // namespace Common

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -603,13 +603,15 @@ void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
     // Fixup charakter script names for 2.x (EGO -> cEgo)
     if (data_ver <= kGameVersion_272)
     {
-        String tempbuffer;
+        char namelwr[LEGACY_MAX_CHAR_NAME_LEN];
         for (int i = 0; i < numcharacters; i++)
         {
-            if (chars[i].scrname[0] == 0)
+            if (chars[i].legacy_scrname[0] == 0)
                 continue;
-            tempbuffer.Format("c%c%s", chars[i].scrname[0], ags_strlwr(&chars[i].scrname[1]));
-            snprintf(chars[i].scrname, MAX_SCRIPT_NAME_LEN, "%s", tempbuffer.GetCStr());
+            memcpy(namelwr, chars[i].legacy_scrname, LEGACY_MAX_CHAR_NAME_LEN);
+            ags_strlwr(namelwr + 1); // lowercase starting with the second char
+            snprintf(chars[i].legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "c%s", namelwr);
+            chars[i].scrname = chars[i].legacy_scrname;
         }
     }
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -723,18 +723,17 @@ void FixupSaveDirectory(GameSetupStruct &game)
 {
     // If the save game folder was not specified by game author, create one of
     // the game name, game GUID, or uniqueid, as a last resort
-    if (!game.saveGameFolderName[0])
+    if (game.saveGameFolderName.IsEmpty())
     {
-        if (game.gamename[0])
-            snprintf(game.saveGameFolderName, MAX_SG_FOLDER_LEN, "%s", game.gamename);
+        if (!game.gamename.IsEmpty())
+            game.saveGameFolderName = game.gamename;
         else if (game.guid[0])
-            snprintf(game.saveGameFolderName, MAX_SG_FOLDER_LEN, "%s", game.guid);
+            game.saveGameFolderName = game.guid;
         else
-            snprintf(game.saveGameFolderName, MAX_SG_FOLDER_LEN, "AGS-Game-%d", game.uniqueid);
+            game.saveGameFolderName.Format("AGS-Game-%d", game.uniqueid);
     }
     // Lastly, fixup folder name by removing any illegal characters
-    String s = Path::FixupSharedFilename(game.saveGameFolderName);
-    snprintf(game.saveGameFolderName, MAX_SG_FOLDER_LEN, "%s", s.GetCStr());
+    game.saveGameFolderName = Path::FixupSharedFilename(game.saveGameFolderName);
 }
 
 HGameFileError ReadSpriteFlags(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver)
@@ -811,6 +810,8 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
     {
         // Extended object names and script names:
         // for object types that had hard name length limits
+        _ents.Game.gamename = StrUtil::ReadString(_in);
+        _ents.Game.saveGameFolderName = StrUtil::ReadString(_in);
         size_t num_chars = _in->ReadInt32();
         if (num_chars != _ents.Game.chars.size())
             return new Error(String::FromFormat("Mismatching number of characters: read %zu expected %zu", num_chars, _ents.Game.chars.size()));
@@ -863,7 +864,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
     GameSetupStruct::SerializeInfo sinfo;
     game.GameSetupStructBase::ReadFromFile(in, data_ver, sinfo);
 
-    Debug::Printf(kDbgMsg_Info, "Game title: '%s'", game.gamename);
+    Debug::Printf(kDbgMsg_Info, "Game title: '%s'", game.gamename.GetCStr());
     Debug::Printf(kDbgMsg_Info, "Game uid (old format): `%d`", game.uniqueid);
     Debug::Printf(kDbgMsg_Info, "Game guid: '%s'", game.guid);
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -267,7 +267,7 @@ void ReadViews(GameSetupStruct &game, std::vector<ViewStruct> &views, Stream *in
     else // 2.x views
     {
         std::vector<ViewStruct272> oldv(game.numviews);
-        for (size_t i = 0; i < game.numviews; ++i)
+        for (int i = 0; i < game.numviews; ++i)
         {
             oldv[i].ReadFromFile(in);
         }
@@ -783,11 +783,11 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
     // }
     if (ext_id.CompareNoCase("v360_fonts") == 0)
     {
-        for (int i = 0; i < _ents.Game.numfonts; ++i)
+        for (FontInfo &finfo : _ents.Game.fonts)
         {
             // adjustable font outlines
-            _ents.Game.fonts[i].AutoOutlineThickness = _in->ReadInt32();
-            _ents.Game.fonts[i].AutoOutlineStyle =
+            finfo.AutoOutlineThickness = _in->ReadInt32();
+            finfo.AutoOutlineStyle =
                 static_cast<enum FontInfo::AutoOutlineStyle>(_in->ReadInt32());
             // reserved
             _in->ReadInt32();
@@ -795,21 +795,61 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
             _in->ReadInt32();
             _in->ReadInt32();
         }
-        return HError::None();
     }
     else if (ext_id.CompareNoCase("v360_cursors") == 0)
     {
-        for (int i = 0; i < _ents.Game.numcursors; ++i)
+        for (MouseCursor &mcur : _ents.Game.mcurs)
         {
-            _ents.Game.mcurs[i].animdelay = _in->ReadInt32();
+            mcur.animdelay = _in->ReadInt32();
             // reserved
             _in->ReadInt32();
             _in->ReadInt32();
             _in->ReadInt32();
         }
-        return HError::None();
     }
-    return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));
+    else if (ext_id.CompareNoCase("v361_objnames") == 0)
+    {
+        // Extended object names and script names:
+        // for object types that had hard name length limits
+        size_t num_chars = _in->ReadInt32();
+        if (num_chars != _ents.Game.chars.size())
+            return new Error(String::FromFormat("Mismatching number of characters: read %zu expected %zu", num_chars, _ents.Game.chars.size()));
+        for (CharacterInfo &chinfo : _ents.Game.chars)
+        {
+            chinfo.scrname = StrUtil::ReadString(_in);
+            chinfo.name = StrUtil::ReadString(_in);
+            // assign to the legacy fields for compatibility with old plugins
+            snprintf(chinfo.legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "%s", chinfo.scrname.GetCStr());
+            snprintf(chinfo.legacy_name, LEGACY_MAX_CHAR_NAME_LEN, "%s", chinfo.name.GetCStr());
+        }
+        size_t num_invitems = _in->ReadInt32();
+        if (num_invitems != _ents.Game.numinvitems)
+            return new Error(String::FromFormat("Mismatching number of inventory items: read %zu expected %zu", num_invitems, (size_t)_ents.Game.numinvitems));
+        for (int i = 0; i < _ents.Game.numinvitems; ++i)
+        {
+            _ents.Game.invinfo[i].name = StrUtil::ReadString(_in);
+        }
+        size_t num_cursors = _in->ReadInt32();
+        if (num_cursors != _ents.Game.mcurs.size())
+            return new Error(String::FromFormat("Mismatching number of cursors: read %zu expected %zu", num_cursors, _ents.Game.mcurs.size()));
+        for (MouseCursor &mcur : _ents.Game.mcurs)
+        {
+            mcur.name = StrUtil::ReadString(_in);
+        }
+        size_t num_clips = _in->ReadInt32();
+        if (num_clips != _ents.Game.audioClips.size())
+            return new Error(String::FromFormat("Mismatching number of audio clips: read %zu expected %zu", num_clips, _ents.Game.audioClips.size()));
+        for (ScriptAudioClip &clip : _ents.Game.audioClips)
+        {
+            clip.scriptName = StrUtil::ReadString(_in);
+            clip.fileName = StrUtil::ReadString(_in);
+        }
+    }
+    else
+    {
+        return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));
+    }
+    return HError::None();
 }
 
 

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -128,7 +128,7 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
             if (data_ver >= kRoomVersion_3415)
                 room->Hotspots[i].ScriptName = StrUtil::ReadString(in);
             else
-                room->Hotspots[i].ScriptName = String::FromStreamCount(in, MAX_SCRIPT_NAME_LEN);
+                room->Hotspots[i].ScriptName = String::FromStreamCount(in, LEGACY_MAX_SCRIPT_NAME_LEN);
         }
     }
 
@@ -379,7 +379,7 @@ HError ReadObjScNamesBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ve
         if (data_ver >= kRoomVersion_3415)
             obj.ScriptName = StrUtil::ReadString(in);
         else
-            obj.ScriptName.ReadCount(in, MAX_SCRIPT_NAME_LEN);
+            obj.ScriptName.ReadCount(in, LEGACY_MAX_SCRIPT_NAME_LEN);
     }
     return HError::None();
 }

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -124,9 +124,9 @@ bool File::DeleteFile(const String &filename)
     return true;
 }
 
-bool File::RenameFile(const String &old_name, const String &new_name)
+bool File::RenameFile(const String &old_name, const String &name)
 {
-    return ags_file_rename(old_name.GetCStr(), new_name.GetCStr()) == 0;
+    return ags_file_rename(old_name.GetCStr(), name.GetCStr()) == 0;
 }
 
 bool File::CopyFile(const String &src_path, const String &dst_path, bool overwrite)

--- a/Common/util/file.h
+++ b/Common/util/file.h
@@ -63,7 +63,7 @@ namespace File
     // Deletes existing file; returns TRUE if was able to delete one
     bool        DeleteFile(const String &filename);
     // Renames existing file to the new name; returns TRUE on success
-    bool        RenameFile(const String &old_name, const String &new_name);
+    bool        RenameFile(const String &old_name, const String &name);
     // Copies a file from src_path to dst_path; returns TRUE on success
     bool        CopyFile(const String &src_path, const String &dst_path, bool overwrite);
 

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -418,7 +418,7 @@ namespace AGS.Editor.Components
         private AudioClip CreateAudioClipForFile(string sourceFileName)
         {
             string newScriptName = EnsureScriptNameIsUnique(
-                Path.GetFileNameWithoutExtension(sourceFileName), AudioClip.MAX_SCRIPTNAME_LENGTH);
+                Path.GetFileNameWithoutExtension(sourceFileName));
             AudioClip newClip = new AudioClip(newScriptName, _agsEditor.CurrentGame.GetNextAudioIndex());
             newClip.ID = _agsEditor.CurrentGame.RootAudioClipFolder.GetAllItemsCount();
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1778,6 +1778,8 @@ namespace AGS.Editor
         // this saves only those properties that were restricted in length previously
         private static void WriteExt_361ObjNames(BinaryWriter writer, Game game, CompileMessages errors)
         {
+            FilePutString(game.Settings.GameName, writer);
+            FilePutString(game.Settings.SaveGameFolderName, writer);
             // Characters
             writer.Write((int)game.Characters.Count);
             for (int i = 0; i < game.Characters.Count; ++i)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -690,7 +690,7 @@ namespace AGS
             if (name->Equals("GAME_DATA_VERSION_CURRENT")) return (int)kGameVersion_Current;
             if (name->Equals("MAX_GUID_LENGTH")) return MAX_GUID_LENGTH;
             if (name->Equals("MAX_SG_EXT_LENGTH")) return MAX_SG_EXT_LENGTH;
-            if (name->Equals("MAX_SG_FOLDER_LEN")) return MAX_SG_FOLDER_LEN;
+            if (name->Equals("MAX_SG_FOLDER_LEN")) return LEGACY_MAX_SG_FOLDER_LEN;
             if (name->Equals("MAX_SCRIPT_NAME_LEN")) return LEGACY_MAX_SCRIPT_NAME_LEN;
             if (name->Equals("FFLG_SIZEMULTIPLIER")) return FFLG_SIZEMULTIPLIER;
             if (name->Equals("IFLG_STARTWITH")) return IFLG_STARTWITH;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -691,7 +691,7 @@ namespace AGS
             if (name->Equals("MAX_GUID_LENGTH")) return MAX_GUID_LENGTH;
             if (name->Equals("MAX_SG_EXT_LENGTH")) return MAX_SG_EXT_LENGTH;
             if (name->Equals("MAX_SG_FOLDER_LEN")) return MAX_SG_FOLDER_LEN;
-            if (name->Equals("MAX_SCRIPT_NAME_LEN")) return MAX_SCRIPT_NAME_LEN;
+            if (name->Equals("MAX_SCRIPT_NAME_LEN")) return LEGACY_MAX_SCRIPT_NAME_LEN;
             if (name->Equals("FFLG_SIZEMULTIPLIER")) return FFLG_SIZEMULTIPLIER;
             if (name->Equals("IFLG_STARTWITH")) return IFLG_STARTWITH;
             if (name->Equals("MCF_ANIMMOVE")) return MCF_ANIMMOVE;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3076,7 +3076,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
   game->Settings->EnforceNewAudio = false;
 	game->Settings->EnforceObjectBasedScript = (thisgame.options[OPT_STRICTSCRIPTING] != 0);
 	game->Settings->FontsForHiRes = (thisgame.options[OPT_HIRES_FONTS] != 0);
-	game->Settings->GameName = gcnew String(thisgame.gamename);
+	game->Settings->GameName = gcnew String(thisgame.gamename.GetCStr());
 	game->Settings->UseGlobalSpeechAnimationDelay = true; // this was always on in pre-3.0 games
 	game->Settings->GUIAlphaStyle = GUIAlphaStyle::Classic;
     game->Settings->SpriteAlphaStyle = SpriteAlphaStyle::Classic;
@@ -3103,7 +3103,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 	game->Settings->WalkInLookMode = (thisgame.options[OPT_WALKONLOOK] != 0);
 	game->Settings->WhenInterfaceDisabled = (InterfaceDisabledAction)thisgame.options[OPT_DISABLEOFF];
 	game->Settings->UniqueID = thisgame.uniqueid;
-    game->Settings->SaveGameFolderName = gcnew String(thisgame.gamename);
+    game->Settings->SaveGameFolderName = gcnew String(thisgame.gamename.GetCStr());
     game->Settings->RenderAtScreenResolution = (RenderAtScreenResolution)thisgame.options[OPT_RENDERATSCREENRES];
     game->Settings->AllowRelativeAssetResolutions = (thisgame.options[OPT_RELATIVEASSETRES] != 0);
     game->Settings->ScaleMovementSpeedWithMaskResolution = (thisgame.options[OPT_WALKSPEEDABSOLUTE] == 0);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3206,8 +3206,8 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 		character->MovementSpeedX = thisgame.chars[i].walkspeed;
 		character->MovementSpeedY = thisgame.chars[i].walkspeed_y;
 		character->NormalView = thisgame.chars[i].defview + 1;
-		character->RealName = gcnew String(thisgame.chars[i].name);
-		character->ScriptName = gcnew String(thisgame.chars[i].scrname);
+		character->RealName = gcnew String(thisgame.chars[i].name.GetCStr());
+		character->ScriptName = gcnew String(thisgame.chars[i].scrname.GetCStr());
 		character->Solid = !(thisgame.chars[i].flags & CHF_NOBLOCKING);
 		character->SpeechColor = thisgame.chars[i].talkcolor;
 		character->SpeechView = (thisgame.chars[i].talkview < 1) ? 0 : (thisgame.chars[i].talkview + 1);
@@ -3296,7 +3296,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 		cursor->HotspotX = thisgame.mcurs[i].hotx;
 		cursor->HotspotY = thisgame.mcurs[i].hoty;
 		cursor->ID = i;
-		cursor->Name = gcnew String(thisgame.mcurs[i].name);
+		cursor->Name = gcnew String(thisgame.mcurs[i].name.GetCStr());
 		cursor->StandardMode = ((thisgame.mcurs[i].flags & MCF_STANDARD) != 0);
 		cursor->View = thisgame.mcurs[i].view + 1;
 		if (cursor->View < 1) cursor->View = 0;
@@ -3331,7 +3331,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 	{
 		InventoryItem^ invItem = gcnew InventoryItem();
     invItem->CursorImage = thisgame.invinfo[i].pic;
-		invItem->Description = gcnew String(thisgame.invinfo[i].name);
+		invItem->Description = gcnew String(thisgame.invinfo[i].name.GetCStr());
 		invItem->Image = thisgame.invinfo[i].pic;
 		invItem->HotspotX = thisgame.invinfo[i].hotx;
 		invItem->HotspotY = thisgame.invinfo[i].hoty;

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -9,7 +9,6 @@ namespace AGS.Types
     public class AudioClip : IToXml, IComparable<AudioClip>
     {
         public const string AUDIO_CACHE_DIRECTORY = "AudioCache";
-        public const int MAX_SCRIPTNAME_LENGTH = 29; // restricted by data format
 
         private int _id;
         private string _sourceFileName;
@@ -80,7 +79,7 @@ namespace AGS.Types
         public string ScriptName
         {
             get { return _scriptName; }
-            set { _scriptName = Utilities.ValidateScriptName(value, MAX_SCRIPTNAME_LENGTH); }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
         // This is a "Fixed Index" that is used as a stable reference the clip,

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -14,7 +14,6 @@ namespace AGS.Types
         public const string PROPERTY_NAME_SCRIPTNAME = "ScriptName";
         public const string PROPERTY_NAME_STARTINGROOM = "StartingRoom";
         public const int NARRATOR_CHARACTER_ID = 999;
-        public const int MAX_SCRIPTNAME_LENGTH = 19; // restricted by data format
 
         private static InteractionSchema _interactionSchema;
 
@@ -78,7 +77,7 @@ namespace AGS.Types
         public string ScriptName
         {
             get { return _scriptName; }
-            set { _scriptName = Utilities.ValidateScriptName(value, MAX_SCRIPTNAME_LENGTH); }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
         [Description("The full name of the character")]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -1134,7 +1134,7 @@ namespace AGS.Types
 				}
 				if (value.Length > 19)
 				{
-					throw new ArgumentException("Save game extension cannot be longer than 15 letters");
+					throw new ArgumentException("Save game extension cannot be longer than 19 letters");
 				}
 				if ((value.Length > 0) && (value.Length < 5))
 				{

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -15,7 +15,7 @@
 // AGS Character functions
 //
 //=============================================================================
-#include <stdio.h>
+#include <cstdio>
 #include "ac/character.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -15,6 +15,7 @@
 // AGS Character functions
 //
 //=============================================================================
+#include <stdio.h>
 #include "ac/character.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
@@ -258,7 +259,7 @@ void Character_ChangeRoomSetLoop(CharacterInfo *chaa, int room, int x, int y, in
         chaa->room = room;
 
 		debug_script_log("%s moved to room %d, location %d,%d, loop %d",
-			chaa->scrname, room, chaa->x, chaa->y, chaa->loop);
+			chaa->scrname.GetCStr(), room, chaa->x, chaa->y, chaa->loop);
 
         return;
     }
@@ -295,7 +296,7 @@ void Character_ChangeView(CharacterInfo *chap, int vii) {
       chap->idleleft = chap->idletime;
     }
 
-    debug_script_log("%s: Change view to %d", chap->scrname, vii+1);
+    debug_script_log("%s: Change view to %d", chap->scrname.GetCStr(), vii+1);
     chap->defview = vii;
     chap->view = vii;
     stop_character_anim(chap);
@@ -416,7 +417,7 @@ void FaceDirectionalLoop(CharacterInfo *char1, int direction, int blockingStyle)
 
 void FaceLocationXY(CharacterInfo *char1, int xx, int yy, int blockingStyle)
 {
-    debug_script_log("%s: Face location %d,%d", char1->scrname, xx, yy);
+    debug_script_log("%s: Face location %d,%d", char1->scrname.GetCStr(), xx, yy);
 
     const int diffrx = xx - char1->x;
     const int diffry = yy - char1->y;
@@ -480,10 +481,10 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
         quit("!FollowCharacterEx: you cannot tell the player character to follow a character in another room");
 
     if (tofollow != nullptr) {
-        debug_script_log("%s: Start following %s (dist %d, eager %d)", chaa->scrname, tofollow->scrname, distaway, eagerness);
+        debug_script_log("%s: Start following %s (dist %d, eager %d)", chaa->scrname.GetCStr(), tofollow->scrname.GetCStr(), distaway, eagerness);
     }
     else {
-        debug_script_log("%s: Stop following other character", chaa->scrname);
+        debug_script_log("%s: Stop following other character", chaa->scrname.GetCStr());
     }
 
     if ((chaa->following >= 0) &&
@@ -601,7 +602,7 @@ void Character_LockViewEx(CharacterInfo *chap, int vii, int stopMoving) {
     vii--; // convert to 0-based
     AssertView("SetCharacterView", vii);
 
-    debug_script_log("%s: View locked to %d", chap->scrname, vii+1);
+    debug_script_log("%s: View locked to %d", chap->scrname.GetCStr(), vii+1);
     if (chap->idleleft < 0) {
         Character_UnlockView(chap);
         chap->idleleft = chap->idletime;
@@ -732,7 +733,7 @@ void Character_PlaceOnWalkableArea(CharacterInfo *chap)
 void Character_RemoveTint(CharacterInfo *chaa) {
 
     if (chaa->flags & (CHF_HASTINT | CHF_HASLIGHT)) {
-        debug_script_log("Un-tint %s", chaa->scrname);
+        debug_script_log("Un-tint %s", chaa->scrname.GetCStr());
         chaa->flags &= ~(CHF_HASTINT | CHF_HASLIGHT);
     }
     else {
@@ -782,7 +783,7 @@ void Character_SetAsPlayer(CharacterInfo *chaa) {
 
     //update_invorder();
 
-    debug_script_log("%s is new player character", playerchar->scrname);
+    debug_script_log("%s is new player character", playerchar->scrname.GetCStr());
 
     // Within game_start, return now
     if (displayed_room < 0)
@@ -834,10 +835,10 @@ void Character_SetIdleView(CharacterInfo *chaa, int iview, int itime) {
         chaa->wait = 0;
 
     if (iview >= 1) {
-        debug_script_log("Set %s idle view to %d (time %d)", chaa->scrname, iview, itime);
+        debug_script_log("Set %s idle view to %d (time %d)", chaa->scrname.GetCStr(), iview, itime);
     }
     else {
-        debug_script_log("%s idle view disabled", chaa->scrname);
+        debug_script_log("%s idle view disabled", chaa->scrname.GetCStr());
     }
     if (chaa->flags & CHF_FIXVIEW) {
         debug_script_warn("SetCharacterIdle called while character view locked with SetCharacterView; idle ignored");
@@ -955,7 +956,7 @@ void Character_StopMoving(CharacterInfo *charp) {
         if ((mls[charp->walking].direct == 0) && (charp->room == displayed_room))
             Character_PlaceOnWalkableArea(charp);
 
-        debug_script_log("%s: stop moving", charp->scrname);
+        debug_script_log("%s: stop moving", charp->scrname.GetCStr());
 
         charp->idleleft = charp->idletime;
         // restart the idle animation straight away
@@ -976,7 +977,7 @@ void Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opaci
         (luminance < 0) || (luminance > 100))
         quit("!Character.Tint: invalid parameter. R,G,B must be 0-255, opacity & luminance 0-100");
 
-    debug_script_log("Set %s tint RGB(%d,%d,%d) %d%%", chaa->scrname, red, green, blue, opacity);
+    debug_script_log("Set %s tint RGB(%d,%d,%d) %d%%", chaa->scrname.GetCStr(), red, green, blue, opacity);
 
     charextra[chaa->index_id].tint_r = red;
     charextra[chaa->index_id].tint_g = green;
@@ -997,7 +998,7 @@ void Character_UnlockView(CharacterInfo *chaa) {
 
 void Character_UnlockViewEx(CharacterInfo *chaa, int stopMoving) {
     if (chaa->flags & CHF_FIXVIEW) {
-        debug_script_log("%s: Released view back to default", chaa->scrname);
+        debug_script_log("%s: Released view back to default", chaa->scrname.GetCStr());
     }
     chaa->flags &= ~CHF_FIXVIEW;
     chaa->view = chaa->defview;
@@ -1274,7 +1275,7 @@ int Character_GetID(CharacterInfo *chaa) {
 
 const char *Character_GetScriptName(CharacterInfo *chin)
 {
-    return CreateNewScriptString(chin->scrname);
+    return CreateNewScriptString(chin->scrname.GetCStr());
 }
 
 int Character_GetFrame(CharacterInfo *chaa) {
@@ -1422,11 +1423,12 @@ int Character_GetDestinationY(CharacterInfo *chaa) {
 }
 
 const char* Character_GetName(CharacterInfo *chaa) {
-    return CreateNewScriptString(chaa->name);
+    return CreateNewScriptString(chaa->name.GetCStr());
 }
 
 void Character_SetName(CharacterInfo *chaa, const char *newName) {
-    snprintf(chaa->name, MAX_CHAR_NAME_LEN, "%s", newName);
+    chaa->name = newName;
+    snprintf(chaa->legacy_name, LEGACY_MAX_CHAR_NAME_LEN, "%s", newName);
     GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
@@ -1701,7 +1703,7 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
 
     if ((tox == charX) && (toy == charY)) {
         StopMoving(chac);
-        debug_script_log("%s already at destination, not moving", chin->scrname);
+        debug_script_log("%s already at destination, not moving", chin->scrname.GetCStr());
         return;
     }
 
@@ -1733,14 +1735,14 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
     chin->frame = oldframe;
     // use toxPassedIn cached variable so the hi-res co-ordinates
     // are still displayed as such
-    debug_script_log("%s: Start move to %d,%d", chin->scrname, toxPassedIn, toyPassedIn);
+    debug_script_log("%s: Start move to %d,%d", chin->scrname.GetCStr(), toxPassedIn, toyPassedIn);
 
     const int move_speed_x = chin->walkspeed;
     const int move_speed_y =
         ((chin->walkspeed_y == UNIFORM_WALK_SPEED) ? chin->walkspeed : chin->walkspeed_y);
 
     if ((move_speed_x == 0) && (move_speed_y == 0)) {
-        debug_script_warn("Warning: MoveCharacter called for '%s' with walk speed 0", chin->name);
+        debug_script_warn("Warning: MoveCharacter called for '%s' with walk speed 0", chin->scrname.GetCStr());
     }
 
     set_route_move_speed(move_speed_x, move_speed_y);
@@ -1942,7 +1944,8 @@ int doNextCharMoveStep (CharacterInfo *chi, int &char_index, CharacterExtras *ch
             chi->x = xwas;
             chi->y = ywas;
         }
-        debug_script_log("%s: Bumped into %s, waiting for them to move", chi->scrname, game.chars[ntf].scrname);
+        debug_script_log("%s: Bumped into %s, waiting for them to move",
+            chi->scrname.GetCStr(), game.chars[ntf].scrname.GetCStr());
         return 1;
     }
     return 0;
@@ -2171,12 +2174,12 @@ void animate_character(CharacterInfo *chap, int loopn, int sppd, int rept,
     {
         quitprintf("!AnimateCharacter: invalid view and/or loop\n"
             "(trying to animate '%s' using view %d (range is 1..%d) and loop %d (view has %d loops)).",
-            chap->name, chap->view + 1, game.numviews, loopn, views[chap->view].numLoops);
+            chap->scrname.GetCStr(), chap->view + 1, game.numviews, loopn, views[chap->view].numLoops);
     }
     // NOTE: there's always frame 0 allocated for safety
     sframe = std::max(0, std::min(sframe, views[chap->view].loops[loopn].numFrames - 1));
     debug_script_log("%s: Start anim view %d loop %d, spd %d, repeat %d, frame: %d",
-        chap->scrname, chap->view+1, loopn, sppd, rept, sframe);
+        chap->scrname.GetCStr(), chap->view+1, loopn, sppd, rept, sframe);
 
     Character_StopMoving(chap);
 
@@ -2238,12 +2241,12 @@ void update_character_scale(int charid)
     if (chin.view < 0)
     {
         quitprintf("!The character '%s' was turned on in the current room (room %d) but has not been assigned a view number.",
-            chin.name, displayed_room);
+            chin.scrname.GetCStr(), displayed_room);
     }
     if (chin.loop >= views[chin.view].numLoops)
     {
         quitprintf("!The character '%s' could not be displayed because there was no loop %d of view %d.",
-            chin.name, chin.loop, chin.view + 1);
+            chin.scrname.GetCStr(), chin.loop, chin.view + 1);
     }
     // If frame is too high -- fallback to the frame 0;
     // there's always at least 1 dummy frame at index 0
@@ -2564,12 +2567,13 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             charFrameWas = speakingChar->frame;
 
         if ((speakingChar->view < 0) || views[speakingChar->view].numLoops == 0)
-            quitprintf("!Character %s current view %d is invalid, or has no loops.", speakingChar->scrname, speakingChar->view + 1);
+            quitprintf("!Character %s current view %d is invalid, or has no loops.",
+                speakingChar->scrname.GetCStr(), speakingChar->view + 1);
         // If current view is missing a loop - use loop 0
         if (speakingChar->loop >= views[speakingChar->view].numLoops)
         {
             debug_script_warn("WARNING: Character %s current view %d does not have necessary loop %d; switching to loop 0.",
-                speakingChar->scrname, speakingChar->view + 1, speakingChar->loop);
+                speakingChar->scrname.GetCStr(), speakingChar->view + 1, speakingChar->loop);
             speakingChar->loop = 0;
         }
 
@@ -2824,12 +2828,13 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             speakingChar->flags|=CHF_FIXVIEW;
 
             if ((speakingChar->view < 0) || views[speakingChar->view].numLoops == 0)
-                quitprintf("!Character %s speech view %d is invalid, or has no loops.", speakingChar->scrname, speakingChar->view + 1);
+                quitprintf("!Character %s speech view %d is invalid, or has no loops.",
+                    speakingChar->scrname.GetCStr(), speakingChar->view + 1);
             // If speech view is missing a loop - use loop 0
             if (speakingChar->loop >= views[speakingChar->view].numLoops)
             {
                 debug_script_warn("WARNING: Character %s speech view %d does not have necessary loop %d; switching to loop 0.",
-                    speakingChar->scrname, speakingChar->view + 1, speakingChar->loop);
+                    speakingChar->scrname.GetCStr(), speakingChar->view + 1, speakingChar->loop);
                 speakingChar->loop = 0;
             }
 

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -31,6 +31,7 @@ enum CharacterSvgVersion
     kCharSvgVersion_350     = 1, // new movelist format (along with pathfinder)
     kCharSvgVersion_36025   = 2, // animation volume
     kCharSvgVersion_36109   = 3, // removed movelists, save externally
+    kCharSvgVersion_36114   = 4, // no limit on character name's length
 };
 
 // The CharacterInfo struct size is fixed because it's exposed to script
@@ -70,8 +71,13 @@ struct CharacterExtras {
     // play linked sounds, and so forth.
     void CheckViewFrame(CharacterInfo *chi);
 
-    void ReadFromSavegame(Common::Stream *in, int save_ver);
-    void WriteToSavegame(Common::Stream *out);
+    // Read character extra data from saves.
+    // NOTE: we read ext name fields into the CharacterInfo struct,
+    // hence require its reference as an argument. This is ugly, but should
+    // be improved when the structs are refactored into having a distinct
+    // runtime Character class, which would hold all relevant data itself.
+    void ReadFromSavegame(Common::Stream *in, CharacterInfo &chinfo, int save_ver);
+    void WriteToSavegame(Common::Stream *out, const CharacterInfo &chinfo);
 };
 
 #endif // __AGS_EE_AC__CHARACTEREXTRAS_H

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -82,7 +82,7 @@ void CharacterInfo::UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, st
         if (loop == views[view].numLoops) // view has no frames?!
         { // amazingly enough there are old games that allow this to happen...
             if (loaded_game_file_version >= kGameVersion_300)
-                quitprintf("!Character %s is assigned view %d that has no frames!", name, view);
+                quitprintf("!Character %s is assigned view %d that has no frames!", scrname.GetCStr(), view);
             loop = 0;
         }
     }
@@ -210,7 +210,8 @@ void CharacterInfo::update_character_moving(int &char_index, CharacterExtras *ch
       }
 
       if (loop >= views[view].numLoops)
-        quitprintf("Unable to render character %d (%s) because loop %d does not exist in view %d", index_id, name, loop, view + 1);
+        quitprintf("Unable to render character %d (%s) because loop %d does not exist in view %d",
+            index_id, scrname.GetCStr(), loop, view + 1);
 
       // check don't overflow loop
       int framesInLoop = views[view].loops[loop].numFrames;
@@ -222,7 +223,8 @@ void CharacterInfo::update_character_moving(int &char_index, CharacterExtras *ch
           frame = 0;
 
         if (framesInLoop < 1)
-          quitprintf("Unable to render character %d (%s) because there are no frames in loop %d", index_id, name, loop);
+          quitprintf("Unable to render character %d (%s) because there are no frames in loop %d",
+              index_id, scrname.GetCStr(), loop);
       }
 
       doing_nothing = 0; // still walking?
@@ -449,7 +451,7 @@ void CharacterInfo::update_character_idle(CharacterExtras *chex, int &doing_noth
       idleleft--;
       if (idleleft == -1) {
         int useloop=loop;
-        debug_script_log("%s: Now idle (view %d)", scrname, idleview+1);
+        debug_script_log("%s: Now idle (view %d)", scrname.GetCStr(), idleview+1);
 		Character_LockView(this, idleview+1);
         // SetCharView resets it to 0
         idleleft = -2;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -674,8 +674,8 @@ const char *Game_GetName() {
 }
 
 void Game_SetName(const char *newName) {
-    snprintf(play.game_name, MAX_GAME_STATE_NAME_LENGTH, "%s", newName);
-    sys_window_set_title(play.game_name);
+    play.game_name = newName;
+    sys_window_set_title(play.game_name.GetCStr());
     GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Gamename);
 }
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -669,7 +669,10 @@ void GameState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameState
     in->Read(playmp3file_name, PLAYMP3FILE_MAX_FILENAME_LEN);
     in->Read(globalstrings, MAXGLOBALSTRINGS * MAX_MAXSTRLEN);
     in->Read(lastParserEntry, MAX_MAXSTRLEN);
-    StrUtil::ReadCStrCount(game_name, in, MAX_GAME_STATE_NAME_LENGTH);
+    if (svg_ver < kGSSvgVersion_361_14)
+        game_name.ReadCount(in, LEGACY_GAMESTATE_GAMENAMELENGTH);
+    else
+        game_name = StrUtil::ReadString(in);
     ground_level_areas_disabled = in->ReadInt32();
     next_screen_transition = in->ReadInt32();
     in->ReadInt32(); // gamma_adjustment -- do not apply gamma level from savegame
@@ -866,7 +869,7 @@ void GameState::WriteForSavegame(Stream *out) const
     out->Write(playmp3file_name, PLAYMP3FILE_MAX_FILENAME_LEN);
     out->Write(globalstrings, MAXGLOBALSTRINGS * MAX_MAXSTRLEN);
     out->Write(lastParserEntry, MAX_MAXSTRLEN);
-    out->Write(game_name, MAX_GAME_STATE_NAME_LENGTH);
+    StrUtil::WriteString(game_name, out);
     out->WriteInt32( ground_level_areas_disabled);
     out->WriteInt32( next_screen_transition);
     out->WriteInt32( gamma_adjustment);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -49,6 +49,7 @@ struct ScriptOverlay;
 
 #define MAX_GAME_STATE_NAME_LENGTH 100
 #define GAME_STATE_RESERVED_INTS 5
+#define LEGACY_GAMESTATE_GAMENAMELENGTH 100
 
 // Savegame data format
 enum GameStateSvgVersion
@@ -58,6 +59,7 @@ enum GameStateSvgVersion
     kGSSvgVersion_350       = 1,
     kGSSvgVersion_350_9     = 2,
     kGSSvgVersion_350_10    = 3,
+    kGSSvgVersion_361_14    = 4,
 };
 
 
@@ -237,7 +239,7 @@ struct GameState
     char  playmp3file_name[PLAYMP3FILE_MAX_FILENAME_LEN]{};
     char  globalstrings[MAXGLOBALSTRINGS][MAX_MAXSTRLEN]{};
     char  lastParserEntry[MAX_MAXSTRLEN]{};
-    char  game_name[MAX_GAME_STATE_NAME_LENGTH]{};
+    AGS::Common::String game_name;
     int   ground_level_areas_disabled = 0;
     int   next_screen_transition = 0;
     int   gamma_adjustment = 0;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -470,9 +470,9 @@ String get_cue_filename(int charid, int sndid)
     {
         // append the first 4 characters of the script name to the filename
         if (game.chars[charid].scrname[0] == 'c')
-            script_name.SetString(&game.chars[charid].scrname[1], 4);
+            script_name.SetString(game.chars[charid].scrname.GetCStr() + 1, 4);
         else
-            script_name.SetString(game.chars[charid].scrname, 4);
+            script_name.SetString(game.chars[charid].scrname.GetCStr(), 4);
     }
     else
     {

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -110,7 +110,8 @@ int GetCharacterWidth(int ww) {
             (char1->loop >= views[char1->view].numLoops) ||
             (char1->frame >= views[char1->view].loops[char1->loop].numFrames))
         {
-            debug_script_warn("GetCharacterWidth: Character %s has invalid frame: view %d, loop %d, frame %d", char1->scrname, char1->view + 1, char1->loop, char1->frame);
+            debug_script_warn("GetCharacterWidth: Character %s has invalid frame: view %d, loop %d, frame %d",
+                char1->scrname.GetCStr(), char1->view + 1, char1->loop, char1->frame);
             return data_to_game_coord(4);
         }
 
@@ -129,7 +130,8 @@ int GetCharacterHeight(int charid) {
             (char1->loop >= views[char1->view].numLoops) ||
             (char1->frame >= views[char1->view].loops[char1->loop].numFrames))
         {
-            debug_script_warn("GetCharacterHeight: Character %s has invalid frame: view %d, loop %d, frame %d", char1->scrname, char1->view + 1, char1->loop, char1->frame);
+            debug_script_warn("GetCharacterHeight: Character %s has invalid frame: view %d, loop %d, frame %d",
+                char1->scrname.GetCStr(), char1->view + 1, char1->loop, char1->frame);
             return data_to_game_coord(2);
         }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -615,7 +615,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
             if (play.get_loc_name_last_time != 1000 + mover)
                 GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
             play.get_loc_name_last_time = 1000 + mover;
-            snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.invinfo[mover].name));
+            snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.invinfo[mover].name.GetCStr()));
         }
         else if ((play.get_loc_name_last_time > 1000) && (play.get_loc_name_last_time < 1000 + MAX_INV)) {
             // no longer selecting an item

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -646,7 +646,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
     // on character
     if (loctype == LOCTYPE_CHAR) {
         onhs = getloctype_index;
-        snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.chars[onhs].name));
+        snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.chars[onhs].name.GetCStr()));
         if (play.get_loc_name_last_time != 2000+onhs)
             GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
         play.get_loc_name_last_time = 2000+onhs;

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -61,7 +61,7 @@ void SetInvItemName(int invi, const char *newName) {
     if ((invi < 1) || (invi > game.numinvitems))
         quit("!SetInvName: invalid inventory item specified");
 
-    snprintf(game.invinfo[invi].name, MAX_INVENTORY_NAME_LENGTH, "%s", newName);
+    game.invinfo[invi].name = newName;
     // might need to redraw the GUI if it has the inv item name on it
     GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
@@ -85,7 +85,7 @@ int GetInvAt(int atx, int aty) {
 void GetInvName(int indx,char*buff) {
   VALIDATE_STRING(buff);
   if ((indx<0) | (indx>=game.numinvitems)) quit("!GetInvName: invalid inventory item specified");
-  snprintf(buff, MAX_MAXSTRLEN, "%s", get_translation(game.invinfo[indx].name));
+  snprintf(buff, MAX_MAXSTRLEN, "%s", get_translation(game.invinfo[indx].name.GetCStr()));
 }
 
 int GetInvGraphic(int indx) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -421,7 +421,7 @@ void replace_macro_tokens(const char *text, String &fixed_text) {
             else if (ags_stricmp(macroname,"scoretext")==0)
                 snprintf(tempo, sizeof(tempo), "%d of %d",play.score,MAXSCORE);
             else if (ags_stricmp(macroname,"gamename")==0)
-                snprintf(tempo, sizeof(tempo), "%s", play.game_name);
+                snprintf(tempo, sizeof(tempo), "%s", play.game_name.GetCStr());
             else if (ags_stricmp(macroname,"overhotspot")==0) {
                 // While game is in Wait mode, no overhotspot text
                 if (!IsInterfaceEnabled())

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -72,7 +72,7 @@ void InventoryItem_GetName(ScriptInvItem *iitem, char *buff) {
 }
 
 const char* InventoryItem_GetName_New(ScriptInvItem *invitem) {
-  return CreateNewScriptString(get_translation(game.invinfo[invitem->id].name));
+  return CreateNewScriptString(get_translation(game.invinfo[invitem->id].name.GetCStr()));
 }
 
 int InventoryItem_GetGraphic(ScriptInvItem *iitem) {

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -258,7 +258,7 @@ int InventoryScreen::Redraw()
     }
 
     for (int i = 0; i < charextra[game.playercharacter].invorder_count; ++i) {
-        if (game.invinfo[charextra[game.playercharacter].invorder[i]].name[0]!=0) {
+        if (!game.invinfo[charextra[game.playercharacter].invorder[i]].name.IsEmpty()) {
             dii[numitems].num = charextra[game.playercharacter].invorder[i];
             dii[numitems].sprnum = game.invinfo[charextra[game.playercharacter].invorder[i]].pic;
             int snn=dii[numitems].sprnum;

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -161,7 +161,7 @@ void InitAndRegisterCharacters(GameSetupStruct &game)
         ccRegisterManagedObject(&game.chars[i], &ccDynamicCharacter);
 
         // export the character's script object
-        ccAddExternalScriptObject(game.chars[i].scrname, &game.chars[i], &ccDynamicCharacter);
+        ccAddExternalScriptObject(game.chars[i].scrname.GetCStr(), &game.chars[i], &ccDynamicCharacter);
     }
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -572,7 +572,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
     // precache current cursor
     spriteset.PrecacheSprite(game.mcurs[r_data.CursorID].pic);
 
-    sys_window_set_title(play.game_name);
+    sys_window_set_title(play.game_name.GetCStr());
 
     if (displayed_room >= 0)
     {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -545,7 +545,7 @@ HSaveError WriteCharacters(Stream *out)
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].WriteToSavegame(out);
-        charextra[i].WriteToSavegame(out);
+        charextra[i].WriteToSavegame(out, game.chars[i]);
         Properties::WriteValues(play.charProps[i], out);
         if (loaded_game_file_version <= kGameVersion_272)
             WriteTimesRun272(*game.intrChar[i], out);
@@ -560,8 +560,8 @@ HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, const PreservedParams& /*
         return err;
     for (int i = 0; i < game.numcharacters; ++i)
     {
-        game.chars[i].ReadFromSavegame(in, cmp_ver);
-        charextra[i].ReadFromSavegame(in, cmp_ver);
+        game.chars[i].ReadFromSavegame(in);
+        charextra[i].ReadFromSavegame(in, game.chars[i], cmp_ver);
         Properties::ReadValues(play.charProps[i], in);
         if (loaded_game_file_version <= kGameVersion_272)
             ReadTimesRun272(*game.intrChar[i], in);
@@ -1209,7 +1209,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Characters",
-        kCharSvgVersion_36109,
+        kCharSvgVersion_36114,
         kCharSvgVersion_350, // skip pre-alpha 3.5.0 ver
         WriteCharacters,
         ReadCharacters

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1195,7 +1195,7 @@ ComponentHandler ComponentHandlers[] =
     // at which a change was introduced, represented as NN,NN,NN,NN.
     {
         "Game State",
-        kGSSvgVersion_350_10,
+        kGSSvgVersion_361_14,
         kGSSvgVersion_Initial,
         WriteGameState,
         ReadGameState

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -498,7 +498,7 @@ HSaveError restore_save_data_v321(Stream *in, GameDataVersion data_ver, const Pr
     // Character extras (runtime only data)
     for (int i = 0; i < game.numcharacters; ++i)
     {
-        charextra[i].ReadFromSavegame(in, 0);
+        charextra[i].ReadFromSavegame(in, game.chars[i], kCharSvgVersion_Initial);
     }
     restore_game_palette(in);
     restore_game_dialogs(in);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -143,7 +143,7 @@ void engine_setup_window()
     Debug::Printf(kDbgMsg_Info, "Setting up window");
 
     our_eip = -198;
-    sys_window_set_title(game.gamename);
+    sys_window_set_title(game.gamename.GetCStr());
     sys_window_set_icon();
     sys_evt_set_quit_callback(winclosehook);
     our_eip = -197;
@@ -823,7 +823,7 @@ void engine_init_game_settings()
     play.speech_textwindow_gui = game.options[OPT_TWCUSTOM];
     if (play.speech_textwindow_gui == 0)
         play.speech_textwindow_gui = -1;
-    snprintf(play.game_name, sizeof(play.game_name), "%s", game.gamename);
+    play.game_name = game.gamename;
     play.lastParserEntry[0] = 0;
     play.follow_change_room_timer = 150;
     for (ee = 0; ee < MAX_ROOM_BGFRAMES; ee++) 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -443,7 +443,7 @@ bool run_service_key_controls(KeyInput &out_key)
             chd = ff;
             sprintf(&bigbuffer[strlen(bigbuffer)],
                 "%s (view/loop/frm:%d,%d,%d  x/y/z:%d,%d,%d  idleview:%d,time:%d,left:%d walk:%d anim:%d follow:%d flags:%X wait:%d zoom:%d)[",
-                game.chars[chd].scrname, game.chars[chd].view + 1, game.chars[chd].loop, game.chars[chd].frame,
+                game.chars[chd].legacy_scrname, game.chars[chd].view + 1, game.chars[chd].loop, game.chars[chd].frame,
                 game.chars[chd].x, game.chars[chd].y, game.chars[chd].z,
                 game.chars[chd].idleview, game.chars[chd].idletime, game.chars[chd].idleleft,
                 game.chars[chd].walking, game.chars[chd].animating, game.chars[chd].following,

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -781,7 +781,7 @@ void IAGSEngine::GetGameInfo(AGSGameInfo* ginfo)
 {
     if (ginfo->Version >= 26)
     {
-        snprintf(ginfo->GameName, sizeof(ginfo->GameName), "%s", game.gamename);
+        snprintf(ginfo->GameName, sizeof(ginfo->GameName), "%s", game.gamename.GetCStr());
         snprintf(ginfo->Guid, sizeof(ginfo->Guid), "%s", game.guid);
         ginfo->UniqueId = game.uniqueid;
     }


### PR DESCRIPTION
Fix #1734 

I got reminded about this recently, unfortunately there still a number of game objects, such as Character and Inventory item, which names are restricted in length by a hard number of bytes. Inventory item's name is the shortest, being 24 bytes.
This may not be a serious limitation for ASCII games, where 1 char = 1 byte (although some games may feature very long item descriptions), but things get worse in Unicode, where text in utf-8 may have 1 char = 1-4 bytes, thus same field may contain up to 4 times less characters.
In the sense this change is complementary to the Unicode support in 3.6.0, but also done for consistency with other non-restricted script name and name fields.

Although user asked only about Inventory names, I went through the game data and gathered all fields with a hard-limit, wanting to cover them all in one bulk change, if i'm addressing name limits anyway.

There's a number of nuances in this change. I added comments to each commit, and also in code, but here's a summary.

1. Affected properties are:
    - Game name (title);
    - Game's savegame folder name;
    - Character's script name and name (description);
    - Inventory item's name (description);
    - Mouse cursor's script name; this one is not much important, since it's not used anywhere, besides compilation time, but I did it nevertheless for consistency (and in case it will be used at some point).
    - Audioclip's script name and filename.

3. CharacterInfo struct must retain old fixed char array fields for compatibility with plugin API. I also write values there too, as much as they may take. Would the plugin API be adjusted and have direct access to a character data struct removed, then these fields may be removed as well. (This is already true in ags4 branch)

4. All the unrestricted name values are added as an "extension" to the game data, without changing the existing data chunks. This is done for both backward and forward compatibility, as explained in this project wiki article: https://github.com/adventuregamestudio/ags/wiki/Extending-game-and-room-data-format
