### PR TITLE
Small fixes for Android and iOS

### DIFF
--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -402,8 +402,10 @@ void AGSAndroid::DisplayAlert(const char *text, ...) {
   va_list args;
   va_start(args, text);
   vsprintf(displbuf, text, args);
-  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "AGSNative",displbuf, nullptr);
   va_end(args);
+
+  Debug::Printf(kDbgMsg_Warn, "%s", displbuf);
+  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "AGSNative", displbuf, nullptr);
 }
 
 void AGSAndroid::Delay(int millis) {

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -247,7 +247,7 @@ int getAvailableTranslations(char* translations)
 }
 
 
-void startEngine(char* filename, char* directory, int loadLastSave)
+void startEngine(const char* filename, const char* directory, int loadLastSave)
 {
     auto &setup = AGSIOS::GetMobileSetup();
     setup.game_file_name = filename;
@@ -262,15 +262,8 @@ void startEngine(char* filename, char* directory, int loadLastSave)
     ReadConfiguration(setup, IOS_CONFIG_FILENAME, true);
 
     // Get the games path.
-    char path[256];
-    strcpy(path, setup.game_file_name.GetCStr());
-    size_t lastindex = strlen(path) - 1;
-    while (path[lastindex] != '/')
-    {
-    path[lastindex] = 0;
-    lastindex--;
-    }
-    chdir(path);
+    String gamepath = Path::GetParent(setup.game_file_name);
+    chdir(gamepath.GetCStr());
 
     setenv("ULTRADIR", "..", 1);
 

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -337,7 +337,7 @@ void AGSIOS::DisplayAlert(const char *text, ...) {
   va_end(ap);
   
   Debug::Printf(kDbgMsg_Warn, "%s", displbuf);
-  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, nullptr, displbuf, nullptr);
+  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "AGSNative", displbuf, nullptr);
 }
 
 void AGSIOS::Delay(int millis) {

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -15,22 +15,20 @@
 
 #if AGS_PLATFORM_OS_IOS
 #include <stdio.h>
-#include <dirent.h>
-#include <sys/stat.h> 
 #include <ctype.h>
 #include <SDL.h>
-
 #include <allegro.h>
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/mobile_base.h"
+#include "ac/gamesetup.h"
 #include "ac/runtime_defines.h"
 #include "main/config.h"
 #include "plugin/agsplugin.h"
-#include "util/string_utils.h"
-#include "util/string_compat.h"
-#include "ac/gamesetup.h"
-#include "util/path.h"
 #include "util/directory.h"
+#include "util/file.h"
+#include "util/path.h"
+#include "util/string_compat.h"
+#include "util/string_utils.h"
 
 
 using namespace AGS::Common;
@@ -238,33 +236,14 @@ void setStringConfigValue(int id, const char* value)
 
 int getAvailableTranslations(char* translations)
 {
-  int i = 0;
-  size_t length;
-  DIR* dir;
-  struct dirent* entry;
-  char buffer[200];
-
-  dir = opendir(".");
-  if (dir)
-  {
-    while ((entry = readdir(dir)) != 0)
+    int count = 0;
+    for (FindFile ff = FindFile::OpenFiles(".", "*.tra"); !ff.AtEnd(); ff.Next())
     {
-      length = strlen(entry->d_name);
-      if (length > 4)
-      {
-        if (ags_stricmp(&entry->d_name[length - 4], ".tra") == 0)
-        {
-          memset(buffer, 0, 200);
-          strncpy(buffer, entry->d_name, length - 4);
-          //env->SetObjectArrayElement(translations, i, env->NewStringUTF(&buffer[0])); // figure out how to pass the string to iOS back
-          i++;
-        }
-      }
+        String filename = Path::RemoveExtension(Path::GetFilename(ff.Current()));
+        // FIXME: figure out how to pass the string to iOS back!
+        //env->SetObjectArrayElement(translations, count++, env->NewStringUTF(filename.GetCStr()));
     }
-    closedir(dir);
-  }
-
-  return i;
+    return count;
 }
 
 


### PR DESCRIPTION
- Use FindFile class when searching for translations;
- Uniform DisplayAlert code.
- Use our Path functions when getting parent path.
- Add `const` to `char*` where makes sense.

Cannot test this on iOS myself.

On a side note, these likely could benefit from a MobilePlatform base class.