### PR TITLE
Fix engine trying to parse voice-over token for the second time

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -364,7 +364,8 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
       else text_color = ds->GetCompatibleColor(utextcol);
     }
 
-    break_up_text_into_lines(get_translation(dtop->optionnames[disporder[ww]]), Lines, areawid-(2*padding+2+bullet_wid), usingfont);
+    const char *draw_text = skip_voiceover_token(get_translation(dtop->optionnames[disporder[ww]]));
+    break_up_text_into_lines(draw_text, Lines, areawid-(2*padding+2+bullet_wid), usingfont);
     dispyp[ww]=curyp;
     if (game.dialog_bullet > 0)
     {
@@ -388,18 +389,6 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
   }
   return curyp;
 }
-
-
-
-#define GET_OPTIONS_HEIGHT {\
-  needheight = 0;\
-  for (int i = 0; i < numdisp; ++i) {\
-    break_up_text_into_lines(get_translation(dtop->optionnames[disporder[i]]), Lines, areawid-(2*padding+2+bullet_wid), usingfont);\
-    needheight += get_text_lines_surf_height(usingfont, Lines.Count()) + data_to_game_coord(game.options[OPT_DIALOGGAP]);\
-  }\
-  if (parserInput) needheight += parserInput->GetHeight() + data_to_game_coord(game.options[OPT_DIALOGGAP]);\
- }
-
 
 void draw_gui_for_dialog_options(Bitmap *ds, GUIMain *guib, int dlgxp, int dlgyp) {
   if (guib->BgColor != 0) {
@@ -494,7 +483,25 @@ struct DialogOptions
     // Process mouse wheel scroll
     bool RunMouseWheel(int mwheelz);
     void Close();
+
+private:
+    void CalcOptionsHeight();
 };
+
+void DialogOptions::CalcOptionsHeight()
+{
+    needheight = 0;
+    for (int i = 0; i < numdisp; ++i)
+    {
+        const char *draw_text = skip_voiceover_token(get_translation(dtop->optionnames[disporder[i]]));
+        break_up_text_into_lines(draw_text, Lines, areawid-(2*padding+2+bullet_wid), usingfont);
+        needheight += get_text_lines_surf_height(usingfont, Lines.Count()) + data_to_game_coord(game.options[OPT_DIALOGGAP]);
+    }
+    if (parserInput)
+    {
+        needheight += parserInput->GetHeight() + data_to_game_coord(game.options[OPT_DIALOGGAP]);
+    }
+}
 
 void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
 {
@@ -613,7 +620,7 @@ void DialogOptions::Show()
         areawid=guib->Width - 5;
         padding = TEXTWINDOW_PADDING_DEFAULT;
 
-        GET_OPTIONS_HEIGHT
+        CalcOptionsHeight();
 
         if (game.options[OPT_DIALOGUPWARDS]) {
           // They want the options upwards from the bottom
@@ -626,7 +633,7 @@ void DialogOptions::Show()
       //dlgyp=(play.viewport.GetHeight()-numdisp*txthit)-1;
       areawid= ui_view.GetWidth()-5;
       padding = TEXTWINDOW_PADDING_DEFAULT;
-      GET_OPTIONS_HEIGHT
+      CalcOptionsHeight();
       dlgyp = ui_view.GetHeight() - needheight;
 
       dirtyx = 0;
@@ -706,7 +713,8 @@ void DialogOptions::Redraw()
       int biggest = 0;
       padding = guis[game.options[OPT_DIALOGIFACE]].Padding;
       for (int i = 0; i < numdisp; ++i) {
-        break_up_text_into_lines(get_translation(dtop->optionnames[disporder[i]]), Lines, areawid-((2*padding+2)+bullet_wid), usingfont);
+        const char *draw_text = skip_voiceover_token(get_translation(dtop->optionnames[disporder[i]]));
+        break_up_text_into_lines(draw_text, Lines, areawid-((2*padding+2)+bullet_wid), usingfont);
         if (longestline > biggest)
           biggest = longestline;
       }
@@ -719,7 +727,7 @@ void DialogOptions::Redraw()
           quit("!game.min_dialogoption_width is larger than game.max_dialogoption_width");
       }
 
-      GET_OPTIONS_HEIGHT
+      CalcOptionsHeight();
 
       int savedwid = areawid;
       int txoffs=0,tyoffs=0,yspos = ui_view.GetHeight()/2-(2*padding+needheight)/2;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -92,6 +92,8 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     // Just in case screen size does is not neatly divisible by 320x200
     const int paddingDoubledScaled = get_fixed_pixel_size(padding * 2);
 
+    // NOTE: we do not process the text using prepare_text_for_drawing() here,
+    // as it is assumed to be done prior to passing into this function
     // Make message copy, because ensure_text_valid_for_font() may modify it
     char todis[STD_BUFFER_SIZE];
     snprintf(todis, STD_BUFFER_SIZE - 1, "%s", text);
@@ -457,7 +459,7 @@ int GetTextDisplayLength(const char *text)
 {
     // Skip voice-over token from the length calculation if required
     if (play.unfactor_speech_from_textlength != 0)
-        text = parse_voiceover_token(text, nullptr);
+        text = skip_voiceover_token(text);
     return static_cast<int>(strlen(text));
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -430,18 +430,16 @@ void display_at(int xx, int yy, int wii, const char *text)
 
 bool try_auto_play_speech(const char *text, const char *&replace_text, int charid)
 {
-    const char *src = text;
-    if (src[0] != '&')
-        return false;
-
-    int sndid = atoi(&src[1]);
-    while ((src[0] != ' ') & (src[0] != 0)) src++;
-    if (src[0] == ' ') src++;
-    if (sndid <= 0)
+    int voice_num;
+    const char *src = parse_voiceover_token(text, &voice_num);
+    if (src == text)
+        return false; // no token
+    
+    if (voice_num <= 0)
         quit("DisplaySpeech: auto-voice symbol '&' not followed by valid integer");
 
     replace_text = src; // skip voice tag
-    if (play_voice_speech(charid, sndid))
+    if (play_voice_speech(charid, voice_num))
     {
         // if Voice Only, then blank out the text
         if (play.speech_mode == kSpeech_VoiceOnly)
@@ -457,17 +455,10 @@ int source_text_length = -1;
 
 int GetTextDisplayLength(const char *text)
 {
-    int len = (int)strlen(text);
-    if ((text[0] == '&') && (play.unfactor_speech_from_textlength != 0))
-    {
-        // if there's an "&12 text" type line, remove "&12 " from the source length
-        size_t j = 0;
-        while ((text[j] != ' ') && (text[j] != 0))
-            j++;
-        j++;
-        len -= j;
-    }
-    return len;
+    // Skip voice-over token from the length calculation if required
+    if (play.unfactor_speech_from_textlength != 0)
+        text = parse_voiceover_token(text, nullptr);
+    return static_cast<int>(strlen(text));
 }
 
 int GetTextDisplayTime(const char *text, int canberel) {

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -33,7 +33,8 @@ using AGS::Common::GUIMain;
 
 struct ScreenOverlay;
 // Generates a textual image from the given text and parameters;
-// see _display_main's comment below for parameters description
+// see _display_main's comment below for parameters description.
+// NOTE: this function treats text as-is, not doing any processing over it.
 Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
     bool &alphaChannel);
@@ -46,6 +47,8 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
 //   != 0 - text color for a speech or a regular textual overlay, where
 //     < 0 - use text window if applicable
 //     > 0 - suppose it's a classic LA-style speech above character's head
+// NOTE: this function treats the text as-is; it assumes that any processing
+// (translation, parsing voice token) was done prior to its call.
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
     int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
 // Displays a standard blocking message box at a given position

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -347,7 +347,8 @@ void DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy,
     sds->PointToGameResolution(&xx, &yy);
     sds->SizeToGameResolution(&wid);
 
-    if (break_up_text_into_lines(msg, Lines, wid, font) == 0)
+    const char *draw_text = skip_voiceover_token(msg);
+    if (break_up_text_into_lines(draw_text, Lines, wid, font) == 0)
         return;
 
     Bitmap *ds = sds->StartDrawing();

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -148,11 +148,13 @@ void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
     data_to_game_coords(&xx, &yy);
     wid = data_to_game_coord(wid);
 
+    // FIXME: wth, this is unsafe!!
     get_message_text (msgm, displbuf);
     // it's probably too late but check anyway
     if (strlen(displbuf) > 2899)
         quit("!RawPrintMessageWrapped: message too long");
-    if (break_up_text_into_lines(displbuf, Lines, wid, font) == 0)
+    const char *draw_text = skip_voiceover_token(displbuf);
+    if (break_up_text_into_lines(draw_text, Lines, wid, font) == 0)
         return;
 
     RAW_START();

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -166,7 +166,8 @@ int GetTextHeight(const char *text, int fontnum, int width) {
   if ((fontnum < 0) || (fontnum >= game.numfonts))
     quit("!GetTextHeight: invalid font number.");
 
-  if (break_up_text_into_lines(text, Lines, data_to_game_coord(width), fontnum) == 0)
+  const char *draw_text = skip_voiceover_token(text);
+  if (break_up_text_into_lines(draw_text, Lines, data_to_game_coord(width), fontnum) == 0)
     return 0;
   return game_to_data_coord(get_text_lines_height(fontnum, Lines.Count()));
 }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -71,12 +71,16 @@ void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_colo
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
     if (text_color == 0) text_color = 16;
 
+    const char *draw_text = get_translation(text);
+    // Skip a voice-over token, if present
+    draw_text = skip_voiceover_token(draw_text);
+
     // Recreate overlay image
     int dummy_x = x, dummy_y = y, adj_x = x, adj_y = y;
     bool has_alpha = false;
     // NOTE: we pass text_color negated to let optionally use textwindow (if applicable)
     // this is a generic ugliness of _display_main args, need to refactor later.
-    Bitmap *image = create_textual_image(get_translation(text), -text_color, 0, dummy_x, dummy_y, adj_x, adj_y,
+    Bitmap *image = create_textual_image(draw_text, -text_color, 0, dummy_x, dummy_y, adj_x, adj_y,
         width, fontid, allow_shrink, has_alpha);
 
     // Update overlay properties
@@ -236,7 +240,9 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
     if (x < 0) x = play.GetUIViewport().GetWidth() / 2 - width / 2;
     if (text_color == 0) text_color = 16;
-    return display_main(x, y, width, text, disp_type, font, -text_color, 0, allow_shrink, false, room_layer);
+    // Skip a voice-over token, if present
+    const char *draw_text = skip_voiceover_token(text);
+    return display_main(x, y, width, draw_text, disp_type, font, -text_color, 0, allow_shrink, false, room_layer);
 }
 
 ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -284,12 +284,8 @@ int String_GetLength(const char *thisString) {
 
 //=============================================================================
 
-size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
-    if (fonnt == -1)
-        fonnt = play.normal_font;
-
-    // Skip voice-over token; FIXME: should not be done in this line-splitting func!
-    todis = parse_voiceover_token(todis, nullptr);
+size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines)
+{
     lines.Reset();
     longestline=0;
 
@@ -297,10 +293,9 @@ size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLi
     if (wii < 3)
         return 0;
 
-    int line_length;
-
     split_lines(todis, lines, wii, fonnt, max_lines);
 
+    int line_length;
     // Right-to-left just means reverse the text then
     // write it as normal
     if (apply_direction && (game.options[OPT_RIGHTLEFTWRITE] != 0))

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -288,11 +288,8 @@ size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLi
     if (fonnt == -1)
         fonnt = play.normal_font;
 
-    //  char sofar[100];
-    if (todis[0]=='&') {
-        while ((todis[0]!=' ') & (todis[0]!=0)) todis++;
-        if (todis[0]==' ') todis++;
-    }
+    // Skip voice-over token; FIXME: should not be done in this line-splitting func!
+    todis = parse_voiceover_token(todis, nullptr);
     lines.Reset();
     longestline=0;
 
@@ -334,6 +331,24 @@ size_t check_strcapacity(char *ptt)
     if (((uintptr_t)&ptt[0] >= charstart) && ((uintptr_t)&ptt[0] <= charend))
         return sizeof(CharacterInfo::name);
     return MAX_MAXSTRLEN;
+}
+
+const char *parse_voiceover_token(const char *text, int *voice_num)
+{
+    if (*text != '&')
+    {
+        if (voice_num)
+            *voice_num = 0;
+        return text; // no token
+    }
+
+    if (voice_num)
+        *voice_num = atoi(&text[1]);
+    // Skip the token and a single following space char
+    for (; *text && *text != ' '; ++text) {}
+    if (*text == ' ')
+        ++text;
+    return text;
 }
 
 //=============================================================================

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -70,5 +70,12 @@ inline size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int
 // cases when the buffer is a field inside one of the game structs,
 // in which case this returns that field's capacity.
 size_t check_strcapacity(char *ptt);
+// Tries if the input string contains a voice-over token ("&N"),
+// *optionally* fills the voice_num value (if the valid int pointer is passed),
+// and returns the pointer to the text portion after the token.
+// If returned pointer equals input pointer, that means that there was no token.
+// voice_num must be > 0 for a valid token, it's assigned 0 if no token was found,
+// or if there have been a parsing error.
+const char *parse_voiceover_token(const char *text, int *voice_num);
 
 #endif // __AGS_EE_AC__STRING_H

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -58,8 +58,8 @@ int StrContains (const char *s1, const char *s2);
 class SplitLines;
 // Break up the text into lines restricted by the given width;
 // returns number of lines, or 0 if text cannot be split well to fit in this width.
-// Does additional processing, like removal of voice-over tags and text reversal if right-to-left text display is on.
-// Optionally applies text direction rules (apply_direction param), otherwise leaves left-to-right always.
+// Optionally applies text direction rules (apply_direction param) and reverses the lines if necessary,
+// otherwise leaves left-to-right always.
 size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1);
 inline size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1)
 {
@@ -77,5 +77,9 @@ size_t check_strcapacity(char *ptt);
 // voice_num must be > 0 for a valid token, it's assigned 0 if no token was found,
 // or if there have been a parsing error.
 const char *parse_voiceover_token(const char *text, int *voice_num);
+inline const char *skip_voiceover_token(const char *text)
+{
+    return parse_voiceover_token(text, nullptr);
+}
 
 #endif // __AGS_EE_AC__STRING_H

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -114,7 +114,8 @@ String GUI::TransformTextForDrawing(const String &text, bool translate, bool app
 size_t GUI::SplitLinesForDrawing(const char *text, bool is_translated, SplitLines &lines, int font, int width, size_t max_lines)
 {
     // Use the engine's word wrap tool, to have RTL writing and other features
-    return break_up_text_into_lines(text, is_translated, lines, width, font);
+    const char *draw_text = skip_voiceover_token(text);
+    return break_up_text_into_lines(draw_text, is_translated, lines, width, font);
 }
 
 void GUIObject::MarkChanged()

--- a/Engine/gui/mylabel.cpp
+++ b/Engine/gui/mylabel.cpp
@@ -35,10 +35,10 @@ MyLabel::MyLabel(int xx, int yy, int wii, const char *tee)
 void MyLabel::draw(Bitmap *ds)
 {
     int cyp = y;
-    char *teptr = &text[0];
     color_t text_color = ds->GetCompatibleColor(0);
 
-    if (break_up_text_into_lines(teptr, Lines, wid, acdialog_font) == 0)
+    const char *draw_text = skip_voiceover_token(text);
+    if (break_up_text_into_lines(draw_text, Lines, wid, acdialog_font) == 0)
         return;
     for (size_t ee = 0; ee < Lines.Count(); ee++) {
         wouttext_outline(ds, x, cyp, acdialog_font, text_color, Lines[ee].GetCStr());

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -294,7 +294,8 @@ void IAGSEngine::DrawTextWrapped (int32 xx, int32 yy, int32 wid, int32 font, int
     // TODO: use generic function from the engine instead of having copy&pasted code here
     const int linespacing = get_font_linespacing(font);
 
-    if (break_up_text_into_lines(text, Lines, wid, font) == 0)
+    const char *draw_text = skip_voiceover_token(text);
+    if (break_up_text_into_lines(draw_text, Lines, wid, font) == 0)
         return;
 
     Bitmap *ds = gfxDriver->GetStageBackBuffer(true);


### PR DESCRIPTION
Fixes #2264.

The root of the problem was that parsing the voice token had been inside a utility function called `break_up_text_into_lines()`.
Having it called implicitly in such function makes it prone to mistakes. In couple of cases the parsing is already done much earlier.

As a side issue, remade the ugly GET_OPTIONS_HEIGHT macro into a DialogOptions::CalcOptionsHeight() method.