### PR TITLE
iOS minor readme and gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ libsrc/theora/
 libsrc/vorbis/
 
 libsrc/SDL2-Framework.dmg
+
+# ags game in ios game project
+iOS/Resources

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -21,7 +21,7 @@ downloaded by `./download.sh` and located in the in the `/libsrc` folder.
 3. Select the target "AGS Game" in the AGS project
 4. Edit the Identity section (Category, Display Name, bundle identifier, and version)
 5. Under Build Phases -> Copy Bundle Resources, add additional game resources that need to be embedded with the game, the ones that were added to `AGS/Resources` (e.g. Lip Sync files)
-4. Build and run the AGS Game target on the simulator or device!
+4. Build and run the AGS Game target on the simulator or device! Remember you need to set a Team, like your Personal Team, and a Bundle identifier (e.g. com.mystudio.mygame).
 5. Modify the `AGS/Resources/ios.cfg` file to make game setup changes (see below)
 
 You may also need to manually assign a launch screen and game icons the way you normally would for an iOS app.


### PR DESCRIPTION
- just put `iOS/Resource` dir on gitignore, in case additional files are added (like lipsync) to avoid commiting by accident.
- added a reminder on the Readme that the project doesn't come with neither Team (your development team or account) set or the bundle identifier set. 
 
I can't confirm in documentation, but I believe that the bundle identifier must be unique per Team. When trying to build the project along with @edmundito, I was having errors `"Failed to register bundle identifier"` and `"no profiles for uk.co.adventuregamestudio.iosgame"`, and after a few failures we concluded this - after using different bundle identifiers worked!