### PR TITLE
Engine: fix log of uninitialized value in gfx driver base

### DIFF
--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -80,7 +80,7 @@ bool GraphicsDriverBase::SetVsync(bool enabled)
     }
     else
     {
-        Debug::Printf("SetVsync: failed, stay at %d", new_value);
+        Debug::Printf("SetVsync: failed, stay at %d", _mode.Vsync);
         _capsVsync = false; // mark as non-capable (at least in current mode)
     }
     return _mode.Vsync;


### PR DESCRIPTION
Noticed when SetVsync fails we log an uninitialized value, instead of the current Vsync. 