### PR TITLE
Update IAGSStream api, and use base Stream class as its direct implementation

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -55,7 +55,7 @@ bool SortLibsPriorityLib(const AssetLibInfo *lib1, const AssetLibInfo *lib2)
 
 /* static */ bool AssetManager::IsDataFile(const String &data_file)
 {
-    Stream *in = File::OpenFileCI(data_file, Common::kFile_Open, Common::kFile_Read);
+    Stream *in = File::OpenFileCI(data_file, Common::kFile_Open, Common::kStream_Read);
     if (in)
     {
         MFLUtil::MFLError err = MFLUtil::TestIsMFL(in, true);
@@ -67,7 +67,7 @@ bool SortLibsPriorityLib(const AssetLibInfo *lib1, const AssetLibInfo *lib2)
 
 /* static */ AssetError AssetManager::ReadDataFileTOC(const String &data_file, AssetLibInfo &lib)
 {
-    Stream *in = File::OpenFileCI(data_file, Common::kFile_Open, Common::kFile_Read);
+    Stream *in = File::OpenFileCI(data_file, Common::kFile_Open, Common::kStream_Read);
     if (in)
     {
         MFLUtil::MFLError err = MFLUtil::ReadHeader(lib, in);
@@ -228,7 +228,7 @@ AssetError AssetManager::RegisterAssetLib(const String &path, AssetLibEx *&out_l
     // ...else try open a data library
     else
     {
-        Stream *in = File::OpenFileCI(path, Common::kFile_Open, Common::kFile_Read);
+        Stream *in = File::OpenFileCI(path, Common::kFile_Open, Common::kStream_Read);
         if (!in)
             return kAssetErrNoLibFile; // can't be opened, return error code
 

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -1273,7 +1273,7 @@ bool SaveToFile(Bitmap* bmp, const char *filename, const RGB *pal)
 
     String ext = Path::GetFileExtension(filename);
     SaveBitmap(ext, out.get(), bmp, pal);
-    return out->HasErrors();
+    return out->GetError(); // FIXME: should return a result from SaveBitmap --> SaveFmt
 }
 
 } // namespace BitmapHelper

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -89,7 +89,7 @@ Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth)
 Bitmap *LoadFromFile(const char *filename)
 {
     std::unique_ptr<Stream> in (
-            File::OpenFile(filename, FileOpenMode::kFile_Open, FileWorkMode::kFile_Read));
+            File::OpenFile(filename, FileOpenMode::kFile_Open, StreamMode::kStream_Read));
     if(!in)
         return nullptr;
 
@@ -1267,7 +1267,7 @@ void SaveBitmap(const String& ext, Stream *out, const Bitmap *bmp, const RGB *pa
 bool SaveToFile(Bitmap* bmp, const char *filename, const RGB *pal)
 {
     std::unique_ptr<Stream> out (
-            File::OpenFile(filename, FileOpenMode::kFile_CreateAlways, FileWorkMode::kFile_Write));
+            File::OpenFile(filename, FileOpenMode::kFile_CreateAlways, StreamMode::kStream_Write));
     if (!out)
         return false;
 

--- a/Common/test/stream_test.cpp
+++ b/Common/test/stream_test.cpp
@@ -210,7 +210,7 @@ protected:
 TEST_F(FileBasedTest, BufferedStreamRead) {
     //-------------------------------------------------------------------------
     // Write data into the temp file
-    FileStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    FileStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     out.WriteInt32(0);
     out.WriteInt32(1);
     out.WriteInt32(2);
@@ -231,7 +231,7 @@ TEST_F(FileBasedTest, BufferedStreamRead) {
 
     //-------------------------------------------------------------------------
     // Read data back
-    BufferedStream in(DummyFile, kFile_Open, kFile_Read);
+    BufferedStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_EQ(in.GetLength(), file_len);
     ASSERT_EQ(in.ReadInt32(), 0);
@@ -255,7 +255,7 @@ TEST_F(FileBasedTest, BufferedStreamRead) {
     in.Close();
 
     // Test seeks
-    BufferedStream in2(DummyFile, kFile_Open, kFile_Read);
+    BufferedStream in2(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in2.CanRead());
     ASSERT_TRUE(in2.CanSeek());
     ASSERT_EQ(in2.GetLength(), file_len);
@@ -279,7 +279,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite1) {
     //-------------------------------------------------------------------------
     // Write data
     const soff_t file_len = sizeof(int32_t) * 10;
-    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    BufferedStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     ASSERT_TRUE(out.CanWrite());
     out.WriteInt32(0);
     out.WriteInt32(1);
@@ -296,7 +296,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite1) {
     out.Close();
     //-------------------------------------------------------------------------
     // Read data back
-    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    FileStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_TRUE(in.CanSeek());
     ASSERT_EQ(in.GetLength(), file_len);
@@ -324,7 +324,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite2) {
     //-------------------------------------------------------------------------
     // Write data
     const soff_t file_len = sizeof(int32_t) * 10 + fill_len;
-    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    BufferedStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     ASSERT_TRUE(out.CanWrite());
     out.WriteInt32(0);
     out.WriteInt32(1);
@@ -342,7 +342,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite2) {
     out.Close();
     //-------------------------------------------------------------------------
     // Read data back
-    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    FileStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_TRUE(in.CanSeek());
     ASSERT_EQ(in.GetLength(), file_len);
@@ -368,7 +368,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite3) {
     //-------------------------------------------------------------------------
     // Write data
     const soff_t file_len = sizeof(int32_t) * 10;
-    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    BufferedStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     ASSERT_TRUE(out.CanWrite());
     ASSERT_TRUE(out.CanSeek());
     out.WriteInt32(0);
@@ -391,7 +391,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite3) {
     out.Close();
     //-------------------------------------------------------------------------
     // Read data back
-    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    FileStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_EQ(in.GetLength(), file_len);
     ASSERT_EQ(in.ReadInt32(), 0);
@@ -418,7 +418,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite4) {
     //-------------------------------------------------------------------------
     // Write data
     const soff_t file_len = sizeof(int32_t) * 8 + fill_len;
-    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    BufferedStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     ASSERT_TRUE(out.CanWrite());
     out.WriteInt32(0);
     out.WriteInt32(1);
@@ -439,7 +439,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite4) {
     out.Close();
     //-------------------------------------------------------------------------
     // Read data back
-    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    FileStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_TRUE(in.CanSeek());
     ASSERT_EQ(in.GetLength(), file_len);
@@ -466,7 +466,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite5) {
     //-------------------------------------------------------------------------
     // Write data
     const soff_t file_len = sizeof(int32_t) * 7 + fill_len;
-    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    BufferedStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     ASSERT_TRUE(out.CanWrite());
     out.WriteByteCount(0, fill_len); // fill to (nearly) force buffer flush
     out.WriteInt32(0);
@@ -486,7 +486,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite5) {
     out.Close();
     //-------------------------------------------------------------------------
     // Read data back
-    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    FileStream in(DummyFile, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_TRUE(in.CanSeek());
     ASSERT_EQ(in.GetLength(), file_len);
@@ -507,7 +507,7 @@ TEST_F(FileBasedTest, BufferedStreamWrite5) {
 TEST_F(FileBasedTest, BufferedSectionStream) {
     //-------------------------------------------------------------------------
     // Write data into the temp file
-    FileStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    FileStream out(DummyFile, kFile_CreateAlways, kStream_Write);
     out.WriteInt32(0);
     out.WriteInt32(1);
     out.WriteInt32(2);
@@ -530,7 +530,7 @@ TEST_F(FileBasedTest, BufferedSectionStream) {
 
     //-------------------------------------------------------------------------
     // Read data back from section 1 and test read limits
-    BufferedSectionStream in(DummyFile, section1_start, section1_end, kFile_Open, kFile_Read);
+    BufferedSectionStream in(DummyFile, section1_start, section1_end, kFile_Open, kStream_Read);
     ASSERT_TRUE(in.CanRead());
     ASSERT_EQ(in.GetPosition(), 0);
     ASSERT_EQ(in.GetLength(), section1_end - section1_start);
@@ -552,7 +552,7 @@ TEST_F(FileBasedTest, BufferedSectionStream) {
 
     // Test limits - reading large chunks: optimized by reading directly
     // into the provided user's buffer, without use of internal buffer
-    BufferedSectionStream in3(DummyFile, section1_start, section1_end, kFile_Open, kFile_Read);
+    BufferedSectionStream in3(DummyFile, section1_start, section1_end, kFile_Open, kStream_Read);
     const size_t try_read = 4 * sizeof(int32_t) + BufferedStream::BufferSize;
     const size_t must_read = 4 * sizeof(int32_t);
     char buf[try_read];
@@ -564,7 +564,7 @@ TEST_F(FileBasedTest, BufferedSectionStream) {
     in3.Close();
 
     // Test seeks limited to section 1
-    BufferedSectionStream in2(DummyFile, section1_start, section2_end, kFile_Open, kFile_Read);
+    BufferedSectionStream in2(DummyFile, section1_start, section2_end, kFile_Open, kStream_Read);
     ASSERT_TRUE(in2.CanRead());
     ASSERT_TRUE(in2.CanSeek());
     ASSERT_EQ(in2.GetPosition(), 0);

--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -54,17 +54,13 @@ namespace AGS
             if(_ownHandle) Close();
         }
 
-        bool AAssetStream::HasErrors() const
-        {
-            return !IsValid();
-        }
-
         void AAssetStream::Close()
         {
             if(_aAsset) {
                 AAsset_close(_aAsset);
                 _aAsset = nullptr;
             }
+            _mode = kStream_None;
         }
 
         bool AAssetStream::Flush()
@@ -72,9 +68,9 @@ namespace AGS
             return false;
         }
 
-        bool AAssetStream::IsValid() const
+        StreamMode AAssetStream::GetMode() const
         {
-            return _aAsset != nullptr;
+            return _mode;
         }
 
         bool AAssetStream::EOS() const
@@ -98,21 +94,6 @@ namespace AGS
                 return _cur_offset - _start;
             }
             return -1;
-        }
-
-        bool AAssetStream::CanRead() const
-        {
-            return IsValid();
-        }
-
-        bool AAssetStream::CanWrite() const
-        {
-            return false;
-        }
-
-        bool AAssetStream::CanSeek() const
-        {
-            return IsValid();
         }
 
         size_t AAssetStream::Read(void *buffer, size_t size)
@@ -187,6 +168,7 @@ namespace AGS
             _cur_offset = 0;
             _start = 0;
             _end = AAsset_getLength64(_aAsset);
+            _mode = static_cast<StreamMode>(kStream_Read | kStream_Seek);
         }
 
 

--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -168,6 +168,7 @@ namespace AGS
             _cur_offset = 0;
             _start = 0;
             _end = AAsset_getLength64(_aAsset);
+            _assetMode = asset_mode;
             _mode = static_cast<StreamMode>(kStream_Read | kStream_Seek);
         }
 

--- a/Common/util/aasset_stream.h
+++ b/Common/util/aasset_stream.h
@@ -57,21 +57,19 @@ namespace AGS
             { return new AAssetStream(aasset, false, asset_mode, stream_end); }
             ~AAssetStream() override;
 
-            bool    HasErrors() const override;
             void    Close() override;
             bool    Flush() override;
 
-            // Is stream valid (underlying data initialized properly)
-            bool    IsValid() const override;
+            // Tells which mode the stream is working in, which defines
+            // supported io operations, such as reading, writing, seeking, etc.
+            // Invalid streams return kStream_None to indicate that they are not functional.
+            StreamMode GetMode() const override;
             // Is end of stream
             bool    EOS() const override;
             // Total length of stream (if known)
             soff_t  GetLength() const override;
             // Current position (if known)
             soff_t  GetPosition() const override;
-            bool    CanRead() const override;
-            bool    CanWrite() const override;
-            bool    CanSeek() const override;
 
             size_t  Read(void *buffer, size_t size) override;
             int32_t ReadByte() override;
@@ -91,8 +89,9 @@ namespace AGS
             void    Open(const String &asset_name, int asset_mode);
             void    OpenSection(const String &asset_name, int asset_mode, soff_t start_pos, soff_t end_pos);
 
-            bool                 _ownHandle;
-            AAsset                *_aAsset = nullptr;
+            bool    _ownHandle = false;
+            AAsset *_aAsset = nullptr;
+            StreamMode _mode = kStream_None;
         };
 
     } // namespace Common

--- a/Common/util/aasset_stream.h
+++ b/Common/util/aasset_stream.h
@@ -57,9 +57,8 @@ namespace AGS
             { return new AAssetStream(aasset, false, asset_mode, stream_end); }
             ~AAssetStream() override;
 
-            void    Close() override;
-            bool    Flush() override;
-
+            // Tells the AASSET_MODE this stream is working in.
+            int     GetAssetMode() const { return _assetMode; }
             // Tells which mode the stream is working in, which defines
             // supported io operations, such as reading, writing, seeking, etc.
             // Invalid streams return kStream_None to indicate that they are not functional.
@@ -78,6 +77,9 @@ namespace AGS
 
             bool    Seek(soff_t offset, StreamSeek origin) override;
 
+            bool    Flush() override;
+            void    Close() override;
+
         protected:
             soff_t _start = 0;
             soff_t _end = 0;
@@ -91,6 +93,7 @@ namespace AGS
 
             bool    _ownHandle = false;
             AAsset *_aAsset = nullptr;
+            int     _assetMode = AASSET_MODE_UNKNOWN;
             StreamMode _mode = kStream_None;
         };
 

--- a/Common/util/bufferedstream.cpp
+++ b/Common/util/bufferedstream.cpp
@@ -30,7 +30,7 @@ namespace Common
 const size_t BufferedStream::BufferSize;
 
 BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode,
-        FileWorkMode work_mode, DataEndianess stream_endianess)
+        StreamMode work_mode, DataEndianess stream_endianess)
     : FileStream(file_name, open_mode, work_mode, stream_endianess)
 {
     if (FileStream::Seek(0, kSeekEnd))
@@ -92,14 +92,14 @@ soff_t BufferedStream::GetPosition() const
 
 void BufferedStream::Close()
 {
-    if (GetWorkMode() == kFile_Write)
+    if (CanWrite())
         FlushBuffer(_position);
     FileStream::Close();
 }
 
 bool BufferedStream::Flush()
 {
-    if (GetWorkMode() == kFile_Write)
+    if (CanWrite())
         FlushBuffer(_position);
     return FileStream::Flush();
 }
@@ -203,7 +203,7 @@ bool BufferedStream::Seek(soff_t offset, StreamSeek origin)
 //-----------------------------------------------------------------------------
 
 BufferedSectionStream::BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
-        FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess)
+        FileOpenMode open_mode, StreamMode work_mode, DataEndianess stream_endianess)
     : BufferedStream(file_name, open_mode, work_mode, stream_endianess)
 {
     assert(start_pos <= end_pos);

--- a/Common/util/bufferedstream.h
+++ b/Common/util/bufferedstream.h
@@ -43,7 +43,7 @@ public:
     // - could not determine the length of the stream
     // It is recommended to use File::OpenFile to safely construct this object.
     BufferedStream(const String &file_name, FileOpenMode open_mode,
-        FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
+        StreamMode work_mode, DataEndianess stream_endianess = kLittleEndian);
     ~BufferedStream();
 
     // Is end of stream
@@ -84,7 +84,7 @@ class BufferedSectionStream : public BufferedStream
 {
 public:
     BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
-        FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
+        FileOpenMode open_mode, StreamMode work_mode, DataEndianess stream_endianess = kLittleEndian);
 };
 
 } // namespace Common

--- a/Common/util/file.h
+++ b/Common/util/file.h
@@ -19,6 +19,7 @@
 #define __AGS_CN_UTIL__FILE_H
 
 #include "core/platform.h"
+#include "util/stream.h"
 #include "util/string.h"
 
 namespace AGS
@@ -31,16 +32,10 @@ class Stream;
 
 enum FileOpenMode
 {
+    kFile_None = 0,
     kFile_Open,         // Open existing file
     kFile_Create,       // Create new file, or open existing one
     kFile_CreateAlways  // Always create a new file, replacing any existing one
-};
-
-enum FileWorkMode
-{
-    kFile_Read      = 0x1,
-    kFile_Write     = 0x2,
-    kFile_ReadWrite = kFile_Read | kFile_Write
 };
 
 namespace File
@@ -68,29 +63,29 @@ namespace File
     bool        CopyFile(const String &src_path, const String &dst_path, bool overwrite);
 
     // Sets FileOpenMode and FileWorkMode values corresponding to C-style file open mode string
-    bool        GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, FileWorkMode &work_mode);
+    bool        GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, StreamMode &work_mode);
     // Gets C-style file mode from FileOpenMode and FileWorkMode
-    String      GetCMode(FileOpenMode open_mode, FileWorkMode work_mode);
+    String      GetCMode(FileOpenMode open_mode, StreamMode work_mode);
 
     // Opens file in the given mode
-    Stream      *OpenFile(const String &filename, FileOpenMode open_mode, FileWorkMode work_mode);
+    Stream      *OpenFile(const String &filename, FileOpenMode open_mode, StreamMode work_mode);
     // Opens file for reading restricted to the arbitrary offset range
     Stream      *OpenFile(const String &filename, soff_t start_off, soff_t end_off);
     // Convenience helpers
     // Create a totally new file, overwrite existing one
     inline Stream *CreateFile(const String &filename)
     {
-        return OpenFile(filename, kFile_CreateAlways, kFile_Write);
+        return OpenFile(filename, kFile_CreateAlways, kStream_Write);
     }
     // Open existing file for reading
     inline Stream *OpenFileRead(const String &filename)
     {
-        return OpenFile(filename, kFile_Open, kFile_Read);
+        return OpenFile(filename, kFile_Open, kStream_Read);
     }
     // Open existing file for writing (append) or create if it does not exist
     inline Stream *OpenFileWrite(const String &filename)
     {
-        return OpenFile(filename, kFile_Create, kFile_Write);
+        return OpenFile(filename, kFile_Create, kStream_Write);
     }
     // Opens stdin stream for reading
     Stream      *OpenStdin();
@@ -122,10 +117,10 @@ namespace File
     // Case insensitive file open: looks up for the file using FindFileCI
     Stream *OpenFileCI(const String &base_dir, const String &file_name,
         FileOpenMode open_mode = kFile_Open,
-        FileWorkMode work_mode = kFile_Read);
+        StreamMode work_mode = kStream_Read);
     inline Stream *OpenFileCI(const String &file_name,
         FileOpenMode open_mode = kFile_Open,
-        FileWorkMode work_mode = kFile_Read)
+        StreamMode work_mode = kStream_Read)
     {
         return OpenFileCI("", file_name, open_mode, work_mode);
     }

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -44,9 +44,13 @@ FileStream::~FileStream()
     Close();
 }
 
-bool FileStream::HasErrors() const
+bool FileStream::GetError() const
 {
-    return IsValid() && ferror(_file) != 0;
+    if (!_file)
+        return false;
+    bool err = ferror(_file) != 0;
+    clearerr(_file);
+    return err;
 }
 
 void FileStream::Close()

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -35,7 +35,7 @@ public:
     struct CloseNotifyArgs
     {
         String Filepath;
-        FileWorkMode WorkMode;
+        StreamMode WorkMode;
     };
 
     // definition of function called when file closes
@@ -47,19 +47,19 @@ public:
     // The constructor may raise std::runtime_error if 
     // - there is an issue opening the file (does not exist, locked, permissions, etc)
     // - the open mode could not be determined
-    FileStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode,
+    FileStream(const String &file_name, FileOpenMode open_mode, StreamMode work_mode,
         DataEndianess stream_endianess = kLittleEndian);
     // Constructs a file stream over an open FILE handle;
     // Take an ownership over it and will close upon disposal
-    static FileStream *OwnHandle(FILE *file, FileWorkMode work_mode, DataEndianess stream_end = kLittleEndian)
+    static FileStream *OwnHandle(FILE *file, StreamMode work_mode, DataEndianess stream_end = kLittleEndian)
         { return new FileStream(file, true, work_mode, stream_end); }
     // Constructs a file stream over an open FILE handle;
     // does NOT take an ownership over it
-    static FileStream *WrapHandle(FILE *file, FileWorkMode work_mode, DataEndianess stream_end = kLittleEndian)
+    static FileStream *WrapHandle(FILE *file, StreamMode work_mode, DataEndianess stream_end = kLittleEndian)
         { return new FileStream(file, false, work_mode, stream_end); }
     ~FileStream() override;
 
-    FileWorkMode GetWorkMode() const { return _workMode; }
+    StreamMode GetMode() const override { return _workMode; }
 
     // Tells if there were errors during previous io operation(s);
     // the call to GetError() *resets* the error record.
@@ -67,17 +67,12 @@ public:
     void    Close() override;
     bool    Flush() override;
 
-    // Is stream valid (underlying data initialized properly)
-    bool    IsValid() const override;
     // Is end of stream
     bool    EOS() const override;
     // Total length of stream (if known)
     soff_t  GetLength() const override;
     // Current position (if known)
     soff_t  GetPosition() const override;
-    bool    CanRead() const override;
-    bool    CanWrite() const override;
-    bool    CanSeek() const override;
 
     size_t  Read(void *buffer, size_t size) override;
     int32_t ReadByte() override;
@@ -87,13 +82,13 @@ public:
     bool    Seek(soff_t offset, StreamSeek origin) override;
 
 private:
-    FileStream(FILE *file, bool own, FileWorkMode work_mode, DataEndianess stream_end);
-    void    Open(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode);
+    FileStream(FILE *file, bool own, StreamMode work_mode, DataEndianess stream_end);
+    void    Open(const String &file_name, FileOpenMode open_mode, StreamMode work_mode);
 
-    FILE                *_file;
-    bool                 _ownHandle;
-    const FileOpenMode  _openMode;
-    const FileWorkMode  _workMode;
+    FILE         *_file = nullptr;
+    bool          _ownHandle = false;
+    FileOpenMode  _openMode = kFile_None;
+    StreamMode    _workMode = kStream_None;
 };
 
 } // namespace Common

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -61,7 +61,9 @@ public:
 
     FileWorkMode GetWorkMode() const { return _workMode; }
 
-    bool    HasErrors() const override;
+    // Tells if there were errors during previous io operation(s);
+    // the call to GetError() *resets* the error record.
+    bool    GetError() const override;
     void    Close() override;
     bool    Flush() override;
 

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -59,14 +59,16 @@ public:
         { return new FileStream(file, false, work_mode, stream_end); }
     ~FileStream() override;
 
+    // Tells which open mode was used when opening a file.
+    FileOpenMode GetFileOpenMode() const { return _openMode; }
+    // Tells which mode the stream is working in, which defines
+    // supported io operations, such as reading, writing, seeking, etc.
+    // Invalid streams return kStream_None to indicate that they are not functional.
     StreamMode GetMode() const override { return _workMode; }
 
     // Tells if there were errors during previous io operation(s);
     // the call to GetError() *resets* the error record.
     bool    GetError() const override;
-    void    Close() override;
-    bool    Flush() override;
-
     // Is end of stream
     bool    EOS() const override;
     // Total length of stream (if known)
@@ -80,6 +82,9 @@ public:
     int32_t WriteByte(uint8_t b) override;
 
     bool    Seek(soff_t offset, StreamSeek origin) override;
+
+    bool    Flush() override;
+    void    Close() override;
 
 private:
     FileStream(FILE *file, bool own, StreamMode work_mode, DataEndianess stream_end);

--- a/Common/util/memorystream.h
+++ b/Common/util/memorystream.h
@@ -44,23 +44,20 @@ public:
     // Construct memory stream in the chosen mode over a given C-buffer;
     // neither reading nor writing will ever exceed buf_sz bytes;
     // buffer must persist in memory until the stream is closed.
-    MemoryStream(uint8_t *buf, size_t buf_sz, StreamWorkMode mode, DataEndianess stream_endianess = kLittleEndian);
+    MemoryStream(uint8_t *buf, size_t buf_sz, StreamMode mode, DataEndianess stream_endianess = kLittleEndian);
     ~MemoryStream() override = default;
 
     void    Close() override;
     bool    Flush() override;
 
-    // Is stream valid (underlying data initialized properly)
-    bool    IsValid() const override;
+    StreamMode GetMode() const override { return _mode; }
+    bool    GetError() const override { return false; }
     // Is end of stream
     bool    EOS() const override;
     // Total length of stream (if known)
     soff_t  GetLength() const override;
     // Current position (if known)
     soff_t  GetPosition() const override;
-    bool    CanRead() const override;
-    bool    CanWrite() const override;
-    bool    CanSeek() const override;
 
     size_t  Read(void *buffer, size_t size) override;
     int32_t ReadByte() override;
@@ -73,7 +70,7 @@ protected:
     const uint8_t           *_cbuf = nullptr; // readonly buffer ptr
     size_t                   _buf_sz = 0u; // hard buffer limit
     size_t                   _len = 0u; // calculated length of stream
-    const StreamWorkMode     _mode;
+    StreamMode               _mode = kStream_None;
     size_t                   _pos = 0u; // current stream pos
 
 private:
@@ -89,13 +86,10 @@ public:
     VectorStream(const std::vector<uint8_t> &cbuf, DataEndianess stream_endianess = kLittleEndian);
     // Construct memory stream in the chosen mode over a given std::vector;
     // vector must persist in memory until the stream is closed.
-    VectorStream(std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess = kLittleEndian);
+    VectorStream(std::vector<uint8_t> &buf, StreamMode mode, DataEndianess stream_endianess = kLittleEndian);
     ~VectorStream() override = default;
 
     void    Close() override;
-
-    bool    CanRead() const override;
-    bool    CanWrite() const override;
 
     size_t  Write(const void *buffer, size_t size) override;
     int32_t WriteByte(uint8_t b) override;

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -87,8 +87,9 @@ public:
     //-----------------------------------------------------
 
     virtual bool        IsValid() const = 0;
-    // Tells if the stream has errors
-    virtual bool        HasErrors() const { return false; }
+    // Tells if there were errors during previous io operation(s);
+    // the call to GetError() *resets* the error record.
+    virtual bool        GetError() const { return false; }
     virtual bool        EOS() const = 0;
     virtual soff_t      GetLength() const = 0;
     virtual soff_t      GetPosition() const = 0;

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -102,6 +102,13 @@ public:
     // Closes the stream
     virtual void   Close() = 0;
 
+    // Closes the stream and deallocates the object memory.
+    // NOTE: this effectively deletes the stream object, making it unusable.
+    // This method is purposed for the plugin API, it should be used instead
+    // of regular *delete* on stream objects that may have been provided
+    // by plugins.
+    virtual void   Dispose() = 0;
+
 protected:
     IStream() = default;
     virtual ~IStream() = default;
@@ -213,6 +220,10 @@ public:
 
 protected:
     String _path; // optional name of the stream's source (e.g. filepath)
+
+private:
+    // Standard streams do not expose this method to avoid incorrect use.
+    void Dispose() override { delete this; }
 };
 
 // Copies N bytes from one stream into another;

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -96,7 +96,7 @@ public:
     // - on failure, returns -1
     virtual int32_t WriteByte(uint8_t b) = 0;
     // Seeks to offset from the origin
-    virtual bool   Seek(soff_t offset, StreamSeek origin) = 0;
+    virtual bool   Seek(soff_t offset, StreamSeek origin = kSeekCurrent) = 0;
     // Flush stream buffer to the underlying device
     virtual bool   Flush() = 0;
     // Closes the stream
@@ -126,7 +126,6 @@ public:
     //-----------------------------------------------------
     // Helpers for learning the stream's state and capabilities
     //-----------------------------------------------------
-
     // Tells if stream is functional, and which operations are supported
     bool        IsValid() const  { return GetMode() != kStream_None; }
     bool        CanRead() const  { return (GetMode() & kStream_Read) != 0; }
@@ -134,38 +133,22 @@ public:
     bool        CanSeek() const  { return (GetMode() & kStream_Seek) != 0; }
 
     //-----------------------------------------------------
-    // Stream interface
+    // IStream interface
     //-----------------------------------------------------
-
     // Returns an optional path of a stream's source, such as a filepath;
     // primarily for diagnostic purposes
     const char         *GetPath() const override { return _path.GetCStr(); }
     // Tells which mode the stream is working in, which defines
     // supported io operations, such as reading, writing, seeking, etc.
     // Invalid streams return kStream_None to indicate that they are not functional.
-    virtual StreamMode  GetMode() const = 0;
+    StreamMode          GetMode() const override { return kStream_None; }
     // Tells if there were errors during previous io operation(s);
     // the call to GetError() *resets* the error record.
-    virtual bool        GetError() const { return false; }
-    virtual bool        EOS() const = 0;
-    virtual soff_t      GetLength() const = 0;
-    virtual soff_t      GetPosition() const = 0;
+    bool                GetError() const override { return false; }
 
-    virtual void        Close() = 0;
-
-    // Reads number of bytes in the provided buffer
-    virtual size_t      Read(void *buffer, size_t size) = 0;
-    // ReadByte conforms to fgetc behavior:
-    // - if stream is valid, then returns an *unsigned char* packed in the int
-    // - if EOS, then returns -1
-    virtual int32_t     ReadByte() = 0;
-    // Writes number of bytes from the provided buffer
-    virtual size_t      Write(const void *buffer, size_t size) = 0;
-    // WriteByte conforms to fputc behavior:
-    // - on success, returns the unsigned char packed in the int
-    // - on failure, returns -1
-    virtual int32_t     WriteByte(uint8_t b) = 0;
-
+    //-----------------------------------------------------
+    // Values reading and writing interface
+    //-----------------------------------------------------
     // Convenience methods for reading values of particular size
     virtual int8_t      ReadInt8() = 0;
     virtual int16_t     ReadInt16() = 0;
@@ -185,11 +168,6 @@ public:
     virtual size_t      WriteArrayOfInt16(const int16_t *buffer, size_t count) = 0;
     virtual size_t      WriteArrayOfInt32(const int32_t *buffer, size_t count) = 0;
     virtual size_t      WriteArrayOfInt64(const int64_t *buffer, size_t count) = 0;
-
-    virtual bool        Seek(soff_t offset, StreamSeek origin = kSeekCurrent) = 0;
-
-    // Flush stream buffer to the underlying device
-    virtual bool        Flush() = 0;
 
     //-----------------------------------------------------
     // Helper methods for read and write

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -34,11 +34,22 @@ namespace AGS
 namespace Common
 {
 
+// The mode in which the stream is opened,
+// defines acceptable operations and capabilities.
 // TODO: merge with FileWorkMode (historical mistake)
-enum StreamWorkMode
+enum StreamMode
 {
-    kStream_Read    = 0x1,
-    kStream_Write   = 0x2
+    // kStream_None defines an invalid (non-functional) stream
+    kStream_None    = 0,
+    // Following capabilities should be passed as request
+    // when opening a stream subclass
+    kStream_Read    = 0x01,
+    kStream_Write   = 0x02,
+    kStream_ReadWrite = kStream_Read | kStream_Write,
+    
+    // Following capabilities should not be requested,
+    // but are defined by each particular stream subclass
+    kStream_Seek    = 0x04
 };
 
 enum StreamSeek
@@ -86,16 +97,23 @@ public:
     // Stream interface
     //-----------------------------------------------------
 
-    virtual bool        IsValid() const = 0;
+    // Tells which mode the stream is working in, which defines
+    // supported io operations, such as reading, writing, seeking, etc.
+    // Invalid streams return kStream_None to indicate that they are not functional.
+    virtual StreamMode GetMode() const = 0;
+
+    // Tells if stream is functional, and which operations are supported
+    bool        IsValid() const  { return GetMode() != kStream_None; }
+    bool        CanRead() const  { return (GetMode() & kStream_Read) != 0; }
+    bool        CanWrite() const { return (GetMode() & kStream_Write) != 0; }
+    bool        CanSeek() const  { return (GetMode() & kStream_Seek) != 0; }
+
     // Tells if there were errors during previous io operation(s);
     // the call to GetError() *resets* the error record.
     virtual bool        GetError() const { return false; }
     virtual bool        EOS() const = 0;
     virtual soff_t      GetLength() const = 0;
     virtual soff_t      GetPosition() const = 0;
-    virtual bool        CanRead() const = 0;
-    virtual bool        CanWrite() const = 0;
-    virtual bool        CanSeek() const = 0;
 
     virtual void        Close() = 0;
 

--- a/Engine/ac/dynobj/scriptfile.cpp
+++ b/Engine/ac/dynobj/scriptfile.cpp
@@ -14,11 +14,11 @@
 #include "ac/dynobj/scriptfile.h"
 #include "ac/global_file.h"
 
-// CHECKME: actually NULLs here will be equal to kFile_Open & kFile_Read
+// CHECKME: actually NULLs here will be equal to kFile_Open & kStream_Read
 const Common::FileOpenMode sc_File::fopenModes[] = 
     {Common::kFile_Open/*CHECKME, was undefined*/, Common::kFile_Open, Common::kFile_CreateAlways, Common::kFile_Create};
-const Common::FileWorkMode sc_File::fworkModes[] = 
-    {Common::kFile_Read/*CHECKME, was undefined*/, Common::kFile_Read, Common::kFile_Write, Common::kFile_Write};
+const Common::StreamMode sc_File::fworkModes[] = 
+    {Common::kStream_Read/*CHECKME, was undefined*/, Common::kStream_Read, Common::kStream_Write, Common::kStream_Write};
 
 int sc_File::Dispose(void* /*address*/, bool /*force*/) {
     Close();

--- a/Engine/ac/dynobj/scriptfile.h
+++ b/Engine/ac/dynobj/scriptfile.h
@@ -20,6 +20,7 @@
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
 #include "util/file.h"
+#include "util/stream.h"
 
 using namespace AGS; // FIXME later
 
@@ -31,7 +32,7 @@ struct sc_File final : CCBasicObject {
     int32_t             handle;
 
     static const Common::FileOpenMode fopenModes[];
-    static const Common::FileWorkMode fworkModes[];
+    static const Common::StreamMode fworkModes[];
 
     int Dispose(void *address, bool force) override;
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -611,7 +611,7 @@ static int ags_pf_feof(void *userdata)
 
 static int ags_pf_ferror(void *userdata)
 {
-    return ((AGS_PACKFILE_OBJ*)userdata)->stream->HasErrors() ? 1 : 0;
+    return ((AGS_PACKFILE_OBJ*)userdata)->stream->GetError() ? 1 : 0;
 }
 
 // Custom PACKFILE callback table

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -694,7 +694,7 @@ public:
     }
     // Returns an optional stream's source description.
     // This may be a file path, or a resource name, or anything of that kind.
-    const char *GetPath() override { return _s->GetPath().GetCStr(); }
+    const char *GetPath() override { return _s->GetPath(); }
     // Reads number of bytes into the provided buffer
     virtual size_t Read(void *buffer, size_t len) override { return _s->Read(buffer, len); }
     // Writes number of bytes from the provided buffer

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -532,10 +532,10 @@ ResolvedPath ResolveWritePathAndCreateDirs(const String &sc_path)
 }
 
 Stream *ResolveScriptPathAndOpen(const String &sc_path,
-    FileOpenMode open_mode, FileWorkMode work_mode)
+    FileOpenMode open_mode, StreamMode work_mode)
 {
     ResolvedPath rp;
-    if (open_mode == kFile_Open && work_mode == kFile_Read)
+    if (open_mode == kFile_Open && work_mode == kStream_Read)
         rp = ResolveScriptPathAndFindFile(sc_path, true);
     else
         rp = ResolveWritePathAndCreateDirs(sc_path);

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -669,9 +669,8 @@ AssetPath get_voice_over_assetpath(const String &filename)
 
 //=============================================================================
 
-// ScriptFileHandle is a wrapper over a Stream object, prepared for script
-// or plugin. Implements IManagedStream, which is a plugin API contract.
-class ScriptFileHandle : public IManagedStream
+// ScriptFileHandle is a wrapper over a Stream object, prepared for script.
+class ScriptFileHandle
 {
 public:
     ScriptFileHandle() = default;
@@ -683,38 +682,6 @@ public:
 
     // Releases Stream ownership; used in case of temporary stream wrap
     Stream *ReleaseStream() { return _s.release(); }
-
-    //-------------------------------------------------------------------------
-    // IManagedStream implementation
-    // Flushes and closes the stream, deallocates the stream object.
-    // After calling this the IAGSStream pointer becomes INVALID.
-    void Close() override
-    {
-        close_file_stream(_handle, "IAGSStream::Close"); // this will dealloc us
-    }
-    // Returns an optional stream's source description.
-    // This may be a file path, or a resource name, or anything of that kind.
-    const char *GetPath() override { return _s->GetPath(); }
-    // Reads number of bytes into the provided buffer
-    virtual size_t Read(void *buffer, size_t len) override { return _s->Read(buffer, len); }
-    // Writes number of bytes from the provided buffer
-    virtual size_t Write(void *buffer, size_t len) override { return _s->Write(buffer, len); }
-    // Returns the total stream's length in bytes
-    virtual int64_t GetLength() override { return _s->GetLength(); }
-    // Returns stream's position
-    virtual int64_t GetPosition() override { return _s->GetPosition(); }
-    // Tells whether the stream's position is at its end
-    virtual bool   EOS() override { return _s->EOS(); }
-    // Seeks to offset from the origin, see AGSSTREAM_SEEK_* constants
-    virtual int64_t Seek(int64_t offset, int origin) override
-    {
-        if (_s->Seek(offset, static_cast<StreamSeek>(origin)))
-            return _s->GetPosition();
-        return -1ll;
-    }
-    // Flushes stream, forcing it to write any buffered data to the
-    // underlying device. Note that the effect may depend on implementation.
-    virtual void   Flush() override { _s->Flush(); }
 
 private:
     std::unique_ptr<Stream> _s;
@@ -763,19 +730,9 @@ Stream *get_file_stream(int32_t fhandle, const char *operation_name)
     return fh ? fh->GetStream() : nullptr;
 }
 
-IManagedStream *get_file_stream_iface(int32_t fhandle, const char *operation_name)
+IStream *get_file_stream_iface(int32_t fhandle, const char *operation_name)
 {
-    return check_file_stream(fhandle, operation_name);
-}
-
-int32_t find_file_stream_handle(AGS::Engine::IManagedStream *iface)
-{
-    for (auto &pfh : file_streams)
-    {
-        if (pfh.get() == iface)
-            return pfh->GetHandle();
-    }
-    return 0;
+    return check_file_stream(fhandle, operation_name)->GetStream();
 }
 
 Stream *release_file_stream(int32_t fhandle, const char *operation_name)

--- a/Engine/ac/file.h
+++ b/Engine/ac/file.h
@@ -47,56 +47,10 @@ int     File_GetPosition(sc_File *fil);
 
 //=============================================================================
 
-namespace AGS
-{
-namespace Engine
-{
-    // IManagedStream interface is a contract for the plugin API,
-    // matching IAGSStream interface there. Having this here is mostly an
-    // issue of code organization. Perhaps this may be reviewed if we change
-    // how plugin API is declared and reused within the engine itself.
-    // NOTE: we cannot use our utility IStream for this, because:
-    //    1) different, extended expectation for Close function;
-    //    2) different types in args or return values: we cannot use
-    //       some of them in plugin API.
-    class IManagedStream
-    {
-    public:
-        // Flushes and closes the stream, deallocates the stream object.
-        // After calling this the IAGSStream pointer becomes INVALID.
-        virtual void   Close() = 0;
-        // Returns an optional stream's source description.
-        // This may be a file path, or a resource name, or anything of that kind.
-        virtual const char *GetPath() = 0;
-        // Reads number of bytes into the provided buffer
-        virtual size_t Read(void *buffer, size_t len) = 0;
-        // Writes number of bytes from the provided buffer
-        virtual size_t Write(void *buffer, size_t len) = 0;
-        // Returns the total stream's length in bytes
-        virtual int64_t GetLength() = 0;
-        // Returns stream's position
-        virtual int64_t GetPosition() = 0;
-        // Tells whether the stream's position is at its end
-        virtual bool   EOS() = 0;
-        // Seeks to offset from the origin, returns new position in stream,
-        // or -1 on error.
-        virtual int64_t Seek(int64_t offset, int origin) = 0;
-        // Flushes stream, forcing it to write any buffered data to the
-        // underlying device. Note that the effect may depend on implementation.
-        virtual void   Flush() = 0;
-    protected:
-        IManagedStream() = default;
-        virtual ~IManagedStream() = default;
-    };
-} // namespace Engine
-} // namespace AGS
-
 // Managed file streams: for script and plugin use
 int32_t add_file_stream(std::unique_ptr<AGS::Common::Stream> &&stream, const char *operation_name);
 void    close_file_stream(int32_t fhandle, const char *operation_name);
 AGS::Common::Stream *get_file_stream(int32_t fhandle, const char *operation_name);
-AGS::Engine::IManagedStream *get_file_stream_iface(int32_t fhandle, const char *operation_name);
-int32_t find_file_stream_handle(AGS::Engine::IManagedStream *iface);
 AGS::Common::Stream *release_file_stream(int32_t fhandle, const char *operation_name);
 void    close_all_file_streams();
 

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -32,7 +32,7 @@ int LoadImageFile(const char *filename)
         return 0;
 
     std::unique_ptr<Stream> in(
-        ResolveScriptPathAndOpen(filename, FileOpenMode::kFile_Open, FileWorkMode::kFile_Read));
+        ResolveScriptPathAndOpen(filename, FileOpenMode::kFile_Open, StreamMode::kStream_Read));
     if (!in)
         return 0;
 

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -95,7 +95,7 @@ int FileIsEOF (int32_t handle) {
     return 1;
 
   // TODO: stream errors
-  if (stream->HasErrors())
+  if (stream->GetError())
     return 1;
 
   if (stream->GetPosition () >= stream->GetLength())
@@ -106,7 +106,7 @@ int FileIsError(int32_t handle) {
   Stream *stream = get_file_stream(handle, "FileIsError");
 
   // TODO: stream errors
-  if (stream->HasErrors())
+  if (stream->GetError())
     return 1;
 
   return 0;

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -30,7 +30,7 @@ using namespace AGS::Common;
 int32_t FileOpenCMode(const char*fnmm, const char* cmode)
 {
   Common::FileOpenMode open_mode;
-  Common::FileWorkMode work_mode;
+  Common::StreamMode work_mode;
   // NOTE: here we ignore the text-mode flag. AGS 2.62 did not let
   // game devs to open files in text mode. The file reading and
   // writing logic in AGS makes extra control characters added for
@@ -43,7 +43,7 @@ int32_t FileOpenCMode(const char*fnmm, const char* cmode)
   return FileOpen(fnmm, open_mode, work_mode);
 }
 
-int32_t FileOpen(const char *fnmm, Common::FileOpenMode open_mode, Common::FileWorkMode work_mode)
+int32_t FileOpen(const char *fnmm, Common::FileOpenMode open_mode, Common::StreamMode work_mode)
 {
   
   debug_script_print(kDbgMsg_Debug, "FileOpen: request: %s, mode: %s",

--- a/Engine/ac/global_file.h
+++ b/Engine/ac/global_file.h
@@ -23,7 +23,7 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWorkMode work_mode);
+int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::StreamMode work_mode);
 // NOTE: FileOpenCMode is a backwards-compatible replacement for old-style global script function FileOpen
 int32_t FileOpenCMode(const char*fnmm, const char* cmode);
 void  FileClose(int32_t handle);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -693,7 +693,7 @@ int SaveScreenShot(const char*namm) {
         filename = Path::ConcatPaths(svg_dir, namm);
     }
 
-    std::unique_ptr<Stream> out(File::OpenFileCI(filename, kFile_CreateAlways, kFile_Write));
+    std::unique_ptr<Stream> out(File::OpenFileCI(filename, kFile_CreateAlways, kStream_Write));
     if (!out)
         return 0;
     std::unique_ptr<Bitmap> bmp(CopyScreenIntoBitmap(play.GetMainViewport().GetWidth(), play.GetMainViewport().GetHeight()));

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -27,6 +27,7 @@
 
 #include "util/file.h"
 #include "util/path.h"
+#include "util/stream.h"
 
 using AGS::Common::String;
 
@@ -125,6 +126,6 @@ ResolvedPath ResolveWritePathAndCreateDirs(const String &sc_path);
 // Fills a full resolved path, if possible.
 // Returns open stream on success, and null on failure.
 AGS::Common::Stream *ResolveScriptPathAndOpen(const String &sc_path,
-    AGS::Common::FileOpenMode open_mode, AGS::Common::FileWorkMode work_mode);
+    AGS::Common::FileOpenMode open_mode, AGS::Common::StreamMode work_mode);
 
 #endif // __AGS_EE_AC__PATHHELPER_H

--- a/Engine/debug/logfile.cpp
+++ b/Engine/debug/logfile.cpp
@@ -37,7 +37,7 @@ void LogFile::PrintMessage(const DebugMessage &msg)
         if (_filePath.IsEmpty())
             return;
         _file.reset(File::OpenFile(_filePath, _openMode == kLogFile_Append ? Common::kFile_Create : Common::kFile_CreateAlways,
-            Common::kFile_Write));
+            Common::kStream_Write));
         if (!_file)
         {
             Debug::Printf("Unable to write log to '%s'.", _filePath.GetCStr());
@@ -73,7 +73,7 @@ bool LogFile::OpenFile(const String &file_path, OpenMode open_mode)
     {
         _file.reset(File::OpenFile(file_path,
                            open_mode == kLogFile_Append ? Common::kFile_Create : Common::kFile_CreateAlways,
-                           Common::kFile_Write));
+                           Common::kStream_Write));
         return _file.get() != nullptr;
     }
 }

--- a/Engine/platform/emscripten/acpemscripten.cpp
+++ b/Engine/platform/emscripten/acpemscripten.cpp
@@ -31,8 +31,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "util/filestream.h"
 
-using AGS::Common::String;
-using AGS::Common::FileStream;
+using namespace AGS::Common;
 
 extern AGS::Engine::IGraphicsDriver *gfxDriver;
 
@@ -180,8 +179,11 @@ void AGSEmscripten::MainInit()
     ags_syncfs_running = false;
 
     FileStream::FileCloseNotify = [this](const FileStream::CloseNotifyArgs &args){
-        if(args.WorkMode == Common::FileWorkMode::kFile_Read) return;
-        if(!Common::Path::IsSameOrSubDir(SavedGamesDirectory.FullDir,args.Filepath)) return;
+        // Only sync if file stream was in write mode
+        if ((args.WorkMode & StreamMode::kStream_ReadWrite) == StreamMode::kStream_Read)
+            return;
+        if (!Path::IsSameOrSubDir(SavedGamesDirectory.FullDir,args.Filepath))
+            return;
         ScheduleSyncFS();
     };
 }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -814,21 +814,15 @@ size_t IAGSEngine::ResolveFilePath(const char *script_path, char *buf, size_t bu
 
 ::IAGSStream *IAGSEngine::OpenFileStream(const char *script_path, int file_mode, int work_mode)
 {
-    std::unique_ptr<Stream> s(ResolveScriptPathAndOpen(script_path,
-        static_cast<FileOpenMode>(file_mode), static_cast<StreamMode>(work_mode)));
-    if (!s)
-        return nullptr;
-    int32_t fhandle = add_file_stream(std::move(s), "IAGSEngine::OpenFileStream");
-    if (fhandle <= 0)
-        return nullptr;
-    return reinterpret_cast<::IAGSStream*>(
-        get_file_stream_iface(fhandle, "IAGSEngine::OpenFileStream"));
+    Stream *s = ResolveScriptPathAndOpen(script_path,
+        static_cast<FileOpenMode>(file_mode), static_cast<StreamMode>(work_mode));
+    return reinterpret_cast<::IAGSStream*>(s);
 }
 
 ::IAGSStream *IAGSEngine::GetFileStreamByHandle(int32 fhandle)
 {
     return reinterpret_cast<::IAGSStream*>(
-        get_file_stream_iface(fhandle, "IAGSEngine::GetFileStreamByHandle"));
+        get_file_stream(fhandle, "IAGSEngine::GetFileStreamByHandle"));
 }
 
 // *********** General plugin implementation **********

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -815,7 +815,7 @@ size_t IAGSEngine::ResolveFilePath(const char *script_path, char *buf, size_t bu
 ::IAGSStream *IAGSEngine::OpenFileStream(const char *script_path, int file_mode, int work_mode)
 {
     std::unique_ptr<Stream> s(ResolveScriptPathAndOpen(script_path,
-        static_cast<FileOpenMode>(file_mode), static_cast<FileWorkMode>(work_mode)));
+        static_cast<FileOpenMode>(file_mode), static_cast<StreamMode>(work_mode)));
     if (!s)
         return nullptr;
     int32_t fhandle = add_file_stream(std::move(s), "IAGSEngine::OpenFileStream");

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1690,7 +1690,7 @@ void ccInstance::DumpInstruction(const ScriptOperation &op) const
         return;
     }
 
-    Stream *data_s = File::OpenFile("script.log", kFile_Create, kFile_Write);
+    Stream *data_s = File::OpenFile("script.log", kFile_Create, kStream_Write);
     TextStreamWriter writer(data_s);
     writer.WriteFormat("Line %3d, IP:%8d (SP:%p) ", line_num, pc, registers[SREG_SP].RValue);
 


### PR DESCRIPTION
### Problem

This PR is following concerns stated in my comment to the previous IAGSStream pr here:
https://github.com/adventuregamestudio/ags/pull/2227#issuecomment-1850532997
summarized in a cleaner way in this PR draft:
https://github.com/adventuregamestudio/ags/pull/2256#issuecomment-1858997247

To put it simply, the primary goal is to make our IStream interface match IAGSStream (or other way around), and make our internal base Stream class work as a direct implementation of IAGSStream, and be able to pass Stream object to plugins, without an additional wrapper class. The purpose of this is to avoid extra wrappers over objects passed to plugins (and stream may be the first new object we expose, but there may be others in the future, such as sound player and decoder, etc). The wrappers like that make clumsy code, and they also make situation more clumsy if same object is passed back to the engine, for example, if there's a function in api that accepts such interface.

E.g. consider example:
```
IAGSStream* OpenFileStream(const char *script_path, int file_mode, int work_mode);
IAGSAudioDecoder *OpenAudioDecoder(IAGSStream *stream);
```
with this plugin may get engine's stream object from OpenFileStream and then pass it into OpenAudioDecoder function. But OpenAudioDecoder function cannot be certain that IAGSStream is engine's stream, it may be also a plugin's own implementation. So it will have to use the interface, which in turn means that the AudioDecoder class must use the stream interface.

For this purpose I also wanted to expand the stream interface, let it have bit more methods, enough to cover user's needs. Stream interface rarely needs alot of functions, so I may be getting a little over the top here, compared to laconic interface of SDL_RW, but it may look more like standard C FILE interface, or one they have in Allegro.

There may be a concern that these changes are done late in 3.6.1 development, but firstly there are no critical changes to internal classes, mostly minor changes to a few already existing methods in attempt to make them more convenient too. And secondly, I want to fix the problem with stream api before it gets "solidified" in plugins.

The PR contents may be split into two parts:
1. Changes to IStream interface,
2. Fixing IAGSStream in plugin api.

### Changes to IStream interface.

1. IStream has more methods now, all copied from the basic Stream class, except one is a "merger" of multiple old methods:
    * GetMode() (see explanation below),
    * GetPath(),
    * EOS(),
    * GetError() (see explanation below),
    * ReadByte(),
    * WriteByte(),
    * Flush(),
    * Close().

2. GetMode() is a new method which merges meaning of IsValid, CanRead, CanWrite and CanSeek. It returns a combination of StreamMode flags, which directly tell what the stream can do. Currently declared are: Read, Write and Seek. Invalid streams return 0 (nothing set). This allows to use 1 method to check for all stream's abilities. The StreamMode flag set may be expanded in the future too.
The old functions: IsValid, CanRead etc, - are still available in the base class, as non-virtual helpers. But they simply read the flags reported by GetMode() now.

4. StreamMode itself is a merge between StreamWorkMode and FileWorkMode. It has Seek added to its constants to let report seeking ability. These flags may be both used when opening a stream and when requesting its actual mode. This means that the stream class should take care of checking the flags, and not comparing to direct values. This should not be a problem so long as you remember doing this correctly.

5. GetError() replaced HasErrors() method. The old method was actually done incorrectly from the start. It was supposed to replicate ferror(), but the thing is that after using ferror() you also have to clear error flag if you intend to use stream further. I did not want to have extra function for that, so added a rule that GetError also resets the error flag. So it only reports error once, and not until there's another one. I think that will be fine, as streams normally should have only one user at a time.

6. Dispose() method is added. This method deletes the stream object, and is primarily needed because of plugin api.
The Stream base class implements this method *as private*, because it is not intended to be used from an actual class.
I cannot make Close() delete the stream, because Close() may be called even from the object on stack when you want to close some stream before the variable's scope ends.

### Changes to plugin api.

1. IAGSStream is a direct match to IStream. For plugins the biggest change is that they should call Dispose() method to delete the stream instead of just Close() (they may call both, or only Dispose()).
2. Deleted IManagedStream wrapper.
3. IAGSEngine::OpenFileStream returns a created Stream object directly.
4. OpenFileStream no longer saves created object in the engine's streams map. This map is only used for a) script streams, b) streams prepared for certain events, such as saving and restoring a game. Plugin can retrieve these using GetFileStreamByHandle as before.

### A note on potential future changes

If #2262 stream refactor is implemented, then the IAGSStream will match IStreamBase, while Stream will work as a wrapper for IStreamBase, that can wrap both our streams and plugin streams.