### PR TITLE
Editor: ensure themed combobox item index is valid

### DIFF
--- a/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
+++ b/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
@@ -63,7 +63,7 @@ namespace AGS.Editor
 
             DrawItem += (s, a) =>
             {
-                if (a.Index >= 0)
+                if (a.Index >= 0 && a.Index < this.Items.Count)
                 {
                     a.DrawBackground();
 


### PR DESCRIPTION
for #1919

Not the proper fix but it should at least prevent things from crashing.