### PR TITLE
More fixes for AAssetStream

### DIFF
--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -179,17 +179,20 @@ namespace AGS
                                                  soff_t start_pos, soff_t end_pos)
         {
             Open(asset_name, asset_mode);
+
+            // clamp requested range to the predetermined full stream range
             assert(start_pos <= end_pos);
-            start_pos = std::min(start_pos, end_pos);
+            end_pos = std::max(_start, std::min(_end, end_pos));
+            start_pos = std::max(_start, std::min(start_pos, end_pos));
 
             if (Seek(start_pos, kSeekBegin) < 0)
             {
                 Close();
-                throw std::runtime_error("Error determining stream end.");
+                throw std::runtime_error("Error setting stream section.");
             }
 
-            _start = std::min(start_pos, _end);
-            _end = std::min(end_pos, _end);
+            _start = start_pos;
+            _end = end_pos;
         }
 
     } // namespace Common

--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -144,8 +144,11 @@ namespace AGS
             }
 
             // clamp to a valid range
-            _cur_offset = std::min(std::max(want_pos, _start), _end);
-            off64_t new_off = AAsset_seek64(_aAsset, (off64_t)_cur_offset, SEEK_SET);
+            want_pos = std::min(std::max(want_pos, _start), _end);
+            off64_t new_off = AAsset_seek64(_aAsset, static_cast<off64_t>(want_pos), SEEK_SET);
+            // if seek returns error (< 0), then the position must remain
+            if (new_off >= 0)
+                _cur_offset = new_off;
             return static_cast<soff_t>(new_off);
         }
 

--- a/Common/util/aasset_stream.h
+++ b/Common/util/aasset_stream.h
@@ -88,8 +88,10 @@ namespace AGS
 
         private:
             AAssetStream(AAsset *aasset, bool own, int asset_mode, DataEndianess stream_end);
-            void    Open(const String &asset_name, int asset_mode);
-            void    OpenSection(const String &asset_name, int asset_mode, soff_t start_pos, soff_t end_pos);
+
+            static AAsset *OpenAAsset(const String &asset_name, int asset_mode);
+            void    Open(AAsset *asset, bool own, const String &asset_name, int asset_mode);
+            void    OpenSection(AAsset *asset, bool own, const String &asset_name, int asset_mode, soff_t start_pos, soff_t end_pos);
 
             bool    _ownHandle = false;
             AAsset *_aAsset = nullptr;


### PR DESCRIPTION
I've been doing adjustments in Stream classes lately, and while reading AAssetStream code noticed that OwnHandle and WrapHandle methods do not actually work, because the associated constructor does not assign a member pointer (and does not init few other members). I guess this was never used nor tested. So I refactored the class a little: picked out a method for opening AAsset pointer by name, and have Open/OpenSection methods take this pointer and "own" parameter. Then they may be called from that non-working constructor too.

Other than that, fixed couple of minor mistakes (minor in the sense that they would rarely be an issue in practice, but still):
* in Seek method "current offset" has to be remembered only after successful asset seek, and old pos kept if there was an error. At least according to fseek documentation, it is supposed to keep old stream position on error. AAsset docs do not explicitly mention this, but I make a guess that it has similar logic.
* in OpenSection method fixed offsets clamping to clamp against real start of the stream (this is in case someone passes a negative offset), and changed the exception message to something more suitable for this case.
