### PR TITLE
3.6.1: safeguard plugin save reading and writing

### DIFF
--- a/Common/util/datastream.cpp
+++ b/Common/util/datastream.cpp
@@ -11,6 +11,7 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
+#include <algorithm>
 #include "util/datastream.h"
 
 namespace AGS
@@ -152,6 +153,82 @@ size_t DataStream::WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t cou
         }
     }
     return elem;
+}
+
+
+DataStreamSection::DataStreamSection(Stream *base, soff_t start, soff_t end)
+    : _base(base)
+{
+    _start = std::max(0ll, std::min(start, end));
+    _end = std::min(std::max(0ll, end), base->GetLength());
+
+    soff_t pos = base->Seek(_start, kSeekBegin);
+    if (pos >= 0)
+        _position = pos;
+    else
+        _position = base->GetPosition();
+}
+
+size_t DataStreamSection::Read(void *buffer, size_t len)
+{
+    if (_position >= _end)
+        return 0;
+    len = std::min(len, static_cast<size_t>(_end - _position));
+    _position += _base->Read(buffer, len);
+    return len;
+}
+
+int32_t DataStreamSection::ReadByte()
+{
+    if (_position >= _end)
+        return -1;
+    int32_t b = _base->ReadByte();
+    if (b >= 0)
+        _position++;
+    return b;
+}
+
+size_t DataStreamSection::Write(const void *buffer, size_t len)
+{
+    len = _base->Write(buffer, len);
+    _position += len;
+    _end = std::max(_end, _position); // we might be overwriting after seeking back
+    return len;
+}
+
+int32_t DataStreamSection::WriteByte(uint8_t b)
+{
+    int32_t rb = _base->WriteByte(b);
+    if (rb == b)
+    {
+        _position++;
+        _end = std::max(_end, _position); // we might be overwriting after seeking back
+    }
+    return rb;
+}
+
+soff_t DataStreamSection::Seek(soff_t offset, StreamSeek origin)
+{
+    soff_t want_pos = -1;
+    switch(origin)
+    {
+        case StreamSeek::kSeekCurrent:  want_pos = _position   + offset; break;
+        case StreamSeek::kSeekBegin:    want_pos = _start      + offset; break;
+        case StreamSeek::kSeekEnd:      want_pos = _end        + offset; break;
+        default: return -1;
+    }
+
+    want_pos = std::min(std::max(want_pos, _start), _end);
+    soff_t new_pos = _base->Seek(want_pos, kSeekBegin);
+    if (new_pos >= 0) // the position remains in case of seek error
+        _position = want_pos;
+    return new_pos;
+}
+
+void DataStreamSection::Close()
+{
+    // We do not close nor delete the base stream, but release it from use
+    _base = nullptr;
 }
 
 } // namespace Common

--- a/Common/util/datastream.cpp
+++ b/Common/util/datastream.cpp
@@ -159,8 +159,8 @@ size_t DataStream::WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t cou
 DataStreamSection::DataStreamSection(Stream *base, soff_t start, soff_t end)
     : _base(base)
 {
-    _start = std::max(0ll, std::min(start, end));
-    _end = std::min(std::max(0ll, end), base->GetLength());
+    _start = std::max((soff_t)0, std::min(start, end));
+    _end = std::min(std::max((soff_t)0, end), base->GetLength());
 
     soff_t pos = base->Seek(_start, kSeekBegin);
     if (pos >= 0)

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -820,26 +820,75 @@ void ReadPluginSaveData(Stream *in, PluginSvgVersion svg_ver, soff_t max_size)
     const soff_t start_pos = in->GetPosition();
     const soff_t end_pos = start_pos + max_size;
 
-    String pl_name;
-    for (int pl_index = 0; pl_query_next_plugin_for_event(AGSE_RESTOREGAME, pl_index, pl_name); ++pl_index)
+    if (svg_ver >= kPluginSvgVersion_36115)
     {
-        auto guard_stream = std::make_unique<DataStreamSection>(in, in->GetPosition(), end_pos);
-        int32_t fhandle = add_file_stream(std::move(guard_stream), "RestoreGame");
-        pl_run_plugin_hook_by_index(pl_index, AGSE_RESTOREGAME, fhandle);
-        close_file_stream(fhandle, "RestoreGame");
+        int num_plugins_read = in->ReadInt32();
+        soff_t cur_pos = start_pos;
+        while ((num_plugins_read--) > 0 && (cur_pos < end_pos))
+        {
+            String pl_name = StrUtil::ReadString(in);
+            size_t data_size = in->ReadInt32();
+            soff_t data_start = in->GetPosition();
+
+            auto guard_stream = std::make_unique<DataStreamSection>(in, in->GetPosition(), end_pos);
+            int32_t fhandle = add_file_stream(std::move(guard_stream), "RestoreGame");
+            pl_run_plugin_hook_by_name(pl_name, AGSE_RESTOREGAME, fhandle);
+            close_file_stream(fhandle, "RestoreGame");
+
+            // Seek to the end of plugin data, in case it ended up reading not in the end
+            cur_pos = data_start + data_size;
+            in->Seek(cur_pos, kSeekBegin);
+        }
+    }
+    else
+    {
+        String pl_name;
+        for (int pl_index = 0; pl_query_next_plugin_for_event(AGSE_RESTOREGAME, pl_index, pl_name); ++pl_index)
+        {
+            auto guard_stream = std::make_unique<DataStreamSection>(in, in->GetPosition(), end_pos);
+            int32_t fhandle = add_file_stream(std::move(guard_stream), "RestoreGame");
+            pl_run_plugin_hook_by_index(pl_index, AGSE_RESTOREGAME, fhandle);
+            close_file_stream(fhandle, "RestoreGame");
+        }
     }
 }
 
 void WritePluginSaveData(Stream *out)
 {
+    soff_t pluginnum_pos = out->GetPosition();
+    out->WriteInt32(0); // number of plugins which wrote data
+
+    int num_plugins_wrote = 0;
     String pl_name;
     for (int pl_index = 0; pl_query_next_plugin_for_event(AGSE_SAVEGAME, pl_index, pl_name); ++pl_index)
     {
+        // NOTE: we don't care if they really write anything,
+        // but count them so long as they subscribed to AGSE_SAVEGAME
+        num_plugins_wrote++;
+
+        // Write a header for plugin data
+        StrUtil::WriteString(pl_name, out);
+        soff_t data_size_pos = out->GetPosition();
+        out->WriteInt32(0); // data size
+
+        // Create a stream section and write plugin data
+        soff_t data_start_pos = out->GetPosition();
         auto guard_stream = std::make_unique<DataStreamSection>(out, out->GetPosition(), INT64_MAX);
         int32_t fhandle = add_file_stream(std::move(guard_stream), "SaveGame");
         pl_run_plugin_hook_by_index(pl_index, AGSE_SAVEGAME, fhandle);
         close_file_stream(fhandle, "SaveGame");
+
+        // Finalize header
+        soff_t data_end_pos = out->GetPosition();
+        out->Seek(data_size_pos, kSeekBegin);
+        out->WriteInt32(data_end_pos - data_start_pos);
+        out->Seek(0, kSeekEnd);
     }
+
+    // Write number of plugins
+    out->Seek(pluginnum_pos, kSeekBegin);
+    out->WriteInt32(num_plugins_wrote);
+    out->Seek(0, kSeekEnd);
 }
 
 } // namespace Engine

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -301,7 +301,7 @@ void ReadViewportState(RestoredData &r_data, Stream *in)
     r_data.Viewports.push_back(view);
 }
 
-HSaveError ReadGameState(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
+HSaveError ReadGameState(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     GameStateSvgVersion svg_ver = (GameStateSvgVersion)cmp_ver;
@@ -423,7 +423,7 @@ enum AudioSvgVersion
     kAudioSvgVersion_36009    = 2, // up number of channels
 };
 
-HSaveError ReadAudio(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
+HSaveError ReadAudio(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     // Game content assertion
@@ -553,7 +553,7 @@ HSaveError WriteCharacters(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numcharacters, "Characters"))
@@ -586,7 +586,7 @@ HSaveError WriteDialogs(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDialogs(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadDialogs(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numdialog, "Dialogs"))
@@ -645,7 +645,7 @@ HSaveError WriteGUI(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadGUI(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadGUI(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     const GuiSvgVersion svg_ver = (GuiSvgVersion)cmp_ver;
@@ -725,7 +725,7 @@ HSaveError WriteInventory(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadInventory(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadInventory(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numinvitems, "Inventory Items"))
@@ -750,7 +750,7 @@ HSaveError WriteMouseCursors(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadMouseCursors(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadMouseCursors(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numcursors, "Mouse Cursors"))
@@ -781,7 +781,7 @@ HSaveError WriteViews(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadViews(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadViews(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numviews, "Views"))
@@ -832,7 +832,7 @@ HSaveError WriteDynamicSprites(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDynamicSprites(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadDynamicSprites(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     const int spr_count = in->ReadInt32();
@@ -870,7 +870,7 @@ HSaveError WriteOverlays(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& r_data)
+HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& r_data)
 {
     // Remember that overlay indexes may be non-sequential
     // the vector may be resized during read
@@ -911,7 +911,7 @@ HSaveError WriteDynamicSurfaces(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDynamicSurfaces(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData &r_data)
+HSaveError ReadDynamicSurfaces(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     if (!AssertCompatLimit(err, in->ReadInt32(), MAX_DYNAMIC_SURFACES, "Dynamic Surfaces"))
@@ -947,7 +947,7 @@ HSaveError WriteScriptModules(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadScriptModules(Stream *in, int32_t /*cmp_ver*/, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadScriptModules(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams &pp, RestoredData &r_data)
 {
     HSaveError err;
     // read the global script data segment
@@ -1000,7 +1000,7 @@ HSaveError WriteRoomStates(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     int roomstat_count = in->ReadInt32();
@@ -1064,7 +1064,7 @@ HSaveError WriteThisRoom(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
+HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     displayed_room = in->ReadInt32();
@@ -1129,7 +1129,7 @@ HSaveError WriteMoveLists(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadMoveLists(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadMoveLists(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     size_t movelist_count = in->ReadInt32();
@@ -1154,7 +1154,7 @@ HSaveError WriteManagedPool(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadManagedPool(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadManagedPool(Stream *in, int32_t /*cmp_ver*/, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     if (ccUnserializeAllObjects(in, &ccUnserializer))
     {
@@ -1171,9 +1171,9 @@ HSaveError WritePluginData(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadPluginData(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadPluginData(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
-    ReadPluginSaveData(in);
+    ReadPluginSaveData(in, static_cast<PluginSvgVersion>(cmp_ver), cmp_size);
     return HSaveError::None();
 }
 
@@ -1185,7 +1185,7 @@ struct ComponentHandler
     int32_t            Version; // current version to write and the highest supported version
     int32_t            LowestVersion; // lowest supported version that the engine can read
     HSaveError       (*Serialize)  (Stream*);
-    HSaveError       (*Unserialize)(Stream*, int32_t cmp_ver, const PreservedParams&, RestoredData&);
+    HSaveError       (*Unserialize)(Stream*, int32_t cmp_ver, soff_t cmp_size, const PreservedParams&, RestoredData&);
 };
 
 // Array of supported components
@@ -1373,7 +1373,7 @@ HSaveError ReadComponent(Stream *in, SvgCmpReadHelper &hlp, ComponentInfo &info)
         return new SavegameError(kSvgErr_UnsupportedComponent);
     if (info.Version > handler->Version || info.Version < handler->LowestVersion)
         return new SavegameError(kSvgErr_UnsupportedComponentVersion, String::FromFormat("Saved version: %d, supported: %d - %d", info.Version, handler->LowestVersion, handler->Version));
-    HSaveError err = handler->Unserialize(in, info.Version, hlp.PP, hlp.RData);
+    HSaveError err = handler->Unserialize(in, info.Version, info.DataSize, hlp.PP, hlp.RData);
     if (!err)
         return err;
     if (in->GetPosition() - info.DataOffset != info.DataSize)

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1307,8 +1307,8 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Plugin Data",
-        0,
-        0,
+        kPluginSvgVersion_36115,
+        kPluginSvgVersion_Initial,
         WritePluginData,
         ReadPluginData
     },

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -148,6 +148,7 @@ struct RestoredData
 enum PluginSvgVersion
 {
     kPluginSvgVersion_Initial = 0,
+    kPluginSvgVersion_36115   = 1,
 };
 
 // Runs plugin events, requesting to read save data from the given stream.

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -145,10 +145,15 @@ struct RestoredData
 };
 
 
+enum PluginSvgVersion
+{
+    kPluginSvgVersion_Initial = 0,
+};
+
 // Runs plugin events, requesting to read save data from the given stream.
 // NOTE: there's no error check in this function, because plugin API currently
 // does not let plugins report any errors when restoring their saved data.
-void ReadPluginSaveData(Stream *in);
+void ReadPluginSaveData(Stream *in, PluginSvgVersion svg_ver, soff_t max_size);
 // Runs plugin events, requesting to write save data into the given stream.
 void WritePluginSaveData(Stream *out);
 

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -530,7 +530,7 @@ HSaveError restore_save_data_v321(Stream *in, GameDataVersion data_ver, const Pr
     if (!err)
         return err;
 
-    ReadPluginSaveData(in);
+    ReadPluginSaveData(in, kPluginSvgVersion_Initial, SIZE_MAX);
     if (static_cast<uint32_t>(in->ReadInt32()) != MAGICNUMBER)
         return new SavegameError(kSvgErr_InconsistentPlugin);
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -849,10 +849,16 @@ void pl_startup_plugins() {
     }
 }
 
-int pl_run_plugin_hooks (int event, int data) {
-    for (auto &plugin : plugins) {
-        if (plugin.wantHook & event) {
+int pl_run_plugin_hooks(int event, int data)
+{
+    for (auto &plugin : plugins)
+    {
+        if (plugin.wantHook & event)
+        {
             int retval = plugin.onEvent(event, data);
+            // FIXME: this is an inconvenient design: breaking out
+            // should be done only for events that are claimable,
+            // such as key press, but not any random event!
             if (retval)
                 return retval;
         }
@@ -867,6 +873,33 @@ int pl_run_plugin_debug_hooks (const char *scriptfile, int linenum) {
             if (retval)
                 return retval;
         }
+    }
+    return 0;
+}
+
+bool pl_query_next_plugin_for_event(int event, int &pl_index, String &pl_name)
+{
+    for (int i = pl_index; i < plugins.size(); ++i)
+    {
+        if (plugins[i].wantHook & event)
+        {
+            pl_index = i;
+            pl_name = plugins[i].filename;
+            return true;
+        }
+    }
+    return false;
+}
+
+int pl_run_plugin_hook_by_index(int pl_index, int event, int data)
+{
+    if (pl_index < 0 || pl_index >= plugins.size())
+        return 0;
+
+    auto &plugin = plugins[pl_index];
+    if (plugin.wantHook & event)
+    {
+        return plugin.onEvent(event, data);
     }
     return 0;
 }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -904,6 +904,18 @@ int pl_run_plugin_hook_by_index(int pl_index, int event, int data)
     return 0;
 }
 
+int pl_run_plugin_hook_by_name(Common::String &pl_name, int event, int data)
+{
+    for (auto &plugin : plugins)
+    {
+        if ((plugin.wantHook & event) && plugin.filename.CompareNoCase(pl_name) == 0)
+        {
+            return plugin.onEvent(event, data);
+        }
+    }
+    return 0;
+}
+
 void pl_run_plugin_init_gfx_hooks (const char *driverName, void *data) {
     for (auto &plugin : plugins)
     {

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -44,9 +44,16 @@ struct PluginObjectReader
 
 void pl_stop_plugins();
 void pl_startup_plugins();
-int  pl_run_plugin_hooks (int event, int data);
+int  pl_run_plugin_hooks(int event, int data);
 void pl_run_plugin_init_gfx_hooks(const char *driverName, void *data);
-int  pl_run_plugin_debug_hooks (const char *scriptfile, int linenum);
+int  pl_run_plugin_debug_hooks(const char *scriptfile, int linenum);
+// Finds a plugin that wants this event, starting with pl_index;
+// returns TRUE on success and fills its index and name;
+// returns FALSE if no more suitable plugins found.
+bool pl_query_next_plugin_for_event(int event, int &pl_index, Common::String &pl_name);
+// Runs event for a plugin identified by an index it was registered under.
+int  pl_run_plugin_hook_by_index(int pl_index, int event, int data);
+
 // Tries to register plugins, either by loading dynamic libraries, or getting any kind of replacement
 Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> &infos);
 bool pl_is_plugin_loaded(const char *pl_name);

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -53,6 +53,8 @@ int  pl_run_plugin_debug_hooks(const char *scriptfile, int linenum);
 bool pl_query_next_plugin_for_event(int event, int &pl_index, Common::String &pl_name);
 // Runs event for a plugin identified by an index it was registered under.
 int  pl_run_plugin_hook_by_index(int pl_index, int event, int data);
+// Runs event for a plugin identified by its name.
+int  pl_run_plugin_hook_by_name(Common::String &pl_name, int event, int data);
 
 // Tries to register plugins, either by loading dynamic libraries, or getting any kind of replacement
 Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> &infos);


### PR DESCRIPTION
Because after #2227 plugins may get a seekable stream from the handle that engine passes to them for reading and writing saves,  there has to be some method for safeguarding their serialization by restricting to certain range of offsets. Technically this may be achieved by several means, one is to load their data in memory and give them a memory stream, another is to give them a proxy stream that serves as a "window" over the portion of the base stream. There won't be any difference from the save format's perspective, it's just an implementation choice.

In this PR I chose the latter method (a stream "window"), but it may be easily replaced with the former (reading and writing a memory buffer).

I also wish i did this in the new save format from the beginning, as this seems most logical thing to do...

Anyway, what this PR does:
1. Expanded format for the plugins component. Now it writes N chunks internally, one for a plugin that wants to write. Each chunk has a header with plugin's name and data size.
2. When reading, it actually looks up for plugin of the read name. Engine may skip the data if such plugin is not present for any reason: it may be missing, or not subscribed for the save/load event. If plugin did not read all data, or seeked somewhere in the middle and forgot to reset to the end, engine does not care and seeks to the end of plugin data itself. So this plugin's mistake does not prevent from reading save further.
3. Introduced DataStreamSection class. This is a simple class that wraps another Stream and restricts it to certain range of offsets: when reading, writing or seeking.

The benefit of this is:
- Plugins can seek and read freely in the restricted range, and regardless of what they do, they won't prevent other plugins or other save components from reading correctly.
- I think that this actually allows to replace a real plugin with a stub which does not know how to read data back, and still restore existing saves.
