### PR TITLE
Script API: in FillSaveGameList() accept a range of slots

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1869,8 +1869,8 @@ builtin managed struct ListBox extends GUIControl {
 	import void Clear();
 	/// Fills the list box with all the filenames that match the specified file mask.
 	import void FillDirList(const string fileMask);
-	/// Fills the list box with all the current user's saved games.
-	import int  FillSaveGameList();
+	/// Fills the list box with the current user's saved games in the given range of slots.
+	import int  FillSaveGameList(int min_slot = 0, int max_slot = 99);
 	/// Gets the item index at the specified screen co-ordinates, if they lie within the list box.
 	import int  GetItemAtLocation(int x, int y);
 #ifndef STRICT_STRINGS

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -228,7 +228,7 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned bot_index, unsigned
 int GetLastSaveSlot()
 {
     std::vector<SaveListItem> saves;
-    FillSaveList(saves, 0, RESTART_POINT_SAVE_GAME_NUMBER - 1);
+    FillSaveList(saves, 0, RESTART_POINT_SAVE_GAME_NUMBER);
     if (saves.size() == 0)
         return -1;
     std::sort(saves.rbegin(), saves.rend());

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -123,20 +123,24 @@ void RestoreGameSlot(int slnum) {
 }
 
 void DeleteSaveSlot (int slnum) {
-    String nametouse;
-    nametouse = get_save_game_path(slnum);
+    String nametouse = get_save_game_path(slnum);
     File::DeleteFile(nametouse);
+
+    if (loaded_game_file_version >= kGameVersion_361_14)
+        return;
+
+    // Rename the highest save game to fill in the gap
+    // CHECKME: is this safe to remove at all, regardless of game version?!
+    // which kind of script logic could depend on this?
     if ((slnum >= 1) && (slnum <= MAXSAVEGAMES)) {
         String thisname;
         for (int i = MAXSAVEGAMES; i > slnum; i--) {
             thisname = get_save_game_path(i);
             if (Common::File::IsFile(thisname)) {
-                // Rename the highest save game to fill in the gap
                 File::RenameFile(thisname, nametouse);
                 break;
             }
         }
-
     }
 }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/global_game.h"
+#include <algorithm>
 #include <math.h>
 #include <stdio.h>
 #include "core/platform.h"
@@ -195,7 +196,7 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
     return add_dynamic_sprite(std::move(screenshot));
 }
 
-void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count)
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned bot_index, unsigned top_index, size_t max_count)
 {
     if (max_count == 0)
         return; // duh
@@ -203,6 +204,8 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
     String svg_dir = get_save_game_directory();
     String svg_suff = get_save_game_suffix();
     String pattern = String::FromFormat("agssave.???%s", svg_suff.GetCStr());
+    bot_index = std::min(999u, bot_index); // NOTE: slots are limited by 0..999 range
+    top_index = std::min(999u, top_index);
 
     for (FindFile ff = FindFile::OpenFiles(svg_dir, pattern); !ff.AtEnd(); ff.Next())
     {
@@ -210,8 +213,9 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
         if (!svg_suff.IsEmpty())
             slotname.ClipRight(svg_suff.GetLength());
         int saveGameSlot = Path::GetFileExtension(slotname).ToInt();
-        // only list games .000 to .XXX (to allow higher slots for other perposes)
-        if (saveGameSlot < 0 || static_cast<unsigned>(saveGameSlot) > top_index)
+        // only list games between .XXX to .YYY (to allow hidden slots for special perposes)
+        if (saveGameSlot < 0 || static_cast<unsigned>(saveGameSlot) < bot_index
+            || static_cast<unsigned>(saveGameSlot) > top_index)
             continue;
         String description;
         GetSaveSlotDescription(saveGameSlot, description);
@@ -224,7 +228,7 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
 int GetLastSaveSlot()
 {
     std::vector<SaveListItem> saves;
-    FillSaveList(saves, RESTART_POINT_SAVE_GAME_NUMBER - 1);
+    FillSaveList(saves, 0, RESTART_POINT_SAVE_GAME_NUMBER - 1);
     if (saves.size() == 0)
         return -1;
     std::sort(saves.rbegin(), saves.rend());

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -46,7 +46,7 @@ void RestoreGameSlot(int slnum);
 void DeleteSaveSlot (int slnum);
 int  GetSaveSlotDescription(int slnum,char*desbuf);
 int  LoadSaveSlotScreenshot(int slnum, int width, int height);
-void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count = -1);
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned bot_index, unsigned top_index, size_t max_count = -1);
 // Find the latest save slot, returns the slot index or -1 at failure
 int  GetLastSaveSlot();
 void PauseGame();

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -104,8 +104,8 @@ int ListBox_FillSaveGameList2(GUIListBox *listbox, int min_slot, int max_slot) {
 
   // TODO: find out if limiting to MAXSAVEGAMES is still necessary here
   std::vector<SaveListItem> saves;
-  FillSaveList(saves, min_slot, max_slot,
-      (loaded_game_file_version < kGameVersion_361_14) ? MAXSAVEGAMES : SIZE_MAX);
+  const size_t item_limit = (loaded_game_file_version < kGameVersion_361_14) ? MAXSAVEGAMES : SIZE_MAX;
+  FillSaveList(saves, min_slot, max_slot, item_limit);
   std::sort(saves.rbegin(), saves.rend()); // sort by modified time in reverse
 
   // fill in the list box
@@ -118,14 +118,14 @@ int ListBox_FillSaveGameList2(GUIListBox *listbox, int min_slot, int max_slot) {
   }
 
   // update the global savegameindex[] array for backward compatibilty
-  for (size_t n = 0; n < saves.size(); ++n)
+  for (size_t n = 0; (n < MAXSAVEGAMES) && (n < saves.size()); ++n)
   {
     play.filenumbers[n] = saves[n].Slot;
   }
 
   listbox->SetSvgIndex(true);
 
-  if (saves.size() >= MAXSAVEGAMES)
+  if (saves.size() >= item_limit)
     return 1;
   return 0;
 }

--- a/Engine/ac/listbox.h
+++ b/Engine/ac/listbox.h
@@ -28,6 +28,7 @@ void		ListBox_Clear(GUIListBox *listbox);
 void		ListBox_FillDirList(GUIListBox *listbox, const char *filemask);
 int			ListBox_GetSaveGameSlots(GUIListBox *listbox, int index);
 int			ListBox_FillSaveGameList(GUIListBox *listbox);
+int			ListBox_FillSaveGameList2(GUIListBox *listbox, int min_slot, int max_slot);
 int			ListBox_GetItemAtLocation(GUIListBox *listbox, int x, int y);
 char		*ListBox_GetItemText(GUIListBox *listbox, int index, char *buffer);
 const char* ListBox_GetItems(GUIListBox *listbox, int index);

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -300,7 +300,7 @@ void preparesavegamelist(int ctrllist)
 {
   // TODO: find out if limiting to MAXSAVEGAMES is still necessary here
   std::vector<SaveListItem> saves;
-  FillSaveList(saves, TOP_LISTEDSAVESLOT, MAXSAVEGAMES);
+  FillSaveList(saves, 0, TOP_LISTEDSAVESLOT, MAXSAVEGAMES);
   std::sort(saves.rbegin(), saves.rend());
 
   // fill in the list box and global savegameindex[] array for backward compatibilty


### PR DESCRIPTION
I don't like adding "last minute" things  to an upcoming release, but this request seemed easy enough to try.

Historically FillSaveGameList has a hardcoded range of 0 to 99 slots, and for some reason also additionally limits total shown slots to 50 items. This change lets user to tell which range of slots to fill, and removes item count limit, because it makes no sense anymore.

```
/// Fills the list box with the current user's saved games in the given range of slots.
import int  FillSaveGameList(int min_slot = 0, int max_slot = 99);
```

**Backwards compatibility**
Old compiled games will be using same old range (0-99) and 50 items limit.