### PR TITLE
Editor: save "Crop sprite edges" operation in sprite's import settings

### DIFF
--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -264,7 +264,7 @@ void change_sprite_number(int oldNumber, int newNumber) {
   spritesModified = true;
 }
 
-int crop_sprite_edges(const std::vector<int> &sprites, bool symmetric) {
+int crop_sprite_edges(const std::vector<int> &sprites, bool symmetric, Rect *crop_rect) {
   // this function has passed in a list of sprites, all the
   // same size, to crop to the size of the smallest
   int xx, yy;
@@ -337,8 +337,11 @@ int crop_sprite_edges(const std::vector<int> &sprites, bool symmetric) {
   }
   int newWidth = (right - left) + 1;
   int newHeight = (bottom - top) + 1;
+  if (crop_rect)
+    *crop_rect = Rect(left, top, right, bottom);
 
-  if ((newWidth == width) && (newHeight == height)) {
+  if ((newWidth == width) && (newHeight == height))
+  {
     // no change in size
     return 0;
   }


### PR DESCRIPTION
Fix #2290.

When the "Crop sprite edges" operation is performed, Editor will update the respective sprites' import settings, such as OffsetX,Y, and ImportWidth,Height. This allows to correctly restore the cropped sprites from their source files.

**How to test**

Create a game using one of the standard templates. Go to character sprites, select multiple frames, do "Crop sprite edges". Notice how sprites became thinner. Save the project, then do either "replace sprites from sources" or "restore all sprites from sources". The cropped sprites must remain cropped.

You may compare this behavior with existing one, where the sprites will get restored to the previous size.