### PR TITLE
Editor: fix '\[' sequences lost in textual properties

### DIFF
--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -292,7 +292,10 @@ namespace AGS.Editor
         /// <param name="text"></param>
         public static string TextProperty(string text)
         {
-            return Regex.Unescape(text);
+            // Escape backslashes before brackets: for '\[' support;
+            // this is needed because Unescape will delete '\' in unrecognized sequence.
+            string escapedText = text.Replace("\\[", "\\\\[");
+            return Regex.Unescape(escapedText);
         }
 
         /// <summary>

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -141,6 +141,9 @@ AGSString TextConverter::ConvertTextProperty(System::String^ clr_str)
     if (clr_str == nullptr)
         return AGSString();
     AGSString str = TextHelper::Convert(clr_str, _encoding);
+    // Escape backslashes before brackets: for '\[' support;
+    // this is needed because Unescape will delete '\' in unrecognized sequence.
+    str.Replace("\\[", "\\\\[");
     return AGS::Common::StrUtil::Unescape(str);
 }
 


### PR DESCRIPTION
Fix #2288

The '[' is still supported as a linebreak in 3.* branch, for backwards compatibility. If user wants to have literal '[' they have to escape it like '\\['. But recent change 432ae84 have introduced Unescape call for properties (in order to support '\n' etc). Unescape call removes backslashes in unrecognized sequences. So now we have to add this hack, escaping a backslash with another backslash, this will keep it intact.
