### PR TITLE
AGS 4: Script API: in FillSaveGameList() accept a range of slots

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1409,8 +1409,8 @@ builtin managed struct ListBox extends GUIControl {
 	import void Clear();
 	/// Fills the list box with all the filenames that match the specified file mask.
 	import void FillDirList(const string fileMask);
-	/// Fills the list box with all the current user's saved games.
-	import int  FillSaveGameList();
+	/// Fills the list box with the current user's saved games in the given range of slots.
+	import int  FillSaveGameList(int min_slot = 0, int max_slot = 50);
 	/// Gets the item index at the specified screen co-ordinates, if they lie within the list box.
 	import int  GetItemAtLocation(int x, int y);
 	/// Inserts a new item before the specified index.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -786,6 +786,10 @@ import void RestartGame();
 import void SaveGameSlot(int slot, const string description);
 /// Restores the game saved to the specified game slot.
 import void RestoreGameSlot(int slot);
+#ifdef SCRIPT_API_v400
+/// Moves the save game from one slot to another, overwriting a save if one was already present at a new slot.
+import void MoveSaveSlot(int old_slot, int new_slot);
+#endif
 /// Deletes the specified save game.
 import void DeleteSaveSlot(int slot);
 /// Sets this as the point at which the game will be restarted.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -777,9 +777,9 @@ import const string GetTranslation (const string originalText);
 /// Checks if a translation is currently in use.
 import int  IsTranslationAvailable ();
 /// Displays the default built-in Restore Game dialog.
-import void RestoreGameDialog();
+import void RestoreGameDialog(int min_slot = 0, int max_slot = 50);
 /// Displays the default built-in Save Game dialog.
-import void SaveGameDialog();
+import void SaveGameDialog(int min_slot = 0, int max_slot = 50);
 /// Restarts the game from the restart point.
 import void RestartGame();
 /// Saves the current game position to the specified slot.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3921,7 +3921,7 @@ void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
     Character_Think(chaa, scsf_buffer);
 }
 
-void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
+void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*compat_api*/)
 {
     ScFnRegister character_api[] = {
         { "Character::GetAtRoomXY^2",             API_FN_PAIR(GetCharacterAtRoom) },

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -537,7 +537,7 @@ void ScPl_DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, in
     DrawingSurface_DrawStringWrapped(sds, xx, yy, wid, font, alignment, scsf_buffer);
 }
 
-void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
+void RegisterDrawingSurfaceAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*compat_api*/)
 {
     ScFnRegister drawsurf_api[] = {
         { "DrawingSurface::Clear^1",              API_FN_PAIR(DrawingSurface_Clear) },

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -397,19 +397,22 @@ const char* Game_GetSaveSlotDescription(int slnum) {
     return nullptr;
 }
 
-
 void restore_game_dialog() {
-    can_run_delayed_command();
-    if (inside_script) {
-        curscript->queue_action(ePSARestoreGameDialog, 0, "RestoreGameDialog");
-        return;
-    }
-    do_restore_game_dialog();
+    restore_game_dialog2(0, LEGACY_TOP_BUILTINDIALOGSAVESLOT);
 }
 
-bool do_restore_game_dialog() {
+void restore_game_dialog2(int min_slot, int max_slot) {
+    can_run_delayed_command();
+    if (inside_script) {
+        curscript->queue_action(ePSARestoreGameDialog, (min_slot & 0xFFFF) | (max_slot & 0xFFFF) << 16, "RestoreGameDialog");
+        return;
+    }
+    do_restore_game_dialog(min_slot, max_slot);
+}
+
+bool do_restore_game_dialog(int min_slot, int max_slot) {
     setup_for_dialog();
-    int toload = loadgamedialog();
+    int toload = loadgamedialog(min_slot, max_slot);
     restore_after_dialog();
     if (toload >= 0)
         try_restore_save(toload);
@@ -417,16 +420,20 @@ bool do_restore_game_dialog() {
 }
 
 void save_game_dialog() {
-    if (inside_script) {
-        curscript->queue_action(ePSASaveGameDialog, 0, "SaveGameDialog");
-        return;
-    }
-    do_save_game_dialog();
+    save_game_dialog2(0, LEGACY_TOP_BUILTINDIALOGSAVESLOT);
 }
 
-bool do_save_game_dialog() {
+void save_game_dialog2(int min_slot, int max_slot) {
+    if (inside_script) {
+        curscript->queue_action(ePSASaveGameDialog, (min_slot & 0xFFFF) | (max_slot & 0xFFFF) << 16, "SaveGameDialog");
+        return;
+    }
+    do_save_game_dialog(min_slot, max_slot);
+}
+
+bool do_save_game_dialog(int min_slot, int max_slot) {
     setup_for_dialog();
-    int toload = savegamedialog();
+    int toload = savegamedialog(min_slot, max_slot);
     restore_after_dialog();
     if (toload >= 0)
         save_game(toload, get_gui_dialog_buffer());

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -125,13 +125,15 @@ bool get_save_slotnum(const Common::String &filename, int &slot);
 // Try calling built-in restore game dialog;
 // NOTE: this is a script command; may be aborted according to the game & room settings
 void restore_game_dialog();
+void restore_game_dialog2(int min_slot, int max_slot);
 // Unconditionally display a built-in restore game dialog
-bool do_restore_game_dialog();
+bool do_restore_game_dialog(int min_slot, int max_slot);
 // Try calling built-in save game dialog;
 // NOTE: this is a script command; may be aborted according to the game & room settings
 void save_game_dialog();
+void save_game_dialog2(int min_slot, int max_slot);
 // Unconditionally display a built-in save game dialog
-bool do_save_game_dialog();
+bool do_save_game_dialog(int min_slot, int max_slot);
 void free_do_once_tokens();
 // Free all the memory associated with the game
 void unload_game_file();

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -573,7 +573,7 @@ void GameState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameState
     in->ReadArrayOfInt16( parsed_words, MAX_PARSED_WORDS);
     in->Read( bad_parsed_word, 100);
     raw_color = in->ReadInt32();
-    in->ReadArrayOfInt16( filenumbers, MAXSAVEGAMES);
+    in->Seek(LEGACY_MAXSAVEGAMES * sizeof(int16_t));// [DEPRECATED]
     mouse_cursor_hidden = in->ReadInt32();
     in->ReadInt32();// [DEPRECATED]
     in->ReadInt32();
@@ -764,7 +764,7 @@ void GameState::WriteForSavegame(Stream *out) const
     out->WriteArrayOfInt16( parsed_words, MAX_PARSED_WORDS);
     out->Write( bad_parsed_word, 100);
     out->WriteInt32( raw_color);
-    out->WriteArrayOfInt16( filenumbers, MAXSAVEGAMES);
+    out->WriteByteCount(0, LEGACY_MAXSAVEGAMES * sizeof(int16_t));// [DEPRECATED]
     out->WriteInt32( mouse_cursor_hidden);
     out->WriteInt32( 0);// [DEPRECATED]
     out->WriteInt32( 0);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -70,6 +70,7 @@ struct GameState {
     static const int LEGACY_MAXGLOBALVARS = 50;
     static const int LEGACY_MAXGSVALUES = 500;
     static const int LEGACY_MAXGLOBALSTRINGS = 51;
+    static const int LEGACY_MAXSAVEGAMES = 50;
 
     int  usedmode = 0;              // set by ProcessClick to last cursor mode used
     int  disabled_user_interface = 0;  // >0 while in cutscene/etc
@@ -181,7 +182,6 @@ struct GameState {
     int   raw_color = 0;
     int   raw_modified[MAX_ROOM_BGFRAMES]{};
     Common::PBitmap raw_drawing_surface;
-    short filenumbers[MAXSAVEGAMES]{}; // [OBSOLETE]
     int   room_changes = 0;
     int   mouse_cursor_hidden = 0;
     unsigned long shakesc_delay = 0;  // unsigned long to match loopcounter

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -668,6 +668,11 @@ RuntimeScriptValue Sc_MoveObjectDirect(const RuntimeScriptValue *params, int32_t
     API_SCALL_VOID_PINT4(MoveObjectDirect);
 }
 
+RuntimeScriptValue Sc_MoveSaveSlot(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT2(MoveSaveSlot);
+}
+
 // void (int obn)
 RuntimeScriptValue Sc_ObjectOff(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1292,6 +1297,7 @@ void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*
         { "MoveCharacterToHotspot",   API_FN_PAIR(MoveCharacterToHotspot) },
         { "MoveObject",               API_FN_PAIR(MoveObject) },
         { "MoveObjectDirect",         API_FN_PAIR(MoveObjectDirect) },
+        { "MoveSaveSlot",             API_FN_PAIR(MoveSaveSlot) },
         { "ObjectOff",                API_FN_PAIR(ObjectOff) },
         { "ObjectOn",                 API_FN_PAIR(ObjectOn) },
         { "PauseGame",                API_FN_PAIR(PauseGame) },

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -24,6 +24,7 @@
 #include "ac/dynamicsprite.h"
 #include "ac/event.h"
 #include "ac/game.h"
+#include "ac/gamestructdefines.h"
 #include "ac/global_audio.h"
 #include "ac/global_character.h"
 #include "ac/global_debug.h"
@@ -743,6 +744,11 @@ RuntimeScriptValue Sc_restore_game_dialog(const RuntimeScriptValue *params, int3
     API_SCALL_VOID(restore_game_dialog);
 }
 
+RuntimeScriptValue Sc_restore_game_dialog2(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT2(restore_game_dialog2);
+}
+
 // void (int slnum)
 RuntimeScriptValue Sc_RestoreGameSlot(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -799,6 +805,11 @@ extern RuntimeScriptValue Sc_SaveCursorForLocationChange(const RuntimeScriptValu
 RuntimeScriptValue Sc_save_game_dialog(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID(save_game_dialog);
+}
+
+RuntimeScriptValue Sc_save_game_dialog2(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT2(save_game_dialog2);
 }
 
 // void (int slotn, const char*descript)
@@ -1167,7 +1178,7 @@ void ScPl_DisplayTopBar(int ypos, int ttexcol, int backcol, char *title, char *t
 }
 
 
-void RegisterGlobalAPI()
+void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
     ScFnRegister global_api[] = {
         { "AbortGame",                Sc_sc_AbortGame, ScPl_sc_AbortGame },
@@ -1293,7 +1304,6 @@ void RegisterGlobalAPI()
         { "RemoveWalkableArea",       API_FN_PAIR(RemoveWalkableArea) },
         { "ResetRoom",                API_FN_PAIR(ResetRoom) },
         { "RestartGame",              API_FN_PAIR(restart_game) },
-        { "RestoreGameDialog",        API_FN_PAIR(restore_game_dialog) },
         { "RestoreGameSlot",          API_FN_PAIR(RestoreGameSlot) },
         { "RestoreWalkableArea",      API_FN_PAIR(RestoreWalkableArea) },
         { "RunAGSGame",               API_FN_PAIR(RunAGSGame) },
@@ -1304,7 +1314,6 @@ void RegisterGlobalAPI()
         { "RunRegionInteraction",     API_FN_PAIR(RunRegionInteraction) },
         { "Said",                     API_FN_PAIR(Said) },
         { "SaveCursorForLocationChange", API_FN_PAIR(SaveCursorForLocationChange) },
-        { "SaveGameDialog",           API_FN_PAIR(save_game_dialog) },
         { "SaveGameSlot",             API_FN_PAIR(save_game) },
         { "SaveScreenShot",           API_FN_PAIR(SaveScreenShot) },
         { "SetAmbientTint",           API_FN_PAIR(SetAmbientTint) },
@@ -1369,4 +1378,23 @@ void RegisterGlobalAPI()
     };
 
     ccAddExternalFunctions(global_api);
+
+    // NOTE: We have to do this because AGS compiler did not produce
+    // "name^argnum" symbol id for non-member functions for some reason....
+    if (base_api < kScriptAPI_v400)
+    {
+        ScFnRegister global_api_dlgs[] = {
+            { "RestoreGameDialog",      API_FN_PAIR(restore_game_dialog) },
+            { "SaveGameDialog",         API_FN_PAIR(save_game_dialog) },
+        };
+        ccAddExternalFunctions(global_api_dlgs);
+    }
+    else
+    {
+        ScFnRegister global_api_dlgs[] = {
+            { "RestoreGameDialog",      API_FN_PAIR(restore_game_dialog2) },
+            { "SaveGameDialog",         API_FN_PAIR(save_game_dialog2) },
+        };
+        ccAddExternalFunctions(global_api_dlgs);
+    }
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -111,21 +111,8 @@ void RestoreGameSlot(int slnum) {
 }
 
 void DeleteSaveSlot (int slnum) {
-    String nametouse;
-    nametouse = get_save_game_path(slnum);
-    File::DeleteFile(nametouse);
-    if ((slnum >= 1) && (slnum <= MAXSAVEGAMES)) {
-        String thisname;
-        for (int i = MAXSAVEGAMES; i > slnum; i--) {
-            thisname = get_save_game_path(i);
-            if (Common::File::IsFile(thisname)) {
-                // Rename the highest save game to fill in the gap
-                File::RenameFile(thisname, nametouse);
-                break;
-            }
-        }
-
-    }
+    String save_filename = get_save_game_path(slnum);
+    File::DeleteFile(save_filename);
 }
 
 void PauseGame() {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/global_game.h"
+#include <algorithm>
 #include <math.h>
 #include <stdio.h>
 #include "core/platform.h"
@@ -171,7 +172,7 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
     return add_dynamic_sprite(std::move(screenshot));
 }
 
-void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count)
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned bot_index, unsigned top_index, size_t max_count)
 {
     if (max_count == 0)
         return; // duh
@@ -179,6 +180,8 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
     String svg_dir = get_save_game_directory();
     String svg_suff = get_save_game_suffix();
     String pattern = String::FromFormat("agssave.???%s", svg_suff.GetCStr());
+    bot_index = std::min(999u, bot_index); // NOTE: slots are limited by 0..999 range
+    top_index = std::min(999u, top_index);
 
     for (FindFile ff = FindFile::OpenFiles(svg_dir, pattern); !ff.AtEnd(); ff.Next())
     {
@@ -186,8 +189,9 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
         if (!svg_suff.IsEmpty())
             slotname.ClipRight(svg_suff.GetLength());
         int saveGameSlot = Path::GetFileExtension(slotname).ToInt();
-        // only list games .000 to .XXX (to allow higher slots for other perposes)
-        if (saveGameSlot < 0 || static_cast<unsigned>(saveGameSlot) > top_index)
+        // only list games between .XXX to .YYY (to allow hidden slots for special perposes)
+        if (saveGameSlot < 0 || static_cast<unsigned>(saveGameSlot) < bot_index
+            || static_cast<unsigned>(saveGameSlot) > top_index)
             continue;
         String description;
         GetSaveSlotDescription(saveGameSlot, description);
@@ -200,7 +204,7 @@ void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t m
 int GetLastSaveSlot()
 {
     std::vector<SaveListItem> saves;
-    FillSaveList(saves, RESTART_POINT_SAVE_GAME_NUMBER - 1);
+    FillSaveList(saves, 0, RESTART_POINT_SAVE_GAME_NUMBER - 1);
     if (saves.size() == 0)
         return -1;
     std::sort(saves.rbegin(), saves.rend());

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -111,6 +111,12 @@ void RestoreGameSlot(int slnum) {
     try_restore_save(slnum);
 }
 
+void MoveSaveSlot(int old_save, int new_save) {
+    String old_filename = get_save_game_path(old_save);
+    String new_filename = get_save_game_path(new_save);
+    File::RenameFile(old_filename, new_filename);
+}
+
 void DeleteSaveSlot (int slnum) {
     String save_filename = get_save_game_path(slnum);
     File::DeleteFile(save_filename);

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -45,7 +45,7 @@ void RestoreGameSlot(int slnum);
 void DeleteSaveSlot (int slnum);
 int  GetSaveSlotDescription(int slnum,char*desbuf);// [DEPRECATED] ?
 int  LoadSaveSlotScreenshot(int slnum, int width, int height);
-void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count = -1);
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned bot_index, unsigned top_index, size_t max_count = -1);
 // Find the latest save slot, returns the slot index or -1 at failure
 int  GetLastSaveSlot();
 void PauseGame();

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -42,6 +42,7 @@ struct SaveListItem
 void AbortGame();
 void restart_game();
 void RestoreGameSlot(int slnum);
+void MoveSaveSlot (int old_slot, int new_slot);
 void DeleteSaveSlot (int slnum);
 int  GetSaveSlotDescription(int slnum,char*desbuf);// [DEPRECATED] ?
 int  LoadSaveSlotScreenshot(int slnum, int width, int height);

--- a/Engine/ac/listbox.h
+++ b/Engine/ac/listbox.h
@@ -28,6 +28,7 @@ void		ListBox_Clear(GUIListBox *listbox);
 void		ListBox_FillDirList(GUIListBox *listbox, const char *filemask);
 int			ListBox_GetSaveGameSlots(GUIListBox *listbox, int index);
 int			ListBox_FillSaveGameList(GUIListBox *listbox);
+int			ListBox_FillSaveGameList2(GUIListBox *listbox, int min_slot, int max_slot);
 int			ListBox_GetItemAtLocation(GUIListBox *listbox, int x, int y);
 char		*ListBox_GetItemText(GUIListBox *listbox, int index, char *buffer);
 const char* ListBox_GetItems(GUIListBox *listbox, int index);

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -142,6 +142,8 @@ enum LegacyScriptAlignment
 
 // topmost save index to be listed with a FillSaveGameList command
 #define LEGACY_TOP_LISTEDSAVESLOT 50
+// topmost save index to be listed with a Save/RestoreGameDialog command
+#define LEGACY_TOP_BUILTINDIALOGSAVESLOT 20
 // topmost supported save slot index
 #define TOP_SAVESLOT 999
 // save slot reserved for the "restart point"

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -34,12 +34,7 @@
 #define DIALOG_NEWTOPIC  12000
 #define MAX_TIMERS       21
 #define MAX_PARSED_WORDS 15
-// how many saves may be listed at once
-#define MAXSAVEGAMES     50
-// topmost save index to be listed with a FillSaveGameList command
-// NOTE: changing this may theoretically affect older games which
-// use slots > 99 for special purposes!
-#define TOP_LISTEDSAVESLOT 99
+
 #define MAX_QUEUED_MUSIC 10
 #define GLED_INTERACTION 1
 #define GLED_EFFECTS     2 
@@ -145,6 +140,11 @@ enum LegacyScriptAlignment
 
 #define MAX_DYNAMIC_SURFACES 20
 
+// topmost save index to be listed with a FillSaveGameList command
+#define LEGACY_TOP_LISTEDSAVESLOT 50
+// topmost supported save slot index
+#define TOP_SAVESLOT 999
+// save slot reserved for the "restart point"
 #define RESTART_POINT_SAVE_GAME_NUMBER 999
 
 #define RETURN_CONTINUE 1

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -42,13 +42,12 @@ int windowPosX, windowPosY, windowPosWidth, windowPosHeight;
 Bitmap *windowBuffer;
 IDriverDependantBitmap *dialogDDB;
 
-#undef MAXSAVEGAMES
-#define MAXSAVEGAMES 20
+#define LEGACY_MAXSAVEGAMES 20
 char *lpTemp, *lpTemp2;
 char bufTemp[260], buffer2[260];
 int numsaves = 0, toomanygames;
-int filenumbers[MAXSAVEGAMES];
-unsigned long filedates[MAXSAVEGAMES];
+int filenumbers[LEGACY_MAXSAVEGAMES];
+unsigned long filedates[LEGACY_MAXSAVEGAMES];
 
 CSCIMessage smes;
 
@@ -317,7 +316,7 @@ void preparesavegamelist(int ctrllist)
 {
   // TODO: find out if limiting to MAXSAVEGAMES is still necessary here
   std::vector<SaveListItem> saves;
-  FillSaveList(saves, TOP_LISTEDSAVESLOT, MAXSAVEGAMES);
+  FillSaveList(saves, 0, LEGACY_TOP_LISTEDSAVESLOT, LEGACY_MAXSAVEGAMES);
   std::sort(saves.rbegin(), saves.rend());
 
   // fill in the list box and global savegameindex[] array for backward compatibilty
@@ -327,7 +326,7 @@ void preparesavegamelist(int ctrllist)
       filenumbers[numsaves] = saves[numsaves].Slot;
       filedates[numsaves] = (long int)saves[numsaves].FileTime;
   }
-  toomanygames = (numsaves >= MAXSAVEGAMES) ? 1 : 0;
+  toomanygames = (numsaves >= LEGACY_MAXSAVEGAMES) ? 1 : 0;
   // Select the first item
   CSCISendControlMessage(ctrllist, CLB_SETCURSEL, 0, 0);
 }

--- a/Engine/gui/guidialog.h
+++ b/Engine/gui/guidialog.h
@@ -32,9 +32,8 @@ void clear_gui_screen();
 // Draws virtual screen contents on the GUI bitmaps and assignes them to
 // the renderer's draw chain
 void refresh_gui_screen();
-int  loadgamedialog();
-int  savegamedialog();
-void preparesavegamelist(int ctrllist);
+int  loadgamedialog(int min_slot, int max_slot);
+int  savegamedialog(int min_slot, int max_slot);
 void enterstringwindow(const char *prompttext, char *stouse);
 int  enternumberwindow(char *prompttext);
 int  roomSelectorWindow(int currentRoom, int numRooms,

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -566,10 +566,10 @@ static void check_keyboard_controls()
 
     // Built-in key-presses
     if ((usetup.key_save_game > 0) && (agskey == usetup.key_save_game)) {
-        do_save_game_dialog();
+        do_save_game_dialog(0, TOP_SAVESLOT - 1);
         return;
     } else if ((usetup.key_restore_game > 0) && (agskey == usetup.key_restore_game)) {
-        do_restore_game_dialog();
+        do_restore_game_dialog(0, TOP_SAVESLOT - 1);
         return;
     }
 

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -31,7 +31,7 @@ extern void RegisterDynamicArrayAPI();
 extern void RegisterDynamicSpriteAPI();
 extern void RegisterFileAPI();
 extern void RegisterGameAPI();
-extern void RegisterGlobalAPI();
+extern void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api);
 extern void RegisterGUIAPI();
 extern void RegisterGUIControlAPI();
 extern void RegisterHotspotAPI();
@@ -73,7 +73,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterDynamicSpriteAPI();
     RegisterFileAPI();
     RegisterGameAPI();
-    RegisterGlobalAPI();
+    RegisterGlobalAPI(base_api, compat_api);
     RegisterGUIAPI();
     RegisterGUIControlAPI();
     RegisterHotspotAPI();

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -616,7 +616,7 @@ void post_script_cleanup() {
         try_restore_save(thisData);
         return;
     case ePSARestoreGameDialog:
-        restore_game_dialog();
+        restore_game_dialog2(thisData & 0xFFFF, (thisData >> 16));
         return;
     case ePSARunAGSGame:
         cancel_all_scripts();
@@ -633,7 +633,7 @@ void post_script_cleanup() {
         save_game(thisData, copyof.postScriptSaveSlotDescription[ii]);
         break;
     case ePSASaveGameDialog:
-        save_game_dialog();
+        save_game_dialog2(thisData & 0xFFFF, (thisData >> 16));
         break;
     default:
         quitprintf("undefined post script action found: %d", copyof.postScriptActions[ii]);


### PR DESCRIPTION
Historically FillSaveGameList has a hardcoded range of 0 to 99 slots, and for some reason also additionally limits total shown slots to 50 items, which normally means that it's limited to slots 0-50. This change lets user to tell which range of slots to fill, and removes item count limit, because it makes no sense anymore.

Same change is done to function RestoreGameDialog and SaveGameDialog. These are old, but may still be used sometimes, so I decided to still do this.

The new functions are declared as
```
/// Fills the list box with the current user's saved games in the given range of slots.
import int  FillSaveGameList(int min_slot = 0, int max_slot = 50);

import void RestoreGameDialog(int min_slot = 0, int max_slot = 50);
import void SaveGameDialog(int min_slot = 0, int max_slot = 50);
```

In addition, removed the historical effect of DeleteSaveSlot which would move topmost save down to fill the gap in the list. This is unexpected to users, and generally is a ugly solution.

In order to let users do the similar behavior if they like (or for any other purpose), added function MoveSaveSlot that moves a save game from one slot to another; effectively this works as a "rename file".

```
/// Moves the save game from one slot to another, overwriting a save if one was already present at a new slot.
import void MoveSaveSlot(int old_slot, int new_slot);
```


**Backwards compatibility**
Old function will be passing same old range (0-50).
The 50 items limit is removed completely though, as there's little purpose.