### PR TITLE
Engine: fixed CharacterInfo breaking script compatibility again

### DIFF
--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -114,11 +114,11 @@ void CharacterInfo::WriteBaseFields(Stream *out) const
     out->WriteInt16(acty);
 }
 
-void CharacterInfo::ReadFromFile(Stream *in, GameDataVersion data_ver)
+void CharacterInfo::ReadFromFile(Stream *in, CharacterInfo2 &chinfo2, GameDataVersion data_ver)
 {
     ReadBaseFields(in);
-    StrUtil::ReadCStrCount(legacy_name, in, LEGACY_MAX_CHAR_NAME_LEN);
-    StrUtil::ReadCStrCount(legacy_scrname, in, LEGACY_MAX_SCRIPT_NAME_LEN);
+    StrUtil::ReadCStrCount(name, in, LEGACY_MAX_CHAR_NAME_LEN);
+    StrUtil::ReadCStrCount(scrname, in, LEGACY_MAX_SCRIPT_NAME_LEN);
     on = in->ReadInt8();
     in->ReadInt8(); // alignment padding to int32
 
@@ -128,32 +128,32 @@ void CharacterInfo::ReadFromFile(Stream *in, GameDataVersion data_ver)
     {
         idle_anim_speed = animspeed + 5;
     }
-    // Assign names from legacy fields
-    name = legacy_name;
-    scrname = legacy_scrname;
+    // Assign unrestricted names from legacy fields
+    chinfo2.name_new = name;
+    chinfo2.scrname_new = scrname;
 }
 
 void CharacterInfo::WriteToFile(Stream *out) const
 {
     WriteBaseFields(out);
-    out->Write(legacy_name, LEGACY_MAX_CHAR_NAME_LEN);
-    out->Write(legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
+    out->Write(name, LEGACY_MAX_CHAR_NAME_LEN);
+    out->Write(scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
     out->WriteInt8(on);
     out->WriteInt8(0); // alignment padding to int32
 }
 
-void CharacterInfo::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
+void CharacterInfo::ReadFromSavegame(Stream *in, CharacterInfo2 &chinfo2, CharacterSvgVersion save_ver)
 {
     ReadBaseFields(in);
     if (save_ver < kCharSvgVersion_36115)
     { // Fixed-size name and scriptname
-        name.ReadCount(in, LEGACY_MAX_CHAR_NAME_LEN);
+        chinfo2.name_new.ReadCount(in, LEGACY_MAX_CHAR_NAME_LEN);
         in->Seek(LEGACY_MAX_SCRIPT_NAME_LEN); // skip legacy scriptname
                                               // (don't overwrite static data from save!)
     }
     else
     {
-        name = StrUtil::ReadString(in);
+        chinfo2.name_new = StrUtil::ReadString(in);
     }
     on = in->ReadInt8();
 
@@ -164,13 +164,13 @@ void CharacterInfo::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
         idle_anim_speed = animspeed + 5;
     }
     // Fill legacy name fields, for compatibility with old scripts and plugins
-    snprintf(legacy_name, LEGACY_MAX_CHAR_NAME_LEN, "%s", name.GetCStr());
+    snprintf(name, LEGACY_MAX_CHAR_NAME_LEN, "%s", chinfo2.name_new.GetCStr());
 }
 
-void CharacterInfo::WriteToSavegame(Stream *out) const
+void CharacterInfo::WriteToSavegame(Stream *out, const CharacterInfo2 &chinfo2) const
 {
     WriteBaseFields(out);
-    StrUtil::WriteString(name, out); // kCharSvgVersion_36115
+    StrUtil::WriteString(chinfo2.name_new, out); // kCharSvgVersion_36115
     out->WriteInt8(on);
 }
 

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -77,14 +77,33 @@ inline int CharFlagsToObjFlags(int chflags)
 }
 
 
-// CharacterInfoBase contains original set of character fields.
-// It's picked out from CharacterInfo for convenience of adding
-// new design-time fields; easier to maintain backwards compatibility.
+enum CharacterSvgVersion
+{
+    kCharSvgVersion_Initial = 0, // [UNSUPPORTED] from 3.5.0 pre-alpha
+    kCharSvgVersion_350     = 1, // new movelist format (along with pathfinder)
+    kCharSvgVersion_36025   = 2, // animation volume
+    kCharSvgVersion_36109   = 3, // removed movelists, save externally
+    kCharSvgVersion_36115   = 4, // no limit on character name's length
+};
+
+
+// Predeclare a design-time Character extension
+struct CharacterInfo2;
+// Predeclare a runtime Character extension (TODO: refactor and remove this from here)
+struct CharacterExtras;
+
+
+// CharacterInfo is a design-time Character data.
+// Contains original set of character fields.
 // IMPORTANT: exposed to script API, and plugin API as AGSCharacter!
-// For older script compatibility the struct also has to maintain its size;
-// do not extend or change existing fields, unless planning breaking compatibility.
-// Prefer to use CharacterInfo or CharacterExtras struct for any extensions.
-struct CharacterInfoBase
+// For older script compatibility the struct also has to maintain its size,
+// and be stored in a plain array to keep the relative memory address offsets
+// between the Character objects!
+// Do not add or change existing fields, unless planning breaking compatibility.
+// Prefer to use CharacterInfo2 and CharacterExtras structs for any extensions.
+//
+// TODO: must refactor, some parts of it should be in a runtime Character class.
+struct CharacterInfo
 {
     int   defview;
     int   talkview;
@@ -120,29 +139,9 @@ struct CharacterInfoBase
     short actx, acty;
     // These two name fields are deprecated, but must stay here
     // for compatibility with old scripts and plugin API
-    char  legacy_name[LEGACY_MAX_CHAR_NAME_LEN];
-    char  legacy_scrname[LEGACY_MAX_SCRIPT_NAME_LEN];
+    char  name[LEGACY_MAX_CHAR_NAME_LEN];
+    char  scrname[LEGACY_MAX_SCRIPT_NAME_LEN];
     char  on;
-};
-
-
-enum CharacterSvgVersion
-{
-    kCharSvgVersion_Initial = 0, // [UNSUPPORTED] from 3.5.0 pre-alpha
-    kCharSvgVersion_350     = 1, // new movelist format (along with pathfinder)
-    kCharSvgVersion_36025   = 2, // animation volume
-    kCharSvgVersion_36109   = 3, // removed movelists, save externally
-    kCharSvgVersion_36115   = 4, // no limit on character name's length
-};
-
-struct CharacterExtras;
-
-// Design-time Character data.
-// TODO: must refactor, some parts of it should be in a runtime Character class.
-struct CharacterInfo : public CharacterInfoBase
-{
-    AGS::Common::String scrname;
-    AGS::Common::String name;
 
     int get_baseline() const;        // return baseline, or Y if not set
     int get_blocking_top() const;    // return Y - BlockingHeight/2
@@ -178,17 +177,26 @@ struct CharacterInfo : public CharacterInfoBase
 	void update_character_idle(CharacterExtras *chex, int &doing_nothing);
 	void update_character_follower(int &char_index, std::vector<int> &followingAsSheep, int &doing_nothing);
 
-    void ReadFromFile(Common::Stream *in, GameDataVersion data_ver);
+    void ReadFromFile(Common::Stream *in, CharacterInfo2 &chinfo2, GameDataVersion data_ver);
     void WriteToFile(Common::Stream *out) const;
     // TODO: move to runtime-only class (?)
-    void ReadFromSavegame(Common::Stream *in, CharacterSvgVersion save_ver);
-    void WriteToSavegame(Common::Stream *out) const;
+    void ReadFromSavegame(Common::Stream *in, CharacterInfo2 &chinfo2, CharacterSvgVersion save_ver);
+    void WriteToSavegame(Common::Stream *out, const CharacterInfo2 &chinfo2) const;
 
 private:
     // Helper functions that read and write first data fields,
     // common for both game file and save.
     void ReadBaseFields(Common::Stream *in);
     void WriteBaseFields(Common::Stream *out) const;
+};
+
+
+// Design-time Character extended fields
+struct CharacterInfo2
+{
+    // Unrestricted scriptname and name fields
+    AGS::Common::String scrname_new;
+    AGS::Common::String name_new;
 };
 
 

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -217,6 +217,7 @@ void GameSetupStruct::WriteMouseCursors(Stream *out)
 void GameSetupStruct::read_characters(Common::Stream *in)
 {
     chars.resize(numcharacters);
+    chars2.resize(numcharacters);
     ReadCharacters(in);
 }
 
@@ -258,7 +259,7 @@ void GameSetupStruct::ReadCharacters(Stream *in)
 {
     for (int i = 0; i < numcharacters; ++i)
     {
-        chars[i].ReadFromFile(in, loaded_game_file_version);
+        chars[i].ReadFromFile(in, chars2[i], loaded_game_file_version);
     }
 }
 

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -66,6 +66,7 @@ struct GameSetupStructBase
     Common::String    messages[MAXGLOBALMES];
     std::unique_ptr<WordsDictionary> dict;
     std::vector<CharacterInfo> chars;
+    std::vector<CharacterInfo2> chars2; // extended character fields
 
     GameSetupStructBase();
     GameSetupStructBase(GameSetupStructBase &&gss) = default;

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -598,20 +598,21 @@ void ScanOldStyleAudio(AssetManager *asset_mgr, GameSetupStruct &game, std::vect
 void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
 {
     auto &chars = game.chars;
+    auto &chars2 = game.chars2;
     const int numcharacters = game.numcharacters;
 
-    // Fixup charakter script names for 2.x (EGO -> cEgo)
+    // Fixup character script names for 2.x (EGO -> cEgo)
     if (data_ver <= kGameVersion_272)
     {
         char namelwr[LEGACY_MAX_SCRIPT_NAME_LEN];
         for (int i = 0; i < numcharacters; i++)
         {
-            if (chars[i].legacy_scrname[0] == 0)
+            if (chars[i].scrname[0] == 0)
                 continue;
-            memcpy(namelwr, chars[i].legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
+            memcpy(namelwr, chars[i].scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
             ags_strlwr(namelwr + 1); // lowercase starting with the second char
-            snprintf(chars[i].legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "c%s", namelwr);
-            chars[i].scrname = chars[i].legacy_scrname;
+            snprintf(chars[i].scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "c%s", namelwr);
+            chars2[i].scrname_new = chars[i].scrname;
         }
     }
 
@@ -815,13 +816,15 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
         size_t num_chars = _in->ReadInt32();
         if (num_chars != _ents.Game.chars.size())
             return new Error(String::FromFormat("Mismatching number of characters: read %zu expected %zu", num_chars, _ents.Game.chars.size()));
-        for (CharacterInfo &chinfo : _ents.Game.chars)
+        for (int i = 0; i < _ents.Game.numcharacters; ++i)
         {
-            chinfo.scrname = StrUtil::ReadString(_in);
-            chinfo.name = StrUtil::ReadString(_in);
+            auto &chinfo = _ents.Game.chars[i];
+            auto &chinfo2 = _ents.Game.chars2[i];
+            chinfo2.scrname_new = StrUtil::ReadString(_in);
+            chinfo2.name_new = StrUtil::ReadString(_in);
             // assign to the legacy fields for compatibility with old plugins
-            snprintf(chinfo.legacy_scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "%s", chinfo.scrname.GetCStr());
-            snprintf(chinfo.legacy_name, LEGACY_MAX_CHAR_NAME_LEN, "%s", chinfo.name.GetCStr());
+            snprintf(chinfo.scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "%s", chinfo2.scrname_new.GetCStr());
+            snprintf(chinfo.name, LEGACY_MAX_CHAR_NAME_LEN, "%s", chinfo2.name_new.GetCStr());
         }
         size_t num_invitems = _in->ReadInt32();
         if (num_invitems != _ents.Game.numinvitems)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3208,8 +3208,8 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 		character->MovementSpeedX = thisgame.chars[i].walkspeed;
 		character->MovementSpeedY = thisgame.chars[i].walkspeed_y;
 		character->NormalView = thisgame.chars[i].defview + 1;
-		character->RealName = gcnew String(thisgame.chars[i].name.GetCStr());
-		character->ScriptName = gcnew String(thisgame.chars[i].scrname.GetCStr());
+		character->RealName = gcnew String(thisgame.chars2[i].name_new.GetCStr());
+		character->ScriptName = gcnew String(thisgame.chars2[i].scrname_new.GetCStr());
 		character->Solid = !(thisgame.chars[i].flags & CHF_NOBLOCKING);
 		character->SpeechColor = thisgame.chars[i].talkcolor;
 		character->SpeechView = (thisgame.chars[i].talkview < 1) ? 0 : (thisgame.chars[i].talkview + 1);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -259,7 +259,7 @@ void Character_ChangeRoomSetLoop(CharacterInfo *chaa, int room, int x, int y, in
         chaa->room = room;
 
 		debug_script_log("%s moved to room %d, location %d,%d, loop %d",
-			chaa->scrname.GetCStr(), room, chaa->x, chaa->y, chaa->loop);
+			chaa->scrname, room, chaa->x, chaa->y, chaa->loop);
 
         return;
     }
@@ -296,7 +296,7 @@ void Character_ChangeView(CharacterInfo *chap, int vii) {
       chap->idleleft = chap->idletime;
     }
 
-    debug_script_log("%s: Change view to %d", chap->scrname.GetCStr(), vii+1);
+    debug_script_log("%s: Change view to %d", chap->scrname, vii+1);
     chap->defview = vii;
     chap->view = vii;
     stop_character_anim(chap);
@@ -417,7 +417,7 @@ void FaceDirectionalLoop(CharacterInfo *char1, int direction, int blockingStyle)
 
 void FaceLocationXY(CharacterInfo *char1, int xx, int yy, int blockingStyle)
 {
-    debug_script_log("%s: Face location %d,%d", char1->scrname.GetCStr(), xx, yy);
+    debug_script_log("%s: Face location %d,%d", char1->scrname, xx, yy);
 
     const int diffrx = xx - char1->x;
     const int diffry = yy - char1->y;
@@ -481,10 +481,10 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
         quit("!FollowCharacterEx: you cannot tell the player character to follow a character in another room");
 
     if (tofollow != nullptr) {
-        debug_script_log("%s: Start following %s (dist %d, eager %d)", chaa->scrname.GetCStr(), tofollow->scrname.GetCStr(), distaway, eagerness);
+        debug_script_log("%s: Start following %s (dist %d, eager %d)", chaa->scrname, tofollow->scrname, distaway, eagerness);
     }
     else {
-        debug_script_log("%s: Stop following other character", chaa->scrname.GetCStr());
+        debug_script_log("%s: Stop following other character", chaa->scrname);
     }
 
     if ((chaa->following >= 0) &&
@@ -602,7 +602,7 @@ void Character_LockViewEx(CharacterInfo *chap, int vii, int stopMoving) {
     vii--; // convert to 0-based
     AssertView("SetCharacterView", vii);
 
-    debug_script_log("%s: View locked to %d", chap->scrname.GetCStr(), vii+1);
+    debug_script_log("%s: View locked to %d", chap->scrname, vii+1);
     if (chap->idleleft < 0) {
         Character_UnlockView(chap);
         chap->idleleft = chap->idletime;
@@ -733,7 +733,7 @@ void Character_PlaceOnWalkableArea(CharacterInfo *chap)
 void Character_RemoveTint(CharacterInfo *chaa) {
 
     if (chaa->flags & (CHF_HASTINT | CHF_HASLIGHT)) {
-        debug_script_log("Un-tint %s", chaa->scrname.GetCStr());
+        debug_script_log("Un-tint %s", chaa->scrname);
         chaa->flags &= ~(CHF_HASTINT | CHF_HASLIGHT);
     }
     else {
@@ -783,7 +783,7 @@ void Character_SetAsPlayer(CharacterInfo *chaa) {
 
     //update_invorder();
 
-    debug_script_log("%s is new player character", playerchar->scrname.GetCStr());
+    debug_script_log("%s is new player character", playerchar->scrname);
 
     // Within game_start, return now
     if (displayed_room < 0)
@@ -835,10 +835,10 @@ void Character_SetIdleView(CharacterInfo *chaa, int iview, int itime) {
         chaa->wait = 0;
 
     if (iview >= 1) {
-        debug_script_log("Set %s idle view to %d (time %d)", chaa->scrname.GetCStr(), iview, itime);
+        debug_script_log("Set %s idle view to %d (time %d)", chaa->scrname, iview, itime);
     }
     else {
-        debug_script_log("%s idle view disabled", chaa->scrname.GetCStr());
+        debug_script_log("%s idle view disabled", chaa->scrname);
     }
     if (chaa->flags & CHF_FIXVIEW) {
         debug_script_warn("SetCharacterIdle called while character view locked with SetCharacterView; idle ignored");
@@ -956,7 +956,7 @@ void Character_StopMoving(CharacterInfo *charp) {
         if ((mls[charp->walking].direct == 0) && (charp->room == displayed_room))
             Character_PlaceOnWalkableArea(charp);
 
-        debug_script_log("%s: stop moving", charp->scrname.GetCStr());
+        debug_script_log("%s: stop moving", charp->scrname);
 
         charp->idleleft = charp->idletime;
         // restart the idle animation straight away
@@ -977,7 +977,7 @@ void Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opaci
         (luminance < 0) || (luminance > 100))
         quit("!Character.Tint: invalid parameter. R,G,B must be 0-255, opacity & luminance 0-100");
 
-    debug_script_log("Set %s tint RGB(%d,%d,%d) %d%%", chaa->scrname.GetCStr(), red, green, blue, opacity);
+    debug_script_log("Set %s tint RGB(%d,%d,%d) %d%%", chaa->scrname, red, green, blue, opacity);
 
     charextra[chaa->index_id].tint_r = red;
     charextra[chaa->index_id].tint_g = green;
@@ -998,7 +998,7 @@ void Character_UnlockView(CharacterInfo *chaa) {
 
 void Character_UnlockViewEx(CharacterInfo *chaa, int stopMoving) {
     if (chaa->flags & CHF_FIXVIEW) {
-        debug_script_log("%s: Released view back to default", chaa->scrname.GetCStr());
+        debug_script_log("%s: Released view back to default", chaa->scrname);
     }
     chaa->flags &= ~CHF_FIXVIEW;
     chaa->view = chaa->defview;
@@ -1275,7 +1275,7 @@ int Character_GetID(CharacterInfo *chaa) {
 
 const char *Character_GetScriptName(CharacterInfo *chin)
 {
-    return CreateNewScriptString(chin->scrname.GetCStr());
+    return CreateNewScriptString(game.chars2[chin->index_id].scrname_new);
 }
 
 int Character_GetFrame(CharacterInfo *chaa) {
@@ -1423,13 +1423,13 @@ int Character_GetDestinationY(CharacterInfo *chaa) {
 }
 
 const char* Character_GetName(CharacterInfo *chaa) {
-    return CreateNewScriptString(chaa->name.GetCStr());
+    return CreateNewScriptString(game.chars2[chaa->index_id].name_new.GetCStr());
 }
 
 void Character_SetName(CharacterInfo *chaa, const char *newName) {
-    chaa->name = newName;
+    game.chars2[chaa->index_id].name_new = newName;
     // Fill legacy name fields, for compatibility with old scripts and plugins
-    snprintf(chaa->legacy_name, LEGACY_MAX_CHAR_NAME_LEN, "%s", newName);
+    snprintf(chaa->name, LEGACY_MAX_CHAR_NAME_LEN, "%s", newName);
     GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
@@ -1704,7 +1704,7 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
 
     if ((tox == charX) && (toy == charY)) {
         StopMoving(chac);
-        debug_script_log("%s already at destination, not moving", chin->scrname.GetCStr());
+        debug_script_log("%s already at destination, not moving", chin->scrname);
         return;
     }
 
@@ -1736,14 +1736,14 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
     chin->frame = oldframe;
     // use toxPassedIn cached variable so the hi-res co-ordinates
     // are still displayed as such
-    debug_script_log("%s: Start move to %d,%d", chin->scrname.GetCStr(), toxPassedIn, toyPassedIn);
+    debug_script_log("%s: Start move to %d,%d", chin->scrname, toxPassedIn, toyPassedIn);
 
     const int move_speed_x = chin->walkspeed;
     const int move_speed_y =
         ((chin->walkspeed_y == UNIFORM_WALK_SPEED) ? chin->walkspeed : chin->walkspeed_y);
 
     if ((move_speed_x == 0) && (move_speed_y == 0)) {
-        debug_script_warn("Warning: MoveCharacter called for '%s' with walk speed 0", chin->scrname.GetCStr());
+        debug_script_warn("Warning: MoveCharacter called for '%s' with walk speed 0", chin->scrname);
     }
 
     set_route_move_speed(move_speed_x, move_speed_y);
@@ -1946,7 +1946,7 @@ int doNextCharMoveStep (CharacterInfo *chi, int &char_index, CharacterExtras *ch
             chi->y = ywas;
         }
         debug_script_log("%s: Bumped into %s, waiting for them to move",
-            chi->scrname.GetCStr(), game.chars[ntf].scrname.GetCStr());
+            chi->scrname, game.chars[ntf].scrname);
         return 1;
     }
     return 0;
@@ -2175,12 +2175,12 @@ void animate_character(CharacterInfo *chap, int loopn, int sppd, int rept,
     {
         quitprintf("!AnimateCharacter: invalid view and/or loop\n"
             "(trying to animate '%s' using view %d (range is 1..%d) and loop %d (view has %d loops)).",
-            chap->scrname.GetCStr(), chap->view + 1, game.numviews, loopn, views[chap->view].numLoops);
+            chap->scrname, chap->view + 1, game.numviews, loopn, views[chap->view].numLoops);
     }
     // NOTE: there's always frame 0 allocated for safety
     sframe = std::max(0, std::min(sframe, views[chap->view].loops[loopn].numFrames - 1));
     debug_script_log("%s: Start anim view %d loop %d, spd %d, repeat %d, frame: %d",
-        chap->scrname.GetCStr(), chap->view+1, loopn, sppd, rept, sframe);
+        chap->scrname, chap->view+1, loopn, sppd, rept, sframe);
 
     Character_StopMoving(chap);
 
@@ -2242,12 +2242,12 @@ void update_character_scale(int charid)
     if (chin.view < 0)
     {
         quitprintf("!The character '%s' was turned on in the current room (room %d) but has not been assigned a view number.",
-            chin.scrname.GetCStr(), displayed_room);
+            chin.scrname, displayed_room);
     }
     if (chin.loop >= views[chin.view].numLoops)
     {
         quitprintf("!The character '%s' could not be displayed because there was no loop %d of view %d.",
-            chin.scrname.GetCStr(), chin.loop, chin.view + 1);
+            chin.scrname, chin.loop, chin.view + 1);
     }
     // If frame is too high -- fallback to the frame 0;
     // there's always at least 1 dummy frame at index 0
@@ -2566,12 +2566,12 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
         if ((speakingChar->view < 0) || views[speakingChar->view].numLoops == 0)
             quitprintf("!Character %s current view %d is invalid, or has no loops.",
-                speakingChar->scrname.GetCStr(), speakingChar->view + 1);
+                speakingChar->scrname, speakingChar->view + 1);
         // If current view is missing a loop - use loop 0
         if (speakingChar->loop >= views[speakingChar->view].numLoops)
         {
             debug_script_warn("WARNING: Character %s current view %d does not have necessary loop %d; switching to loop 0.",
-                speakingChar->scrname.GetCStr(), speakingChar->view + 1, speakingChar->loop);
+                speakingChar->scrname, speakingChar->view + 1, speakingChar->loop);
             speakingChar->loop = 0;
         }
 
@@ -2827,12 +2827,12 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
             if ((speakingChar->view < 0) || views[speakingChar->view].numLoops == 0)
                 quitprintf("!Character %s speech view %d is invalid, or has no loops.",
-                    speakingChar->scrname.GetCStr(), speakingChar->view + 1);
+                    speakingChar->scrname, speakingChar->view + 1);
             // If speech view is missing a loop - use loop 0
             if (speakingChar->loop >= views[speakingChar->view].numLoops)
             {
                 debug_script_warn("WARNING: Character %s speech view %d does not have necessary loop %d; switching to loop 0.",
-                    speakingChar->scrname.GetCStr(), speakingChar->view + 1, speakingChar->loop);
+                    speakingChar->scrname, speakingChar->view + 1, speakingChar->loop);
                 speakingChar->loop = 0;
             }
 

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -82,7 +82,7 @@ void CharacterInfo::UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, st
         if (loop == views[view].numLoops) // view has no frames?!
         { // amazingly enough there are old games that allow this to happen...
             if (loaded_game_file_version >= kGameVersion_300)
-                quitprintf("!Character %s is assigned view %d that has no frames!", scrname.GetCStr(), view);
+                quitprintf("!Character %s is assigned view %d that has no frames!", scrname, view);
             loop = 0;
         }
     }
@@ -211,7 +211,7 @@ void CharacterInfo::update_character_moving(int &char_index, CharacterExtras *ch
 
       if (loop >= views[view].numLoops)
         quitprintf("Unable to render character %d (%s) because loop %d does not exist in view %d",
-            index_id, scrname.GetCStr(), loop, view + 1);
+            index_id, scrname, loop, view + 1);
 
       // check don't overflow loop
       int framesInLoop = views[view].loops[loop].numFrames;
@@ -224,7 +224,7 @@ void CharacterInfo::update_character_moving(int &char_index, CharacterExtras *ch
 
         if (framesInLoop < 1)
           quitprintf("Unable to render character %d (%s) because there are no frames in loop %d",
-              index_id, scrname.GetCStr(), loop);
+              index_id, scrname, loop);
       }
 
       doing_nothing = 0; // still walking?
@@ -451,7 +451,7 @@ void CharacterInfo::update_character_idle(CharacterExtras *chex, int &doing_noth
       idleleft--;
       if (idleleft == -1) {
         int useloop=loop;
-        debug_script_log("%s: Now idle (view %d)", scrname.GetCStr(), idleview+1);
+        debug_script_log("%s: Now idle (view %d)", scrname, idleview+1);
 		Character_LockView(this, idleview+1);
         // SetCharView resets it to 0
         idleleft = -2;

--- a/Engine/ac/dynobj/cc_staticarray.h
+++ b/Engine/ac/dynobj/cc_staticarray.h
@@ -17,6 +17,22 @@
 // real element size in the engine's memory.
 // The purpose of this is to remove size restriction from the engine's structs
 // exposed to scripts.
+//
+// FIXME: [ivan-mogilko] the above was meant to work, but in reality it doesn't
+// and won't, at least not without some extra workarounds.
+// The problem that I missed here is following:
+//   when the script compiler is told to get an Nth element of a global struct
+//   array, such as character[n], it calculates the memory address as
+//   array address + sizeof(Character) * n.
+//   If this address is used for the read/write operations, these ops can be
+//   intercepted by interpreter and remapped into the real fields
+//      (see IScriptObject::ReadN, WriteN interface)
+//   But if this address is used IN POINTER COMPARISON, then we cannot do
+//   anything. And if our real struct in the engine is stored on a different
+//   relative memory offset than one expected by compiler, then this pointer
+//   comparison will fail, e.g. script expression like
+//      if (player == character[n])
+//
 // NOTE: on the other hand, similar effect could be achieved by separating
 // object data into two or more structs, where "base" structs are stored in
 // the exposed arrays (part of API), while extending structs are stored

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -460,10 +460,10 @@ String get_cue_filename(int charid, int sndid)
     if (charid >= 0)
     {
         // append the first 4 characters of the script name to the filename
-        if (game.chars[charid].scrname[0] == 'c')
-            script_name.SetString(game.chars[charid].scrname.GetCStr() + 1, 4);
+        if (game.chars2[charid].scrname_new[0] == 'c')
+            script_name.SetString(game.chars2[charid].scrname_new.GetCStr() + 1, 4);
         else
-            script_name.SetString(game.chars[charid].scrname.GetCStr(), 4);
+            script_name.SetString(game.chars2[charid].scrname_new.GetCStr(), 4);
     }
     else
     {

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -111,7 +111,7 @@ int GetCharacterWidth(int ww) {
             (char1->frame >= views[char1->view].loops[char1->loop].numFrames))
         {
             debug_script_warn("GetCharacterWidth: Character %s has invalid frame: view %d, loop %d, frame %d",
-                char1->scrname.GetCStr(), char1->view + 1, char1->loop, char1->frame);
+                char1->scrname, char1->view + 1, char1->loop, char1->frame);
             return data_to_game_coord(4);
         }
 
@@ -131,7 +131,7 @@ int GetCharacterHeight(int charid) {
             (char1->frame >= views[char1->view].loops[char1->loop].numFrames))
         {
             debug_script_warn("GetCharacterHeight: Character %s has invalid frame: view %d, loop %d, frame %d",
-                char1->scrname.GetCStr(), char1->view + 1, char1->loop, char1->frame);
+                char1->scrname, char1->view + 1, char1->loop, char1->frame);
             return data_to_game_coord(2);
         }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -646,7 +646,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
     // on character
     if (loctype == LOCTYPE_CHAR) {
         onhs = getloctype_index;
-        snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.chars[onhs].name.GetCStr()));
+        snprintf(tempo, MAX_MAXSTRLEN, "%s", get_translation(game.chars2[onhs].name_new.GetCStr()));
         if (play.get_loc_name_last_time != 2000+onhs)
             GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
         play.get_loc_name_last_time = 2000+onhs;

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -324,7 +324,7 @@ size_t check_scstrcapacity(const char *ptr)
     const void *charstart = &game.chars[0];
     const void *charend = &game.chars[0] + game.chars.size();
     if ((ptr >= charstart) && (ptr <= charend))
-        return sizeof(CharacterInfo::legacy_name);
+        return sizeof(CharacterInfo::name);
     return MAX_MAXSTRLEN;
 }
 
@@ -337,7 +337,7 @@ void commit_scstr_update(const char *ptr)
     if ((ptr >= charstart) && (ptr <= charend))
     {
         size_t char_index = ((uintptr_t)ptr - (uintptr_t)charstart) / sizeof(CharacterInfo);
-        game.chars[char_index].name = game.chars[char_index].legacy_name;
+        game.chars2[char_index].name_new = game.chars[char_index].name;
     }
 }
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -161,7 +161,7 @@ void InitAndRegisterCharacters(GameSetupStruct &game)
         ccRegisterManagedObject(&game.chars[i], &ccDynamicCharacter);
 
         // export the character's script object
-        ccAddExternalScriptObject(game.chars[i].scrname, &game.chars[i], &ccDynamicCharacter);
+        ccAddExternalScriptObject(game.chars2[i].scrname_new, &game.chars[i], &ccDynamicCharacter);
     }
 }
 
@@ -263,7 +263,7 @@ void InitAndRegisterRegions()
 // Registers static entity arrays in the script system
 void RegisterStaticArrays(GameSetupStruct &game)
 {
-    StaticCharacterArray.Create(&ccDynamicCharacter, sizeof(CharacterInfoBase), sizeof(CharacterInfo));
+    StaticCharacterArray.Create(&ccDynamicCharacter, sizeof(CharacterInfo), sizeof(CharacterInfo));
     StaticObjectArray.Create(&ccDynamicObject, sizeof(ScriptObject), sizeof(ScriptObject));
     StaticGUIArray.Create(&ccDynamicGUI, sizeof(ScriptGUI), sizeof(ScriptGUI));
     StaticHotspotArray.Create(&ccDynamicHotspot, sizeof(ScriptHotspot), sizeof(ScriptHotspot));

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -544,7 +544,7 @@ HSaveError WriteCharacters(Stream *out)
     out->WriteInt32(game.numcharacters);
     for (int i = 0; i < game.numcharacters; ++i)
     {
-        game.chars[i].WriteToSavegame(out);
+        game.chars[i].WriteToSavegame(out, game.chars2[i]);
         charextra[i].WriteToSavegame(out);
         Properties::WriteValues(play.charProps[i], out);
         if (loaded_game_file_version <= kGameVersion_272)
@@ -560,7 +560,7 @@ HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Pr
         return err;
     for (int i = 0; i < game.numcharacters; ++i)
     {
-        game.chars[i].ReadFromSavegame(in, static_cast<CharacterSvgVersion>(cmp_ver));
+        game.chars[i].ReadFromSavegame(in, game.chars2[i], static_cast<CharacterSvgVersion>(cmp_ver));
         charextra[i].ReadFromSavegame(in, static_cast<CharacterSvgVersion>(cmp_ver));
         Properties::ReadValues(play.charProps[i], in);
         if (loaded_game_file_version <= kGameVersion_272)

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -443,7 +443,7 @@ bool run_service_key_controls(KeyInput &out_key)
             chd = ff;
             sprintf(&bigbuffer[strlen(bigbuffer)],
                 "%s (view/loop/frm:%d,%d,%d  x/y/z:%d,%d,%d  idleview:%d,time:%d,left:%d walk:%d anim:%d follow:%d flags:%X wait:%d zoom:%d)[",
-                game.chars[chd].legacy_scrname, game.chars[chd].view + 1, game.chars[chd].loop, game.chars[chd].frame,
+                game.chars[chd].scrname, game.chars[chd].view + 1, game.chars[chd].loop, game.chars[chd].frame,
                 game.chars[chd].x, game.chars[chd].y, game.chars[chd].z,
                 game.chars[chd].idleview, game.chars[chd].idletime, game.chars[chd].idleleft,
                 game.chars[chd].walking, game.chars[chd].animating, game.chars[chd].following,


### PR DESCRIPTION
Fix #2296

This fixes a mistake introduced in commit 4be1556, which in turn followed b02814b8bb3bb7a2cd00110466e2bd3047e772d1

The problem is, that CCStaticArray does not work as intended, and seems won't (at least not without some extra workarounds).

When the script compiler is told to get an Nth element of a global struct array, such as character[n], it calculates the memory address as

    Character* ptr = (array address + sizeof(Character) * n).

If this address is used for the read/write operations, these ops can be intercepted by interpreter and remapped into the real fields (see IScriptObject::ReadN, WriteN interface). But if this address is used IN POINTER COMPARISON BY VALUE, then we cannot do anything. And if our real struct in the engine is stored on a different relative memory offset than one expected by compiler, then this pointer comparison will fail. This breaks script expressions like e.g.:

      if (player == character[n])

---

This PR moves two new "unrestricted" name and scriptname fields out of CharacterInfo and into a new small CharacterInfo2 struct. These structs are stored alongside with CharacterInfo array in GameSetupStruct.

One thing, I left original fixed-length CharacterInfo::scriptname used in engine warnings (logging and error messages), because replacing all those with access to new struct would be too annoying of a change. I'd rather leave this be for now, and look for a better way later.

I do believe that there *might* be a more elegant solution to this issue, but I'd like to keep this as a hotfix for now, and do not want to do much experiment patching upcoming 3.6.1 release.

NOTE: only data organization in memory has changed, file data formats should not be affected (neither game files, nor saves).