### PR TITLE
Add a script for updating SDL_Sound revision in readmes and cmake files

### DIFF
--- a/CMake/FetchSDL_Sound.cmake
+++ b/CMake/FetchSDL_Sound.cmake
@@ -2,7 +2,7 @@ FetchContent_Declare(
     sdlsound_content
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     URL https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.tar.gz
-    URL_HASH MD5=d1037daa0e444efa8a09defaa1a6321f
+    URL_HASH SHA1=2e9ab24fd861f61349b9386fd66c9851e9f03a60
 )
 
 FetchContent_GetProperties(sdlsound_content)

--- a/OSX/README.md
+++ b/OSX/README.md
@@ -78,7 +78,7 @@ The Xcode project depends on the prebuilt SDL2 Framework and library sources.
 
 The project also requires sources of library dependencies, either using the `libsrc/download.sh` script or manually downloading them and extracting them as below.
 
-- Download [SDL_sound](https://github.com/icculus/SDL_sound/archive/1507be95c3605e4fd6a48ea4c527e4aa711a1566.zip) source code and place it in `ags/libsrc/SDL_sound`
+- Download [SDL_sound](https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.zip) source code and place it in `ags/libsrc/SDL_sound`
 - Download xiph [theora](https://github.com/xiph/theora/archive/7180717276af1ebc7da15c83162d6c5d6203aabf.tar.gz) source code, and place it in `ags/libsrc/theora`
 - Download xiph [ogg](https://github.com/xiph/ogg/archive/refs/tags/v1.3.5.tar.gz) source code, and place in `ags/libsrc/ogg`
 - Download xiph [vorbis](https://github.com/xiph/vorbis/archive/84c023699cdf023a32fa4ded32019f194afcdad0.tar.gz) source code, and place in `ags/libsrc/vorbis`
@@ -104,7 +104,7 @@ Make sure you have at least SDL 2.24.1 installed, if you have problems updating 
 
 The SDL_sound available in brew is not really well updated and it's a bit different from what's in the repository, using a different timidity and libmodplug. It's best to build it and install it from source. You will need CMake for this.
 
-    SDL2_SOUND_VERSION=8d96d4cc0e1df35835a222ee51a7c32f273ec63e
+    SDL2_SOUND_VERSION=c5639414c1bb24fb4eef5861c13adb42a4aab950
     cd /tmp
     curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz
     tar -xvzf SDL_sound.tar.gz

--- a/Script/push_sdlsound.py
+++ b/Script/push_sdlsound.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+import codecs
+import json
+import os
+import re
+import sys
+from collections import namedtuple
+
+SDLSoundVersion = namedtuple('SDLSoundVersion', ['revision', 'url_hash'])
+
+def load_version(path):
+    with open(path, "r") as f:
+        j = json.load(f)
+
+    sdlsound_data = j['sdlsound'];
+    revision = sdlsound_data['revision']
+    url_hash = sdlsound_data['urlHash']
+    return SDLSoundVersion(revision, url_hash)
+
+def read_file(path, encoding):
+    print(path, encoding)
+
+    with codecs.open(path, "r", encoding=encoding) as f:
+        try:
+            return f.read()
+        except UnicodeDecodeError:
+            return None
+        except:
+            raise
+
+def write_file(path, encoding, data):
+    with codecs.open(path, "w", encoding=encoding) as f:
+        f.write(data)
+
+def replace_group(match, group, data, replacement):
+    return data[:match.start(group)] + replacement + data[match.end(group):]
+    
+def replace_in_file(file_path, encoding, version):
+    data = read_file(file_path, encoding)
+    if data is None:
+        print('\t\t- READ FAILED')
+        return
+
+    m = re.search(r'https://github.com/icculus/SDL_sound/archive/(\w+).tar.gz', data)
+    if m is not None:
+        data = replace_group(m, 1, data, version.revision)
+
+    m = re.search(r'https://github.com/icculus/SDL_sound/archive/(\w+).zip', data)
+    if m is not None:
+        data = replace_group(m, 1, data, version.revision)
+
+    m = re.search(r'SDL2_SOUND_VERSION=(\w+)', data)
+    if m is not None:
+        data = replace_group(m, 1, data, version.revision)
+
+    # must lookup for a double line section here, avoid changing any random MD5 string
+    m = re.search(r'URL https://github.com/icculus/SDL_sound/\S*.tar.gz\s+URL_HASH MD5=(\w*)', data)
+    if m is not None:
+        data = replace_group(m, 1, data, version.url_hash)
+
+    write_file(file_path, encoding, data)
+    print('\t\t- PROCESSED')
+
+def main():
+
+    # load key/value data, we will use it as a replacement reference
+    version = load_version("../version.json")
+    
+    # -----------------------------------------------------------------------------
+    # Do the replacement in all the code dirs, where applicable
+    replace_in_file("../CMake/FetchSDL_Sound.cmake", "utf-8", version)
+    replace_in_file("../debian/README.md", "utf-8", version)
+    replace_in_file("../OSX/README.md", "utf-8", version)
+    replace_in_file("../Windows/README.md", "utf-8", version)
+
+
+if __name__ == "__main__":
+    main()

--- a/Script/push_sdlsound.py
+++ b/Script/push_sdlsound.py
@@ -54,13 +54,27 @@ def replace_in_file(file_path, encoding, version):
     if m is not None:
         data = replace_group(m, 1, data, version.revision)
 
-    # must lookup for a double line section here, avoid changing any random MD5 string
-    m = re.search(r'URL https://github.com/icculus/SDL_sound/\S*.tar.gz\s+URL_HASH MD5=(\w*)', data)
+    # must lookup for a double line section here, avoid changing any random SHA1 string
+    m = re.search(r'URL https://github.com/icculus/SDL_sound/\S*.tar.gz\s+URL_HASH SHA1=(\w*)', data)
     if m is not None:
         data = replace_group(m, 1, data, version.url_hash)
 
     write_file(file_path, encoding, data)
     print('\t\t- PROCESSED')
+
+def replace_shasums_in_file(file_path, encoding, version):
+    data = read_file(file_path, encoding)
+    if data is None:
+        print('\t\t- READ FAILED')
+        return
+
+    m = re.search(r'(\w*)  SDL_sound.tar.gz', data)
+    if m is not None:
+        data = replace_group(m, 1, data, version.url_hash)
+
+    write_file(file_path, encoding, data)
+    print('\t\t- PROCESSED')
+
 
 def main():
 
@@ -73,6 +87,8 @@ def main():
     replace_in_file("../debian/README.md", "utf-8", version)
     replace_in_file("../OSX/README.md", "utf-8", version)
     replace_in_file("../Windows/README.md", "utf-8", version)
+
+    replace_shasums_in_file("../libsrc/sha1sums", "utf-8", version)
 
 
 if __name__ == "__main__":

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -50,7 +50,7 @@ and SDL2.dll to run.
 Official page for SDL_Sound library is https://www.icculus.org/SDL_sound/, but downloads are hosted on github: https://github.com/icculus/SDL_sound/releases.
 Any latest 2.0.X release should be good.
 
-For the reference, at the time of writing our build server is using revision c5639414c1: https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.tar.gz
+For the reference, at the time of last update our build server is using following revision: https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.zip
 
 After you downloaded the source this way or another, you should use CMake to generate MSVS solution from their provided CMakeList.txt.
 Note that when doing this you may have to direct CMake to the SDL2's cmake config files. First go to the SDL2's sources location and find "cmake" directory inside. It should contain the file called "sdl2-config.cmake". If the file is not present, this means something is wrong with the SDL2's package, or maybe you've downloaded a way too old version of SDL2.

--- a/version.json
+++ b/version.json
@@ -10,6 +10,6 @@
     
     "sdlsound": {
         "revision": "c5639414c1bb24fb4eef5861c13adb42a4aab950",
-        "urlHash": "d1037daa0e444efa8a09defaa1a6321f"
+        "urlHash": "2e9ab24fd861f61349b9386fd66c9851e9f03a60"
     }
 }

--- a/version.json
+++ b/version.json
@@ -6,5 +6,10 @@
     "versionMonth": "January",
     "versionIsBeta": "true",
     "appID": "6fcbc804-4887-4786-bcf6-b0786e1e983d",
-    "licenseLink": "https://opensource.org/license/artistic-2-0/"
+    "licenseLink": "https://opensource.org/license/artistic-2-0/",
+    
+    "sdlsound": {
+        "revision": "c5639414c1bb24fb4eef5861c13adb42a4aab950",
+        "urlHash": "d1037daa0e444efa8a09defaa1a6321f"
+    }
 }


### PR DESCRIPTION
I noticed that SDL_Sound's revision is changed by hand all the time, and some files already have different revisions mentioned (even multiple different ones in a single readme).

Added another python script for updating the revision number. This requires a new values group in version.json:
```
    "sdlsound": {
        "revision": "c5639414c1bb24fb4eef5861c13adb42a4aab950",
        "urlHash": "d1037daa0e444efa8a09defaa1a6321f"
    }
```

Affected files are hardcoded in the script, and may be amended as necessary. Currently they are:
* CMake/FetchSDL_Sound.cmake
* debian/README.md
* OSX/README.md
* Windows/README.md

---

The full script's work may be tested by inserting random values into json, and running "push_sdlsound.py".