### PR TITLE
Unify DisplayAlert in all platform classes

### DIFF
--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -157,9 +157,7 @@ void main_print_help() {
            "                                 --log-file=all:warn\n"
            "  --log-file-path=PATH         Define custom path for the log file\n"
           //--------------------------------------------------------------------------------|
-#if AGS_PLATFORM_OS_WINDOWS
            "  --no-message-box             Disable alerts as modal message boxes\n"
-#endif
            "  --no-translation             Use default game language on start\n"
            "  --noiface                    Don't draw game GUI\n"
            "  --noscript                   Don't run room scripts; *WARNING:* unreliable\n"

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -45,7 +45,6 @@ struct AGSAndroid : AGSPlatformDriver {
   void ReadConfiguration(ConfigTree &cfg) override;
   int  CDPlayerCommand(int cmdd, int datt) override;
   void Delay(int millis) override;
-  void DisplayAlert(const char*, ...) override;
   FSLocation GetAllUsersDataDirectory() override;
   FSLocation GetUserSavedgamesDirectory() override;
   FSLocation GetUserGlobalConfigDirectory() override;
@@ -395,17 +394,6 @@ void AGSAndroid::ReadConfiguration(ConfigTree &cfg)
 
 int AGSAndroid::CDPlayerCommand(int cmdd, int datt) {
   return 1;
-}
-
-void AGSAndroid::DisplayAlert(const char *text, ...) {
-  char displbuf[2000];
-  va_list args;
-  va_start(args, text);
-  vsprintf(displbuf, text, args);
-  va_end(args);
-
-  Debug::Printf(kDbgMsg_Warn, "%s", displbuf);
-  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "AGSNative", displbuf, nullptr);
 }
 
 void AGSAndroid::Delay(int millis) {

--- a/Engine/platform/base/agsplatform_xdg_unix.cpp
+++ b/Engine/platform/base/agsplatform_xdg_unix.cpp
@@ -32,18 +32,6 @@ FSLocation CommonDataDirectory;
 FSLocation UserDataDirectory;
 
 
-void AGSPlatformXDGUnix::DisplayAlert(const char *text, ...) {
-    char displbuf[2000];
-    va_list ap;
-    va_start(ap, text);
-    vsprintf(displbuf, text, ap);
-    va_end(ap);
-    if (_logToStdErr)
-        fprintf(stderr, "%s\n", displbuf);
-    else
-        fprintf(stdout, "%s\n", displbuf);
-}
-
 static FSLocation BuildXDGPath()
 {
     // Check to see if XDG_DATA_HOME is set in the enviroment

--- a/Engine/platform/base/agsplatform_xdg_unix.h
+++ b/Engine/platform/base/agsplatform_xdg_unix.h
@@ -26,7 +26,6 @@
 #include "platform/base/agsplatformdriver.h"
 
 struct AGSPlatformXDGUnix : AGSPlatformDriver {
-    void DisplayAlert(const char*, ...) override;
     FSLocation GetAllUsersDataDirectory() override;
     FSLocation GetUserSavedgamesDirectory() override;
     FSLocation GetUserConfigDirectory() override;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -114,12 +114,13 @@ void AGSPlatformDriver::DisplayAlert(const char *text, ...)
         DisplayMessageBox(displbuf);
 }
 
-void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
+void AGSPlatformDriver::WriteStdOut(const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    vprintf(fmt, args);
+    vfprintf(stdout, fmt, args);
     va_end(args);
-    printf("\n");
+    fprintf(stdout, "\n");
     fflush(stdout);
 }
 
@@ -130,7 +131,7 @@ void AGSPlatformDriver::WriteStdErr(const char *fmt, ...)
     vfprintf(stderr, fmt, args);
     va_end(args);
     fprintf(stderr, "\n");
-    fflush(stdout);
+    fflush(stderr);
 }
 
 void AGSPlatformDriver::DisplayMessageBox(const char *text)

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -63,6 +63,7 @@ class AGSPlatformDriver
     : public AGS::Common::IOutputHandler
 {
 public:
+    AGSPlatformDriver();
     virtual ~AGSPlatformDriver() = default;
 
     // Called at the creation of the platform driver
@@ -140,7 +141,7 @@ public:
     // Store command line arguments for the future use
     void SetCommandArgs(const char *const argv[], size_t argc);
     // Set whether PrintMessage should output to stdout or stderr
-    void SetOutputToErr(bool on) { _logToStdErr = on; }
+    void SetOutputToErr(bool on);
     // Set whether DisplayAlert is allowed to show modal GUIs on some systems;
     // it will print to either stdout or stderr otherwise, depending on above flag
     void SetGUIMode(bool on) { _guiMode = on; }
@@ -158,6 +159,9 @@ protected:
     // with both going through PlatformDriver need to figure a better
     // design first.
     bool _logToStdErr = false;
+    // A function pointer for stdout write;
+    // this is used when printing log, and may be set to null disabling an output
+    void (AGSPlatformDriver::*_writeStdOut)(const char *fmt, ...) = nullptr;
     // Defines whether engine is allowed to display important warnings
     // and errors by showing a message box kind of GUI.
     bool _guiMode = false;

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -77,7 +77,7 @@ public:
     virtual void PostBackendExit() { };
 
     virtual void Delay(int millis);
-    virtual void DisplayAlert(const char*, ...) = 0;
+    virtual void DisplayAlert(const char *text, ...);
     virtual void AttachToParentConsole();
     virtual int  GetLastSystemError() { return errno; }
     // platform specific data file
@@ -109,6 +109,9 @@ public:
     // Formats message and writes to platform's error output;
     // Always adds trailing '\n' after formatted string
     virtual void WriteStdErr(const char *fmt, ...);
+    // Display a text in a message box with a "warning" icon.
+    // Platforms which do not support this should do nothing.
+    virtual void DisplayMessageBox(const char *text);
     virtual void YieldCPU();
     // Called when the application is being paused completely (e.g. when player alt+tabbed from it).
     // This function should suspend any platform-specific realtime processing.

--- a/Engine/platform/emscripten/acpemscripten.cpp
+++ b/Engine/platform/emscripten/acpemscripten.cpp
@@ -83,7 +83,6 @@ extern "C"
 struct AGSEmscripten : AGSPlatformDriver {
 
   int  CDPlayerCommand(int cmdd, int datt) override;
-  void DisplayAlert(const char*, ...) override;
   void Delay(int millis) override;
   void YieldCPU() override;
   FSLocation GetAllUsersDataDirectory() override;
@@ -110,25 +109,6 @@ struct AGSEmscripten : AGSPlatformDriver {
 int AGSEmscripten::CDPlayerCommand(int cmdd, int datt) 
 {
     return 0;
-}
-
-void AGSEmscripten::DisplayAlert(const char *text, ...) 
-{
-    char displbuf[2000];
-    va_list ap;
-    va_start(ap, text);
-    vsprintf(displbuf, text, ap);
-    va_end(ap);
-    if (_logToStdErr)
-    {
-        fprintf(stderr, "%s\n", displbuf);
-        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "AGS Error", displbuf, nullptr);
-    }
-    else
-    {
-        fprintf(stdout, "%s\n", displbuf);
-        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "AGS Alert", displbuf, nullptr);
-    }
 }
 
 void AGSEmscripten::SyncEmscriptenFS()

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -66,7 +66,6 @@ struct AGSIOS : AGSPlatformDriver {
   void ReadConfiguration(ConfigTree &cfg) override;
   int  CDPlayerCommand(int cmdd, int datt) override;
   void Delay(int millis) override;
-  void DisplayAlert(const char*, ...) override;
   FSLocation GetAllUsersDataDirectory() override;
   FSLocation GetUserSavedgamesDirectory() override;
   FSLocation GetUserGlobalConfigDirectory() override;
@@ -320,17 +319,6 @@ void AGSIOS::ReadConfiguration(Common::ConfigTree &cfg)
 
 int AGSIOS::CDPlayerCommand(int cmdd, int datt) {
   return 0;//cd_player_control(cmdd, datt);
-}
-
-void AGSIOS::DisplayAlert(const char *text, ...) {
-  char displbuf[2000];
-  va_list ap;
-  va_start(ap, text);
-  vsnprintf(displbuf, 2000, text, ap);
-  va_end(ap);
-  
-  Debug::Printf(kDbgMsg_Warn, "%s", displbuf);
-  SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "AGSNative", displbuf, nullptr);
 }
 
 void AGSIOS::Delay(int millis) {

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -37,7 +37,6 @@ struct AGSMac : AGSPlatformDriver {
   void PreBackendInit() override;
 
   int  CDPlayerCommand(int cmdd, int datt) override;
-  void DisplayAlert(const char*, ...) override;
   uint64_t GetDiskFreeSpaceMB() override;
   eScriptSystemOSID GetSystemOSID() override;
   int  InitializeCDPlayer() override;
@@ -66,18 +65,6 @@ void AGSMac::PreBackendInit()
 
 int AGSMac::CDPlayerCommand(int cmdd, int datt) {
   return 0;//cd_player_control(cmdd, datt);
-}
-
-void AGSMac::DisplayAlert(const char *text, ...) {
-  char displbuf[2000];
-  va_list ap;
-  va_start(ap, text);
-  vsprintf(displbuf, text, ap);
-  va_end(ap);
-  if (_logToStdErr)
-    fprintf(stderr, "%s\n", displbuf);
-  else
-    fprintf(stdout, "%s\n", displbuf);
 }
 
 uint64_t AGSMac::GetDiskFreeSpaceMB() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -83,6 +83,8 @@ struct AGSWin32 : AGSPlatformDriver {
   String GetCommandArg(size_t arg_index) override;
 
 private:
+  void WriteStdOutImpl(FILE *file, const char *prefix, const char *fmt, va_list args);
+
   bool _isDebuggerPresent; // indicates if the win app is running in the context of a debugger
   bool _isAttachedToParentConsole; // indicates if the win app is attached to the parent console
 };
@@ -348,44 +350,42 @@ SetupReturnValue AGSWin32::RunSetup(const ConfigTree &cfg_in, ConfigTree &cfg_ou
   return AGS::Engine::WinSetup(cfg_in, cfg_out, usetup.main_data_dir, version_str);
 }
 
-void AGSWin32::WriteStdOut(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  if (_isDebuggerPresent)
-  {
-    // Add "AGS:" prefix when outputting to debugger, to make it clear that this
-    // is a text from the program log
-    char buf[2048] = "AGS: ";
-    vsnprintf(buf + 5, sizeof(buf) - 5, fmt, ap);
-    OutputDebugString(buf);
-    OutputDebugString("\n");
-  }
-  else
-  {
-    vprintf(fmt, ap);
-    printf("\n");
-  }
-  va_end(ap);
+void AGSWin32::WriteStdOut(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    WriteStdOutImpl(stdout, "AGS: ", fmt, args);
+    va_end(args);
 }
 
-void AGSWin32::WriteStdErr(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  if (_isDebuggerPresent)
-  {
-    // Add "AGS:" prefix when outputting to debugger, to make it clear that this
-    // is a text from the program log
-    char buf[2048] = "AGS ERR: ";
-    vsnprintf(buf + 9, sizeof(buf) - 9, fmt, ap);
-    OutputDebugString(buf);
-    OutputDebugString("\n");
-  }
-  else
-  {
-    vfprintf(stderr, fmt, ap);
-    fprintf(stderr, "\n");
-  }
-  va_end(ap);
+void AGSWin32::WriteStdErr(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    WriteStdOutImpl(stderr, "AGS ERR:", fmt, args);
+    va_end(args);
+}
+
+void AGSWin32::WriteStdOutImpl(FILE *file, const char *prefix, const char *fmt, va_list args)
+{
+    va_list args_cpy;
+    va_copy(args_cpy, args);
+    if (_isDebuggerPresent)
+    {
+        // Add "AGS:" prefix when outputting to debugger, to make it clear that this
+        // is a text from the program log
+        char buf[2048];
+        char *pbuf = buf + snprintf(buf, sizeof(buf), "%s", prefix);
+        vsnprintf(pbuf, sizeof(buf) - (pbuf - buf), fmt, args_cpy);
+        OutputDebugString(buf);
+        OutputDebugString("\n");
+    }
+    else
+    {
+        vfprintf(file, fmt, args_cpy);
+        fprintf(file, "\n");
+    }
+    va_end(args_cpy);
 }
 
 void AGSWin32::DisplayMessageBox(const char *text)

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -168,7 +168,7 @@ Following OPTIONS are supported when running from command line:
     * --log-file=all:warn
     * --log-stdout=+mg:debug
 * --log-file-path=PATH - define custom path for the log file.
-* --no-message-box - disable alerts as modal message boxes (Windows only).
+* --no-message-box - disable alerts as modal message boxes (on platforms that support them in the first place).
 * --no-translation - use default game language on start.
 * --noiface - don't draw game GUI (for test purposes).
 * --noscript - don't run room scripts (for test purposes); *WARNING:* unreliable.


### PR DESCRIPTION
Fix #2279

1. Implement general DisplayAlert logic in the base AGSPlatformDriver class. This method does 3 things: print to log, write to stdout and display message box, depending on current settings.
2. Add new method called DisplayMessageBox which purpose is strictly to display a message box if platform can do that. Platforms that cannot or should not may override this method, or override _guiMode variable.
3. Added a "dirty" fix for duplicate alert in stdout, which may appear because of passing the message to the log system. The platform class will store a pointer to a function that has to be called when printing a message. This pointer is assigned according to "_logToStdErr" setting. When printing, use this pointer instead of checking for the setting. This also lets setting this pointer to null, or a stub that does nothing, hence temporarily disabling an output.