### PR TITLE
AGS 4: Script API: implement FaceDirectionRatio

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -52,9 +52,6 @@ struct GameSetupStruct : public GameSetupStructBase
     std::vector<FontInfo> fonts;
     InventoryItemInfo invinfo[MAX_INV]{};
     std::vector<MouseCursor> mcurs;
-    // CLNUP old interactions
-    //Interaction     **intrChar;
-    //Interaction      *intrInv[MAX_INV];
     std::vector<PInteractionScripts> charScripts;
     std::vector<PInteractionScripts> invScripts;
     // TODO: why we do not use this in the engine instead of
@@ -84,6 +81,10 @@ struct GameSetupStruct : public GameSetupStructBase
     int               numGameChannels = 0;
     // backward-compatible channel limit that may be exported to script and reserved by audiotypes
     int               numCompatGameChannels = 0;
+
+    // Extended global game properties
+    // Character face direction ratio (y/x)
+    float             faceDirectionRatio = 1.f;
     
     // TODO: I converted original array of sprite infos to vector here, because
     // statistically in most games sprites go in long continious sequences with minimal

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -526,6 +526,12 @@ HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
             _in->Seek(sizeof(int32_t) * 11);
         }
     }
+    else if (ext_id.CompareNoCase("v400_gameopts") == 0)
+    {
+        _ents.Game.faceDirectionRatio = _in->ReadFloat32();
+        // reserve few more 32-bit values (for a total of 10)
+        _in->Seek(sizeof(int32_t) * 9);
+    }
     else
     {
         return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -25,6 +25,7 @@ namespace Common
 RoomOptions::RoomOptions()
     : PlayerCharOff(false)
     , PlayerView(0)
+    , FaceDirectionRatio(0.f)
     , Flags(0)
 {
 }
@@ -73,6 +74,7 @@ WalkArea::WalkArea()
     , ScalingFar(0)
     , ScalingNear(NOT_VECTOR_SCALED)
     , PlayerView(0)
+    , FaceDirectionRatio(0.f)
     , Top(-1)
     , Bottom(-1)
 {

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -105,6 +105,8 @@ struct RoomOptions
     bool PlayerCharOff;
     // Apply player character's normal view when entering this room
     int  PlayerView;
+    // Optional character facing dir ratio (y / x), 0 = ignore
+    float FaceDirectionRatio;
     // A collection of RoomFlags
     int  Flags;
 
@@ -197,6 +199,8 @@ struct WalkArea
     int32_t     ScalingNear;
     // Optional override for player character view
     int32_t     PlayerView;
+    // Optional character face direction ratio, 0 = ignore
+    float       FaceDirectionRatio;
     // Top and bottom Y of the area
     int32_t     Top;
     int32_t     Bottom;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -110,7 +110,8 @@ namespace AGS.Editor
          * 3.99.99.01     - Open rooms
          * 3.99.99.07     - PO translations
          * 4.00.00.00     - Raised for org purposes without project changes
-         * 4.00.00.03     - Distinct Character and Object Enabled and Visible properties.
+         * 4.00.00.03     - Distinct Character and Object Enabled and Visible properties;
+         *                - FaceDirectionRatio
          *
         */
         public const int    LATEST_XML_VERSION_INDEX = 4000003;

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1723,6 +1723,7 @@ namespace AGS.Editor
             WriteExtension("v360_cursors", WriteExt_360Cursors, writer, game, errors);
             WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, game, errors);
             WriteExtension("ext_ags399", WriteExt_Ags399, writer, game, errors);
+            WriteExtension("v400_gameopts", WriteExt_400GameOpts, writer, game, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1819,6 +1820,14 @@ namespace AGS.Editor
                 // Reserved for transform options (see brief list in the engine)
                 writer.Write(new byte[11 * 4]);
             }
+        }
+
+        private static void WriteExt_400GameOpts(BinaryWriter writer, Game game, CompileMessages errors)
+        {
+            writer.Write((float)game.Settings.FaceDirectionRatio);
+            // reserve more 32-bit values for a total of 10
+            for (int i = 0; i < 9; ++i)
+                writer.Write((int)0);
         }
 
         private delegate void WriteExtensionProc(BinaryWriter writer, Game game, CompileMessages errors);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -741,6 +741,8 @@ builtin struct Room {
   import static readonly attribute WalkableArea *WalkableAreas[];   // $AUTOCOMPLETESTATICONLY$
   /// Accesses the Walk-behinds in the current room.
   import static readonly attribute Walkbehind *Walkbehinds[];   // $AUTOCOMPLETESTATICONLY$
+  /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character in the current room.
+  import static attribute float FaceDirectionRatio;
 #endif
 };
 
@@ -1654,6 +1656,8 @@ builtin managed struct WalkableArea {
   import readonly attribute int ScalingMin;
   /// Gets this walkable area's maximal scaling level.
   import readonly attribute int ScalingMax;
+  /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character while on this area.
+  import static attribute float FaceDirectionRatio;
 };
 #endif
 
@@ -2290,6 +2294,8 @@ builtin managed struct Character {
   import attribute bool Enabled;
   /// Gets/sets whether the character is currently visible.
   import attribute bool Visible;
+  /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection while Character moves and turns.
+  import attribute float FaceDirectionRatio;
 #endif
 #ifdef SCRIPT_COMPAT_v399
   char  on;
@@ -2404,6 +2410,10 @@ builtin struct Game {
   import static void   PrecacheSprite(int sprnum);
   /// Preloads and caches sprites and linked sounds for a view, within a selected range of loops.
   import static void   PrecacheView(int view, int first_loop, int last_loop);
+#endif
+#ifdef SCRIPT_API_v400
+  /// Gets/sets the default y/x ratio of character's facing directions, determining directional loop selection for all Characters in game.
+  import static attribute float FaceDirectionRatio;
 #endif
 };
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2855,6 +2855,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		RoomWalkableArea ^area = room->WalkableAreas[i];
 		area->ID = i;
 		area->AreaSpecificView = rs.WalkAreas[i].PlayerView;
+        area->FaceDirectionRatio = rs.WalkAreas[i].FaceDirectionRatio;
 		area->UseContinuousScaling = !(rs.WalkAreas[i].ScalingNear == NOT_VECTOR_SCALED);
 		area->ScalingLevel = rs.WalkAreas[i].ScalingFar + 100;
 		area->MinScalingLevel = rs.WalkAreas[i].ScalingFar + 100;
@@ -2966,7 +2967,8 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 	{
 		RoomWalkableArea ^area = room->WalkableAreas[i];
 		rs.WalkAreas[i].PlayerView = area->AreaSpecificView;
-		
+        rs.WalkAreas[i].FaceDirectionRatio = area->FaceDirectionRatio;
+
 		if (area->UseContinuousScaling) 
 		{
 			rs.WalkAreas[i].ScalingFar = area->MinScalingLevel - 100;

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -314,7 +314,10 @@ namespace AGS.Types
             set { _playerCharacterView = value; }
         }
 
-        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\nThis property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior in this room.")]
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. " +
+            "Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\n" +
+            "Negative values switch up and down loops.\n" +
+            "This property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior in this room.")]
         [DefaultValue(0.0f)]
         [Category("Settings")]
         public float FaceDirectionRatio

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -38,6 +38,7 @@ namespace AGS.Types
         private int _bottomEdgeY;
         private bool _showPlayerCharacter = true;
         private int _playerCharacterView;
+        private float _faceDirectionRatio = 0.0f;
         private int _maskResolution = 1;
         private int _colorDepth;
         private int _width;
@@ -311,6 +312,15 @@ namespace AGS.Types
         {
             get { return _playerCharacterView; }
             set { _playerCharacterView = value; }
+        }
+
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\nThis property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior in this room.")]
+        [DefaultValue(0.0f)]
+        [Category("Settings")]
+        public float FaceDirectionRatio
+        {
+            get { return _faceDirectionRatio; }
+            set { _faceDirectionRatio = value; }
         }
 
         [Obsolete]

--- a/Editor/AGS.Types/RoomWalkableArea.cs
+++ b/Editor/AGS.Types/RoomWalkableArea.cs
@@ -47,7 +47,10 @@ namespace AGS.Types
             set { _areaSpecificView = value; }
         }
 
-        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\nThis property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior on this area.")]
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. " +
+            "Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\n" +
+            "Negative values switch up and down loops.\n" +
+            "This property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior on this area.")]
         [DefaultValue(0.0f)]
         [Category("Design")]
         public float FaceDirectionRatio

--- a/Editor/AGS.Types/RoomWalkableArea.cs
+++ b/Editor/AGS.Types/RoomWalkableArea.cs
@@ -12,6 +12,7 @@ namespace AGS.Types
     {
         private int _id;
         private int _areaSpecificView;
+        private float _faceDirectionRatio = 0.0f;
         private int _scalingLevel = 100;
         private bool _useContinuousScaling;
         private int _scalingLevelMin = 100;
@@ -44,6 +45,15 @@ namespace AGS.Types
         {
             get { return _areaSpecificView; }
             set { _areaSpecificView = value; }
+        }
+
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\nThis property is optional, and is disabled by assigning a 0. If non-zero, then it will override character behavior on this area.")]
+        [DefaultValue(0.0f)]
+        [Category("Design")]
+        public float FaceDirectionRatio
+        {
+            get { return _faceDirectionRatio; }
+            set { _faceDirectionRatio = value; }
         }
 
         [Description("Enables this area to have a graduated scaling level from the top to bottom, rather than a fixed scaling.")]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -533,7 +533,9 @@ namespace AGS.Types
         }
 
         [DisplayName("Face direction ratio")]
-        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".")]
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. " +
+            "Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".\n" +
+            "Negative values switch up and down loops.")]
         [DefaultValue(1.0f)]
         [Category("Character behavior")]
         public float FaceDirectionRatio

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -75,6 +75,7 @@ namespace AGS.Types
         private ScriptAPIVersion _scriptCompatLevelReal = Utilities.GetActualAPI(ScriptAPIVersion.Highest);
         private bool _oldKeyHandling = false;
         private bool _scaleCharacterSpriteOffsets = true;
+        private float _faceDirectionRatio = 1.0f;
         private int _dialogOptionsGUI = 0;
         private int _dialogOptionsGap = 0;
         private int _dialogBulletImage = 0;
@@ -529,6 +530,23 @@ namespace AGS.Types
         {
             get { return _scaleCharacterSpriteOffsets; }
             set { _scaleCharacterSpriteOffsets = value; }
+        }
+
+        [DisplayName("Face direction ratio")]
+        [Description("The Y/X relation of diagonal directions at which Character switches from horizontal to vertical walking loops. Default is 1.0. < 1.0 would make diagonal direction more \"vertical\", > 1.0 would make it more \"horizontal\".")]
+        [DefaultValue(1.0f)]
+        [Category("Character behavior")]
+        public float FaceDirectionRatio
+        {
+            get { return _faceDirectionRatio; }
+            set
+            {
+                if (value <= 0.0f || float.IsInfinity(value) || float.IsNaN(value))
+                {
+                    throw new ArgumentException("Face direction ratio must be a valid positive value.");
+                }
+                _faceDirectionRatio = value;
+            }
         }
 
         [DisplayName("Enable Debug Mode")]

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -329,15 +329,15 @@ enum DirectionalLoop
 float GetFaceDirRatio(CharacterInfo *chinfo)
 {
     CharacterExtras &chex = charextra[chinfo->index_id];
-    if (chex.face_dir_ratio > 0.f)
+    if (chex.face_dir_ratio != 0.f)
         return chex.face_dir_ratio;
     // TODO: cache current area in CharacterExtras somewhere during early char update
     int onarea = get_walkable_area_at_location(chinfo->x, chinfo->y);
-    if (onarea > 0 && thisroom.WalkAreas[onarea].FaceDirectionRatio > 0.f)
+    if (onarea > 0 && thisroom.WalkAreas[onarea].FaceDirectionRatio != 0.f)
         return thisroom.WalkAreas[onarea].FaceDirectionRatio;
-    if (croom->face_dir_ratio > 0.f)
+    if (croom->face_dir_ratio != 0.f)
         return croom->face_dir_ratio;
-    if (play.face_dir_ratio > 0.f)
+    if (play.face_dir_ratio != 0.f)
         return play.face_dir_ratio;
     return 1.f;
 }
@@ -348,7 +348,7 @@ DirectionalLoop GetDirectionalLoop(CharacterInfo *chinfo, float x_diff, float y_
 
     // TODO: cache this in CharacterExtras for bit more performance
     float dir_ratio = GetFaceDirRatio(chinfo);
-    assert(dir_ratio > 0.f);
+    assert(dir_ratio != 0.f);
     y_diff *= dir_ratio; // dir ratio is a y/x relation
 
     const ViewStruct &chview  = views[chinfo->view];

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -24,6 +24,7 @@
 #include "ac/draw.h"
 #include "ac/event.h"
 #include "ac/game.h"
+#include "ac/gamestate.h"
 #include "ac/global_audio.h"
 #include "ac/global_character.h"
 #include "ac/global_game.h"
@@ -38,18 +39,18 @@
 #include "ac/overlay.h"
 #include "ac/properties.h"
 #include "ac/room.h"
+#include "ac/roomstatus.h"
+#include "ac/route_finder.h"
 #include "ac/screenoverlay.h"
+#include "ac/spritecache.h"
 #include "ac/string.h"
 #include "ac/system.h"
 #include "ac/viewframe.h"
 #include "ac/walkablearea.h"
-#include "gui/guimain.h"
-#include "ac/route_finder.h"
-#include "ac/gamestate.h"
 #include "debug/debug_log.h"
+#include "gui/guimain.h"
 #include "main/game_run.h"
 #include "main/update.h"
-#include "ac/spritecache.h"
 #include "util/string_compat.h"
 #include <math.h>
 #include "gfx/graphicsdriver.h"
@@ -68,6 +69,7 @@ using namespace AGS::Engine;
 extern GameSetupStruct game;
 extern int displayed_room,starting_room;
 extern RoomStruct thisroom;
+extern RoomStatus *croom;
 extern std::vector<ViewStruct> views;
 extern RoomObject*objs;
 extern ScriptInvItem scrInv[MAX_INV];
@@ -324,9 +326,30 @@ enum DirectionalLoop
 
 // Internal direction-facing functions
 
+float GetFaceDirRatio(CharacterInfo *chinfo)
+{
+    CharacterExtras &chex = charextra[chinfo->index_id];
+    if (chex.face_dir_ratio > 0.f)
+        return chex.face_dir_ratio;
+    // TODO: cache current area in CharacterExtras somewhere during early char update
+    int onarea = get_walkable_area_at_location(chinfo->x, chinfo->y);
+    if (onarea > 0 && thisroom.WalkAreas[onarea].FaceDirectionRatio > 0.f)
+        return thisroom.WalkAreas[onarea].FaceDirectionRatio;
+    if (croom->face_dir_ratio > 0.f)
+        return croom->face_dir_ratio;
+    if (play.face_dir_ratio > 0.f)
+        return play.face_dir_ratio;
+    return 1.f;
+}
+
 DirectionalLoop GetDirectionalLoop(CharacterInfo *chinfo, float x_diff, float y_diff)
 {
     DirectionalLoop next_loop = kDirLoop_Left; // NOTE: default loop was Left for some reason
+
+    // TODO: cache this in CharacterExtras for bit more performance
+    float dir_ratio = GetFaceDirRatio(chinfo);
+    assert(dir_ratio > 0.f);
+    y_diff *= dir_ratio; // dir ratio is a y/x relation
 
     const ViewStruct &chview  = views[chinfo->view];
     const bool has_down_loop  = ((chview.numLoops > kDirLoop_Down)  && (chview.loops[kDirLoop_Down].numFrames > 0));
@@ -1592,6 +1615,14 @@ float Character_GetRotation(CharacterInfo *chaa) {
 void Character_SetRotation(CharacterInfo *chaa, float degrees) {
     charextra[chaa->index_id].rotation = Math::ClampAngle360(degrees);
     charextra[chaa->index_id].UpdateGraphicSpace(chaa);
+}
+
+float Character_GetFaceDirectionRatio(CharacterInfo *chaa) {
+    return charextra[chaa->index_id].face_dir_ratio;
+}
+
+void Character_SetFaceDirectionRatio(CharacterInfo *chaa, float ratio) {
+    charextra[chaa->index_id].face_dir_ratio = ratio;
 }
 
 int Character_GetTurnBeforeWalking(CharacterInfo *chaa) {
@@ -3937,6 +3968,16 @@ RuntimeScriptValue Sc_Character_SetRotation(void *self, const RuntimeScriptValue
     API_OBJCALL_VOID_PFLOAT(CharacterInfo, Character_SetRotation);
 }
 
+RuntimeScriptValue Sc_Character_GetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(CharacterInfo, Character_GetFaceDirectionRatio);
+}
+
+RuntimeScriptValue Sc_Character_SetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(CharacterInfo, Character_SetFaceDirectionRatio);
+}
+
 //=============================================================================
 //
 // Exclusive variadic API implementation for Plugins
@@ -4135,6 +4176,9 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::set_UseRegionTint",         API_FN_PAIR(Character_SetUseRegionTint) },
         { "Character::get_GraphicRotation",       API_FN_PAIR(Character_GetRotation) },
         { "Character::set_GraphicRotation",       API_FN_PAIR(Character_SetRotation) },
+
+        { "Character::get_FaceDirectionRatio",    API_FN_PAIR(Character_GetFaceDirectionRatio) },
+        { "Character::set_FaceDirectionRatio",    API_FN_PAIR(Character_SetFaceDirectionRatio) },
     };
 
     ccAddExternalFunctions(character_api);

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -90,6 +90,14 @@ void CharacterExtras::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
     {
         blend_mode = kBlend_Normal;
     }
+    if (save_ver >= kCharSvgVersion_400_03)
+    {
+        face_dir_ratio = in->ReadFloat32();
+        // Reserve for 4 total int32
+        in->ReadInt32();
+        in->ReadInt32();
+        in->ReadInt32();
+    }
 }
 
 void CharacterExtras::WriteToSavegame(Stream *out) const
@@ -130,4 +138,10 @@ void CharacterExtras::WriteToSavegame(Stream *out) const
     out->WriteInt32(0); // sprite pivot y
     out->WriteInt32(0); // sprite anchor x
     out->WriteInt32(0); // sprite anchor y
+    // -- kCharSvgVersion_400_03
+    out->WriteFloat32(face_dir_ratio);
+    // Reserve for 4 total int32
+    out->WriteInt32(0);
+    out->WriteInt32(0);
+    out->WriteInt32(0);
 }

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -63,6 +63,8 @@ struct CharacterExtras
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
     Common::BlendMode blend_mode = Common::kBlend_Normal;
     float rotation = 0.f;
+    // Optional character face direction ratio, 0 = ignore
+    float face_dir_ratio = 0.f;
 
     // Following fields are deriatives of the above (calculated from these
     // and other factors), and hence are not serialized.

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -809,6 +809,16 @@ void Game_PrecacheView(int view, int first_loop, int last_loop)
     precache_view(view - 1 /* to 0-based view index */, first_loop, last_loop, true);
 }
 
+float Game_GetFaceDirectionRatio()
+{
+    return play.face_dir_ratio;
+}
+
+void Game_SetFaceDirectionRatio(float ratio)
+{
+    play.face_dir_ratio = ratio;
+}
+
 //=============================================================================
 
 // save game functions
@@ -1717,6 +1727,16 @@ RuntimeScriptValue Sc_Game_PrecacheView(const RuntimeScriptValue *params, int32_
     API_SCALL_VOID_PINT3(Game_PrecacheView);
 }
 
+RuntimeScriptValue Sc_Game_GetFaceDirectionRatio(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_FLOAT(Game_GetFaceDirectionRatio);
+}
+
+RuntimeScriptValue Sc_Game_SetFaceDirectionRatio(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PFLOAT(Game_SetFaceDirectionRatio);
+}
+
 void RegisterGameAPI()
 {
     ScFnRegister game_api[] = {
@@ -1774,6 +1794,8 @@ void RegisterGameAPI()
         { "Game::get_Camera",                             API_FN_PAIR(Game_GetCamera) },
         { "Game::get_CameraCount",                        API_FN_PAIR(Game_GetCameraCount) },
         { "Game::geti_Cameras",                           API_FN_PAIR(Game_GetAnyCamera) },
+        { "Game::get_FaceDirectionRatio",                 API_FN_PAIR(Game_GetFaceDirectionRatio) },
+        { "Game::set_FaceDirectionRatio",                 API_FN_PAIR(Game_SetFaceDirectionRatio) },
     };
 
     ccAddExternalFunctions(game_api);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -631,12 +631,20 @@ void GameState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameState
     text_min_display_time_ms = in->ReadInt32();
     ignore_user_input_after_text_timeout_ms = in->ReadInt32();
     if (svg_ver < kGSSvgVersion_350_9)
+    {
         in->ReadInt32(); // ignore_user_input_until_time -- do not apply from savegame
-    if (svg_ver >= kGSSvgVersion_350_9)
+    }
+    else // (svg_ver >= kGSSvgVersion_350_9)
     {
         int voice_speech_flags = in->ReadInt32();
         speech_has_voice = voice_speech_flags != 0;
         speech_voice_blocking = (voice_speech_flags & 0x02) != 0;
+    }
+    if (svg_ver >= kGSSvgVersion_400_03)
+    {
+        face_dir_ratio = in->ReadFloat32();
+        // reserve few more 32-bit values (for a total of 10)
+        in->Seek(sizeof(int32_t) * 9);
     }
 }
 
@@ -822,6 +830,11 @@ void GameState::WriteForSavegame(Stream *out) const
     if (speech_voice_blocking)
         voice_speech_flags |= 0x02;
     out->WriteInt32(voice_speech_flags);
+
+    // --- kGSSvgVersion_400_03
+    out->WriteFloat32(face_dir_ratio);
+    // reserve few more 32-bit values (for a total of 10)
+    out->WriteByteCount(0, sizeof(int32_t) * 9);
 }
 
 void GameState::FreeProperties()

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -218,6 +218,7 @@ struct GameState {
     int   text_min_display_time_ms = 0;
     int   ignore_user_input_after_text_timeout_ms = 0;
     int   default_audio_type_volumes[MAX_AUDIO_TYPES]{};
+    float face_dir_ratio = 1.f; // character face direction ratio, defines y/x relation
 
     // Dynamic custom property values for characters and items
     std::vector<AGS::Common::StringIMap> charProps;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -547,6 +547,10 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         for (int cc = 0; cc < MAX_ROOM_REGIONS; cc++) {
             croom->region_enabled[cc] = 1;
         }
+        for (int i = 0; i < MAX_WALK_AREAS; ++i)
+        {
+            croom->walkareas[i].FaceDirectionRatio = thisroom.WalkAreas[i].FaceDirectionRatio;
+        }
 
         croom->beenhere=1;
         in_new_room=2;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -190,6 +190,16 @@ bool Room_SetTextProperty(const char *property, const char *value)
     return set_text_property(croom->roomProps, property, value);
 }
 
+float Room_GetFaceDirectionRatio()
+{
+    return croom->face_dir_ratio;
+}
+
+void Room_SetFaceDirectionRatio(float ratio)
+{
+    croom->face_dir_ratio = ratio;
+}
+
 bool Room_Exists(int room)
 {
     String room_filename;
@@ -508,6 +518,8 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         croom->tsdatasize=0;
         croom->obj.resize(croom->numobj);
         croom->objProps.resize(croom->numobj);
+        croom->face_dir_ratio = thisroom.Options.FaceDirectionRatio;
+
         for (uint32_t cc=0;cc<croom->numobj;cc++) {
             const auto &trobj = thisroom.Objects[cc];
             auto &crobj = croom->obj[cc];
@@ -1032,6 +1044,16 @@ RuntimeScriptValue Sc_Room_GetWidth(const RuntimeScriptValue *params, int32_t pa
     API_SCALL_INT(Room_GetWidth);
 }
 
+RuntimeScriptValue Sc_Room_GetFaceDirectionRatio(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_FLOAT(Room_GetFaceDirectionRatio);
+}
+
+RuntimeScriptValue Sc_Room_SetFaceDirectionRatio(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PFLOAT(Room_SetFaceDirectionRatio);
+}
+
 // void (int xx,int yy,int mood)
 RuntimeScriptValue Sc_RoomProcessClick(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1071,6 +1093,7 @@ RuntimeScriptValue Sc_Room_GetiWalkbehinds(void *self, const RuntimeScriptValue 
 void RegisterRoomAPI()
 {
     ScFnRegister room_api[] = {
+        { "Room::Exists",                             API_FN_PAIR(Room_Exists) },
         { "Room::GetDrawingSurfaceForBackground^1",   API_FN_PAIR(Room_GetDrawingSurfaceForBackground) },
         { "Room::GetProperty^1",                      API_FN_PAIR(Room_GetProperty) },
         { "Room::GetTextProperty^1",                  API_FN_PAIR(Room_GetTextProperty) },
@@ -1086,7 +1109,8 @@ void RegisterRoomAPI()
         { "Room::get_RightEdge",                      API_FN_PAIR(Room_GetRightEdge) },
         { "Room::get_TopEdge",                        API_FN_PAIR(Room_GetTopEdge) },
         { "Room::get_Width",                          API_FN_PAIR(Room_GetWidth) },
-        { "Room::Exists",                             API_FN_PAIR(Room_Exists) },
+        { "Room::get_FaceDirectionRatio",             API_FN_PAIR(Room_GetFaceDirectionRatio) },
+        { "Room::set_FaceDirectionRatio",             API_FN_PAIR(Room_SetFaceDirectionRatio) },
         { "Room::geti_Hotspots",                      API_FN_PAIR(Room_GetiHotspots) },
         { "Room::geti_Objects",                       API_FN_PAIR(Room_GetiObjects) },
         { "Room::geti_Regions",                       API_FN_PAIR(Room_GetiRegions) },

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -63,6 +63,7 @@ struct RoomStatus
     HotspotState hotspot[MAX_ROOM_HOTSPOTS];
     char  region_enabled[MAX_ROOM_REGIONS];
     short walkbehind_base[MAX_WALK_BEHINDS];
+    float face_dir_ratio = 0.f;
 
     // A version of a save this RoomStatus was restored from.
     // This is used as a hint when merging RoomStatus with the loaded room file (upon room enter).

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -23,16 +23,6 @@
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
 using AGS::Common::Stream;
-//using AGS::Common::Interaction;
-
-struct HotspotState
-{
-    bool Enabled = false;
-    Common::String Name;
-
-    void ReadFromSavegame(Common::Stream *in, int save_ver);
-    void WriteToSavegame(Common::Stream *out) const;
-};
 
 // RoomStatus runtime save format
 enum RoomStatSvgVersion
@@ -44,8 +34,25 @@ enum RoomStatSvgVersion
     kRoomStatSvgVersion_36041    = 4, // room state's contentFormat
     kRoomStatSvgVersion_36109    = 5, // removed movelists, save externally
     kRoomStatSvgVersion_400      = 4000000, // room object blendmodes etc
-    kRoomStatSvgVersion_40003    = 4000003, // room object flags as 32-bit
+    kRoomStatSvgVersion_40003    = 4000003, // room object flags as 32-bit, facedirratio
     kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_40003
+};
+
+struct HotspotState
+{
+    bool Enabled = false;
+    Common::String Name;
+
+    void ReadFromSavegame(Common::Stream *in, RoomStatSvgVersion save_ver);
+    void WriteToSavegame(Common::Stream *out) const;
+};
+
+struct WalkareaState
+{
+    float FaceDirectionRatio = 0.f;
+
+    void ReadFromSavegame(Common::Stream *in, RoomStatSvgVersion save_ver);
+    void WriteToSavegame(Common::Stream *out) const;
 };
 
 // RoomStatus contains everything about a room that could change at runtime.
@@ -64,6 +71,7 @@ struct RoomStatus
     char  region_enabled[MAX_ROOM_REGIONS];
     short walkbehind_base[MAX_WALK_BEHINDS];
     float face_dir_ratio = 0.f;
+    WalkareaState walkareas[MAX_WALK_AREAS];
 
     // A version of a save this RoomStatus was restored from.
     // This is used as a hint when merging RoomStatus with the loaded room file (upon room enter).
@@ -79,7 +87,7 @@ struct RoomStatus
     void FreeProperties();
 
     void ReadFromSavegame(Common::Stream *in, RoomStatSvgVersion cmp_ver);
-    void WriteToSavegame(Common::Stream *out, GameDataVersion data_ver) const;
+    void WriteToSavegame(Common::Stream *out) const;
 };
 
 // Replaces all accesses to the roomstats array

--- a/Engine/ac/walkablearea.cpp
+++ b/Engine/ac/walkablearea.cpp
@@ -264,6 +264,16 @@ int Walkarea_GetScalingMax(ScriptWalkableArea *wa)
     return thisroom.WalkAreas[wa->id].ScalingNear;
 }
 
+float Walkarea_GetFaceDirectionRatio(ScriptWalkableArea *wa)
+{
+    return thisroom.WalkAreas[wa->id].FaceDirectionRatio;
+}
+
+void Walkarea_SetFaceDirectionRatio(ScriptWalkableArea *wa, float ratio)
+{
+    thisroom.WalkAreas[wa->id].FaceDirectionRatio = ratio;
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -315,6 +325,16 @@ RuntimeScriptValue Sc_Walkarea_GetScalingMax(void *self, const RuntimeScriptValu
     API_OBJCALL_INT(ScriptWalkableArea, Walkarea_GetScalingMax);
 }
 
+RuntimeScriptValue Sc_Walkarea_GetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptWalkableArea, Walkarea_GetFaceDirectionRatio);
+}
+
+RuntimeScriptValue Sc_Walkarea_SetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptWalkableArea, Walkarea_SetFaceDirectionRatio);
+}
+
 
 void RegisterWalkareaAPI()
 {
@@ -329,6 +349,8 @@ void RegisterWalkareaAPI()
         { "WalkableArea::get_ID",              API_FN_PAIR(Walkarea_GetID) },
         { "WalkableArea::get_ScalingMin",      API_FN_PAIR(Walkarea_GetScalingMin) },
         { "WalkableArea::get_ScalingMax",      API_FN_PAIR(Walkarea_GetScalingMax) },
+        { "WalkableArea::get_FaceDirectionRatio", API_FN_PAIR(Walkarea_GetFaceDirectionRatio) },
+        { "WalkableArea::set_FaceDirectionRatio", API_FN_PAIR(Walkarea_SetFaceDirectionRatio) },
     };
 
     ccAddExternalFunctions(walkarea_api);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -893,7 +893,7 @@ HSaveError WriteRoomStates(Stream *out)
             {
                 out->WriteInt32(i);
                 WriteFormatTag(out, "RoomState", true);
-                roomstat->WriteToSavegame(out, loaded_game_file_version);
+                roomstat->WriteToSavegame(out);
                 WriteFormatTag(out, "RoomState", false);
             }
             else
@@ -964,7 +964,7 @@ HSaveError WriteThisRoom(Stream *out)
     out->WriteBool(persist);
     // write the current troom state, in case they save in temporary room
     if (!persist)
-        troom.WriteToSavegame(out, loaded_game_file_version);
+        troom.WriteToSavegame(out);
     return HSaveError::None();
 }
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -812,6 +812,7 @@ void engine_init_game_settings()
     if (debug_flags & DBG_DEBUGMODE)
         play.debug_mode = 1;
     play.shake_screen_yoff = 0;
+    play.face_dir_ratio = game.faceDirectionRatio;
 
     GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);
     GUI::Options.ClipControls = game.options[OPT_CLIPGUICONTROLS] != 0;

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -180,6 +180,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, (P1CLASS*)params[4].Ptr); \
     return RuntimeScriptValue((int32_t)0)
 
+#define API_SCALL_VOID_PFLOAT(FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 1); \
+    FUNCTION(params[0].FValue); \
+    return RuntimeScriptValue((int32_t)0)
+
 #define API_SCALL_VOID_PFLOAT2(FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 2); \
     FUNCTION(params[0].FValue, params[1].FValue); \


### PR DESCRIPTION
Resolves #2243

This implements new property called FaceDirectionRatio for Game, Room, WalkableArea and Character. This property affects selection of directional loop while Character moves and turns.

```
/// Gets/sets the default y/x ratio of character's facing directions, determining directional loop selection for all Characters in game.
static attribute float Game.FaceDirectionRatio;

/// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character in the current room.
static attribute float Room.FaceDirectionRatio;

/// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character while on this area.
static attribute float FaceDirectionRatio;

/// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection while Character moves and turns.
attribute float Character.FaceDirectionRatio;
```

Ratio's implementation is loosely based on the experimental commit in @AlanDrake 's custom "Draconian" engine. The meaning of ratio is (Y / X) relation. Default value is 1.0, where loop selection strictly corresponds to movement and facing dir. Values >1.0 mean that Y axis has more "weight", and vertical loops are chosen for the wider range of angles. Values <1.0 mean that X axis has more "weight", and horizontal loops are chosen for the wider range of angles.

This may be also illustrated with this pic:

![](https://i.imgur.com/XsGxJ7j.png)

The properties are checked in following order:

1. Individual Character.FaceDirectionRatio, if it's > 0;
2. WalkableArea.FaceDirectionRatio, if it's > 0;
3. Room.FaceDirectionRatio, if it's > 0;
4. If none of above, then Game.FaceDirectionRatio

---

Potential TODOs:
- [x] Add respective properties in General Settings and Room properties in the Editor. Idk if Characters need an individual design-time property for this, I suppose character's property serves rather as an override in some narrow use cases.
- [x] Add property for Walkable Areas in the Editor, in which case it will be checked after Character's but before Room's.
- [x] Float properties are parsed depending on Culture, which should not be happening. To clarify: on some systems it will require "2.5" (with a dot) and on others "2,5" (with a comma). Need to figure out how to enforce InvariantCulture in the PropertyGrid.
- [x] Add script property for Walkable Areas, but I don't want to do this right away here, as WAs don't have their respective struct. I'd rather wait until their api is replaced with OO-style api first (opened pr for this #2307).
- [x] Save properties that may be changed at runtime.

~[ ] Optimize direction ration calculation by caching few things in character class.~

---

Test game, made with assets by user who requested this feature recently:
[IsoBikeDemo.zip](https://github.com/adventuregamestudio/ags/files/14316758/IsoBikeDemo.zip)

