### PR TITLE
AGS 4: Script API: convert Walk-areas and Walkbehinds API to OO-style

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -730,6 +730,18 @@ builtin struct Room {
   /// Checks if the specified room exists
   import static bool Exists(int room);   // $AUTOCOMPLETESTATICONLY$
 #endif
+#ifdef SCRIPT_API_v400
+  /// Accesses the Hotspots in the current room.
+  import static readonly attribute Hotspot *Hotspots[];   // $AUTOCOMPLETESTATICONLY$
+  /// Accesses the Objects in the current room.
+  import static readonly attribute Object *Objects[];   // $AUTOCOMPLETESTATICONLY$
+  /// Accesses the Regions in the current room.
+  import static readonly attribute Region *Regions[];   // $AUTOCOMPLETESTATICONLY$
+  /// Accesses the Walkable areas in the current room.
+  import static readonly attribute WalkableArea *WalkableAreas[];   // $AUTOCOMPLETESTATICONLY$
+  /// Accesses the Walk-behinds in the current room.
+  import static readonly attribute Walkbehind *Walkbehinds[];   // $AUTOCOMPLETESTATICONLY$
+#endif
 };
 
 builtin struct Parser {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -26,6 +26,8 @@
 #define AGS_MAX_OBJECTS   256
 #define AGS_MAX_HOTSPOTS  50
 #define AGS_MAX_REGIONS   16
+#define AGS_MAX_WALKABLE_AREAS 16
+#define AGS_MAX_WALKBEHINDS 16
 // MAX_ROOM_OBJECTS is a duplicate and was added by an oversight
 #define MAX_ROOM_OBJECTS  40
 #define MAX_LEGACY_GLOBAL_VARS  50
@@ -689,6 +691,12 @@ builtin managed struct Camera;
 builtin managed struct Viewport;
 #endif
 
+builtin managed struct Hotspot;
+builtin managed struct Object;
+builtin managed struct Region;
+builtin managed struct WalkableArea;
+builtin managed struct Walkbehind;
+
 builtin struct Room {
   /// Gets a custom text property associated with this room.
   import static String GetTextProperty(const string property);
@@ -796,6 +804,7 @@ import void DeleteSaveSlot(int slot);
 import void SetRestartPoint();
 /// Gets what type of thing is in the room at the specified co-ordinates.
 import LocationType GetLocationType(int x, int y);
+#ifdef SCRIPT_COMPAT_v399
 #ifdef SCRIPT_API_v3507
 /// Returns which walkable area is at the specified position on screen.
 import int  GetWalkableAreaAtScreen(int screenX, int screenY);
@@ -808,6 +817,7 @@ import DrawingSurface* GetDrawingSurfaceForWalkableArea();
 /// Gets the drawing surface for the 8-bit walk-behind mask
 import DrawingSurface* GetDrawingSurfaceForWalkbehind();
 #endif
+#endif // SCRIPT_COMPAT_v399
 /// Returns the scaling level at the specified position within the room.
 import int  GetScalingAt (int x, int y);
 /// Returns whether the game is currently paused.
@@ -1126,24 +1136,27 @@ import void SetNextScreenTransition(TransitionStyle);
 import void SetFadeColor(int red, int green, int blue);
 /// Checks whether an event handler is registered to handle clicking at the specified location on the screen.
 import int  IsInteractionAvailable (int x, int y, CursorMode);
-/// Removes the specified walkable area from the room.
-import void RemoveWalkableArea(int area);
-/// Brings back a previously removed walkable area.
-import void RestoreWalkableArea(int area);
-/// Changes the specified walkable area's scaling level.
-import void SetAreaScaling(int area, int min, int max);
 /// Disables all region events, and optionally light levels and tints.
 import void DisableGroundLevelAreas(int disableTints);
 /// Re-enables region events, light levels and tints.
 import void EnableGroundLevelAreas();
-/// Changes the baseline of the specified walk-behind area.
-import void SetWalkBehindBase(int area, int baseline);
 /// Plays a FLI/FLC animation.
 import void PlayFlic(int flcNumber, int options);
 /// Plays an AVI/MPG video.
 import void PlayVideo(const string filename, VideoSkipStyle, int flags);
 /// Sets an ambient light level that affects all objects and characters in the room.
 import void SetAmbientLightLevel(int light_level);
+
+#ifdef SCRIPT_COMPAT_v399
+/// Removes the specified walkable area from the room.
+import void RemoveWalkableArea(int area);
+/// Brings back a previously removed walkable area.
+import void RestoreWalkableArea(int area);
+/// Changes the specified walkable area's scaling level.
+import void SetAreaScaling(int area, int min, int max);
+/// Changes the baseline of the specified walk-behind area.
+import void SetWalkBehindBase(int area, int baseline);
+#endif // SCRIPT_COMPAT_v399
 
 import int  IsVoxAvailable();
 /// Changes the voice speech volume.
@@ -1610,6 +1623,42 @@ builtin managed struct Region {
 #endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
+
+#ifdef SCRIPT_API_v400
+builtin managed struct WalkableArea {
+  /// Gets the walkable area at the specified position on the screen.
+  import static WalkableArea* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Returns the walkable area at the specified position within this room.
+  import static WalkableArea* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Gets the drawing surface for the 8-bit walkable mask
+  import static DrawingSurface* GetDrawingSurface();  // $AUTOCOMPLETESTATICONLY$
+  /// Changes this walkable area's scaling level.
+  import void SetScaling(int min, int max);
+  /// Gets the ID number for this area.
+  import readonly attribute int ID;
+  /// Gets/sets whether this walkable area is enabled.
+  import attribute bool Enabled;
+  /// Gets this walkable area's minimal scaling level.
+  import readonly attribute int ScalingMin;
+  /// Gets this walkable area's maximal scaling level.
+  import readonly attribute int ScalingMax;
+};
+#endif
+
+#ifdef SCRIPT_API_v400
+builtin managed struct Walkbehind {
+  /// Gets the walk-behind at the specified position on the screen.
+  import static Walkbehind* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Returns the walk-behind at the specified position within this room.
+  import static Walkbehind* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Gets the drawing surface for the 8-bit walk-behind mask
+  import static DrawingSurface* GetDrawingSurface();  // $AUTOCOMPLETESTATICONLY$
+  /// Gets the ID number for this walk-behind.
+  import readonly attribute int ID;
+  /// Gets/sets this walk-behind's baseline.
+  import attribute int Baseline;
+};
+#endif
 
 builtin managed struct Dialog {
 #ifdef SCRIPT_API_v361
@@ -2594,6 +2643,8 @@ import readonly Character *player;
 import readonly Object *object[AGS_MAX_OBJECTS];
 import readonly Hotspot *hotspot[AGS_MAX_HOTSPOTS];
 import readonly Region *region[AGS_MAX_REGIONS];
+import readonly WalkableArea *walkarea[AGS_MAX_WALKABLE_AREAS];
+import readonly Walkbehind *walkbehind[AGS_MAX_WALKBEHINDS];
 
 #undef CursorMode
 #undef FontType

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -77,6 +77,10 @@ target_sources(engine
     ac/dynobj/cc_region.h
     ac/dynobj/cc_serializer.cpp
     ac/dynobj/cc_serializer.h
+    ac/dynobj/cc_walkablearea.cpp
+    ac/dynobj/cc_walkablearea.h
+    ac/dynobj/cc_walkbehind.cpp
+    ac/dynobj/cc_walkbehind.h
     ac/dynobj/dynobj_manager.cpp
     ac/dynobj/dynobj_manager.h
     ac/dynobj/managedobjectpool.cpp

--- a/Engine/ac/dynobj/all_dynamicclasses.h
+++ b/Engine/ac/dynobj/all_dynamicclasses.h
@@ -29,6 +29,8 @@
 #include "ac/dynobj/cc_inventory.h"
 #include "ac/dynobj/cc_object.h"
 #include "ac/dynobj/cc_region.h"
+#include "ac/dynobj/cc_walkablearea.h"
+#include "ac/dynobj/cc_walkbehind.h"
 
 #include "ac/dynobj/cc_serializer.h"
 

--- a/Engine/ac/dynobj/cc_walkablearea.cpp
+++ b/Engine/ac/dynobj/cc_walkablearea.cpp
@@ -1,0 +1,43 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2023 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "ac/dynobj/cc_walkablearea.h"
+#include "ac/dynobj/scriptobjects.h"
+#include "ac/dynobj/dynobj_manager.h"
+#include "ac/common_defines.h"
+#include "game/roomstruct.h"
+#include "util/stream.h"
+
+using namespace AGS::Common;
+
+extern ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
+
+// return the type name of the object
+const char *CCWalkableArea::GetType() {
+    return "WalkableArea";
+}
+
+size_t CCWalkableArea::CalcSerializeSize(const void* /*address*/)
+{
+    return sizeof(int32_t);
+}
+
+void CCWalkableArea::Serialize(const void *address, Stream *out) {
+    const ScriptWalkableArea *shh = static_cast<const ScriptWalkableArea*>(address);
+    out->WriteInt32(shh->id);
+}
+
+void CCWalkableArea::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
+    int num = in->ReadInt32();
+    ccRegisterUnserializedPersistentObject(index, &scrWalkarea[num], this);
+}

--- a/Engine/ac/dynobj/cc_walkablearea.h
+++ b/Engine/ac/dynobj/cc_walkablearea.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2023 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AC_CCWALKABLEAREA_H
+#define __AC_CCWALKABLEAREA_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+
+struct CCWalkableArea final : AGSCCDynamicObject
+{
+public:
+    // return the type name of the object
+    const char *GetType() override;
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
+protected:
+    // Calculate and return required space for serialization, in bytes
+    size_t CalcSerializeSize(const void *address) override;
+    // Write object data into the provided stream
+    void Serialize(const void *address, AGS::Common::Stream *out) override;
+};
+
+#endif // __AC_CCWALKABLEAREA_H

--- a/Engine/ac/dynobj/cc_walkbehind.cpp
+++ b/Engine/ac/dynobj/cc_walkbehind.cpp
@@ -1,0 +1,43 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2023 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "ac/dynobj/cc_walkbehind.h"
+#include "ac/dynobj/scriptobjects.h"
+#include "ac/dynobj/dynobj_manager.h"
+#include "ac/common_defines.h"
+#include "game/roomstruct.h"
+#include "util/stream.h"
+
+using namespace AGS::Common;
+
+extern ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
+
+// return the type name of the object
+const char *CCWalkbehind::GetType() {
+    return "Walkbehind";
+}
+
+size_t CCWalkbehind::CalcSerializeSize(const void* /*address*/)
+{
+    return sizeof(int32_t);
+}
+
+void CCWalkbehind::Serialize(const void *address, Stream *out) {
+    const ScriptWalkbehind *shh = static_cast<const ScriptWalkbehind*>(address);
+    out->WriteInt32(shh->id);
+}
+
+void CCWalkbehind::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
+    int num = in->ReadInt32();
+    ccRegisterUnserializedPersistentObject(index, &scrWalkbehind[num], this);
+}

--- a/Engine/ac/dynobj/cc_walkbehind.h
+++ b/Engine/ac/dynobj/cc_walkbehind.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2023 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AC_CCWALKBEHIND_H
+#define __AC_CCWALKBEHIND_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+
+struct CCWalkbehind final : AGSCCDynamicObject
+{
+public:
+    // return the type name of the object
+    const char *GetType() override;
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
+protected:
+    // Calculate and return required space for serialization, in bytes
+    size_t CalcSerializeSize(const void *address) override;
+    // Write object data into the provided stream
+    void Serialize(const void *address, AGS::Common::Stream *out) override;
+};
+
+#endif // __AC_CCWALKBEHIND_H

--- a/Engine/ac/dynobj/scriptobjects.h
+++ b/Engine/ac/dynobj/scriptobjects.h
@@ -38,5 +38,7 @@ struct ScriptHotspot : public ScriptSimpleRef {};
 struct ScriptInvItem : public ScriptSimpleRef {};
 struct ScriptObject : public ScriptSimpleRef {};
 struct ScriptRegion : public ScriptSimpleRef {};
+struct ScriptWalkableArea : public ScriptSimpleRef {};
+struct ScriptWalkbehind : public ScriptSimpleRef {};
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTOBJECTS_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -122,6 +122,8 @@ CCGUIObject ccDynamicGUIObject;
 CCCharacter ccDynamicCharacter;
 CCHotspot   ccDynamicHotspot;
 CCRegion    ccDynamicRegion;
+CCWalkableArea ccDynamicWalkarea;
+CCWalkbehind ccDynamicWalkbehind;
 CCInventory ccDynamicInv;
 CCGUI       ccDynamicGUI;
 CCObject    ccDynamicObject;
@@ -135,6 +137,8 @@ ScriptInvItem scrInv[MAX_INV];
 ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
 ScriptObject scrObj[MAX_ROOM_OBJECTS];
 ScriptRegion scrRegion[MAX_ROOM_REGIONS];
+ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
+ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
 
 
 std::vector<ViewStruct> views;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -85,7 +85,6 @@ extern Bitmap *walkareabackup, *walkable_areas_temp;
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern SpriteCache spriteset;
 extern int in_new_room, new_room_was;  // 1 in new room, 2 first time in new room, 3 loading saved game
-extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
 extern int in_leaves_screen;
 extern CharacterInfo*playerchar;
 extern int starting_room;
@@ -97,6 +96,14 @@ extern bool logScriptRTTI;
 
 extern CCHotspot ccDynamicHotspot;
 extern CCObject ccDynamicObject;
+extern CCRegion ccDynamicRegion;
+extern CCWalkableArea ccDynamicWalkarea;
+extern CCWalkbehind ccDynamicWalkbehind;
+extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
+extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
+extern ScriptRegion scrRegion[MAX_ROOM_REGIONS];
+extern ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
+extern ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
 
 RGB_MAP rgb_table;  // for 256-col antialiasing
 int new_room_flags=0;
@@ -209,6 +216,41 @@ ScriptDrawingSurface *Hotspot_GetDrawingSurface()
 ScriptDrawingSurface *Region_GetDrawingSurface()
 {
     return Room_GetDrawingSurfaceForMask(kRoomAreaRegion);
+}
+
+ScriptHotspot* Room_GetiHotspots(int idx)
+{
+    if ((idx < 0) || (idx >= MAX_ROOM_HOTSPOTS))
+        return nullptr;
+    return &scrHotspot[idx];
+}
+
+ScriptObject* Room_GetiObjects(int idx)
+{
+    if ((idx < 0) || (idx >= MAX_ROOM_OBJECTS))
+        return nullptr;
+    return &scrObj[idx];
+}
+
+ScriptRegion* Room_GetiRegions(int idx)
+{
+    if ((idx < 0) || (idx >= MAX_ROOM_REGIONS))
+        return nullptr;
+    return &scrRegion[idx];
+}
+
+ScriptWalkableArea* Room_GetiWalkableAreas(int idx)
+{
+    if ((idx < 0) || (idx >= MAX_WALK_AREAS))
+        return nullptr;
+    return &scrWalkarea[idx];
+}
+
+ScriptWalkbehind* Room_GetiWalkbehinds(int idx)
+{
+    if ((idx < 0) || (idx >= MAX_WALK_BEHINDS))
+        return nullptr;
+    return &scrWalkbehind[idx];
 }
 
 //=============================================================================
@@ -1006,6 +1048,31 @@ RuntimeScriptValue Sc_Room_Exists(const RuntimeScriptValue *params, int32_t para
     API_SCALL_BOOL_PINT(Room_Exists);
 }
 
+RuntimeScriptValue Sc_Room_GetiHotspots(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(ScriptHotspot, ccDynamicHotspot, Room_GetiHotspots);
+}
+
+RuntimeScriptValue Sc_Room_GetiObjects(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(ScriptObject, ccDynamicObject, Room_GetiObjects);
+}
+
+RuntimeScriptValue Sc_Room_GetiRegions(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(ScriptRegion, ccDynamicRegion, Room_GetiRegions);
+}
+
+RuntimeScriptValue Sc_Room_GetiWalkableAreas(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(ScriptWalkableArea, ccDynamicWalkarea, Room_GetiWalkableAreas);
+}
+
+RuntimeScriptValue Sc_Room_GetiWalkbehinds(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(ScriptWalkbehind, ccDynamicWalkbehind, Room_GetiWalkbehinds);
+}
+
 void RegisterRoomAPI()
 {
     ScFnRegister room_api[] = {
@@ -1025,6 +1092,11 @@ void RegisterRoomAPI()
         { "Room::get_TopEdge",                        API_FN_PAIR(Room_GetTopEdge) },
         { "Room::get_Width",                          API_FN_PAIR(Room_GetWidth) },
         { "Room::Exists",                             API_FN_PAIR(Room_Exists) },
+        { "Room::geti_Hotspots",                      API_FN_PAIR(Room_GetiHotspots) },
+        { "Room::geti_Objects",                       API_FN_PAIR(Room_GetiObjects) },
+        { "Room::geti_Regions",                       API_FN_PAIR(Room_GetiRegions) },
+        { "Room::geti_WalkableAreas",                 API_FN_PAIR(Room_GetiWalkableAreas) },
+        { "Room::geti_Walkbehinds",                   API_FN_PAIR(Room_GetiWalkbehinds) },
     };
 
     ccAddExternalFunctions(room_api);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -504,6 +504,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     objs = croom->obj.size() > 0 ? &croom->obj[0] : nullptr;
 
+    // Register named Objects and Hotspots
     for (uint32_t cc = 0; cc < croom->numobj; cc++) {
         // export the object's script object
         if (thisroom.Objects[cc].ScriptName.IsEmpty())

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -59,6 +59,8 @@ extern CCGUIObject ccDynamicGUIObject;
 extern CCCharacter ccDynamicCharacter;
 extern CCHotspot   ccDynamicHotspot;
 extern CCRegion    ccDynamicRegion;
+extern CCWalkableArea ccDynamicWalkarea;
+extern CCWalkbehind ccDynamicWalkbehind;
 extern CCInventory ccDynamicInv;
 extern CCGUI       ccDynamicGUI;
 extern CCObject    ccDynamicObject;
@@ -70,6 +72,8 @@ extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern std::vector<ScriptGUI> scrGui;
 extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
 extern ScriptRegion scrRegion[MAX_ROOM_REGIONS];
+extern ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
+extern ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
 extern ScriptInvItem scrInv[MAX_INV];
 extern ScriptAudioChannel scrAudioChannel[MAX_GAME_CHANNELS];
 
@@ -88,6 +92,8 @@ std::vector<int> StaticObjectArray;
 std::vector<int> StaticGUIArray;
 std::vector<int> StaticHotspotArray;
 std::vector<int> StaticRegionArray;
+std::vector<int> StaticWalkareaArray;
+std::vector<int> StaticWalkbehindArray;
 std::vector<int> StaticInventoryArray;
 std::vector<int> StaticDialogArray;
 
@@ -256,45 +262,28 @@ void InitAndRegisterInvItems(const GameSetupStruct &game)
     }
 }
 
-// Initializes room hotspots and registers them in the script system
-void InitAndRegisterHotspots()
+// Register room script entity of a given type
+template <typename TScriptType>
+void RegisterRoomEntities(std::vector<int> &static_arr, TScriptType scr_objs[], size_t count, AGSCCDynamicObject &mgr)
 {
-    StaticHotspotArray.resize(MAX_ROOM_HOTSPOTS);
-
-    for (int i = 0; i < MAX_ROOM_HOTSPOTS; ++i)
+    static_arr.resize(count);
+    for (size_t i = 0; i < count; ++i)
     {
-        scrHotspot[i].id = i;
+        scr_objs[i].id = i;
         // register and save handle
-        int handle = ccRegisterPersistentObject(&scrHotspot[i], &ccDynamicHotspot);
-        StaticHotspotArray[i] = handle;
+        int handle = ccRegisterPersistentObject(&scr_objs[i], &mgr);
+        static_arr[i] = handle;
     }
 }
 
-// Initializes room objects and registers them in the script system
-void InitAndRegisterRoomObjects()
+// Initializes room entities and registers them in the script system
+void InitAndRegisterRoomEntities()
 {
-    StaticObjectArray.resize(MAX_ROOM_OBJECTS);
-
-    for (int i = 0; i < MAX_ROOM_OBJECTS; ++i)
-    {
-        // register and save handle
-        int handle = ccRegisterPersistentObject(&scrObj[i], &ccDynamicObject);
-        StaticObjectArray[i] = handle;
-    }
-}
-
-// Initializes room regions and registers them in the script system
-void InitAndRegisterRegions()
-{
-    StaticRegionArray.resize(MAX_ROOM_REGIONS);
-
-    for (int i = 0; i < MAX_ROOM_REGIONS; ++i)
-    {
-        scrRegion[i].id = i;
-        // register and save handle
-        int handle = ccRegisterPersistentObject(&scrRegion[i], &ccDynamicRegion);
-        StaticRegionArray[i] = handle;
-    }
+    RegisterRoomEntities(StaticHotspotArray, scrHotspot, MAX_ROOM_HOTSPOTS, ccDynamicHotspot);
+    RegisterRoomEntities(StaticObjectArray, scrObj, MAX_ROOM_OBJECTS, ccDynamicObject);
+    RegisterRoomEntities(StaticRegionArray, scrRegion, MAX_ROOM_REGIONS, ccDynamicRegion);
+    RegisterRoomEntities(StaticWalkareaArray, scrWalkarea, MAX_WALK_AREAS, ccDynamicWalkarea);
+    RegisterRoomEntities(StaticWalkbehindArray, scrWalkbehind, MAX_WALK_BEHINDS, ccDynamicWalkbehind);
 }
 
 // Registers static entity arrays in the script system
@@ -311,6 +300,8 @@ void RegisterStaticArrays(GameSetupStruct &game)
     ccAddExternalScriptObject("hotspot", &StaticHotspotArray[0], &StaticHandlesArray);
     ccAddExternalScriptObject("object", &StaticObjectArray[0], &StaticHandlesArray);
     ccAddExternalScriptObject("region", &StaticRegionArray[0], &StaticHandlesArray);
+    ccAddExternalScriptObject("walkarea", &StaticWalkareaArray[0], &StaticHandlesArray);
+    ccAddExternalScriptObject("walkbehind", &StaticWalkbehindArray[0], &StaticHandlesArray);
 }
 
 // Initializes various game entities and registers them in the script system
@@ -326,9 +317,7 @@ HError InitAndRegisterGameEntities(const LoadedGameEntities &ents)
         return err;
     InitAndRegisterInvItems(game);
 
-    InitAndRegisterHotspots();
-    InitAndRegisterRegions();
-    InitAndRegisterRoomObjects();
+    InitAndRegisterRoomEntities();
     play.CreatePrimaryViewportAndCamera();
 
     RegisterStaticArrays(game);

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -55,6 +55,8 @@ extern void RegisterSystemAPI();
 extern void RegisterTextBoxAPI();
 extern void RegisterViewFrameAPI();
 extern void RegisterViewportAPI();
+extern void RegisterWalkareaAPI();
+extern void RegisterWalkbehindAPI();
 
 extern void RegisterStaticObjects();
 
@@ -97,6 +99,8 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterTextBoxAPI();
     RegisterViewFrameAPI();
     RegisterViewportAPI();
+    RegisterWalkareaAPI();
+    RegisterWalkbehindAPI();
 
     RegisterStaticObjects();
 }

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -470,6 +470,8 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\cc_dialog.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\cc_dynamicarray.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\cc_staticarray.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\cc_walkablearea.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\cc_walkbehind.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\dynobj_manager.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\cc_gui.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\cc_guiobject.cpp" />
@@ -713,6 +715,8 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_region.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_serializer.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_staticarray.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_walkablearea.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_walkbehind.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\dynobj_manager.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\managedobjectpool.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptcamera.h" />
@@ -726,7 +730,6 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptgame.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptjoystick.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptmouse.h" />
-    <ClInclude Include="..\..\Engine\ac\dynobj\scriptobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptoverlay.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptstring.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -756,6 +756,12 @@
     <ClCompile Include="..\..\Engine\plugin\plugin_stubs.cpp">
       <Filter>Source Files\plugin</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\cc_walkablearea.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\cc_walkbehind.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1056,9 +1062,6 @@
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptmouse.h">
-      <Filter>Header Files\ac\dynobj</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\Engine\ac\dynobj\scriptobject.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptoverlay.h">
@@ -1515,6 +1518,12 @@
       <Filter>Header Files\plugin</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptobjects.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_walkbehind.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_walkablearea.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Converting walkable areas and walk-behinds script api to OO-style, in compliance with existing Hotspot, Regions etc api.

This adds two managed structs, and array properties in the Room struct for getting these.

```
builtin managed struct WalkableArea {
  /// Gets the walkable area at the specified position on the screen.
  import static WalkableArea* GetAtScreenXY(int x, int y);
  /// Returns the walkable area at the specified position within this room.
  import static WalkableArea* GetAtRoomXY(int x, int y);
  /// Gets the drawing surface for the 8-bit walkable mask
  import static DrawingSurface* GetDrawingSurface();
  /// Changes this walkable area's scaling level.
  import void SetScaling(int min, int max);
  /// Gets the ID number for this area.
  import readonly attribute int ID;
  /// Gets/sets whether this walkable area is enabled.
  import attribute bool Enabled;
  /// Gets/sets this walkable area's minimal scaling level.
  import readonly attribute int ScalingMin;
  /// Gets/sets this walkable area's maximal scaling level.
  import readonly attribute int ScalingMax;
};

builtin managed struct Walkbehind {
  /// Gets the walk-behind at the specified position on the screen.
  import static WalkableArea* GetAtScreenXY(int x, int y);
  /// Returns the walk-behind at the specified position within this room.
  import static WalkableArea* GetAtRoomXY(int x, int y);
  /// Gets the drawing surface for the 8-bit walk-behind mask
  import static DrawingSurface* GetDrawingSurface();
  /// Gets the ID number for this walk-behind.
  import readonly attribute int ID;
  /// Gets/sets this walk-behind's baseline.
  import attribute int Baseline;
};
```

Added 2 global arrays of pointers to match existing ones, since they are still in use:
```
import readonly WalkableArea *walkarea[AGS_MAX_WALKABLE_AREAS];
import readonly Walkbehind *walkbehind[AGS_MAX_WALKBEHINDS];
```

But also added Room properties that return room's elements, as a suggestion for future use:
```
  /// Accesses the Hotspots in the current room.
  import static readonly attribute Hotspot *Hotspots[];
  /// Accesses the Objects in the current room.
  import static readonly attribute Object *Objects[];
  /// Accesses the Regions in the current room.
  import static readonly attribute Region *Regions[];
  /// Accesses the Walkable areas in the current room.
  import static readonly attribute WalkableArea *WalkableAreas[];
  /// Accesses the Walk-behinds in the current room.
  import static readonly attribute Walkbehind *Walkbehinds[];
```