### PR TITLE
OpenGL: use GL_CLAMP_TO_EDGE with Linear filter

### DIFF
--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -36,8 +36,6 @@
 
 #if AGS_OPENGL_ES2
 
-#define GL_CLAMP GL_CLAMP_TO_EDGE
-
 const char* fbo_extension_string = "GL_OES_framebuffer_object";
 
 #define glGenFramebuffersEXT glGenFramebuffers
@@ -1130,18 +1128,20 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry,
     {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
     else if (_do_render_to_texture)
     {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
     }
     else
     {
       _filter->SetFilteringForStandardSprite();
     }
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 
     if (txdata->_vertex != nullptr)
     {
@@ -1639,8 +1639,12 @@ void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap
   else
     BitmapToVideoMem(bitmap, has_alpha, &fixedTile, memPtr, pitch, usingLinearFiltering);
 
-  // Mimic the behaviour of GL_CLAMP_EDGE for the tile edges
-  // NOTE: on some platforms GL_CLAMP_EDGE does not work with the version of OpenGL we're using.
+  // Mimic the behaviour of GL_CLAMP_TO_EDGE for the tile edges
+  // NOTE: on some platforms GL_CLAMP_TO_EDGE does not work with the version of OpenGL we're using.
+  // TODO: test the GL version to see if this is even necessary?!
+  // Info on CLAMP types:
+  // https://docs.gl/gl2/glTexParameter
+  // https://stackoverflow.com/questions/56823126/how-is-gl-clamp-in-opengl-different-from-gl-clamp-to-edge
   if (tile->width < tileWidth)
   {
     if (tilex > 0)

--- a/Engine/gfx/gfxfilter_aaogl.cpp
+++ b/Engine/gfx/gfxfilter_aaogl.cpp
@@ -37,6 +37,10 @@ void AAOGLGfxFilter::SetFilteringForStandardSprite()
 {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    // Prevent sprite pixels mixing with "texture border" pixels sometimes
+    // See: https://stackoverflow.com/questions/56823126/how-is-gl-clamp-in-opengl-different-from-gl-clamp-to-edge
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
 const GfxFilterInfo &AAOGLGfxFilter::GetInfo() const

--- a/Engine/gfx/gfxfilter_ogl.cpp
+++ b/Engine/gfx/gfxfilter_ogl.cpp
@@ -37,6 +37,8 @@ void OGLGfxFilter::SetFilteringForStandardSprite()
 {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 }
 
 const GfxFilterInfo &OGLGfxFilter::GetInfo() const

--- a/Engine/gfx/ogl_headers.h
+++ b/Engine/gfx/ogl_headers.h
@@ -38,3 +38,9 @@
 #ifndef GLAPI
 #define GLAD_GL_VERSION_2_0 (0)
 #endif
+
+#if AGS_OPENGL_ES2
+#ifndef GL_CLAMP
+    #define GL_CLAMP GL_CLAMP_TO_EDGE
+#endif
+#endif // AGS_OPENGL_ES2


### PR DESCRIPTION
This supposedly fixes occasional edge lines around sprites, occurring in "render in screen resolution" mode with Linear filter, and certain scaling factors.

A quote from Khronos specs, about a difference between GL_CLAMP and GL_CLAMP_TO_EDGE :

> GL normally clamps such that the texture coordinates are limited to exactly the range [0;1]. When a texture coordinate is clamped using this algorithm, the texture sampling filter straddles the edge of the texture image, taking half its sample values from within the texture image, and the other half from the texture border. It is sometimes desirable to clamp a texture without requiring a border, and without using the constant border color.

> <...> CLAMP_TO_EDGE, clamps texture coordinates at all mipmap levels such that the texture filter never samples a border texel. The color returned when clamping is derived only from texels at the edge of the texture image.