### PR TITLE
Refactor `our_eip=X` to use `set_our_eip(X)` function

### DIFF
--- a/Common/ac/common.cpp
+++ b/Common/ac/common.cpp
@@ -15,6 +15,7 @@
 #include "util/string.h"
 
 using namespace AGS::Common;
+int our_eip = 0;
 
 void quit(const String &str)
 {
@@ -28,4 +29,14 @@ void quitprintf(const char *fmt, ...)
     String text = String::FromFormatV(fmt, ap);
     va_end(ap);
     quit(text);
+}
+
+void set_our_eip(int eip)
+{
+    our_eip = eip;
+}
+
+int get_our_eip()
+{
+    return our_eip;
 }

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -11,6 +11,7 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
+#include "ac/common.h"
 #include "gui/guimain.h"
 #include <algorithm>
 #include "ac/game_version.h"
@@ -244,12 +245,12 @@ bool GUIMain::BringControlToFront(int index)
 
 void GUIMain::DrawSelf(Bitmap *ds)
 {
-    SET_EIP(375);
+    set_our_eip(375);
 
     if ((Width < 1) || (Height < 1))
         return;
 
-    SET_EIP(376);
+    set_our_eip(376);
     // stop border being transparent, if the whole GUI isn't
     if ((FgColor == 0) && (BgColor != 0))
         FgColor = 16;
@@ -257,7 +258,7 @@ void GUIMain::DrawSelf(Bitmap *ds)
     if (BgColor != 0)
         ds->Fill(ds->GetCompatibleColor(BgColor));
 
-    SET_EIP(377);
+    set_our_eip(377);
 
     color_t draw_color;
     if (FgColor != BgColor)
@@ -268,12 +269,12 @@ void GUIMain::DrawSelf(Bitmap *ds)
             ds->DrawRect(Rect(1, 1, ds->GetWidth() - 2, ds->GetHeight() - 2), draw_color);
     }
 
-    SET_EIP(378);
+    set_our_eip(378);
 
     if (BgImage > 0 && spriteset.DoesSpriteExist(BgImage))
         draw_gui_sprite(ds, BgImage, 0, 0, false);
 
-    SET_EIP(379);
+    set_our_eip(379);
 }
 
 void GUIMain::DrawWithControls(Bitmap *ds)
@@ -346,7 +347,7 @@ void GUIMain::DrawWithControls(Bitmap *ds)
         }
     }
 
-    SET_EIP(380);
+    set_our_eip(380);
 }
 
 void GUIMain::DrawBlob(Bitmap *ds, int x, int y, color_t draw_color)

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -304,7 +304,6 @@ extern int get_fixed_pixel_size(int pixels);
 extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);
 
 extern void set_our_eip(int eip);
-#define SET_EIP(x) set_our_eip(x);
 extern void set_eip_guiobj(int eip);
 extern int get_eip_guiobj();
 

--- a/Editor/Native/acfonts_agsnative.cpp
+++ b/Editor/Native/acfonts_agsnative.cpp
@@ -14,15 +14,6 @@
 extern GameSetupStruct thisgame;
 extern int antiAliasFonts;
 
-void set_our_eip(int eip)
-{
-  // do nothing
-}
-
-int get_our_eip()
-{
-  return 0;
-}
 
 bool ShouldAntiAliasText()
 {

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -76,7 +76,6 @@ extern Bitmap *walkable_areas_temp;
 extern IGraphicsDriver *gfxDriver;
 extern int said_speech_line;
 extern int said_text;
-extern int our_eip;
 extern CCCharacter ccDynamicCharacter;
 extern CCInventory ccDynamicInv;
 
@@ -2469,7 +2468,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
     // the strings are pre-translated
     //texx = get_translation(texx);
-    our_eip=150;
+    set_our_eip(150);
 
     int isPause = 1;
     // if the message is all .'s, don't display anything
@@ -2501,7 +2500,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     if (bwidth < 0)
         bwidth = ui_view.GetWidth()/2 + ui_view.GetWidth()/4;
 
-    our_eip=151;
+    set_our_eip(151);
 
     int useview = speakingChar->talkview;
     if (isThought) {
@@ -2523,7 +2522,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
     if (game.options[OPT_SPEECHTYPE] == 3)
         remove_screen_overlay(OVER_COMPLETE);
-    our_eip=1500;
+    set_our_eip(1500);
 
     if (game.options[OPT_SPEECHTYPE] == 0)
         allowShrink = 1;
@@ -2552,7 +2551,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         // If the character is in this room, go for it - otherwise
         // run the "else" clause which  does text in the middle of
         // the screen.
-        our_eip=1501;
+        set_our_eip(1501);
 
         if (speakingChar->walking)
             StopMoving(aschar);
@@ -2575,7 +2574,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             speakingChar->loop = 0;
         }
 
-        our_eip=1504;
+        set_our_eip(1504);
 
         // Calculate speech position based on character's position on screen
         auto view = FindNearestViewport(aschar);
@@ -2597,7 +2596,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         if (tdyp < 5)
             tdyp = 5;
 
-        our_eip=152;
+        set_our_eip(152);
 
         if ((useview >= 0) && (game.options[OPT_SPEECHTYPE] > 0)) {
             // Sierra-style close-up portrait
@@ -2687,7 +2686,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             if (widd > 0)
                 bwidth = widd - bigx;
 
-            our_eip=153;
+            set_our_eip(153);
             int ovr_yp = get_fixed_pixel_size(20);
             int view_frame_x = 0;
             int view_frame_y = 0;
@@ -2812,7 +2811,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         }
         else if (useview >= 0) {
             // Lucasarts-style speech
-            our_eip=154;
+            set_our_eip(154);
 
             oldview = speakingChar->view;
             oldloop = speakingChar->loop;
@@ -2871,9 +2870,9 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     if (isThought)
         char_thinking = aschar;
 
-    our_eip=155;
+    set_our_eip(155);
     display_main(tdxp, tdyp, bwidth, texx, DISPLAYTEXT_SPEECH, FONT_SPEECH, textcol, isThought, allowShrink, overlayPositionFixed);
-    our_eip=156;
+    set_our_eip(156);
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
         closeupface = nullptr;
     if (closeupface!=nullptr)
@@ -2881,7 +2880,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     mark_screen_dirty();
     face_talking = -1;
     facetalkchar = nullptr;
-    our_eip=157;
+    set_our_eip(157);
     if (oldview>=0) {
         speakingChar->flags &= ~CHF_FIXVIEW;
         if (viewWasLocked)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -75,7 +75,6 @@ extern RoomStruct thisroom;
 extern unsigned int loopcounter;
 extern SpriteCache spriteset;
 extern RoomStatus*croom;
-extern int our_eip;
 extern int in_new_room;
 extern RoomObject*objs;
 extern std::vector<ViewStruct> views;
@@ -1647,7 +1646,7 @@ static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr
         return src; // No transform: return source image
 
     recycle_bitmap(dst, src->GetColorDepth(), dst_sz.Width, dst_sz.Height, true);
-    our_eip = 339;
+    set_our_eip(339);
 
     // If scaled: first scale then optionally mirror
     if (src->GetSize() != dst_sz)
@@ -1961,7 +1960,7 @@ bool construct_object_gfx(int objid, bool force_software)
 
 void prepare_objects_for_drawing()
 {
-    our_eip=32;
+    set_our_eip(32);
 
     const bool hw_accel = !drawstate.SoftwareRender;
 
@@ -2070,7 +2069,7 @@ bool construct_char_gfx(int charid, bool force_software)
 
 void prepare_characters_for_drawing()
 {
-    our_eip=33;
+    set_our_eip(33);
     const bool hw_accel = !drawstate.SoftwareRender;
 
     // draw characters
@@ -2171,7 +2170,7 @@ void prepare_room_sprites()
 
         if ((debug_flags & DBG_NODRAWSPRITES) == 0)
         {
-            our_eip = 34;
+            set_our_eip(34);
 
             if (drawstate.WalkBehindMethod == DrawAsSeparateSprite)
             {
@@ -2193,7 +2192,7 @@ void prepare_room_sprites()
             draw_sprite_list(true);
         }
     }
-    our_eip = 36;
+    set_our_eip(36);
 
     // Debug room overlay
     update_room_debug();
@@ -2223,7 +2222,7 @@ void draw_preroom_background()
 // whatsoever.
 PBitmap draw_room_background(Viewport *view)
 {
-    our_eip = 31;
+    set_our_eip(31);
 
     // For the sake of software renderer, if there is any kind of camera transform required
     // except screen offset, we tell it to draw on separate bitmap first with zero transformation.
@@ -2386,7 +2385,7 @@ void draw_gui_and_overlays()
     }
 
     // Add GUIs
-    our_eip=35;
+    set_our_eip(35);
     if (((debug_flags & DBG_NOIFACE)==0) && (displayed_room >= 0)) {
         if (playerchar->activeinv >= MAX_INV) {
             quit("!The player.activeinv variable has been corrupted, probably as a result\n"
@@ -2394,7 +2393,7 @@ void draw_gui_and_overlays()
         }
         if (playerchar->activeinv < 1) gui_inv_pic=-1;
         else gui_inv_pic=game.invinfo[playerchar->activeinv].pic;
-        our_eip = 37;
+        set_our_eip(37);
         // Prepare and update GUI textures
         {
             for (int index = 0; index < game.numgui; ++index)
@@ -2405,7 +2404,7 @@ void draw_gui_and_overlays()
                 if (gui.Transparency == 255) continue; // 100% transparent
 
                 eip_guinum = index;
-                our_eip = 372;
+                set_our_eip(372);
                 const bool draw_with_controls = !draw_controls_as_textures;
                 if (gui.HasChanged() || (draw_with_controls && gui.HasControlsChanged()))
                 {
@@ -2428,19 +2427,19 @@ void draw_gui_and_overlays()
                     sync_object_texture(gbg, is_alpha);
                 }
 
-                our_eip = 373;
+                set_our_eip(373);
                 // Update control textures, if they have changed themselves
                 if (draw_controls_as_textures && gui.HasControlsChanged())
                 {
                     construct_guictrl_tex(gui);
                 }
 
-                our_eip = 374;
+                set_our_eip(374);
 
                 gui.ClearChanged();
             }
         }
-        our_eip = 38;
+        set_our_eip(38);
         // Draw the GUIs
         for (int index = 0; index < game.numgui; ++index)
         {
@@ -2475,7 +2474,7 @@ void draw_gui_and_overlays()
     // Move the resulting sprlist with guis and overlays to render
     draw_sprite_list(false);
     put_sprite_list_on_screen(false);
-    our_eip = 1099;
+    set_our_eip(1099);
 }
 
 // Push the gathered list of sprites into the active graphic renderer
@@ -2500,7 +2499,7 @@ void put_sprite_list_on_screen(bool in_room)
         }
     }
 
-    our_eip = 1100;
+    set_our_eip(1100);
 }
 
 bool GfxDriverSpriteEvtCallback(int evt, int data)
@@ -2685,7 +2684,7 @@ void construct_game_scene(bool full_redraw)
     if (play.fast_forward)
         return;
 
-    our_eip=3;
+    set_our_eip(3);
 
     // React to changes to viewports and cameras (possibly from script) just before the render
     play.UpdateViewports();
@@ -2727,7 +2726,7 @@ void construct_game_scene(bool full_redraw)
         }
     }
 
-    our_eip=4;
+    set_our_eip(4);
 
     // Stage: UI overlay
     if (play.screen_is_faded_out == 0)
@@ -2903,7 +2902,7 @@ void render_graphics(IDriverDependantBitmap *extraBitmap, int extraX, int extraY
     update_shakescreen();
 
     construct_game_scene(false);
-    our_eip=5;
+    set_our_eip(5);
     // TODO: extraBitmap is a hack, used to place an additional gui element
     // on top of the screen. Normally this should be a part of the game UI stage.
     if (extraBitmap != nullptr)

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -106,7 +106,7 @@ int new_room_pos=0;
 int new_room_x = SCR_NO_VALUE, new_room_y = SCR_NO_VALUE;
 int new_room_loop = SCR_NO_VALUE;
 bool new_room_placeonwalkable = false;
-int proper_exit=0,our_eip=0;
+int proper_exit=0;
 
 AGS::Common::SpriteCache::Callbacks spritecallbacks = {
     get_new_size_for_sprite,
@@ -1019,8 +1019,8 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
     data_overwritten = false;
     gameHasBeenRestored++;
 
-    oldeip = our_eip;
-    our_eip = 2050;
+    oldeip = get_our_eip();
+    set_our_eip(2050);
 
     HSaveError err;
     SavegameSource src;
@@ -1074,7 +1074,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
     if (!err)
         return err;
     src.InputStream.reset();
-    our_eip = oldeip;
+    set_our_eip(oldeip);
 
     // ensure input state is reset
     ags_clear_input_state();

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -80,7 +80,6 @@ extern int displayed_room;
 extern RoomObject*objs;
 extern AGSPlatformDriver *platform;
 extern int done_es_error;
-extern int our_eip;
 extern Bitmap *walkareabackup, *walkable_areas_temp;
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern SpriteCache spriteset;
@@ -485,7 +484,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
 
     // load the room from disk
-    our_eip=200;
+    set_our_eip(200);
     thisroom.GameID = NO_GAME_ID_IN_ROOM_FILE;
     load_room(room_filename, &thisroom, game.IsLegacyHiRes(), game.SpriteInfos);
 
@@ -501,7 +500,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     convert_room_coordinates_to_data_res(&thisroom);
 
-    our_eip=201;
+    set_our_eip(201);
 
     play.room_width = thisroom.Width;
     play.room_height = thisroom.Height;
@@ -527,13 +526,13 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         thisroom.BgFrames[i].Graphic = PrepareSpriteForUse(thisroom.BgFrames[i].Graphic, false);
     }
 
-    our_eip=202;
+    set_our_eip(202);
     // Update game viewports
     if (game.IsLegacyLetterbox())
         update_letterbox_mode();
     SetMouseBounds(0, 0, 0, 0);
 
-    our_eip=203;
+    set_our_eip(203);
     in_new_room=1;
 
     set_color_depth(game.GetColorDepth());
@@ -551,11 +550,11 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     // copy the walls screen
     walkareabackup=BitmapHelper::CreateBitmapCopy(thisroom.WalkAreaMask.get());
 
-    our_eip=204;
+    set_our_eip(204);
     redo_walkable_areas();
     walkbehinds_recalc();
 
-    our_eip=205;
+    set_our_eip(205);
     // setup objects
     if (forchar != nullptr) {
         // if not restoring a game, always reset this room
@@ -685,7 +684,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         ccAddExternalScriptObject(thisroom.Hotspots[cc].ScriptName, &scrHotspot[cc], &ccDynamicHotspot);
     }
 
-    our_eip = 210;
+    set_our_eip(210);
     if (IS_ANTIALIAS_SPRITES) {
         // sometimes the palette has corrupt entries, which crash
         // the create_rgb_table call
@@ -701,7 +700,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         create_rgb_table (&rgb_table, palette, nullptr);
         rgb_map = &rgb_table;
     }
-    our_eip = 211;
+    set_our_eip(211);
     if (forchar!=nullptr) {
         // if it's not a Restore Game
 
@@ -736,7 +735,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             memcpy(&roominst->globaldata[0],croom->tsdata.data(),croom->tsdatasize);
         }
     }
-    our_eip=207;
+    set_our_eip(207);
     play.entered_edge = -1;
 
     if ((new_room_x != SCR_NO_VALUE) && (forchar != nullptr))
@@ -845,7 +844,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     if (thisroom.Options.StartupMusic>0)
         PlayMusicResetQueue(thisroom.Options.StartupMusic);
 
-    our_eip=208;
+    set_our_eip(208);
     if (forchar!=nullptr) {
         if (thisroom.Options.PlayerCharOff==0) { forchar->on=1;
         enable_cursor_mode(0); }
@@ -864,7 +863,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
     color_map = nullptr;
 
-    our_eip = 209;
+    set_our_eip(209);
     generate_light_table();
     update_music_volume();
 
@@ -879,7 +878,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
     init_room_drawdata();
 
-    our_eip = 212;
+    set_our_eip(212);
     invalidate_screen();
     for (uint32_t cc=0;cc<croom->numobj;cc++) {
         if (objs[cc].on == 2)
@@ -895,7 +894,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     if (game.color_depth > 1)
         setpal();
 
-    our_eip=220;
+    set_our_eip(220);
     update_polled_stuff();
     debug_script_log("Now in room %d", displayed_room);
     GUI::MarkAllGUIForUpdate(true, true);

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -26,7 +26,7 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
-extern int our_eip, eip_guinum, eip_guiobj;
+extern int eip_guinum, eip_guiobj;
 extern RGB palette[256];
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
@@ -96,9 +96,9 @@ Bitmap *remove_alpha_channel(Bitmap *from)
 
 Bitmap *initialize_sprite(sprkey_t index, Bitmap *image, uint32_t &sprite_flags)
 {
-    int oldeip = our_eip;
-    our_eip = 4300;
-    
+    int oldeip = get_our_eip();
+    set_our_eip(4300);
+
     if (sprite_flags & SPF_HADALPHACHANNEL)
     {
         // we stripped the alpha channel out last time, put
@@ -130,7 +130,7 @@ Bitmap *initialize_sprite(sprkey_t index, Bitmap *image, uint32_t &sprite_flags)
         sprite_flags |= SPF_HADALPHACHANNEL;
     }
 
-    our_eip = oldeip;
+    set_our_eip(oldeip);
     return use_bmp;
 }
 

--- a/Engine/font/fonts_engine.cpp
+++ b/Engine/font/fonts_engine.cpp
@@ -19,19 +19,4 @@
 #include <alfont.h>
 #include "ac/gamesetupstruct.h"
 
-extern int our_eip;
 extern GameSetupStruct game;
-
-//=============================================================================
-// Engine-specific implementation split out of acfonts.cpp
-//=============================================================================
-
-void set_our_eip(int eip)
-{
-  our_eip = eip;
-}
-
-int get_our_eip()
-{
-  return our_eip;
-}

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -81,7 +81,6 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern char check_dynamic_sprites_at_exit;
-extern int our_eip;
 extern volatile bool want_exit, abort_engine;
 extern bool justRunSetup;
 extern GameSetupStruct game;
@@ -105,7 +104,7 @@ t_engine_pre_init_callback engine_pre_init_callback = nullptr;
 
 bool engine_init_backend()
 {
-    our_eip = -199;
+    set_our_eip(-199);
     platform->PreBackendInit();
     // Initialize SDL
     Debug::Printf(kDbgMsg_Info, "Initializing backend libs");
@@ -142,11 +141,11 @@ void engine_setup_window()
 {
     Debug::Printf(kDbgMsg_Info, "Setting up window");
 
-    our_eip = -198;
+    set_our_eip(-198);
     sys_window_set_title(game.gamename.GetCStr());
     sys_window_set_icon();
     sys_evt_set_quit_callback(winclosehook);
-    our_eip = -197;
+    set_our_eip(-197);
 }
 
 // Fills map with game settings, to e.g. let setup application(s)
@@ -419,7 +418,7 @@ void atexit_handler() {
             "Program pointer: %+03d  (write this number down), engine version %s\n"
             "If you see a list of numbers above, please write them down and contact\n"
             "developers. Otherwise, note down any other information displayed.",
-            our_eip, EngineVersion.LongString.GetCStr());
+                               get_our_eip(), EngineVersion.LongString.GetCStr());
     }
 }
 
@@ -445,7 +444,7 @@ void engine_pre_init_gfx()
 int engine_load_game_data()
 {
     Debug::Printf("Load game data");
-    our_eip=-17;
+    set_our_eip(-17);
     HError err = load_game_file();
     if (!err)
     {
@@ -484,7 +483,7 @@ int check_write_access() {
   if (platform->GetDiskFreeSpaceMB() < 2)
     return 0;
 
-  our_eip = -1895;
+  set_our_eip(-1895);
 
   // The Save Game Dir is the only place that we should write to
   String svg_dir = get_save_game_directory();
@@ -493,12 +492,12 @@ int check_write_access() {
   if (!temp_s)
     return 0;
 
-  our_eip = -1896;
+  set_our_eip(-1896);
 
   temp_s->Write("just to test the drive free space", 30);
   delete temp_s;
 
-  our_eip = -1897;
+  set_our_eip(-1897);
 
   if (!File::DeleteFile(tempPath))
     return 0;
@@ -595,7 +594,7 @@ int engine_init_sprites()
 // move this elsewhere (InitGameState?).
 void engine_init_game_settings()
 {
-    our_eip=-7;
+    set_our_eip(-7);
     Debug::Printf("Initialize game settings");
 
     // Initialize randomizer
@@ -644,7 +643,7 @@ void engine_init_game_settings()
     if (playerchar->view >= 0)
         precache_view(playerchar->view, 0, Character_GetDiagonalWalking(playerchar) ? 8 : 4);
 
-    our_eip=-6;
+    set_our_eip(-6);
 
     for (ee = 0; ee < MAX_ROOM_OBJECTS; ee++) {
         scrObj[ee].id = ee;
@@ -677,7 +676,7 @@ void engine_init_game_settings()
         charextra[ee].animwait = 0;
     }
 
-    our_eip=-5;
+    set_our_eip(-5);
     for (ee=0;ee<game.numinvitems;ee++) {
         if (game.invinfo[ee].flags & IFLG_STARTWITH) playerchar->inv[ee]=1;
         else playerchar->inv[ee]=0;
@@ -849,7 +848,7 @@ void engine_init_game_settings()
     displayed_room = -10;
 
     currentcursor=0;
-    our_eip=-4;
+    set_our_eip(-4);
     mousey=100;  // stop icon bar popping up
 
     // We use same variable to read config and be used at runtime for now,
@@ -1217,48 +1216,48 @@ int initialize_engine(const ConfigTree &startup_opts)
         return EXIT_NORMAL;
     }
 
-    our_eip = -190;
+    set_our_eip(-190);
 
     //-----------------------------------------------------
     // Init auxiliary data files and other directories, initialize asset manager
     engine_init_user_directories();
 
-    our_eip = -191;
+    set_our_eip(-191);
 
     engine_locate_speech_pak();
 
-    our_eip = -192;
+    set_our_eip(-192);
 
     engine_locate_audio_pak();
 
-    our_eip = -193;
+    set_our_eip(-193);
 
     engine_assign_assetpaths();
 
     //-----------------------------------------------------
     // Begin setting up systems
 
-    our_eip = -194;
+    set_our_eip(-194);
 
     engine_init_fonts();
 
-    our_eip = -195;
+    set_our_eip(-195);
 
     engine_init_keyboard();
 
-    our_eip = -196;
+    set_our_eip(-196);
 
     engine_init_mouse();
 
-    our_eip = -198;
+    set_our_eip(-198);
 
     engine_init_audio();
 
-    our_eip = -199;
+    set_our_eip(-199);
 
     engine_init_debug();
 
-    our_eip = -10;
+    set_our_eip(-10);
 
     engine_init_exit_handler();
 
@@ -1266,14 +1265,14 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     set_game_speed(40);
 
-    our_eip=-20;
-    our_eip=-19;
+    set_our_eip(-20);
+    set_our_eip(-19);
 
     int res = engine_load_game_data();
     if (res != 0)
         return res;
 
-    our_eip = -189;
+    set_our_eip(-189);
 
     res = engine_check_disk_space();
     if (res != 0)
@@ -1286,7 +1285,7 @@ int initialize_engine(const ConfigTree &startup_opts)
     if (res != 0)
         return res;
 
-    our_eip = -179;
+    set_our_eip(-179);
 
     engine_adjust_for_rotation_settings();
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -72,7 +72,7 @@ using namespace AGS::Engine;
 extern int mouse_on_iface;   // mouse cursor is over this interface
 extern int ifacepopped;
 extern volatile bool want_exit, abort_engine;
-extern int proper_exit,our_eip;
+extern int proper_exit;
 extern int displayed_room, starting_room, in_new_room, new_room_was;
 extern ScriptSystem scsystem;
 extern GameSetupStruct game;
@@ -589,7 +589,7 @@ static void check_keyboard_controls()
 
 // check_controls: checks mouse & keyboard interface
 static void check_controls() {
-    our_eip = 1007;
+    set_our_eip(1007);
 
     sys_evt_process_pending();
 
@@ -650,7 +650,7 @@ static void check_room_edges(size_t numevents_was)
                     }
             }
     }
-    our_eip = 1008;
+    set_our_eip(1008);
 
 }
 
@@ -882,7 +882,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     }
 
     ccNotifyScriptStillAlive ();
-    our_eip=1;
+    set_our_eip(1);
 
     game_loop_check_problems_at_start();
 
@@ -890,18 +890,18 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     if ((play.no_hicolor_fadein) && (game.options[OPT_FADETYPE] == FADE_NORMAL))
         play.screen_is_faded_out = 0;
 
-    our_eip = 1014;
+    set_our_eip(1014);
 
     update_gui_disabled_status();
 
-    our_eip = 1004;
+    set_our_eip(1004);
 
     game_loop_do_early_script_update();
     // run this immediately to make sure it gets done before fade-in
     // (player enters screen)
     check_new_room();
 
-    our_eip = 1005;
+    set_our_eip(1005);
 
     res = game_loop_check_ground_level_interactions();
     if (res != RETURN_CONTINUE) {
@@ -924,7 +924,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     // handle actual input (keys, mouse, and so forth)
     game_loop_check_controls(checkControls);
 
-    our_eip=2;
+    set_our_eip(2);
 
     // do the overall game state update
     game_loop_do_update();
@@ -945,11 +945,11 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     if (!play.fast_forward)
         render_graphics(extraBitmap, extraX, extraY);
 
-    our_eip=6;
+    set_our_eip(6);
 
     game_loop_update_events();
 
-    our_eip=7;
+    set_our_eip(7);
 
     update_polled_stuff();
 
@@ -961,7 +961,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     if (play.fast_forward)
         return;
 
-    our_eip=72;
+    set_our_eip(72);
 
     game_loop_update_fps();
 
@@ -1061,7 +1061,7 @@ static int UpdateWaitMode()
 
     if (!ShouldStayInWaitMode())
         restrict_until.type = 0;
-    our_eip = 77;
+    set_our_eip(77);
 
     if (restrict_until.type > 0) { return RETURN_CONTINUE; }
 
@@ -1099,7 +1099,7 @@ static int GameTick()
     UpdateGameOnce(true);
     UpdateMouseOverLocation();
 
-    our_eip=76;
+    set_our_eip(76);
 
     int res = UpdateWaitMode();
     if (res == RETURN_CONTINUE) { return 0; } // continue looping 
@@ -1138,7 +1138,7 @@ static void GameLoopUntilEvent(int untilwhat, const void* data_ptr = nullptr, in
   SetupLoopParameters(untilwhat, data_ptr, data1, data2);
   while (GameTick()==0);
 
-  our_eip = 78;
+  set_our_eip(78);
 
   restrict_until = cached_restrict_until;
 }

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -41,7 +41,7 @@
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
-extern int our_eip, displayed_room;
+extern int displayed_room;
 extern GameSetupStruct game;
 extern GameState play;
 extern CharacterInfo*playerchar;
@@ -63,21 +63,21 @@ void start_game() {
     Mouse::SetPosition(Point(160, 100));
     newmusic(0);
 
-    our_eip = -42;
+    set_our_eip(-42);
 
     // skip ticks to account for initialisation or a restored game.
     skipMissedTicks();
 
     RunScriptFunctionInModules("game_start");
 
-    our_eip = -43;
+    set_our_eip(-43);
 
     // Only auto-set first restart point in < 3.6.1 games,
     // since 3.6.1+ users are suggested to set one manually in script.
     if (loaded_game_file_version < kGameVersion_361_10)
         SetRestartPoint();
 
-    our_eip=-3;
+    set_our_eip(-3);
 
     if (displayed_room < 0) {
         current_fade_out_effect();

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -55,7 +55,6 @@ String appDirectory; // engine dir
 String cmdGameDataPath; // game path received from cmdline
 
 extern GameState play;
-extern int our_eip;
 extern int editor_debugging_initialized;
 extern char editor_debugger_instance_token[100];
 
@@ -76,7 +75,7 @@ AGS::Common::Version EngineVersion;
 
 void main_init(int argc, char*argv[])
 {
-    our_eip = -999;
+    set_our_eip(-999);
 
     // Init libraries: set text encoding
     set_uformat(U_UTF8);

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -55,7 +55,6 @@ extern GameSetupStruct game;
 extern SpriteCache spriteset;
 extern RoomStruct thisroom;
 extern RoomStatus troom;    // used for non-saveable rooms, eg. intro
-extern int our_eip;
 extern char pexbuf[STD_BUFFER_SIZE];
 extern int proper_exit;
 extern char check_dynamic_sprites_at_exit;
@@ -104,7 +103,7 @@ void quit_check_dynamic_sprites(QuitReason qreason)
 
 void quit_shutdown_audio()
 {
-    our_eip = 9917;
+    set_our_eip(9917);
     game.options[OPT_CROSSFADEMUSIC] = 0;
     shutdown_sound();
 }
@@ -197,22 +196,22 @@ void quit(const char *quitmsg)
 
     quit_tell_editor_debugger(errmsg, qreason);
 
-    our_eip = 9900;
+    set_our_eip(9900);
 
     quit_shutdown_scripts();
 
-    our_eip = 9016;
+    set_our_eip(9016);
 
     quit_stop_cd();
     if (use_cdplayer)
         platform->ShutdownCDPlayer();
 
-    our_eip = 9019;
+    set_our_eip(9019);
 
     video_shutdown();
     quit_shutdown_audio();
 
-    our_eip = 9908;
+    set_our_eip(9908);
 
     shutdown_pathfinder();
 
@@ -242,7 +241,7 @@ void quit(const char *quitmsg)
 
     platform->PostBackendExit();
 
-    our_eip = 9903;
+    set_our_eip(9903);
 
     proper_exit=1;
 
@@ -251,7 +250,7 @@ void quit(const char *quitmsg)
     shutdown_debug();
     AGSPlatformDriver::Shutdown();
 
-    our_eip = 9904;
+    set_our_eip(9904);
     exit(EXIT_NORMAL);
 }
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -52,7 +52,6 @@ extern GameState play;
 extern RoomStruct thisroom;
 extern RoomObject*objs;
 extern std::vector<ViewStruct> views;
-extern int our_eip;
 extern CharacterInfo*playerchar;
 extern CharacterInfo *facetalkchar;
 extern int face_talking,facetalkview,facetalkwait,facetalkframe;
@@ -544,18 +543,18 @@ void update_sierra_speech()
 // update_stuff: moves and animates objects, executes repeat scripts, and
 // the like.
 void update_stuff() {
-  
-  our_eip = 20;
+
+  set_our_eip(20);
 
   update_script_timers();
 
   update_cycling_views();
 
-  our_eip = 21;
+  set_our_eip(21);
 
   update_player_view();
-  
-  our_eip = 22;
+
+  set_our_eip(22);
 
   std::vector<int> followingAsSheep;
 
@@ -563,15 +562,15 @@ void update_stuff() {
 
   update_following_exactly_characters(followingAsSheep);
 
-  our_eip = 23;
+  set_our_eip(23);
 
   update_overlay_timers();
 
   update_speech_and_messages();
 
-  our_eip = 24;
+  set_our_eip(24);
 
   update_sierra_speech();
 
-  our_eip = 25;
+  set_our_eip(25);
 }

--- a/Engine/platform/windows/win_ex_handling.cpp
+++ b/Engine/platform/windows/win_ex_handling.cpp
@@ -35,7 +35,6 @@
 
 using namespace AGS::Common;
 
-extern int our_eip;
 extern int eip_guinum;
 extern int eip_guiobj;
 extern int proper_exit;
@@ -58,7 +57,7 @@ static void DisplayException()
         "AGS cannot continue, this exception was fatal. Please note down the numbers above, remember what you were doing at the time and contact the game author for support "
         "or post these details on the AGS Technical Forum.\n\n%s\n\n"
         "Most versions of Windows allow you to press Ctrl+C now to copy this entire message to the clipboard for easy reporting.\n\n%s (code %d)",
-        excinfo.ExceptionCode, (int)sizeof(intptr_t) * 2, (intptr_t)excinfo.ExceptionAddress, our_eip, EngineVersion.LongString.GetCStr(), eip_guinum, eip_guiobj, sc_error.CallStack.GetCStr(),
+        excinfo.ExceptionCode, (int)sizeof(intptr_t) * 2, (intptr_t)excinfo.ExceptionAddress, get_our_eip(), EngineVersion.LongString.GetCStr(), eip_guinum, eip_guiobj, sc_error.CallStack.GetCStr(),
         (miniDumpResultCode == 0) ? "An error file CrashInfo.dmp has been created. You may be asked to upload this file when reporting this problem on the AGS Forums." :
         "Unable to create an error dump file.", miniDumpResultCode);
     MessageBoxA((HWND)sys_win_get_window(), printfworkingspace, "Illegal exception", MB_ICONSTOP | MB_OK);
@@ -94,7 +93,8 @@ int malloc_fail_handler(size_t amountwanted)
 #endif
     free(printfworkingspace);
 
-    cur += snprintf(cur, end-cur, "Out of memory: failed to allocate %zu bytes (at PP=%d)\n\n", amountwanted, our_eip);
+    cur += snprintf(cur, end-cur, "Out of memory: failed to allocate %zu bytes (at PP=%d)\n\n", amountwanted,
+                    get_our_eip());
 
     const size_t total_normspr = spriteset.GetCacheSize();
     const size_t total_lockspr = spriteset.GetLockedSize();

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -48,7 +48,6 @@ extern GameState play;
 extern int gameHasBeenRestored, displayed_room;
 extern unsigned int load_new_game;
 extern RoomObject*objs;
-extern int our_eip;
 extern CharacterInfo*playerchar;
 
 ExecutingScript scripts[MAX_SCRIPT_AT_ONCE];
@@ -756,10 +755,10 @@ InteractionVariable *FindGraphicalVariable(const char *varName) {
 struct TempEip {
     int oldval;
     TempEip (int newval) {
-        oldval = our_eip;
-        our_eip = newval;
+        oldval = get_our_eip();
+        set_our_eip(newval);
     }
-    ~TempEip () { our_eip = oldval; }
+    ~TempEip () { set_our_eip(oldval); }
 };
 
 // the 'cmdsrun' parameter counts how many commands are run.


### PR DESCRIPTION
Hey, just to make it easier to search our codebase when someone reports a `PP=X` in a crash / exception. There was a mix of SET_EIP, `our_eip=X` and `our_eip = X` (varying blank spaces). If all eip changes are guarded in a macro, it's much easier to find using the code search feature of an IDE or `git grep` in the command line.

I am letting it be a draft because the `SET_EIP` macro is in `"gui/guimain.h"` and perhaps it should be in somewhere else, but not sure where.