### PR TITLE
gitignore: ignore dll files placed in References

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ libsrc/SDL2-Framework.dmg
 
 # ags game in ios game project
 iOS/Resources
+
+# ignore libraries dependencies manually placed in Editor
+Editor/References/**/*.dll


### PR DESCRIPTION
I am remaking the Editor x64 branch locally and going a bit crazy (switching branches cause it to forget my gitignore changes...) because I need to place the x64 irrKlang and stuff in `Editor/References` and I think all dll files there could just be ignored.