### PR TITLE
Print graphics adapter info + OpenGL video memory detection

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -684,9 +684,9 @@ void init_draw_method()
         size_t tx_cache_size = usetup.TextureCacheSize * 1024;
         // If graphics driver can report available texture memory,
         // then limit the setting by, let's say, 66% of it (we use it for other things)
-        size_t avail_tx_mem = gfxDriver->GetAvailableTextureMemory();
+        uint64_t avail_tx_mem = gfxDriver->GetAvailableTextureMemory();
         if (avail_tx_mem > 0)
-            tx_cache_size = std::min<size_t>(tx_cache_size, avail_tx_mem * 0.66);
+            tx_cache_size = std::min<size_t>(SIZE_MAX, std::min<uint64_t>(tx_cache_size, avail_tx_mem * 0.66));
         texturecache.SetMaxCacheSize(tx_cache_size);
         Debug::Printf("Texture cache set: %zu KB", tx_cache_size / 1024);
     }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -225,14 +225,6 @@ void OGLGraphicsDriver::SetBlendOpRGBAlpha(GLenum rgb_op, GLenum srgb_factor, GL
 
 bool OGLGraphicsDriver::FirstTimeInit()
 {
-  String ogl_v_str;
-#ifdef GLAPI
-  ogl_v_str.Format("%d.%d", GLVersion.major, GLVersion.minor);
-#else
-  ogl_v_str = (const char*)glGetString(GL_VERSION);
-#endif
-  Debug::Printf(kDbgMsg_Info, "Running OpenGL: %s", ogl_v_str.GetCStr());
-
   TestRenderToTexture();
 
   if(!CreateShaders()) { // requires glad Load successful
@@ -347,6 +339,15 @@ bool OGLGraphicsDriver::CreateWindowAndGlContext(const DisplayMode &mode)
   // Instead of using framebuffer 0, we ask OpenGL to get the current framebuffer.
   glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_screenFramebuffer);
 #endif
+
+  const char *gl_version = (const char*)glGetString(GL_VERSION);
+  const char *gl_vendor = (const char*)glGetString(GL_VENDOR);
+  const char *gl_renderer = (const char*)glGetString(GL_RENDERER);
+  String adapter_info = String::FromFormat(
+      "\tOpenGL: %s\n\tVendor: %s\n\tRenderer: %s",
+      gl_version, gl_vendor, gl_renderer
+    );
+  Debug::Printf(kDbgMsg_Info, "OpenGL adapter info:\n%s", adapter_info.GetCStr());
   return true;
 }
 
@@ -795,8 +796,8 @@ bool OGLGraphicsDriver::SetDisplayMode(const DisplayMode &mode)
   {
     if (!InitGlScreen(mode))
       return false;
-    if (!_firstTimeInit)
-      if(!FirstTimeInit()) return false;
+    if (!_firstTimeInit && !FirstTimeInit())
+      return false;
     InitGlParams(mode);
   }
   catch (Ali3DException exception)

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -242,7 +242,8 @@ public:
     // Clears the screen rectangle. The coordinates are expected in the **native game resolution**.
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
-    size_t GetAvailableTextureMemory() override;
+    // Returns available texture memory in bytes, or 0 if this query is not supported
+    uint64_t GetAvailableTextureMemory() override;
 
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -171,7 +171,8 @@ public:
     // Clears the screen rectangle. The coordinates are expected in the **native game resolution**.
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
-    size_t GetAvailableTextureMemory() override { return 0; /* not using textures for sprites anyway */ }
+    // Returns available texture memory in bytes, or 0 if this query is not supported
+    uint64_t GetAvailableTextureMemory() override { return 0; /* not using textures for sprites anyway */ }
 
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap *CreateDDB(std::shared_ptr<Texture> txdata, bool opaque) override

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -138,8 +138,8 @@ public:
   // Gets closest recommended bitmap format (currently - only color depth) for the given original format.
   // Engine needs to have game bitmaps brought to the certain range of formats, easing conversion into the video bitmaps.
   virtual int  GetCompatibleBitmapFormat(int color_depth) = 0;
-  // Returns available texture memory, or 0 if this query is not supported
-  virtual size_t GetAvailableTextureMemory() = 0;
+  // Returns available texture memory in bytes, or 0 if this query is not supported
+  virtual uint64_t GetAvailableTextureMemory() = 0;
 
   // Creates a "raw" DDB, without pixel initialization.
   virtual IDriverDependantBitmap *CreateDDB(int width, int height, int color_depth, bool opaque = false) = 0;

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <algorithm>
+#include <inttypes.h>
 #include <SDL.h>
 #include "core/platform.h"
 #include "ac/draw.h"
@@ -523,9 +524,9 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
         rdm.Width, rdm.Height, rdm.ColorDepth,
         rdm.IsWindowed() ? "windowed" : (rdm.IsRealFullscreen() ? "fullscreen" : "fullscreen desktop"));
     Debug::Printf(kDbgMsg_Info, "Graphics mode set: refresh rate (optional): %d, vsync: %d", rdm.RefreshRate, rdm.Vsync);
-    size_t tex_mem = gfxDriver->GetAvailableTextureMemory();
+    uint64_t tex_mem = gfxDriver->GetAvailableTextureMemory();
     if (tex_mem > 0u)
-        Debug::Printf("Graphics driver texture memory (approx): %zu bytes", tex_mem);
+        Debug::Printf("Graphics driver texture memory (approx): %" PRIu64 " KB", tex_mem / 1024u);
     return true;
 }
 

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -523,6 +523,9 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
         rdm.Width, rdm.Height, rdm.ColorDepth,
         rdm.IsWindowed() ? "windowed" : (rdm.IsRealFullscreen() ? "fullscreen" : "fullscreen desktop"));
     Debug::Printf(kDbgMsg_Info, "Graphics mode set: refresh rate (optional): %d, vsync: %d", rdm.RefreshRate, rdm.Vsync);
+    size_t tex_mem = gfxDriver->GetAvailableTextureMemory();
+    if (tex_mem > 0u)
+        Debug::Printf("Graphics driver texture memory (approx): %zu bytes", tex_mem);
     return true;
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1664,7 +1664,7 @@ int D3DGraphicsDriver::GetCompatibleBitmapFormat(int color_depth)
   return 32;
 }
 
-size_t D3DGraphicsDriver::GetAvailableTextureMemory()
+uint64_t D3DGraphicsDriver::GetAvailableTextureMemory()
 {
   return direct3ddevice->GetAvailableTextureMem();
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -2174,6 +2174,17 @@ bool D3DGraphicsFactory::Init()
         SDL_SetError("Direct3DCreate failed!");
         return false;
     }
+
+    D3DADAPTER_IDENTIFIER9 adapterid;
+    _direct3d->GetAdapterIdentifier(D3DADAPTER_DEFAULT, 0, &adapterid);
+    String adapter_info = String::FromFormat(
+        "\tDriver: %s, v%d.%d.%d.%d\n\tDescription: %s",
+        adapterid.Driver,
+        HIWORD(adapterid.DriverVersion.HighPart), LOWORD(adapterid.DriverVersion.HighPart),
+        HIWORD(adapterid.DriverVersion.LowPart), LOWORD(adapterid.DriverVersion.LowPart),
+        adapterid.Description
+    );
+    Debug::Printf(kDbgMsg_Info, "Direct3D adapter info:\n%s", adapter_info.GetCStr());
     return true;
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -227,7 +227,8 @@ public:
     // Clears the screen rectangle. The coordinates are expected in the **native game resolution**.
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
-    size_t GetAvailableTextureMemory() override;
+    // Returns available texture memory in bytes, or 0 if this query is not supported
+    uint64_t GetAvailableTextureMemory() override;
 
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;


### PR DESCRIPTION
Print available adapter info for Direct3D and OpenGL (this basically means GPU / system driver description).

Print approximate available video memory to the log.

For OpenGL: use ATI / Nvidia extensions if available to get their gpu memory info.
