### PR TITLE
Windows: enable /LARGEADDRESSAWARE for 32-bit builds

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -622,6 +622,15 @@ if (WIN32)
     set_target_properties(ags PROPERTIES
         WIN32_EXECUTABLE TRUE
     )
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        # enable more than 2 GB in a 32-bit application
+        if (MINGW)
+            target_link_options(ags PUBLIC "-Wl,--large-address-aware")
+        endif ()
+        if (MSVC)
+            target_link_options(ags PUBLIC "/LARGEADDRESSAWARE")
+        endif ()
+    endif ()
 endif()
 
 # Test

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1446,7 +1446,7 @@ size_t OGLGraphicsDriver::RenderSpriteBatch(const OGLSpriteBatch &batch, size_t 
         if (e.skip)
             continue;
 
-        switch (reinterpret_cast<intptr_t>(e.ddb))
+        switch (reinterpret_cast<uintptr_t>(e.ddb))
         {
         case DRAWENTRY_STAGECALLBACK:
             // raw-draw plugin support

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -131,9 +131,9 @@ public:
 
 protected:
     // Special internal values, applied to DrawListEntry
-    static const intptr_t DRAWENTRY_STAGECALLBACK = 0x0;
-    static const intptr_t DRAWENTRY_FADE = 0x1;
-    static const intptr_t DRAWENTRY_TINT = 0x2;
+    static const uintptr_t DRAWENTRY_STAGECALLBACK = 0x0;
+    static const uintptr_t DRAWENTRY_FADE = 0x1;
+    static const uintptr_t DRAWENTRY_TINT = 0x2;
 
     // Called after graphics driver was initialized for use for the first time
     virtual void OnInit();

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1439,7 +1439,7 @@ size_t D3DGraphicsDriver::RenderSpriteBatch(const D3DSpriteBatch &batch, size_t 
         if (e.skip)
             continue;
 
-        switch (reinterpret_cast<intptr_t>(e.ddb))
+        switch (reinterpret_cast<uintptr_t>(e.ddb))
         {
         case DRAWENTRY_STAGECALLBACK:
             // raw-draw plugin support

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1279,13 +1279,13 @@ int ccInstance::Run(int32_t curpc)
             int32_t instId = codeOp.Instruction.InstanceId;
             // determine the offset into the code of the instance we want
             runningInst = loadedInstances[instId];
-            intptr_t callAddr = reg1.PtrU8 - reinterpret_cast<uint8_t*>(&runningInst->code[0]);
-            if (callAddr % sizeof(intptr_t) != 0)
+            uintptr_t callAddr = reg1.PtrU8 - reinterpret_cast<uint8_t*>(&runningInst->code[0]);
+            if (callAddr % sizeof(uintptr_t) != 0)
             {
                 cc_error("call address not aligned");
                 return -1;
             }
-            callAddr /= sizeof(intptr_t); // size of ccScript::code elements
+            callAddr /= sizeof(uintptr_t); // size of ccScript::code elements
 
             if (Run(static_cast<int32_t>(callAddr)))
                 return -1;
@@ -1870,7 +1870,8 @@ bool ccInstance::_Create(PScript scri, const ccInstance * joined)
         {
             // NOTE: unfortunately, there seems to be no way to know if
             // that's an extender function that expects object pointer
-            exports[i].SetCodePtr((static_cast<intptr_t>(eaddr) * sizeof(intptr_t) + reinterpret_cast<uint8_t*>(&code[0])));
+            exports[i].SetCodePtr(reinterpret_cast<uint8_t*>(&code[0]) 
+                + (static_cast<uintptr_t>(eaddr) * sizeof(uintptr_t)));
         }
         else if (etype == EXPORT_DATA)
         {

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1331,11 +1331,11 @@ int ccInstance::Run(int32_t curpc)
                 {
                     RuntimeScriptValue obj_rval = registers[SREG_OP];
                     obj_rval.DirectPtrObj();
-                    int_ret_val = call_function((intptr_t)reg1.Ptr, &obj_rval, num_args_to_func, func_callstack.GetHead() + 1);
+                    int_ret_val = call_function(reg1.Ptr, &obj_rval, num_args_to_func, func_callstack.GetHead() + 1);
                 }
                 else
                 {
-                    int_ret_val = call_function((intptr_t)reg1.Ptr, nullptr, num_args_to_func, func_callstack.GetHead() + 1);
+                    int_ret_val = call_function(reg1.Ptr, nullptr, num_args_to_func, func_callstack.GetHead() + 1);
                 }
 
                 if (GlobalReturnValue.IsValid())

--- a/Engine/script/runtimescriptvalue.cpp
+++ b/Engine/script/runtimescriptvalue.cpp
@@ -213,7 +213,7 @@ RuntimeScriptValue &RuntimeScriptValue::DirectPtrObj()
     return *this;
 }
 
-intptr_t RuntimeScriptValue::GetDirectPtr() const
+void *RuntimeScriptValue::GetDirectPtr() const
 {
     const RuntimeScriptValue *temp_val = this;
     int ival = temp_val->IValue;
@@ -223,7 +223,7 @@ intptr_t RuntimeScriptValue::GetDirectPtr() const
         ival     += temp_val->IValue;
     }
     if (temp_val->Type == kScValScriptObject)
-        return (intptr_t)temp_val->ObjMgr->GetFieldPtr(temp_val->Ptr, ival);
+        return temp_val->ObjMgr->GetFieldPtr(temp_val->Ptr, ival);
     else
-        return (intptr_t)(temp_val->PtrU8 + ival);
+        return temp_val->PtrU8 + ival;
 }

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -447,7 +447,7 @@ public:
     // tell for certain that we are expecting a pointer to the object and not its (first) field.
     RuntimeScriptValue &DirectPtrObj();
     // Resolve and return direct pointer to the referenced data; non pointer types return IValue
-    intptr_t           GetDirectPtr() const;
+    void *      GetDirectPtr() const;
 };
 
 #endif // __AGS_EE_SCRIPT__RUNTIMESCRIPTVALUE_H

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -133,9 +133,9 @@ void ccSetDebugHook(new_line_hook_type jibble)
     new_line_hook = jibble;
 }
 
-int call_function(intptr_t addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms)
+int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms)
 {
-    if (!addr)
+    if (!fn_addr)
     {
         cc_error("null function pointer in call_function");
         return -1;
@@ -212,61 +212,61 @@ int call_function(intptr_t addr, const RuntimeScriptValue *object, int numparm, 
     case 0:
         {
             int (*fparam) ();
-            fparam = (int (*)())addr;
+            fparam = (int (*)())fn_addr;
             return fparam();
         }
     case 1:
         {
             int (*fparam) (intptr_t);
-            fparam = (int (*)(intptr_t))addr;
+            fparam = (int (*)(intptr_t))fn_addr;
             return fparam(parm_value[0]);
         }
     case 2:
         {
             int (*fparam) (intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1]);
         }
     case 3:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2]);
         }
     case 4:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3]);
         }
     case 5:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4]);
         }
     case 6:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5]);
         }
     case 7:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6]);
         }
     case 8:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7]);
         }
     case 9:
         {
             int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))addr;
+            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
             return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7], parm_value[8]);
         }
     }

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -97,6 +97,6 @@ void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout, un
 // reset the current while loop counter
 void ccNotifyScriptStillAlive();
 // for calling exported plugin functions old-style
-int call_function(intptr_t addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
+int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
 
 #endif // __AGS_EE_CC__SCRIPTRUNTIME_H

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -221,6 +221,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
@@ -277,6 +278,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
@@ -337,6 +339,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
@@ -408,6 +411,7 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX86</TargetMachine>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>


### PR DESCRIPTION
I've been looking into a Dave Gilbert's problem with "out of mem" errors, and it turned out that the texture cache functionality is not behaving as I expected it to. The problem is that engine allocates system memory proportional to video memory allocation when caching textures. It feels as if there were a duplicate of each texture's surface in RAM. It might be that this is normal and I simply don't have enough theoretical knowledge about how textures are stored to judge; but it might also mean that we have something done wrong.
In any case, as an effect the total usage of system memory becomes approximately equal to the sum of sprite cache and texture cache.

Strictly speaking, if we have a large texture cache allocated, then we don't need spritecache at all. But that does not change the fact that creating texture images allocates system memory of comparable amount.

I also noticed strange issue that OpenGL allocates around x1.5-x2 more system memory in comparison with Direct3D.

It does not look like a memory leak though, as the memory usage resets immediately if sprite/texture caches are reset at runtime.

This is quite worrying and has to be investigated. But in the meantime, I'd like to try enabling /LARGEADDRESSAWARE program setting for 32-bit windows builds. This presumably will increase program's address range to 3 or 4 GB, while the program will likely stay compatible with existing 32-bit windows plugins.

Quick test shows that it's enough to run "Old Skies" with (unnecessarily) large caches, with memory usage getting close to 3 GB even. I sent the engine to Dave for a test, and he confirmed that this stopped OOM crashes with OpenGL and 1 GB of texture cache.

So maybe we could use this as a safety workaround for now.