### PR TITLE
ci: switch Windows docker to GitHub registry

### DIFF
--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -1,5 +1,5 @@
 # base will already have Chocolatey installed
-FROM ericoporto/min-ags-dev-env:1.0.0
+FROM ghcr.io/ericoporto/min-ags-dev-env:1.0.0
 
 # if no temp folder exists by default, create it
 RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )


### PR DESCRIPTION
I put a copy of the docker image we were using before in the GitHub Container Registry. It looks like it pulls faster from there than the Dockerhub. It's also an 11GB image that is the base of our Windows image. While the CI problem we had before is probably something in Cirrus CI , I think we could try switching this and see if the time to fetch the image improves.

Here is the image

https://github.com/ericoporto/min-ags-dev-env/pkgs/container/min-ags-dev-env

It is a copy of the image we have here

https://hub.docker.com/repository/docker/ericoporto/min-ags-dev-env/