### PR TITLE
ci: use ags3 specific auto-test game

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,6 @@ jobs:
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
         pip install tap.py
-        curl -sLo auto-test.ags https://github.com/adventuregamestudio/ags-test-games/releases/latest/download/auto-test.ags
+        curl -sLo auto-test.ags https://github.com/adventuregamestudio/ags-test-games/releases/latest/download/ags3-auto-test.ags
         ${{matrix.platform.runbin}} --no-message-box --log-stdout=script:info,main:info --user-data-dir . auto-test.ags        
         tappy agstest.tap


### PR DESCRIPTION
I am separating ags3 and ags4 specific builds of the auto-test game, since the last release of the ags-test-games repository

https://github.com/adventuregamestudio/ags-test-games/releases

This is because ags4 and ags3 aren't binary compatible, so we would need to rebuild the test game with ags4 for ags4. I think it's easier to have two separate games, since ags4 has features that ags3 doesn't have, and ags3 has worries with backwards compatibility that ags4 doesn't have, so it's better to have room for the specific tests necessary for each.

This change should also make into 3.6.1 branch (better wait until this builds ok in the ci below).