### PR TITLE
AGS 4: non-blocking video playback

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2659,6 +2659,51 @@ builtin managed struct Joystick {
 };
 #endif
 
+#ifdef SCRIPT_API_v400
+enum PlaybackState {
+  ePlaybackOn = 2,
+  ePlaybackPaused = 3,
+  ePlaybackStopped = 4
+};
+
+builtin managed struct VideoPlayer {
+  import static VideoPlayer* Open(const string filename, bool autoPlay=true, RepeatStyle=eOnce);
+  /// Starts or resumes the playback.
+  import void Play();
+  /// Pauses the playback.
+  import void Pause();
+  /// Advances video by 1 frame, may be called when the video is paused.
+  import void NextFrame();
+  /// Changes playback to continue from the specified frame; returns new position or -1 on error.
+  import int  SeekFrame(int frame);
+  /// Changes playback to continue from the specified position in milliseconds; returns new position or -1 on error.
+  import int  SeekMs(int position);
+  /// Stops the video completely.
+  import void Stop();
+
+  /// Gets current frame index.
+  import readonly attribute int Frame;
+  /// Gets total number of frames in this video.
+  import readonly attribute int FrameCount;
+  /// Gets this video's framerate (number of frames per second).
+  import readonly attribute float FrameRate;
+  /// Gets the number of sprite this video renders to.
+  import readonly attribute int Graphic;
+  /// The length of the currently playing video, in milliseconds.
+  import readonly attribute int LengthMs;
+  /// Gets/sets whether the video should loop.
+  import attribute bool Looping;
+  /// The current playback position, in milliseconds.
+  import readonly attribute int PositionMs;
+  /// The speed of playing (1.0 is default).
+  import attribute float Speed;
+  /// Gets the current playback state (playing, paused, etc).
+  import readonly attribute PlaybackState State;
+  /// The volume of this video's sound, from 0 to 100.
+  import attribute int Volume;
+};
+#endif
+
 
 import ColorType palette[PALETTE_SIZE];
 import Mouse mouse;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -375,6 +375,8 @@ target_sources(engine
     media/video/theora_player.h
     media/video/video.cpp
     media/video/video.h
+    media/video/video_core.cpp
+    media/video/video_core.h
     media/video/videoplayer.cpp
     media/video/videoplayer.h
     platform/base/agsplatformdriver.cpp
@@ -415,6 +417,7 @@ target_sources(engine
     util/library_posix.h
     util/sdl2_util.h
     util/sdl2_util.cpp
+    util/threading.h
 
     platform/windows/acplwin.cpp
     platform/windows/debug/namedpipesagsdebugger.cpp

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -117,6 +117,8 @@ target_sources(engine
     ac/dynobj/scriptsystem.cpp
     ac/dynobj/scriptuserobject.cpp
     ac/dynobj/scriptuserobject.h
+    ac/dynobj/scriptvideoplayer.cpp
+    ac/dynobj/scriptvideoplayer.h
     ac/dynobj/scriptviewframe.cpp
     ac/dynobj/scriptviewframe.h
     ac/dynobj/scriptviewport.cpp
@@ -248,6 +250,7 @@ target_sources(engine
     ac/timer.h
     ac/translation.cpp
     ac/translation.h
+    ac/video_script.cpp
     ac/viewframe.cpp
     ac/viewframe.h
     ac/viewport_script.cpp

--- a/Engine/ac/dynobj/scriptvideoplayer.cpp
+++ b/Engine/ac/dynobj/scriptvideoplayer.cpp
@@ -1,0 +1,51 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "ac/dynobj/scriptvideoplayer.h"
+#include "ac/dynobj/dynobj_manager.h"
+#include "media/video/video.h"
+#include "util/stream.h"
+
+using namespace AGS::Common;
+
+const char *ScriptVideoPlayer::GetType()
+{
+    return "VideoPlayer";
+}
+
+int ScriptVideoPlayer::Dispose(void* /*address*/, bool /*force*/)
+{
+    if (_id >= 0)
+    {
+        video_stop(_id);
+    }
+
+    delete this;
+    return 1;
+}
+
+size_t ScriptVideoPlayer::CalcSerializeSize(const void* /*address*/)
+{
+    return sizeof(int32_t);
+}
+
+void ScriptVideoPlayer::Serialize(const void* /*address*/, Stream *out)
+{
+    out->WriteInt32(_id);
+}
+
+void ScriptVideoPlayer::Unserialize(int index, Stream *in, size_t /*data_sz*/)
+{
+    _id = in->ReadInt32();
+    ccRegisterUnserializedObject(index, this, this);
+}

--- a/Engine/ac/dynobj/scriptvideoplayer.h
+++ b/Engine/ac/dynobj/scriptvideoplayer.h
@@ -1,0 +1,41 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AC_SCRIPTVIDEOPLAYER_H
+#define __AC_SCRIPTVIDEOPLAYER_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+
+struct ScriptVideoPlayer final : AGSCCDynamicObject
+{
+public:
+    ScriptVideoPlayer(int id) : _id(id) {}
+    // Get videoplayer's index; negative means the video was removed
+    int GetID() const { return _id; }
+    // Reset videoplayer's index to indicate that this reference is no longer valid
+    void Invalidate() { _id = -1; }
+
+    const char *GetType() override;
+    int Dispose(void *address, bool force) override;
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
+private:
+    // Calculate and return required space for serialization, in bytes
+    size_t CalcSerializeSize(const void *address) override;
+    // Write object data into the provided stream
+    void Serialize(const void *address, AGS::Common::Stream *out) override;
+
+    int _id = -1; // index of videoplayer in the video subsystem
+};
+
+#endif // __AC_SCRIPTVIDEOPLAYER_H

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -18,6 +18,7 @@
 #include "debug/debugger.h"
 #include "debug/debug_log.h"
 #include "media/video/video.h"
+#include "media/video/videoplayer.h" // for flags
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -18,6 +18,7 @@
 #include "platform/base/agsplatformdriver.h"
 #if defined(AGS_DISABLE_THREADS)
 #include "media/audio/audio_core.h"
+#include "media/video/video_core.h"
 #endif
 #if AGS_PLATFORM_OS_EMSCRIPTEN
 #include "SDL.h"
@@ -71,6 +72,7 @@ void WaitForNextFrame()
     // Do the last polls on this frame, if necessary
 #if defined(AGS_DISABLE_THREADS)
     audio_core_entry_poll();
+    video_core_entry_poll();
 #endif
 
     const auto now = AGS_Clock::now();

--- a/Engine/ac/video_script.cpp
+++ b/Engine/ac/video_script.cpp
@@ -1,0 +1,336 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// VideoPlayer script API.
+//
+//=============================================================================
+#include "ac/dynobj/dynobj_manager.h"
+#include "ac/dynobj/scriptvideoplayer.h"
+#include "debug/debug_log.h"
+#include "media/video/video.h"
+#include "media/video/videoplayer.h"
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+
+using namespace AGS::Common;
+using namespace AGS::Engine;
+
+ScriptVideoPlayer *VideoPlayer_Open(const char *filename, bool auto_play, int repeat_style)
+{
+    int video_id;
+    HError err = open_video(filename,
+        kVideo_EnableVideo | kVideo_EnableAudio | kVideo_DropFrames, video_id);
+    if (!err)
+    {
+        debug_script_warn("Failed to play video '%s': %s", filename, err->FullMessage().GetCStr());
+        return nullptr;
+    }
+
+    VideoControl *video_ctrl = get_video_control(video_id);
+    video_ctrl->SetLooping((repeat_style) ? true : false);
+    if (auto_play)
+    {
+        video_ctrl->Play();
+    }
+
+    ScriptVideoPlayer *sc_video = new ScriptVideoPlayer(video_id);
+    int handle = ccRegisterManagedObject(sc_video, sc_video);
+    video_ctrl->SetScriptHandle(handle);
+    return sc_video;
+}
+
+void VideoPlayer_Play(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    video_ctrl->Play();
+}
+
+void VideoPlayer_Pause(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    video_ctrl->Pause();
+}
+
+void VideoPlayer_NextFrame(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    video_ctrl->NextFrame();
+}
+
+int VideoPlayer_SeekFrame(ScriptVideoPlayer *sc_video, int frame)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->SeekFrame(frame);
+}
+
+int VideoPlayer_SeekMs(ScriptVideoPlayer *sc_video, int pos)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->SeekMs(pos);
+}
+
+void VideoPlayer_Stop(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    video_stop(sc_video->GetID());
+    sc_video->Invalidate();
+}
+
+int VideoPlayer_GetFrame(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetFrame();
+}
+
+int VideoPlayer_GetFrameCount(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetFrameCount();
+}
+
+float VideoPlayer_GetFrameRate(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0.f;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetFrameRate();
+}
+
+int VideoPlayer_GetGraphic(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetSpriteID();
+}
+
+int VideoPlayer_GetLengthMs(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetDurationMs();
+}
+
+int VideoPlayer_GetLooping(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return false;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetLooping();
+}
+
+void VideoPlayer_SetLooping(ScriptVideoPlayer *sc_video, bool loop)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->SetLooping(loop);
+}
+
+int VideoPlayer_GetPositionMs(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetPositionMs();
+}
+
+float VideoPlayer_GetSpeed(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0.f;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetSpeed();
+}
+
+void VideoPlayer_SetSpeed(ScriptVideoPlayer *sc_video, float speed)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    video_ctrl->SetSpeed(speed);
+}
+
+int VideoPlayer_GetState(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return PlaybackState::PlayStateInvalid;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetState();
+}
+
+int VideoPlayer_GetVolume(ScriptVideoPlayer *sc_video)
+{
+    if (sc_video->GetID() < 0)
+        return 0;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    return video_ctrl->GetVolume();
+}
+
+void VideoPlayer_SetVolume(ScriptVideoPlayer *sc_video, int volume)
+{
+    if (sc_video->GetID() < 0)
+        return;
+    VideoControl *video_ctrl = get_video_control(sc_video->GetID());
+    video_ctrl->SetVolume(volume);
+}
+
+//=============================================================================
+
+RuntimeScriptValue Sc_VideoPlayer_Open(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_POBJ_PINT2(ScriptVideoPlayer, VideoPlayer_Open, const char);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_Play(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptVideoPlayer, VideoPlayer_Play);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_Pause(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptVideoPlayer, VideoPlayer_Pause);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_NextFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptVideoPlayer, VideoPlayer_NextFrame);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_SeekFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_PINT(ScriptVideoPlayer, VideoPlayer_SeekFrame);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_SeekMs(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_PINT(ScriptVideoPlayer, VideoPlayer_SeekMs);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_Stop(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptVideoPlayer, VideoPlayer_Stop);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetFrame);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetFrameCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetFrameCount);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetFrameRate(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptVideoPlayer, VideoPlayer_GetFrameRate);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetGraphic);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetLengthMs(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetLengthMs);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetLooping(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetLooping);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_SetLooping(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PBOOL(ScriptVideoPlayer, VideoPlayer_SetLooping);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetPositionMs(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetPositionMs);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetSpeed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptVideoPlayer, VideoPlayer_GetSpeed);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_SetSpeed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptVideoPlayer, VideoPlayer_SetSpeed);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetState(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetState);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_GetVolume(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptVideoPlayer, VideoPlayer_GetVolume);
+}
+
+RuntimeScriptValue Sc_VideoPlayer_SetVolume(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptVideoPlayer, VideoPlayer_SetVolume);
+}
+
+
+
+void RegisterVideoAPI()
+{
+    ScFnRegister video_api[] = {
+        { "VideoPlayer::Open",          API_FN_PAIR(VideoPlayer_Open) },
+        { "VideoPlayer::Play",          API_FN_PAIR(VideoPlayer_Play) },
+        { "VideoPlayer::Pause",         API_FN_PAIR(VideoPlayer_Pause) },
+        { "VideoPlayer::NextFrame",     API_FN_PAIR(VideoPlayer_NextFrame) },
+        { "VideoPlayer::SeekFrame",     API_FN_PAIR(VideoPlayer_SeekFrame) },
+        { "VideoPlayer::SeekMs",        API_FN_PAIR(VideoPlayer_SeekMs) },
+        { "VideoPlayer::Stop",          API_FN_PAIR(VideoPlayer_Stop) },
+
+        { "VideoPlayer::get_Frame",     API_FN_PAIR(VideoPlayer_GetFrame) },
+        { "VideoPlayer::get_FrameCount", API_FN_PAIR(VideoPlayer_GetFrameCount) },
+        { "VideoPlayer::get_FrameRate", API_FN_PAIR(VideoPlayer_GetFrameRate) },
+        { "VideoPlayer::get_Graphic",   API_FN_PAIR(VideoPlayer_GetGraphic) },
+        { "VideoPlayer::get_LengthMs",  API_FN_PAIR(VideoPlayer_GetLengthMs) },
+        { "VideoPlayer::get_Looping",   API_FN_PAIR(VideoPlayer_GetLooping) },
+        { "VideoPlayer::set_Looping",   API_FN_PAIR(VideoPlayer_SetLooping) },
+        { "VideoPlayer::get_PositionMs", API_FN_PAIR(VideoPlayer_GetPositionMs) },
+        { "VideoPlayer::get_Speed",     API_FN_PAIR(VideoPlayer_GetSpeed) },
+        { "VideoPlayer::set_Speed",     API_FN_PAIR(VideoPlayer_SetSpeed) },
+        { "VideoPlayer::get_State",     API_FN_PAIR(VideoPlayer_GetState) },
+        { "VideoPlayer::get_Volume",    API_FN_PAIR(VideoPlayer_GetVolume) },
+        { "VideoPlayer::set_Volume",    API_FN_PAIR(VideoPlayer_SetVolume) }
+    };
+
+    ccAddExternalFunctions(video_api);
+}

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -11,6 +11,7 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
+#include <SDL.h>
 #include "core/platform.h"
 #include "ac/common.h"
 #include "ac/display.h"

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -60,6 +60,7 @@
 #include "main/game_run.h"
 #include "main/update.h"
 #include "media/audio/audio_system.h"
+#include "media/video/video.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin_evts.h"
 #include "plugin/plugin_engine.h"
@@ -1092,6 +1093,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     update_cursor_over_location(mwasatx, mwasaty);
     update_cursor_view();
 
+    update_video_system_on_game_loop();
     update_audio_system_on_game_loop();
 
     // Only render if we are not skipping a cutscene

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -416,7 +416,7 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
             soundfx->set_volume100(0);
     }
 
-    if (soundfx->play_from(fromOffset) == 0)
+    if (!soundfx->play_from(fromOffset))
     {
         delete soundfx;
         debug_script_log("AudioClip.Play: failed to play sound file");
@@ -564,7 +564,7 @@ SOUNDCLIP *load_sound_and_play(ScriptAudioClip *aclip, bool repeat)
     SOUNDCLIP *soundfx = load_sound_clip(aclip, repeat);
     if (!soundfx) { return nullptr; }
 
-    if (soundfx->play() == 0) {
+    if (!soundfx->play()) {
         delete soundfx;
         return nullptr;
     }

--- a/Engine/media/audio/audio_core.cpp
+++ b/Engine/media/audio/audio_core.cpp
@@ -67,6 +67,9 @@ static void audio_core_entry();
 
 void audio_core_init() 
 {
+    if (g_acore.audio_core_thread_running)
+        return; // already running
+
     /* InitAL opens a device and sets up a context using default attributes, making
      * the program ready to call OpenAL functions. */
 
@@ -105,6 +108,10 @@ void audio_core_init()
 
 void audio_core_shutdown()
 {
+    if (!g_acore.audio_core_thread_running)
+        return; // not running
+
+    Debug::Printf(kDbgMsg_Info, "AudioCore: shutting down...");
     g_acore.audio_core_thread_running = false;
 #if !defined(AGS_DISABLE_THREADS)
     if (g_acore.audio_core_thread.joinable())
@@ -127,6 +134,8 @@ void audio_core_shutdown()
         alcCloseDevice(g_acore.alcDevice);
         g_acore.alcDevice = nullptr;
     }
+
+    Debug::Printf(kDbgMsg_Info, "AudioCore: shutdown");
 }
 
 

--- a/Engine/media/audio/audio_core.h
+++ b/Engine/media/audio/audio_core.h
@@ -17,57 +17,18 @@
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__AUDIOCORE_H
 #define __AGS_EE_MEDIA__AUDIOCORE_H
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <vector>
 #include "media/audio/audiodefines.h"
 #include "media/audio/audioplayer.h"
 #include "util/string.h"
+#include "util/threading.h"
 
-
-namespace AGS
-{
-namespace Engine
-{
 
 // AudioPlayerLock wraps a AudioPlayer pointer guarded by a mutex lock.
 // Unlocks the mutex on destruction (e.g. when going out of scope).
-class AudioPlayerLock
-{
-public:
-    AudioPlayerLock(AudioPlayer *player, std::unique_lock<std::mutex> &&ulk, std::condition_variable *cv)
-        : _player(player)
-        , _ulock(std::move(ulk))
-        , _cv(cv)
-    {
-    }
-
-    AudioPlayerLock(AudioPlayerLock &&lock)
-        : _player(lock._player)
-        , _ulock(std::move(lock._ulock))
-        , _cv(lock._cv)
-    {
-        lock._cv = nullptr;
-    }
-
-    ~AudioPlayerLock()
-    {
-        if (_cv)
-            _cv->notify_all();
-    }
-
-    const AudioPlayer *operator ->() const { return _player; }
-    AudioPlayer *operator ->() { return _player; }
-
-private:
-    AudioPlayer *_player = nullptr;
-    std::unique_lock<std::mutex> _ulock;
-    std::condition_variable *_cv = nullptr;
-};
-
-} // namespace Engine
-} // namespace AGS
+typedef AGS::Engine::LockedObjectPtr<AGS::Engine::AudioPlayer>
+    AudioPlayerLock;
 
 // Initializes audio core system;
 // starts polling on a background thread.
@@ -82,18 +43,18 @@ void audio_core_set_master_volume(float newvol);
 
 // Audio slot controls: slots are abstract holders for a playback.
 //
-// Initializes playback on a free playback slot (reuses spare one or allocates new if there's none).
+// Initializes playback on a free playback slot.
 // Data array must contain full wave data to play.
-int audio_core_slot_init(std::shared_ptr<std::vector<uint8_t>> &data, const AGS::Common::String &extension_hint, bool repeat);
+int audio_core_slot_init(std::shared_ptr<std::vector<uint8_t>> &data, const AGS::Common::String &ext_hint, bool repeat);
 // Initializes playback streaming
-int audio_core_slot_init(std::unique_ptr<AGS::Common::Stream> in, const AGS::Common::String &extension_hint, bool repeat);
+int audio_core_slot_init(std::unique_ptr<AGS::Common::Stream> in, const AGS::Common::String &ext_hint, bool repeat);
 // Returns a AudioPlayer from the given slot, wrapped in a auto-locking struct.
-AGS::Engine::AudioPlayerLock audio_core_get_player(int slot_handle);
+AudioPlayerLock audio_core_get_player(int slot_handle);
 // Stop and release the audio player at the given slot
 void audio_core_slot_stop(int slot_handle);
 
 #if defined(AGS_DISABLE_THREADS)
-// polls the audio core if we have no threads, polled in Engine/ac/timer.cpp
+// Polls the audio core if we have no threads, polled in WaitForNextFrame()
 void audio_core_entry_poll();
 #endif
 

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -49,7 +49,7 @@ SOUNDCLIP::~SOUNDCLIP()
         audio_core_slot_stop(slot_);
 }
 
-int SOUNDCLIP::play()
+bool SOUNDCLIP::play()
 {
     if (!is_ready())
         return false;

--- a/Engine/media/audio/soundclip.h
+++ b/Engine/media/audio/soundclip.h
@@ -57,7 +57,7 @@ public:
     int xSource, ySource;
     int maximumPossibleDistanceAway;
 
-    int  play();
+    bool play();
     void pause();
     void resume();
     // Seeks to the position, where pos units depend on the audio type
@@ -71,7 +71,7 @@ public:
     // Returns if the clip is still playing, otherwise it's finished
     bool update();
 
-    inline int play_from(int position)
+    inline bool play_from(int position)
     {
         seek(position);
         return play();

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -14,6 +14,11 @@
 //
 // Theora (OGV) video player implementation.
 //
+// TODO:
+//     - support random Seek (APEG only provides reset/rewind atm).
+//     - for the long term - consider replacing APEG with a contemporary and
+//       feature-complete library.
+//
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__THEORAPLAYER_H
 #define __AGS_EE_MEDIA__THEORAPLAYER_H

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -662,10 +662,39 @@ void video_shutdown()
 
 #else
 
-HError play_theora_video(const char *name, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip) { return HError::None(); }
-HError play_flc_video(int numb, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip) { return HError::None(); }
-void video_pause() {}
-void video_resume() {}
-void video_shutdown() {}
+//-----------------------------------------------------------------------------
+// Stubs for the video support
+//-----------------------------------------------------------------------------
+
+using namespace AGS::Common;
+
+HError play_theora_video(const char *, int, int, AGS::Engine::VideoSkipType)
+{
+    return new Error("Video playback is not supported in this engine build.");
+}
+HError play_flc_video(int, int, int, AGS::Engine::VideoSkipType)
+{
+    return new Error("Video playback is not supported in this engine build.");
+}
+void video_single_pause() {}
+void video_single_resume() {}
+void video_single_stop() {}
+
+HError open_video(const char *, int, int &)
+{
+    return new Error("Video playback is not supported in this engine build.");
+}
+VideoControl *get_video_control(int) { return nullptr; }
+void video_stop(int) { }
+void sync_video_playback() { }
+void update_video_system_on_game_loop() { }
+void video_shutdown() { }
+
+void VideoControl::SetScriptHandle(int) {}
+bool VideoControl::Play() { return false; }
+void VideoControl::Pause() {}
+bool VideoControl::NextFrame() { return false; }
+uint32_t VideoControl::SeekFrame(uint32_t) { return -1; }
+float VideoControl::SeekMs(float) { return -1.f; }
 
 #endif

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -18,7 +18,8 @@
 #ifndef __AGS_EE_MEDIA__VIDEO_H
 #define __AGS_EE_MEDIA__VIDEO_H
 
-#include "media/video/videoplayer.h"
+#include "gfx/bitmap.h"
+#include "media/audio/audiodefines.h"
 #include "util/geometry.h"
 #include "util/string.h"
 #include "util/error.h"
@@ -54,7 +55,7 @@ enum VideoSkipType
 } // namespace AGS
 
 
-// Blocking video API
+// Legacy Blocking video API
 //
 // Start a blocking OGV playback
 AGS::Common::HError play_theora_video(const char *name, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip);
@@ -67,6 +68,94 @@ void video_single_resume();
 // Stop current blocking video playback and dispose all video resource
 void video_single_stop();
 
+// Non-blocking video API
+//
+class VideoControl
+{
+public:
+    VideoControl(int video_id, int sprite_id);
+    ~VideoControl();
+
+    // Gets if the video is valid (playing or ready to play)
+    bool IsReady() const
+    {
+        return IsPlaybackReady(_state);
+    }
+
+    int GetVideoID() const { return _videoID; }
+    int GetSpriteID() const { return _spriteID; }
+    int GetScriptHandle() const { return _scriptHandle; }
+
+    void SetScriptHandle(int sc_handle);
+
+    int GetFrame() const { return _frameIndex; }
+    int GetFrameCount() const { return _frameCount; }
+    float GetFrameRate() const { return _frameRate; }
+    float GetDurationMs() const { return _durMs; }
+    float GetPositionMs() const { return _posMs; }
+    bool GetLooping() const { return _looping; }
+    PlaybackState GetState() const { return _state; }
+    float GetSpeed() const { return _speed; }
+    int GetVolume() const { return _volume; }
+
+    void SetLooping(bool looping)
+    {
+        _looping = looping;
+        _paramsChanged = true;
+    }
+
+    void SetSpeed(float speed)
+    {
+        _speed = speed;
+        _paramsChanged = true;
+    }
+
+    void SetVolume(int vol)
+    {
+        _volume = vol;
+        _paramsChanged = true;
+    }
+
+    bool Play();
+    void Pause();
+    bool NextFrame();
+    uint32_t SeekFrame(uint32_t frame);
+    float SeekMs(float pos_ms);
+
+    // Synchronize VideoControl with the video playback subsystem;
+    // - start scheduled playback;
+    // - apply all accumulated sound parameters;
+    // - read and save current position;
+    // Returns if the clip is still playing, otherwise it's finished
+    bool Update();
+
+private:
+    std::unique_ptr<AGS::Common::Bitmap> SetNewFrame(std::unique_ptr<AGS::Common::Bitmap> frame);
+
+    const int _videoID;
+    const int _spriteID;
+    int       _scriptHandle = -1;
+    float     _frameRate = 0.f;
+    float     _durMs = 0.f;
+    uint32_t  _frameCount = 0;
+    int       _volume = 100;
+    float     _speed = 1.f;
+    bool      _looping = false;
+    PlaybackState _state = PlayStateInitial;
+    uint32_t  _frameIndex = 0;
+    float     _posMs = 0.f;
+    bool      _paramsChanged = false;
+};
+
+// open_video starts video and returns a VideoControl object
+// associated with it.
+AGS::Common::HError open_video(const char *name, int video_flags, int &video_id);
+VideoControl *get_video_control(int video_id);
+void video_stop(int video_id);
+// syncs logical video objects with the video core state
+void sync_video_playback();
+// update non-blocking videos
+void update_video_system_on_game_loop();
 // Stop all videos and video thread
 void video_shutdown();
 

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -12,7 +12,44 @@
 //
 //=============================================================================
 //
-// Game-blocking video interface.
+// Video playback logical frontend. Serves as a control layer between game
+// script and working video thread(s). Synchronizes logical and real playback
+// states once during each game update: this is done to guarantee that the
+// video state is fixed within a script callback.
+//
+// Videos play in their own FPS rate by default, which typically may be
+// different from the game's, but the frame that the game is displaying
+// on screen is updated in game's FPS rate. This also means that if a video
+// has higher FPS than the game's, then there will be visible frame skips.
+// If video's FPS is lower, then the same video frame will simply be displayed
+// for more than 1 game's frame (not a bad thing).
+//
+// There are two kinds of playback controls below: blocking and non-blocking.
+//
+// Blocking video is a legacy interface left for backwards compatibility.
+// It completely stops game updates for the duration of video (optionally with
+// exception of game's audio track). No game elements are drawn while it plays
+// (neither GUI, nor even a mouse cursor).
+//
+// Non-blocking video interface is a new default, which supports full playback
+// control, and lets assign a video frame to any game object on screen.
+// Game script is responsible for anything that happens during playback.
+//
+//-----------------------------------------------------------------------------
+//
+// TODO:
+//     - in the engine support tagging sprites as "opaque" so that the renderer
+//       would know to use simpler texture update method (video frames do not
+//       have transparency in them... or can they?.. this may depend on info
+//       retrieved from the video file too).
+//
+// TODO: POTENTIAL ALTERNATIVES (for consideration)
+//     - current implementation of a non-blocking video provides a sprite
+//       as a raw bitmap that may be updated to a texture. This lets to assign
+//       video frame on any object. But a downside is the increased complexity,
+//       which may make optimizing for performance somewhat more difficult.
+//       An alternate implementation could instead render video frames on a
+//       specialized game object, e.g. VideoOverlay, a subclass of Overlay.
 //
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__VIDEO_H

--- a/Engine/media/video/video_core.cpp
+++ b/Engine/media/video/video_core.cpp
@@ -118,7 +118,8 @@ int video_core_slot_init(std::unique_ptr<AGS::Common::Stream> in,
     auto player = create_video_player(ext_hint);
     if (!player)
         return -1;
-    if (!player->Open(std::move(in), name, params.Flags, params.TargetSize, params.TargetColorDepth))
+    if (!player->Open(std::move(in), name,
+            params.Flags, params.TargetSize, params.TargetColorDepth, params.FPS))
         return -1;
     return video_core_slot_init(std::move(player));
 }

--- a/Engine/media/video/video_core.cpp
+++ b/Engine/media/video/video_core.cpp
@@ -170,10 +170,28 @@ static void video_core_entry()
         g_vcore.poll_cv.wait_for(lk, std::chrono::milliseconds(8));
     }
 }
-#endif
+#endif // !AGS_DISABLE_THREADS
 
 #else // AGS_NO_VIDEO_PLAYER
 
-// TODO
+void video_core_init(/*config*/)
+{
+    Debug::Printf(kDbgMsg_Warn, "VideoCore: video playback is not supported in this engine build.");
+}
+void video_core_shutdown() { }
+int video_core_slot_init(std::unique_ptr<AGS::Common::Stream>,
+    const AGS::Common::String &, const AGS::Common::String &, const VideoInitParams &)
+{
+    return -1;
+}
+VideoPlayerLock video_core_get_player(int)
+{
+    throw std::runtime_error("Video playback is not supported in this engine build.");
+}
+void video_core_slot_stop(int) {}
+
+#if defined(AGS_DISABLE_THREADS)
+void video_core_entry_poll() {}
+#endif
 
 #endif // !AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/video_core.cpp
+++ b/Engine/media/video/video_core.cpp
@@ -1,0 +1,166 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "media/video/video_core.h"
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include "debug/out.h"
+#include "media/video/videoplayer.h"
+#include "media/video/theora_player.h"
+
+using namespace AGS::Common;
+using namespace AGS::Engine;
+
+#ifndef AGS_NO_VIDEO_PLAYER
+
+// Global audio core state and resources
+static struct 
+{
+    // Audio thread: polls sound decoders, feeds OpenAL sources
+    std::thread video_core_thread;
+    bool video_core_thread_running = false;
+
+    // Slot id counter
+    int nextId = 0;
+
+    // One mutex to lock them all... any operation on individual players
+    // is done under this only mutex, which means that they are currently
+    // polled one by one, any action like pause/resume is also synced.
+    std::mutex poll_mutex_m;
+    std::condition_variable poll_cv;
+    std::unordered_map<int, std::unique_ptr<VideoPlayer>> slots_;
+} g_vcore;
+
+static void video_core_entry();
+
+// -------------------------------------------------------------------------------------------------
+// INIT / SHUTDOWN
+// -------------------------------------------------------------------------------------------------
+
+void video_core_init()
+{
+    if (g_vcore.video_core_thread_running)
+        return; // already running
+
+    g_vcore.video_core_thread_running = true;
+#if !defined(AGS_DISABLE_THREADS)
+    g_vcore.video_core_thread = std::thread(video_core_entry);
+#endif
+    Debug::Printf(kDbgMsg_Info, "VideoCore: init thread");
+}
+
+void video_core_shutdown()
+{
+    if (!g_vcore.video_core_thread_running)
+        return; // not running
+
+    Debug::Printf(kDbgMsg_Info, "VideoCore: shutting down...");
+    g_vcore.video_core_thread_running = false;
+#if !defined(AGS_DISABLE_THREADS)
+    if (g_vcore.video_core_thread.joinable())
+        g_vcore.video_core_thread.join();
+#endif
+
+    // dispose all the active slots
+    g_vcore.slots_.clear();
+    Debug::Printf(kDbgMsg_Info, "VideoCore: shutdown");
+}
+
+
+// -------------------------------------------------------------------------------------------------
+// SLOTS
+// -------------------------------------------------------------------------------------------------
+
+static int avail_slot_id()
+{
+    return g_vcore.nextId++;
+}
+
+static int video_core_slot_init(std::unique_ptr<VideoPlayer> player)
+{
+    auto handle = avail_slot_id();
+    std::lock_guard<std::mutex> lk(g_vcore.poll_mutex_m);
+    g_vcore.slots_[handle] = std::move(player);
+    g_vcore.poll_cv.notify_all();
+    return handle;
+}
+
+static std::unique_ptr<VideoPlayer> create_video_player(const AGS::Common::String &ext_hint)
+{
+    std::unique_ptr<VideoPlayer> player;
+    // Table of video format detection
+    if (ext_hint.CompareNoCase("ogv") == 0)
+        player.reset(new TheoraPlayer());
+    else
+        return nullptr; // not supported
+    return player;
+}
+
+int video_core_slot_init(std::unique_ptr<AGS::Common::Stream> in,
+    const String &name, const AGS::Common::String &ext_hint, const VideoInitParams &params)
+{
+    auto player = create_video_player(ext_hint);
+    if (!player)
+        return -1;
+    if (!player->Open(std::move(in), name, params.Flags, params.TargetSize, params.TargetColorDepth))
+        return -1;
+    return video_core_slot_init(std::move(player));
+}
+
+VideoPlayerLock video_core_get_player(int slot_handle)
+{
+    std::unique_lock<std::mutex> ulk(g_vcore.poll_mutex_m);
+    auto it = g_vcore.slots_.find(slot_handle);
+    if (it == g_vcore.slots_.end())
+        return VideoPlayerLock(nullptr, std::move(ulk), &g_vcore.poll_cv);
+    return VideoPlayerLock(it->second.get(), std::move(ulk), &g_vcore.poll_cv);
+}
+
+// -------------------------------------------------------------------------------------------------
+// VIDEO PROCESSING
+// -------------------------------------------------------------------------------------------------
+
+void video_core_entry_poll()
+{
+    for (auto &entry : g_vcore.slots_) {
+        auto &slot = entry.second;
+
+        try {
+            slot->Poll();
+        } catch (const std::exception& e) {
+            Debug::Printf(kDbgMsg_Error, "VideoCore poll exception: %s", e.what());
+        }
+    }
+}
+
+#if !defined(AGS_DISABLE_THREADS)
+static void video_core_entry()
+{
+    std::unique_lock<std::mutex> lk(g_vcore.poll_mutex_m);
+
+    while (g_vcore.video_core_thread_running) {
+
+        video_core_entry_poll();
+
+        g_vcore.poll_cv.wait_for(lk, std::chrono::milliseconds(8));
+    }
+}
+#endif
+
+#else // AGS_NO_VIDEO_PLAYER
+
+// TODO
+
+#endif // !AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/video_core.h
+++ b/Engine/media/video/video_core.h
@@ -51,6 +51,8 @@ int video_core_slot_init(std::unique_ptr<AGS::Common::Stream> in,
     const AGS::Common::String &name, const AGS::Common::String &ext_hint, const VideoInitParams &params);
 // Returns a VideoPlayer from the given slot, wrapped in a auto-locking struct.
 VideoPlayerLock video_core_get_player(int slot_handle);
+// Stop and release the video player at the given slot
+void video_core_slot_stop(int slot_handle);
 
 #if defined(AGS_DISABLE_THREADS)
 // Polls the video core if we have no threads, polled in WaitForNextFrame()

--- a/Engine/media/video/video_core.h
+++ b/Engine/media/video/video_core.h
@@ -1,0 +1,60 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Video Core: an video backend interface.
+//
+//=============================================================================
+#ifndef __AGS_EE_MEDIA__VIDEOCORE_H
+#define __AGS_EE_MEDIA__VIDEOCORE_H
+#include <memory>
+#include "media/video/videoplayer.h"
+#include "util/string.h"
+#include "util/threading.h"
+
+// AudioPlayerLock wraps a AudioPlayer pointer guarded by a mutex lock.
+// Unlocks the mutex on destruction (e.g. when going out of scope).
+typedef AGS::Engine::LockedObjectPtr<AGS::Engine::VideoPlayer>
+    VideoPlayerLock;
+
+// Initializes video core system;
+// starts polling on a background thread.
+void video_core_init(/*config*/);
+// Shut downs video core system;
+// stops any associated threads.
+void video_core_shutdown();
+
+struct VideoInitParams
+{
+    AGS::Engine::VideoFlags Flags = AGS::Engine::kVideo_None;
+    Size TargetSize;
+    int TargetColorDepth = 0;
+    int FPS = 0;
+};
+
+// Video slot controls: slots are abstract holders for a playback.
+//
+// Initializes video playback on a free playback slot, uses provided
+// stream for data streaming.
+// TODO: return HError on error?
+int video_core_slot_init(std::unique_ptr<AGS::Common::Stream> in,
+    const AGS::Common::String &name, const AGS::Common::String &ext_hint, const VideoInitParams &params);
+// Returns a VideoPlayer from the given slot, wrapped in a auto-locking struct.
+VideoPlayerLock video_core_get_player(int slot_handle);
+
+#if defined(AGS_DISABLE_THREADS)
+// Polls the video core if we have no threads, polled in WaitForNextFrame()
+void video_core_entry_poll();
+#endif
+
+#endif // __AGS_EE_MEDIA__VIDEOCORE_H

--- a/Engine/media/video/video_core.h
+++ b/Engine/media/video/video_core.h
@@ -39,7 +39,7 @@ struct VideoInitParams
     AGS::Engine::VideoFlags Flags = AGS::Engine::kVideo_None;
     Size TargetSize;
     int TargetColorDepth = 0;
-    int FPS = 0;
+    float FPS = 0.f;
 };
 
 // Video slot controls: slots are abstract holders for a playback.

--- a/Engine/media/video/video_core.h
+++ b/Engine/media/video/video_core.h
@@ -14,6 +14,11 @@
 //
 // Video Core: an video backend interface.
 //
+// TODO:
+//     - multiple working threads.
+//     - separate thread(s) for buffering, so that it continues even while
+//       the videoplayer is being synchronized with the game logic.
+//
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__VIDEOCORE_H
 #define __AGS_EE_MEDIA__VIDEOCORE_H

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -22,10 +22,20 @@
 //     - allow skip frames if late (add to settings);
 //     - a video-audio sync mechanism; perhaps rely on audio,
 //       because it's more time-sensitive in human perception;
-//       drop video frames if video is lagging, but this also has to
-//       be done in decoder to avoid converting vframe to a bitmap.
+//       drop video frames if video is lagging. But this also may have to
+//       be done in decoder to avoid converting vframe to a bitmap (yuv->rgb).
 //     - other options: slow down playback speed until video-audio
 //       relation stabilizes.
+//
+// TODO: POTENTIAL OPTIMIZATIONS
+//     - create and buffer textures along the bitmaps.
+//     - perhaps skip bitmap and decode onto texture right away,
+//       that would require modifying the video decoding lib (or using other).
+//       but then there also has to be a reverse conversion made in case
+//       someone would like to use the frame for raw drawing.
+//     - expose buffering in video player's interface, and guard buffer queues
+//       with mutexes. This would allow to keep buffering constantly even
+//       during next ready frame retrieval by the engine.
 //
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__VIDEOPLAYER_H

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -117,6 +117,8 @@ public:
 
     // Retrieve the currently prepared video frame
     std::unique_ptr<Common::Bitmap> GetReadyFrame();
+    // Retrieve a dummy clear frame, may be used as a temp placeholder
+    std::unique_ptr<Common::Bitmap> GetEmptyFrame();
     // Tell VideoPlayer that this frame is not used anymore, and may be recycled
     // TODO: redo this part later, by introducing some kind of a RAII lock wrapper.
     void ReleaseFrame(std::unique_ptr<Common::Bitmap> frame);
@@ -165,6 +167,8 @@ private:
     void BufferAudio();
     // Update playback timing
     void UpdateTime();
+    // Retrieve a frame from the pool, or create a new one
+    std::unique_ptr<Common::Bitmap> GetPooledFrame();
     // Retrieve first available frame from queue,
     // advance output frame counter
     std::unique_ptr<Common::Bitmap> NextFrameFromQueue();

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -48,6 +48,7 @@ namespace Engine
 
 enum VideoFlags
 {
+    kVideo_None           = 0,
     kVideo_EnableVideo    = 0x0001,
     kVideo_EnableAudio    = 0x0002,
     kVideo_Loop           = 0x0004,

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -55,6 +55,7 @@ extern void RegisterSystemAPI();
 extern void RegisterTextBoxAPI();
 extern void RegisterViewFrameAPI();
 extern void RegisterViewportAPI();
+extern void RegisterVideoAPI();
 extern void RegisterWalkareaAPI();
 extern void RegisterWalkbehindAPI();
 
@@ -99,6 +100,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterTextBoxAPI();
     RegisterViewFrameAPI();
     RegisterViewportAPI();
+    RegisterVideoAPI();
     RegisterWalkareaAPI();
     RegisterWalkbehindAPI();
 

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -382,6 +382,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     RET_CLASS* ret_obj = (RET_CLASS*)FUNCTION((P1CLASS*)params[0].Ptr, params[1].IValue); \
     return RuntimeScriptValue().SetScriptObject(ret_obj, ret_obj)
 
+#define API_SCALL_OBJAUTO_POBJ_PINT2(RET_CLASS, FUNCTION, P1CLASS) \
+    ASSERT_PARAM_COUNT(FUNCTION, 3); \
+    RET_CLASS* ret_obj = (RET_CLASS*)FUNCTION((P1CLASS*)params[0].Ptr, params[1].IValue, params[2].IValue); \
+    return RuntimeScriptValue().SetScriptObject(ret_obj, ret_obj)
+
 #define API_SCALL_OBJAUTO_POBJ_PINT4(RET_CLASS, FUNCTION, P1CLASS) \
     ASSERT_PARAM_COUNT(FUNCTION, 5); \
     RET_CLASS* ret_obj = FUNCTION((P1CLASS*)params[0].Ptr, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue); \

--- a/Engine/util/threading.h
+++ b/Engine/util/threading.h
@@ -1,0 +1,70 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Threading utilities
+//
+//=============================================================================
+#ifndef __AGS_EE_UTIL__THREADING_H
+#define __AGS_EE_UTIL__THREADING_H
+#include <condition_variable>
+#include <mutex>
+
+namespace AGS
+{
+namespace Engine
+{
+    
+// LockedObjectPtr wraps an object pointer guarded by a mutex lock.
+// Unlocks the mutex on destruction (e.g. when going out of scope).
+// Optionally accepts a condition variable, sends notification on destruction.
+template <typename T>
+class LockedObjectPtr
+{
+public:
+    LockedObjectPtr(T *object, std::unique_lock<std::mutex> &&ulk, std::condition_variable *cv)
+        : _object(object)
+        , _ulock(std::move(ulk))
+        , _cv(cv)
+    {
+    }
+
+    LockedObjectPtr(LockedObjectPtr<T> &&lock)
+        : _object(lock._object)
+        , _ulock(std::move(lock._ulock))
+        , _cv(lock._cv)
+    {
+        lock._cv = nullptr;
+    }
+
+    ~LockedObjectPtr()
+    {
+        if (_cv)
+            _cv->notify_all();
+    }
+
+    const T *operator ->() const { return _object; }
+    T *operator ->() { return _object; }
+    const T &operator *() const { return *_object; }
+    T &operator *() { return *_object; }
+
+private:
+    T *_object = nullptr;
+    std::unique_lock<std::mutex> _ulock;
+    std::condition_variable *_cv = nullptr;
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_UTIL__THREADING_H

--- a/Engine/util/threading.h
+++ b/Engine/util/threading.h
@@ -53,6 +53,7 @@ public:
             _cv->notify_all();
     }
 
+    operator bool() const { return _object != nullptr; }
     const T *operator ->() const { return _object; }
     T *operator ->() { return _object; }
     const T &operator *() const { return *_object; }

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -502,6 +502,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptviewframe.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptviewport.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptset.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptvideoplayer.cpp" />
     <ClCompile Include="..\..\Engine\ac\event.cpp" />
     <ClCompile Include="..\..\Engine\ac\file.cpp" />
     <ClCompile Include="..\..\Engine\ac\game.cpp" />
@@ -563,6 +564,7 @@
     <ClCompile Include="..\..\Engine\ac\textbox.cpp" />
     <ClCompile Include="..\..\Engine\ac\timer.cpp" />
     <ClCompile Include="..\..\Engine\ac\translation.cpp" />
+    <ClCompile Include="..\..\Engine\ac\video_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\viewframe.cpp" />
     <ClCompile Include="..\..\Engine\ac\viewport_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\walkablearea.cpp" />
@@ -747,6 +749,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptviewframe.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptviewport.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptobjects.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptvideoplayer.h" />
     <ClInclude Include="..\..\Engine\ac\event.h" />
     <ClInclude Include="..\..\Engine\ac\file.h" />
     <ClInclude Include="..\..\Engine\ac\game.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -635,6 +635,7 @@
     <ClCompile Include="..\..\Engine\media\video\theora_player.cpp" />
     <ClCompile Include="..\..\Engine\media\video\video.cpp" />
     <ClCompile Include="..\..\Engine\media\video\videoplayer.cpp" />
+    <ClCompile Include="..\..\Engine\media\video\video_core.cpp" />
     <ClCompile Include="..\..\Engine\platform\base\agsplatformdriver.cpp" />
     <ClCompile Include="..\..\Engine\platform\base\sys_main.cpp" />
     <ClCompile Include="..\..\Engine\platform\windows\acplwin.cpp" />
@@ -888,6 +889,7 @@
     <ClInclude Include="..\..\Engine\media\video\theora_player.h" />
     <ClInclude Include="..\..\Engine\media\video\video.h" />
     <ClInclude Include="..\..\Engine\media\video\videoplayer.h" />
+    <ClInclude Include="..\..\Engine\media\video\video_core.h" />
     <ClInclude Include="..\..\Engine\platform\base\agsplatformdriver.h" />
     <ClInclude Include="..\..\Engine\platform\base\sys_main.h" />
     <ClInclude Include="..\..\Engine\platform\windows\debug\namedpipesagsdebugger.h" />
@@ -914,6 +916,7 @@
     <ClInclude Include="..\..\Engine\util\library.h" />
     <ClInclude Include="..\..\Engine\util\library_windows.h" />
     <ClInclude Include="..\..\Engine\util\sdl2_util.h" />
+    <ClInclude Include="..\..\Engine\util\threading.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\al.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\alc.h" />
   </ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -774,6 +774,9 @@
     <ClCompile Include="..\..\Engine\media\video\theora_player.cpp">
       <Filter>Source Files\media\video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\media\video\video_core.cpp">
+      <Filter>Source Files\media\video</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1549,6 +1552,12 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\media\video\theora_player.h">
       <Filter>Header Files\media\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\media\video\video_core.h">
+      <Filter>Header Files\media\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\util\threading.h">
+      <Filter>Header Files\util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -777,6 +777,12 @@
     <ClCompile Include="..\..\Engine\media\video\video_core.cpp">
       <Filter>Source Files\media\video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\video_script.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptvideoplayer.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1558,6 +1564,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\util\threading.h">
       <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptvideoplayer.h">
+      <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
For #2155.

This is not a complete functionality, but a draft, meant to test out the idea. Random mistakes are to be expected.

1. Rewrote VideoPlayer class, so that it buffers video frames and prepares a "ready frame" when the time is right, but does not draw anything itself. The plan for the VideoPlayer is that it can work in 2 modes: autoplay and frame-by-frame mode. In the first mode it calculates timing when the next frame should be presented, and switches the "ready frame". In the frame-by-frame mode it will be in paused state but advance to next frame by a call to NextFrame(). Audio is not played in the frame-by-frame mode.
2. Picked out BlockingVideoPlayer class which is basically a "game state" singleton that runs VideoPlayer, blocking the rest of the game. This is used for the old PlayVideo command.
3. Implemented "video core", similar to existing "audio core", with a running thread, which polls video players.
4. Wrote a video object control, that starts and stops videos, and acquires their "ready frames", placing them into the spriteset, as dynamic sprites (so that they don't get deleted). Besides being video frames, these act entirely like any sprite, so may be assigned anywhere, e.g. to Overlay. When frame is changed, game objects are notified of a sprite's change as usual, and redraw themselves as necessary.
5. Implemented new VideoPlayer API as follows:
```
enum PlaybackState {
  ePlaybackOn = 2,
  ePlaybackPaused = 3,
  ePlaybackStopped = 4
};

builtin managed struct VideoPlayer {
  import static VideoPlayer* Open(const string filename, bool autoPlay=true, RepeatStyle=eOnce);
  /// Starts or resumes the playback.
  import void Play();
  /// Pauses the playback.
  import void Pause();
  /// Advances video by 1 frame, will pause video when called.
  import void NextFrame();
  /// Changes playback to continue from the specified frame.
  import void SeekFrame(int frame);
  /// Changes playback to continue from the specified position in milliseconds.
  import void SeekMs(int position);
  /// Stops the video completely.
  import void Stop();

  /// Gets current frame index.
  import readonly attribute int Frame;
  /// Gets total number of frames in this video.
  import readonly attribute int FrameCount;
  /// Gets this video's framerate (number of frames per second).
  import readonly attribute float FrameRate;
  /// Gets the number of sprite this video renders to.
  import readonly attribute int Graphic;
  /// The length of the currently playing video, in milliseconds.
  import readonly attribute int LengthMs;
  /// Gets/sets whether the video should loop.
  import attribute bool Looping;
  /// The current playback position, in milliseconds.
  import readonly attribute int PositionMs;
  /// The speed of playing (1.0 is default).
  import attribute float Speed;
  /// Gets the current playback state (playing, paused, etc).
  import readonly attribute PlaybackState State;
  /// The volume of this video's sound, from 0 to 100.
  import attribute int Volume;
};
```

A key point is a Graphic property that returns an index of a sprite where the video renders to. This sprite may then be assigned to anything that may normally have a sprite, such as Overlay, GUI button, etc.

Basic script example may be:
```
VideoPlayer *video = VideoPlayer.Open("video.ogv", true, eRepeat);
if (video)
{
    Overlay *over = Overlay.CreateGraphical(0, 0, video.Graphic);
    Wait(100);
    over = null;
    video = null;
}
```

---

TODO:
- [x] Proper script API
- [x] Fix timing after resuming
- [ ] Autofix audio/video desync
- [x] Support speed setting
- [ ] Support seek, APEG does not provide this!
- [x] Stubs for AGS_NO_VIDEO_PLAYER build (?)

POTENTIAL OPTIMIZATIONS
- [ ] Buffer frame textures along with the bitmaps
- [ ] Store "opaque" flag per sprite, so that updating sprite's texture would be a bit faster. This may be still done separately, as a general improvement, if "buffer texture" path is taken.
- [ ] Might have separate locks for buffering and processing/control, as buffering only touches the queue and frame pool, and might as well keep running while the ready frame is being retrieved (or rather, we should let retrieve the ready frame while the decoding and buffering is run). This may be done in "audio core" too, but with video this is more important, as video frames take more time to process.

OTHER THINGS:
- [ ] Consider finding/writing a new library code for working with ogg theora, because APEG is very old, and does not have all required functionality prepared.
