### PR TITLE
Redesign audio core to return a locked AudioPlayer object instead of having a multitude of helper functions

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -388,6 +388,8 @@ target_sources(engine
     media/audio/audio.h
     media/audio/audio_system.h
     media/audio/audiodefines.h
+    media/audio/audioplayer.cpp
+    media/audio/audioplayer.h
     media/audio/sdldecoder.cpp
     media/audio/sdldecoder.h
     media/audio/openalsource.cpp

--- a/Engine/media/audio/audio_core.cpp
+++ b/Engine/media/audio/audio_core.cpp
@@ -27,12 +27,6 @@
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
-// A volume scale factor between AGS->OpenAL
-// TODO: find out why 0.7f is here?
-// TODO: should move this to OpenAL output?
-// but one problem is that this is also used for the "master volume".
-const auto GlobalGainScaling = 0.7f;
-
 // Global audio core state and resources
 static struct 
 {
@@ -214,7 +208,9 @@ void audio_core_slot_seek_ms(int slot_handle, float pos_ms)
 
 void audio_core_set_master_volume(float newvol) 
 {
-    alListenerf(AL_GAIN, newvol*GlobalGainScaling);
+    // TODO: review this later; how do we apply master volume
+    // if we use alternate audio output (e.g. from plugin)?
+    alListenerf(AL_GAIN, newvol);
     dump_al_errors();
 }
 
@@ -222,7 +218,7 @@ void audio_core_slot_configure(int slot_handle, float volume, float speed, float
 {
     std::lock_guard<std::mutex> lk(g_acore.mixer_mutex_m);
     auto *player = g_acore.slots_[slot_handle].get();
-    player->SetVolume(volume * GlobalGainScaling);
+    player->SetVolume(volume);
     player->SetSpeed(speed);
     player->SetPanning(panning);
 }

--- a/Engine/media/audio/audioplayer.cpp
+++ b/Engine/media/audio/audioplayer.cpp
@@ -1,0 +1,143 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "media/audio/audioplayer.h"
+#include "util/memory_compat.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+AudioPlayer::AudioPlayer(int handle, std::unique_ptr<SDLDecoder> decoder)
+    : handle_(handle), _decoder(std::move(decoder))
+{
+    _source = std::make_unique<OpenAlSource>(
+        _decoder->GetFormat(), _decoder->GetChannels(), _decoder->GetFreq());
+}
+
+void AudioPlayer::Init()
+{
+    bool success;
+    if (_decoder->IsValid()) // if already opened, then just seek to start
+        success = _decoder->Seek(_onLoadPositionMs) == _onLoadPositionMs;
+    else
+        success = _decoder->Open(_onLoadPositionMs);
+    _playState = success ? _onLoadPlayState : PlayStateError;
+    if (_playState == PlayStatePlaying)
+        _source->Play();
+}
+
+void AudioPlayer::Poll()
+{
+    if (_playState == PlaybackState::PlayStateInitial)
+        Init();
+    if (_playState != PlayStatePlaying)
+        return;
+
+    // Read data from Decoder and pass into the Al Source
+    if (!_bufferPending.Data && !_decoder->EOS())
+    { // if no buffer saved, and still something to decode, then read a buffer
+        _bufferPending = _decoder->GetData();
+        assert(_bufferPending.Data || (_bufferPending.Size == 0));
+    }
+    if (_bufferPending.Data && (_bufferPending.Size > 0))
+    { // if having a buffer already, then try to put into source
+        if (_source->PutData(_bufferPending) > 0)
+            _bufferPending = SoundBuffer(); // clear buffer on success
+    }
+    _source->Poll();
+    // If both finished decoding and playing, we done here.
+    if (_decoder->EOS() && _source->IsEmpty())
+    {
+        _playState = PlayStateFinished;
+    }
+}
+
+void AudioPlayer::Play()
+{
+    switch (_playState)
+    {
+    case PlayStateInitial:
+        _onLoadPlayState = PlayStatePlaying;
+        break;
+    case PlayStateStopped:
+        _decoder->Seek(0.0f);
+        /* fall-through */
+    case PlayStatePaused:
+        _playState = PlayStatePlaying;
+        _source->Play();
+        break;
+    default:
+        break;
+    }
+}
+
+void AudioPlayer::Pause()
+{
+    switch (_playState)
+    {
+    case PlayStateInitial:
+        _onLoadPlayState = PlayStatePaused;
+        break;
+    case PlayStatePlaying:
+        _playState = PlayStatePaused;
+        _source->Pause();
+        break;
+    default:
+        break;
+    }
+}
+
+void AudioPlayer::Stop()
+{
+    switch (_playState)
+    {
+    case PlayStateInitial:
+        _onLoadPlayState = PlayStateStopped;
+        break;
+    case PlayStatePlaying:
+    case PlayStatePaused:
+        _playState = PlayStateStopped;
+        _source->Stop();
+        _bufferPending = SoundBuffer(); // clear
+        break;
+    default:
+        break;
+    }
+}
+
+void AudioPlayer::Seek(float pos_ms)
+{
+    switch (_playState)
+    {
+    case PlayStateInitial:
+        _onLoadPositionMs = pos_ms;
+        break;
+    case PlayStatePlaying:
+    case PlayStatePaused:
+    case PlayStateStopped:
+        {
+            _source->Stop();
+            _bufferPending = SoundBuffer(); // clear
+            float new_pos = _decoder->Seek(pos_ms);
+            _source->SetPlaybackPosMs(new_pos);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/media/audio/audioplayer.h
+++ b/Engine/media/audio/audioplayer.h
@@ -1,0 +1,85 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Audio playback class.
+// Controls playback state. Retrieves audio data from decoder and passes into
+// the audio output.
+//
+// TODO: a virtual Decoder and AudioOutput interfaces, to let hide current
+// implementations, and also substitute default implementations
+// (e.g. with plugins).
+//
+//=============================================================================
+#ifndef __AGS_EE_MEDIA__AUDIOPLAYER_H
+#define __AGS_EE_MEDIA__AUDIOPLAYER_H
+#include <memory>
+#include "media/audio/audiodefines.h" // PlaybackState etc
+#include "media/audio/sdldecoder.h"
+#include "media/audio/openalsource.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+class AudioPlayer
+{
+public:
+    AudioPlayer(int handle, std::unique_ptr<SDLDecoder> decoder);
+
+    // Gets current playback state
+    PlaybackState GetPlayState() const { return _playState; }
+    // Gets frequency (sample rate)
+    float GetFrequency() const { return _decoder->GetFreq(); }
+    // Gets duration, in ms
+    float GetDurationMs() const { return _decoder->GetDurationMs(); }
+    // Gets playback position, in ms
+    float GetPositionMs() const { return _source->GetPositionMs(); }
+
+    // Sets the sound panning (-1.0f to 1.0)
+    void SetPanning(float panning) { _source->SetPanning(panning); }
+    // Sets the playback speed (fraction of normal);
+    // NOTE: the speed is implemented through resampling
+    void SetSpeed(float speed) { _source->SetSpeed(speed); }
+    // Sets the playback volume (gain)
+    void SetVolume(float volume) { _source->SetVolume(volume); }
+
+    // Update state, transfer data from decoder to player if possible
+    void Poll();
+    // Begin playback
+    void Play();
+    // Pause playback
+    void Pause();
+    // Stop playback completely
+    void Stop();
+    // Seek to the given time position
+    void Seek(float pos_ms);
+
+private:
+    // Opens decoder and sets up playback state
+    void Init();
+
+    const int handle_ = -1; // for diagnostic purposes only
+    std::unique_ptr<SDLDecoder> _decoder;
+    std::unique_ptr<OpenAlSource> _source;
+    PlaybackState _playState = PlayStateInitial;
+    PlaybackState _onLoadPlayState = PlayStatePaused;
+    float _onLoadPositionMs = 0.0f;
+    SoundBuffer _bufferPending{};
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_MEDIA__AUDIOPLAYER_H

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 #include "media/audio/sound.h"
-#include <cmath>
 #include <list>
 #include <unordered_map>
 #include "core/assetmanager.h"
@@ -25,6 +24,7 @@
 #include "util/string_types.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 static int GuessSoundTypeFromExt(const String &extension)
 {
@@ -157,11 +157,5 @@ SOUNDCLIP *load_sound_clip(const AssetPath &apath, const char *extension_hint, b
     if (slot < 0) { return nullptr; }
 
     const auto sound_type = GuessSoundTypeFromExt(ext_hint);
-    const auto lengthMs = (int)std::round(audio_core_slot_get_duration(slot));
-
-    auto clip = new SOUNDCLIP(slot);
-    clip->repeat = loop;
-    clip->soundType = sound_type;
-    clip->lengthMs = lengthMs;
-    return clip;
+    return new SOUNDCLIP(slot, sound_type, loop);
 }

--- a/Engine/media/audio/soundclip.h
+++ b/Engine/media/audio/soundclip.h
@@ -41,7 +41,7 @@
 class SOUNDCLIP final
 {
 public:
-    SOUNDCLIP(int slot);
+    SOUNDCLIP(int slot, int snd_type, bool loop);
     ~SOUNDCLIP();
 
     // TODO: move these to private

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -640,6 +640,7 @@
     <ClCompile Include="..\..\Engine\main\update.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\ambientsound.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\audio.cpp" />
+    <ClCompile Include="..\..\Engine\media\audio\audioplayer.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\audio_core.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\openalsource.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\queuedaudioitem.cpp" />
@@ -905,6 +906,7 @@
     <ClInclude Include="..\..\Engine\media\audio\ambientsound.h" />
     <ClInclude Include="..\..\Engine\media\audio\audio.h" />
     <ClInclude Include="..\..\Engine\media\audio\audiodefines.h" />
+    <ClInclude Include="..\..\Engine\media\audio\audioplayer.h" />
     <ClInclude Include="..\..\Engine\media\audio\audio_core.h" />
     <ClInclude Include="..\..\Engine\media\audio\audio_system.h" />
     <ClInclude Include="..\..\Engine\media\audio\sdldecoder.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -804,6 +804,9 @@
     <ClCompile Include="..\..\Engine\plugin\plugin_stubs.cpp">
       <Filter>Source Files\plugin</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\media\audio\audioplayer.cpp">
+      <Filter>Source Files\media\audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1618,6 +1621,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\plugin\agsplugin_evts.h">
       <Filter>Header Files\plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\media\audio\audioplayer.h">
+      <Filter>Header Files\media\audio</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The "audio core" system was implemented in 3.6.0, as a part of moving from Allegro 4 towards SDL-based utilities and a more convenient audio thread.

Although the original idea of "audio core" interface was to have everything behind the set of functions, in practice it proved to be rather annoying, as we had to have a duplicate function per each "audio player" action. This creates a mostly redundant layer of complexity.
But besides that, there's a technical issue: each "audio core" function's call locks the mutex, and sometimes we need to do several things at once. This means either call several functions with a lock/unlock pair in a succession, or write more cumbersome helper functions that do a number of things under one lock/unlock pair. If calling several functions, the state of the audio player may actually change in between. (In fact, it may even get disposed in between, although this probably never happened in practice because of how our synchronization is organized.)

The new design is inspired by the older "Channel Lock" existing in versions 3.5.0-3.5.1 (e.g. [see this code](https://github.com/adventuregamestudio/ags/blob/4571e60fa4eb123683b8491de83495865c4bb80a/Engine/media/audio/audio.h#L30-L56)), and follows this outline:
1. AudioCoreSlot is picked out to a separate code unit and renamed to AudioPlayer.
2. Majority of audio core's playback control and state reading functions are REMOVED.
3. Instead, there's ONE function called audio_core_get_player() that returns a AudioPlayer's pointer wrapped into a AudioPlayerLock class, which holds a mutex lock, and unlocks on destruction. AudioPlayerLock class lets user to work with AudioPlayer, doing any manipulation necessary, and unlocks the provided mutex as soon as it gets out of scope.
