### PR TITLE
Engine: allow disabling exclusive fullscreen checkbox

### DIFF
--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -744,6 +744,11 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
         EnableWindow(_hRenderAtScreenRes, FALSE);
     if (CfgReadBoolInt(_cfgIn, "disabled", "translation"))
         EnableWindow(_hLanguageList, FALSE);
+    if (CfgReadBoolInt(_cfgIn, "disabled", "fullscreen")) {
+        EnableWindow(_hFullscreenDesktop, FALSE);
+        EnableWindow(_hGfxModeList, FALSE);
+    }
+
 
     RECT win_rect, gfx_rect, adv_rect, border;
     GetWindowRect(_hwnd, &win_rect);

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -130,6 +130,7 @@ Locations of two latter files differ between running platforms:
   * \<gfxdriver id\> = \[0; 1\] - tells to remove particular graphics driver from the selection list;
   * filters = \[0; 1\] - tells to lock "Graphics filter" selection in a default state;
   * \<filter id\> = \[0; 1\] - tells to remove particular graphics filter from the selection list;
+  * fullscreen = \[0; 1\] - tells to disable fullscreen desktop checkbox and fullscreen mode selection list;
   * antialias = \[0; 1\] - tells to lock "Smooth scaled sprites" in a default state;
   * render_at_screenres = \[0; 1\] - tells to lock "Render sprites in screen resolution" in a default state;
   * speechvox = \[0; 1\] - tells to lock "Use digital speech pack" in a default state;


### PR DESCRIPTION
if you have `fullscreen=full_window`, using 

```
[disabled]
fullscreen=1
```

Will lock it. This is from my own suggestion here for the Direct3D alt+tab issue

https://github.com/adventuregamestudio/ags/issues/1287#issuecomment-1894818412

Now, when I built ags here and tried to trigger the alt+tab hanging issue I could not cause it anymore - not sure if something magically fixed it in either my computer or ags, will have to experiment more later.