### PR TITLE
Separate VideoPlayer and BlockingVideoPlayer game state classes

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -400,8 +400,14 @@ target_sources(engine
     media/audio/sound.h
     media/audio/soundclip.cpp
     media/audio/soundclip.h
+    media/video/flic_player.cpp
+    media/video/flic_player.h
+    media/video/theora_player.cpp
+    media/video/theora_player.h
     media/video/video.cpp
     media/video/video.h
+    media/video/videoplayer.cpp
+    media/video/videoplayer.h
     platform/base/agsplatformdriver.cpp
     platform/base/agsplatformdriver.h
     platform/base/agsplatform_xdg_unix.cpp

--- a/Engine/ac/asset_helper.h
+++ b/Engine/ac/asset_helper.h
@@ -47,9 +47,9 @@ struct AGS_PACKFILE_OBJ
     size_t asset_size = 0u;
     size_t remains = 0u;
 };
-// Creates PACKFILE stream from AGS asset.
+// Creates PACKFILE stream from AGS stream.
 // This function is supposed to be used only when you have to create Allegro
 // object, passing PACKFILE stream to constructor.
-PACKFILE *PackfileFromAsset(const AssetPath &path);
+PACKFILE *PackfileFromStream(std::unique_ptr<Stream> stream);
 
 #endif // __AGS_EE_AC__ASSETHELPER_H

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -628,14 +628,12 @@ static PACKFILE_VTABLE ags_packfile_vtable = {
 };
 //
 
-PACKFILE *PackfileFromAsset(const AssetPath &path)
+PACKFILE *PackfileFromStream(std::unique_ptr<Stream> stream)
 {
-    Stream *asset_stream = AssetMgr->OpenAsset(path);
-    if (!asset_stream) return nullptr;
-    const size_t asset_size = asset_stream->GetLength();
+    const size_t asset_size = stream->GetLength();
     if (asset_size == 0) return nullptr;
     AGS_PACKFILE_OBJ* obj = new AGS_PACKFILE_OBJ;
-    obj->stream.reset(asset_stream);
+    obj->stream = std::move(stream);
     obj->asset_size = asset_size;
     obj->remains = asset_size;
     return pack_fopen_vtable(&ags_packfile_vtable, obj);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1286,7 +1286,7 @@ void display_switch_out_suspend()
 
     // TODO: find out if anything has to be done here for SDL backend
 
-    video_pause();
+    video_single_pause();
     // Pause all the sounds
     for (int i = 0; i < TOTAL_AUDIO_CHANNELS; i++) {
         auto* ch = AudioChans::GetChannelIfPlaying(i);
@@ -1322,7 +1322,7 @@ void display_switch_in_resume()
             ch->resume();
         }
     }
-    video_resume();
+    video_single_resume();
 
     // release render targets if switching back to the full screen mode;
     // unfortunately, otherwise Direct3D fails to reset device when restoring fullscreen.

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -135,7 +135,10 @@ bool Game_ChangeSpeechVox(const char *newFilename);
 //=============================================================================
 
 void set_debug_mode(bool on);
+// Sets logical game FPS, telling how often the game should update
 void set_game_speed(int new_fps);
+// Gets strictly logical game FPS, regardless of whether this is real FPS right now or not.
+float get_game_speed();
 void setup_for_dialog();
 void restore_after_dialog();
 Common::String get_save_game_directory();

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -80,6 +80,12 @@ public:
     // Update the state during a game tick;
     // returns whether should continue to run state loop, or stop
     virtual bool Run() = 0;
+
+    // Pause the state, makes sure that all related timers, threads etc
+    // are also paused, avoiding any unexpected updates
+    virtual void Pause() { /* do nothing */ };
+    // Resume the state after pausing
+    virtual void Resume() { /* do nothing */ };
 };
 
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -422,6 +422,8 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
+    // TODO: consider return strictly logical game fps;
+    // need to investigate what would be consequence of this in "infinite FPS" mode
     return ::lround(get_game_fps()) - play.game_speed_modifier;
 }
 

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -54,7 +54,9 @@ void PlayFlic(int numb, int scr_flags)
     10: play the video at original size
     100: do not clear the screen before starting playback
     */
-    int video_flags = kVideo_EnableVideo | kVideo_DropFrames;
+    // NOTE: don't enable frame drop with FLIC, or it will play too fast
+    // (also see a note about kVideoState_SetGameFps below)
+    int video_flags = kVideo_EnableVideo;
     int state_flags = 0;
     VideoSkipType skip = VideoSkipNone;
     // skip type

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -54,7 +54,7 @@ void PlayFlic(int numb, int scr_flags)
     10: play the video at original size
     100: do not clear the screen before starting playback
     */
-    int video_flags = kVideo_EnableVideo;
+    int video_flags = kVideo_EnableVideo | kVideo_DropFrames;
     int state_flags = 0;
     VideoSkipType skip = VideoSkipNone;
     // skip type
@@ -102,7 +102,7 @@ void PlayVideo(const char* name, int skip, int scr_flags) {
     -- since 3.6.0:
     20: play both game audio and video's own audio
     */
-    int video_flags = kVideo_EnableVideo;
+    int video_flags = kVideo_EnableVideo | kVideo_DropFrames;
     int state_flags = 0;
     // video size
     switch (scr_flags % 10)
@@ -130,7 +130,7 @@ void PlayVideo(const char* name, int skip, int scr_flags) {
         video_flags |= kVideo_LegacyFrameSize;
 
     // original engine's behavior was to adjust FPS to match video's,
-    // but we may rethink this later
+    // but we may rethink this later (or add an explicit setting)
     state_flags |= kVideoState_SetGameFps;
 
     play_video_with_audio(name, video_flags, state_flags, static_cast<VideoSkipType>(skip));

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -77,6 +77,10 @@ void PlayFlic(int numb, int scr_flags)
     default: state_flags |= kVideoState_ClearScreen;
     }
 
+    // NOTE: do not set kVideoState_SetGameFps for FLIC,
+    // it seems like existing games featured FLICs with over-top FPS,
+    // but limited it to ~60 FPS using vsync.
+
     HError err = play_flc_video(numb, video_flags, state_flags, skip);
     if (!err)
         debug_script_warn("Failed to play FLIC %d: %s", numb, err->FullMessage().GetCStr());
@@ -124,6 +128,10 @@ void PlayVideo(const char* name, int skip, int scr_flags) {
     // for old versions: allow slightly offset video frames
     if (loaded_game_file_version < kGameVersion_360_16)
         video_flags |= kVideo_LegacyFrameSize;
+
+    // original engine's behavior was to adjust FPS to match video's,
+    // but we may rethink this later
+    state_flags |= kVideoState_SetGameFps;
 
     play_video_with_audio(name, video_flags, state_flags, static_cast<VideoSkipType>(skip));
 }

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -190,7 +190,6 @@ void engine_post_gfxmode_setup(const Size &init_desktop, const DisplayMode &old_
     // reset multitasking (may be overridden by the current display mode)
     SetMultitasking(usetup.multitasking);
 
-    video_on_gfxmode_changed();
     invalidate_screen();
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -937,6 +937,10 @@ float get_real_fps() {
     return fps;
 }
 
+float get_game_speed() {
+    return frames_per_second;
+}
+
 void set_loop_counter(unsigned int new_counter) {
     loopcounter = new_counter;
     t1 = AGS_Clock::now();

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -29,7 +29,7 @@ FlicPlayer::~FlicPlayer()
 }
 
 HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
-    const String &/*name*/, int& /*flags*/, int /*target_depth*/)
+    const String &/*name*/, int& flags, int /*target_depth*/)
 {
     data_stream->Seek(8);
     const int fliwidth = data_stream->ReadInt16();
@@ -52,6 +52,8 @@ HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
     _frameTime = fli_speed;
     _frameCount = fli_frame_count;
     _durationMs = fli_frame_count * fli_speed;
+    // FLIC must accumulate frame image because its frames contain diff since the last frame
+    flags |= kVideo_AccumFrame;
     return HError::None();
 }
 

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -46,7 +46,6 @@ HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
 
     get_palette_range(_oldpal, 0, 255);
 
-    _videoFrame.reset(BitmapHelper::CreateClearBitmap(fliwidth, fliheight, 8));
     _frameDepth = 8;
     _frameSize = Size(fliwidth, fliheight);
     _frameRate = 1000 / fli_speed;
@@ -63,7 +62,7 @@ void FlicPlayer::CloseImpl()
     set_palette_range(_oldpal, 0, 255, 0);
 }
 
-bool FlicPlayer::NextFrame()
+bool FlicPlayer::NextVideoFrame(Bitmap *dst)
 {
     // actual FLI playback state, base on original Allegro 4's do_play_fli
 
@@ -75,9 +74,9 @@ bool FlicPlayer::NextFrame()
     if (fli_pal_dirty_from <= fli_pal_dirty_to)
         set_palette_range(fli_palette, fli_pal_dirty_from, fli_pal_dirty_to, TRUE);
 
-    /* update the screen */
+    /* blit the changed portion of the frame */
     if (fli_bmp_dirty_from <= fli_bmp_dirty_to) {
-        blit(fli_bitmap, _videoFrame->GetAllegroBitmap(), 0, fli_bmp_dirty_from, 0, fli_bmp_dirty_from,
+        blit(fli_bitmap, dst->GetAllegroBitmap(), 0, fli_bmp_dirty_from, 0, fli_bmp_dirty_from,
             fli_bitmap->w, 1 + fli_bmp_dirty_to - fli_bmp_dirty_from);
     }
 

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -48,7 +48,7 @@ HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
 
     _frameDepth = 8;
     _frameSize = Size(fliwidth, fliheight);
-    _frameRate = 1000 / fli_speed;
+    _frameRate = 1000.f / fli_speed;
     return HError::None();
 }
 

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -49,6 +49,9 @@ HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
     _frameDepth = 8;
     _frameSize = Size(fliwidth, fliheight);
     _frameRate = 1000.f / fli_speed;
+    _frameTime = fli_speed;
+    _frameCount = fli_frame_count;
+    _durationMs = fli_frame_count * fli_speed;
     return HError::None();
 }
 

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -1,0 +1,91 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "media/video/flic_player.h"
+#include "ac/asset_helper.h"
+
+#ifndef AGS_NO_VIDEO_PLAYER
+
+namespace AGS
+{
+namespace Engine
+{
+
+using namespace Common;
+
+FlicPlayer::~FlicPlayer()
+{
+    CloseImpl();
+}
+
+HError FlicPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
+    const String &/*name*/, int& /*flags*/, int /*target_depth*/)
+{
+    data_stream->Seek(8);
+    const int fliwidth = data_stream->ReadInt16();
+    const int fliheight = data_stream->ReadInt16();
+    data_stream->Seek(0, kSeekBegin);
+
+    PACKFILE *pf = PackfileFromStream(std::move(data_stream));
+    if (open_fli_pf(pf) != FLI_OK)
+    {
+        pack_fclose(pf);
+        return new Error("Failed to open FLI/FLC animation; could be an invalid or unsupported format");
+    }
+    _pf = pf;
+
+    get_palette_range(_oldpal, 0, 255);
+
+    _videoFrame.reset(BitmapHelper::CreateClearBitmap(fliwidth, fliheight, 8));
+    _frameDepth = 8;
+    _frameSize = Size(fliwidth, fliheight);
+    _frameRate = 1000 / fli_speed;
+    return HError::None();
+}
+
+void FlicPlayer::CloseImpl()
+{
+    close_fli();
+    if (_pf)
+        pack_fclose(_pf);
+    _pf = nullptr;
+
+    set_palette_range(_oldpal, 0, 255, 0);
+}
+
+bool FlicPlayer::NextFrame()
+{
+    // actual FLI playback state, base on original Allegro 4's do_play_fli
+
+    /* get next frame */
+    if (next_fli_frame(IsLooping() ? 1 : 0) != FLI_OK)
+        return false;
+
+    /* update the palette */
+    if (fli_pal_dirty_from <= fli_pal_dirty_to)
+        set_palette_range(fli_palette, fli_pal_dirty_from, fli_pal_dirty_to, TRUE);
+
+    /* update the screen */
+    if (fli_bmp_dirty_from <= fli_bmp_dirty_to) {
+        blit(fli_bitmap, _videoFrame->GetAllegroBitmap(), 0, fli_bmp_dirty_from, 0, fli_bmp_dirty_from,
+            fli_bitmap->w, 1 + fli_bmp_dirty_to - fli_bmp_dirty_from);
+    }
+
+    reset_fli_variables();
+    return true;
+}
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/flic_player.h
+++ b/Engine/media/video/flic_player.h
@@ -1,0 +1,49 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// FLIC video player implementation.
+//
+//=============================================================================
+#ifndef __AGS_EE_MEDIA__FLICPLAYER_H
+#define __AGS_EE_MEDIA__FLICPLAYER_H
+
+#include "media/video/videoplayer.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+class FlicPlayer : public VideoPlayer
+{
+public:
+    FlicPlayer() = default;
+    ~FlicPlayer();
+
+    bool IsValid() override { return _pf != nullptr; }
+
+private:
+    Common::HError OpenImpl(std::unique_ptr<Common::Stream> data_stream,
+        const String &name, int &flags, int target_depth) override;
+    void CloseImpl() override;
+    bool NextFrame() override;
+
+    PACKFILE *_pf = nullptr;
+    RGB _oldpal[256]{};
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_MEDIA__FLICPLAYER_H

--- a/Engine/media/video/flic_player.h
+++ b/Engine/media/video/flic_player.h
@@ -37,7 +37,8 @@ private:
     Common::HError OpenImpl(std::unique_ptr<Common::Stream> data_stream,
         const String &name, int &flags, int target_depth) override;
     void CloseImpl() override;
-    bool NextFrame() override;
+    // Retrieves next video frame, implementation-specific
+    bool NextVideoFrame(Common::Bitmap *dst) override;
 
     PACKFILE *_pf = nullptr;
     RGB _oldpal[256]{};

--- a/Engine/media/video/theora_player.cpp
+++ b/Engine/media/video/theora_player.cpp
@@ -61,7 +61,7 @@ HError TheoraPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
     // we must disable length detection, otherwise it takes ages to start
     // playing if the file is large because it seeks through the whole thing
     apeg_disable_length_detection(TRUE);
-    apeg_ignore_audio((flags & kVideoPlayer_EnableAudio) == 0);
+    apeg_ignore_audio((flags & kVideo_EnableAudio) == 0);
 
     APEG_STREAM* apeg_stream = apeg_open_stream_ex(data_stream.get());
     if (!apeg_stream)
@@ -75,6 +75,10 @@ HError TheoraPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
     }
 
     _apegStream = apeg_stream;
+    if ((_apegStream->flags & APEG_HAS_VIDEO) == 0)
+        flags &= ~kVideo_EnableVideo;
+    if ((_apegStream->flags & APEG_HAS_AUDIO) == 0)
+        flags &= ~kVideo_EnableAudio;
 
     // Init APEG
     _dataStream = std::move(data_stream);
@@ -86,7 +90,7 @@ HError TheoraPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
     // Which means that the original content may end up positioned on a larger frame.
     // In such case we store this surface in a separate wrapper for the reference,
     // while the actual video frame is assigned a sub-bitmap (a portion of the full frame).
-    if (((flags & kVideoPlayer_LegacyFrameSize) == 0) &&
+    if (((flags & kVideo_LegacyFrameSize) == 0) &&
         Size(_apegStream->bitmap->w, _apegStream->bitmap->h) != video_size)
     {
         _theoraFrame.reset(BitmapHelper::CreateRawBitmapWrapper(_apegStream->bitmap));

--- a/Engine/media/video/theora_player.cpp
+++ b/Engine/media/video/theora_player.cpp
@@ -1,0 +1,154 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "media/video/theora_player.h"
+
+#ifndef AGS_NO_VIDEO_PLAYER
+
+namespace AGS
+{
+namespace Engine
+{
+
+using namespace Common;
+
+TheoraPlayer::~TheoraPlayer()
+{
+    CloseImpl();
+}
+
+//
+// Theora stream reader callbacks. We need these because APEG library does not
+// provide means to supply user's PACKFILE directly.
+//
+// Open stream for reading (return suggested cache buffer size).
+int apeg_stream_init(void *ptr)
+{
+    if (!ptr) return 0;
+    ((Stream*)ptr)->Seek(0, kSeekBegin);
+    return F_BUF_SIZE;
+}
+// Read requested number of bytes into provided buffer,
+// return actual number of bytes managed to read.
+int apeg_stream_read(void *buffer, int bytes, void *ptr)
+{
+    return ((Stream*)ptr)->Read(buffer, bytes);
+}
+// Skip requested number of bytes
+void apeg_stream_skip(int bytes, void *ptr)
+{
+    ((Stream*)ptr)->Seek(bytes);
+}
+//
+
+HError TheoraPlayer::OpenImpl(std::unique_ptr<Common::Stream> data_stream,
+    const String &name, int &flags, int target_depth)
+{
+    // NOTE: following settings affect only next apeg_open_stream* or
+    // apeg_reset_stream.
+    apeg_set_stream_reader(apeg_stream_init, apeg_stream_read, apeg_stream_skip);
+    apeg_set_display_depth(target_depth);
+    // we must disable length detection, otherwise it takes ages to start
+    // playing if the file is large because it seeks through the whole thing
+    apeg_disable_length_detection(TRUE);
+    apeg_ignore_audio((flags & kVideoPlayer_EnableAudio) == 0);
+
+    APEG_STREAM* apeg_stream = apeg_open_stream_ex(data_stream.get());
+    if (!apeg_stream)
+    {
+        return new Error(String::FromFormat("Failed to open theora video '%s'; could be an invalid or unsupported format", name.GetCStr()));
+    }
+    int video_w = apeg_stream->w, video_h = apeg_stream->h;
+    if (video_w <= 0 || video_h <= 0)
+    {
+        return new Error(String::FromFormat("Failed to run theora video '%s': invalid frame dimensions (%d x %d)", name.GetCStr(), video_w, video_h));
+    }
+
+    _apegStream = apeg_stream;
+
+    // Init APEG
+    _dataStream = std::move(data_stream);
+    _frameDepth = target_depth;
+    _frameRate = _apegStream->frame_rate;
+    const Size video_size = Size(video_w, video_h);
+    // According to the documentation:
+    // encoded theora frames must be a multiple of 16 in width and height.
+    // Which means that the original content may end up positioned on a larger frame.
+    // In such case we store this surface in a separate wrapper for the reference,
+    // while the actual video frame is assigned a sub-bitmap (a portion of the full frame).
+    if (((flags & kVideoPlayer_LegacyFrameSize) == 0) &&
+        Size(_apegStream->bitmap->w, _apegStream->bitmap->h) != video_size)
+    {
+        _theoraFrame.reset(BitmapHelper::CreateRawBitmapWrapper(_apegStream->bitmap));
+        _videoFrame.reset(BitmapHelper::CreateSubBitmap(_theoraFrame.get(), RectWH(video_size)));
+    }
+    else
+    {
+        _videoFrame.reset(BitmapHelper::CreateRawBitmapWrapper(_apegStream->bitmap));
+    }
+    _frameSize = _videoFrame->GetSize();
+
+    _audioChannels = _apegStream->audio.channels;
+    _audioFreq = _apegStream->audio.freq;
+    _audioFormat = AUDIO_S16SYS;
+    apeg_set_error(_apegStream, NULL);
+    return HError::None();
+}
+
+void TheoraPlayer::CloseImpl()
+{
+    apeg_close_stream(_apegStream);
+    _apegStream = nullptr;
+}
+
+bool TheoraPlayer::NextFrame()
+{
+    assert(_apegStream);
+    // reset some data
+    bool has_audio = false, has_video = false;
+    _apegStream->frame_updated = -1;
+    _apegStream->audio.flushed = FALSE;
+
+    if ((_apegStream->flags & APEG_HAS_AUDIO) && _wantAudio)
+    {
+        unsigned char *buf = nullptr;
+        int count = 0;
+        int ret = apeg_get_audio_frame(_apegStream, &buf, &count);
+        if (ret == APEG_ERROR)
+            return false;
+        _audioFrame = SoundBuffer(buf, count);
+        has_audio = ret != APEG_EOF;
+    }
+
+    if ((_apegStream->flags & APEG_HAS_VIDEO))
+    {
+        int ret = apeg_get_video_frame(_apegStream);
+        if (ret == APEG_ERROR)
+            return false;
+
+        // Update frame count
+        ++(_apegStream->frame);
+
+        // Update the display frame
+        _apegStream->frame_updated = 0;
+        ret = apeg_display_video_frame(_apegStream);
+        has_video = ret != APEG_EOF;
+    }
+
+    return has_audio || has_video;
+}
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/theora_player.cpp
+++ b/Engine/media/video/theora_player.cpp
@@ -101,8 +101,11 @@ HError TheoraPlayer::OpenAPEGStream(Stream *data_stream, const Common::String &n
     _usedDepth = target_depth;
 
     _frameDepth = target_depth;
-    _frameRate = _apegStream->frame_rate;
     _frameSize = Size(video_w, video_h);
+    _frameRate = _apegStream->frame_rate;
+    _frameTime = 1000.f / _apegStream->frame_rate;
+    _frameCount = _apegStream->length / _frameTime;
+    _durationMs = _apegStream->length;
     // According to the documentation:
     // encoded theora frames must be a multiple of 16 in width and height.
     // Which means that the original content may end up positioned on a larger frame.

--- a/Engine/media/video/theora_player.cpp
+++ b/Engine/media/video/theora_player.cpp
@@ -59,7 +59,6 @@ HError TheoraPlayer::OpenImpl(std::unique_ptr<Stream> data_stream,
     if (!err)
         return err;
 
-    _name = name;
     if ((_apegStream->flags & APEG_HAS_VIDEO) == 0)
         flags &= ~kVideo_EnableVideo;
     if ((_apegStream->flags & APEG_HAS_AUDIO) == 0)
@@ -139,7 +138,7 @@ bool TheoraPlayer::RewindImpl()
 {
     if (apeg_reset_stream(_apegStream) != APEG_OK)
     {
-        OpenAPEGStream(_dataStream.get(), _name, _usedFlags, _usedDepth);
+        OpenAPEGStream(_dataStream.get(), GetName(), _usedFlags, _usedDepth);
     }
     return _apegStream != nullptr;
 }

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -38,12 +38,18 @@ private:
     Common::HError OpenImpl(std::unique_ptr<Common::Stream> data_stream,
         const String &name, int &flags, int target_depth) override;
     void CloseImpl() override;
+    bool RewindImpl() override;
     // Retrieves next video frame, implementation-specific
     bool NextVideoFrame(Common::Bitmap *dst) override;
     // Retrieves next audio frame, implementation-specific
     SoundBuffer NextAudioFrame() override;
 
+    Common::HError OpenAPEGStream(Stream *data_stream, const String &name, int flags, int target_depth);
+
+    String _name;
     std::unique_ptr<Stream> _dataStream;
+    int _usedFlags = 0;
+    int _usedDepth = 0;
     APEG_STREAM *_apegStream = nullptr;
     // Optional wrapper around original buffer frame (in case we want to extract a portion of it)
     std::unique_ptr<Common::Bitmap> _theoraFullFrame;

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -38,12 +38,17 @@ private:
     Common::HError OpenImpl(std::unique_ptr<Common::Stream> data_stream,
         const String &name, int &flags, int target_depth) override;
     void CloseImpl() override;
-    bool NextFrame() override;
+    // Retrieves next video frame, implementation-specific
+    bool NextVideoFrame(Common::Bitmap *dst) override;
+    // Retrieves next audio frame, implementation-specific
+    SoundBuffer NextAudioFrame() override;
 
     std::unique_ptr<Stream> _dataStream;
     APEG_STREAM *_apegStream = nullptr;
     // Optional wrapper around original buffer frame (in case we want to extract a portion of it)
-    std::unique_ptr<Common::Bitmap> _theoraFrame;
+    std::unique_ptr<Common::Bitmap> _theoraFullFrame;
+    // Wrapper over portion of theora frame which we want to use
+    std::unique_ptr<Common::Bitmap> _theoraSrcFrame;
 };
 
 } // namespace Engine

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -1,0 +1,52 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Theora (OGV) video player implementation.
+//
+//=============================================================================
+#ifndef __AGS_EE_MEDIA__THEORAPLAYER_H
+#define __AGS_EE_MEDIA__THEORAPLAYER_H
+
+#include <apeg.h>
+#include "media/video/videoplayer.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+class TheoraPlayer : public VideoPlayer
+{
+public:
+    TheoraPlayer() = default;
+    ~TheoraPlayer();
+
+    bool IsValid() override { return _apegStream != nullptr; }
+
+private:
+    Common::HError OpenImpl(std::unique_ptr<Common::Stream> data_stream,
+        const String &name, int &flags, int target_depth) override;
+    void CloseImpl() override;
+    bool NextFrame() override;
+
+    std::unique_ptr<Stream> _dataStream;
+    APEG_STREAM *_apegStream = nullptr;
+    // Optional wrapper around original buffer frame (in case we want to extract a portion of it)
+    std::unique_ptr<Common::Bitmap> _theoraFrame;
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_MEDIA__THEORAPLAYER_H

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -46,7 +46,6 @@ private:
 
     Common::HError OpenAPEGStream(Stream *data_stream, const String &name, int flags, int target_depth);
 
-    String _name;
     std::unique_ptr<Stream> _dataStream;
     int _usedFlags = 0;
     int _usedDepth = 0;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -145,8 +145,14 @@ void BlockingVideoPlayer::Begin()
         render_to_screen();
     }
 
-    _oldFps = get_game_fps();
-    set_game_speed(_player->GetFramerate());
+    auto video_fps = _player->GetFramerate();
+    auto game_fps = get_game_speed();
+    _oldFps = game_fps;
+    if (((_stateFlags & kVideoState_SetGameFps) != 0) &&
+        (game_fps < video_fps))
+    {
+        set_game_speed(video_fps);
+    }
 
     _player->Play();
     _playbackState = _player->GetPlayState();

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -196,11 +196,12 @@ bool BlockingVideoPlayer::Run()
     // update/render next frame
     if ((_videoFlags & kVideo_EnableVideo) != 0)
     {
-        const Bitmap *frame = _player->GetVideoFrame();
+        auto frame = _player->GetReadyFrame();
         if (frame)
         {
-            gfxDriver->UpdateDDBFromBitmap(_videoDDB, frame, false);
+            gfxDriver->UpdateDDBFromBitmap(_videoDDB, frame.get(), false);
             _videoDDB->SetStretch(_dstRect.GetWidth(), _dstRect.GetHeight(), false);
+            _player->ReleaseFrame(std::move(frame));
         }
     }
 

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -14,31 +14,19 @@
 #include "media/video/video.h"
 
 #ifndef AGS_NO_VIDEO_PLAYER
-#include <SDL.h>
-#include "apeg.h"
-#include "core/platform.h"
-#include "debug/debug_log.h"
-#include "debug/out.h"
-#include "ac/asset_helper.h"
-#include "ac/common.h"
+#include "core/assetmanager.h"
 #include "ac/draw.h"
-#include "ac/game_version.h"
+#include "ac/game.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
-#include "ac/global_display.h"
-#include "ac/keycode.h"
-#include "ac/mouse.h"
 #include "ac/sys_events.h"
-#include "ac/runtime_defines.h"
-#include "ac/system.h"
-#include "core/assetmanager.h"
-#include "gfx/bitmap.h"
-#include "gfx/ddb.h"
+#include "debug/debug_log.h"
 #include "gfx/graphicsdriver.h"
 #include "main/game_run.h"
-#include "util/stream.h"
-#include "media/audio/audio_system.h"
-#include "media/audio/openal.h"
+#include "media/video/videoplayer.h"
+#include "media/video/flic_player.h"
+#include "media/video/theora_player.h"
+#include "util/memory_compat.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -56,175 +44,113 @@ namespace AGS
 namespace Engine
 {
 
-VideoPlayer::~VideoPlayer()
+// Blocking video playback state
+class BlockingVideoPlayer
 {
-    Close();
-}
+public:
+    HError Open(std::unique_ptr<VideoPlayer> player, const String &asset_name, int flags);
+    void Close();
 
-HError VideoPlayer::Open(const String &name, int flags)
+    const VideoPlayer *GetVideoPlayer() const { return _player.get(); }
+    PlaybackState GetPlayState() const { return _player->GetPlayState(); }
+
+    void Play();
+    void Pause();
+    // Updates the video playback, renders next frame
+    bool Poll();
+
+private:
+    int _flags = 0;
+    std::unique_ptr<VideoPlayer> _player;
+    IDriverDependantBitmap *_videoDDB = nullptr;
+    Rect _dstRect;
+};
+
+HError BlockingVideoPlayer::Open(std::unique_ptr<VideoPlayer> player, const String &asset_name, int flags)
 {
-    HError err = OpenImpl(name, flags);
-    if (!err)
-        return err;
-
-    _flags = flags;
-    // Start the audio stream
-    if ((flags & kVideo_EnableAudio) != 0)
+    std::unique_ptr<Stream> video_stream(AssetMgr->OpenAsset(asset_name));
+    if (!video_stream)
     {
-        if ((_audioFormat > 0) && (_audioChannels > 0) && (_audioFreq > 0))
-        {
-            _audioOut.reset(new OpenAlSource(_audioFormat, _audioChannels, _audioFreq));
-            _audioOut->Play();
-            _wantAudio = true;
-        }
+        return new Error(String::FromFormat("Failed to open file: %s", asset_name.GetCStr()));
     }
+
+    const int dst_depth = game.GetColorDepth();
+    HError err = player->Open(std::move(video_stream), asset_name, flags, Size(), dst_depth);
+    if (!err)
+    {
+        return err;
+    }
+
+    _player = std::move(player);
+    _flags = flags;
     // Setup video
     if ((flags & kVideo_EnableVideo) != 0)
     {
-        _dstRect = PlaceInRect(play.GetMainViewport(), RectWH(_frameSize),
+        const bool software_draw = gfxDriver->HasAcceleratedTransform();
+        Size frame_sz = _player->GetFrameSize();
+        Rect dest = PlaceInRect(play.GetMainViewport(), RectWH(frame_sz),
             ((_flags & kVideo_Stretch) == 0) ? kPlaceCenter : kPlaceStretchProportional);
         // override the stretch option if necessary
-        if (_frameSize == _dstRect.GetSize())
+        if (frame_sz == dest.GetSize())
             _flags &= ~kVideo_Stretch;
         else
             _flags |= kVideo_Stretch;
 
-        if (gfxDriver->HasAcceleratedTransform() || ((_flags & kVideo_Stretch) == 0))
+        // We only need to resize target bitmap for software renderer,
+        // because texture-based ones can scale the texture themselves.
+        if (software_draw && (frame_sz != dest.GetSize()))
         {
-            _videoDDB = gfxDriver->CreateDDB(_frameSize.Width, _frameSize.Height, _frameDepth, true);
+            _player->SetTargetFrame(dest.GetSize());
+        }
+
+        if (!software_draw || ((_flags & kVideo_Stretch) == 0))
+        {
+            _videoDDB = gfxDriver->CreateDDB(frame_sz.Width, frame_sz.Height, dst_depth, true);
         }
         else
         {
-            // For software rendering - create helper bitmaps in case of stretching;
-            // If we are decoding a 8-bit frame in a hi-color game, and stretching,
-            // then create a hi-color buffer, as bitmap lib cannot stretch with depth change
-            if ((_frameDepth == 8) && (game.GetColorDepth() > 8))
-                _hicolBuf.reset(BitmapHelper::CreateBitmap(_frameSize.Width, _frameSize.Height, game.GetColorDepth()));
-            _targetBitmap.reset(BitmapHelper::CreateBitmap(_dstRect.GetWidth(), _dstRect.GetHeight(), game.GetColorDepth()));
-            _videoDDB = gfxDriver->CreateDDB(_dstRect.GetWidth(), _dstRect.GetHeight(), game.GetColorDepth(), true);
+            _videoDDB = gfxDriver->CreateDDB(dest.GetWidth(), dest.GetHeight(), dst_depth, true);
         }
+        _dstRect = dest;
     }
-
-    _frameTime = 1000 / _frameRate;
-    _loop = false;
     return HError::None();
 }
 
-void VideoPlayer::Close()
+void BlockingVideoPlayer::Close()
 {
-    // Shutdown openal source
-    _audioOut.reset();
-    // Close video decoder and free resources
-    CloseImpl();
+    if (_player)
+        _player->Stop();
 
-    _videoFrame.reset();
-    _hicolBuf.reset();
-    _targetBitmap.reset();
     if (_videoDDB)
         gfxDriver->DestroyDDB(_videoDDB);
     _videoDDB = nullptr;
 }
 
-void VideoPlayer::Play()
+void BlockingVideoPlayer::Play()
 {
-    if (!IsValid())
-        return;
-
-    switch (_playState)
-    {
-    case PlayStatePaused: Resume(); /* fall-through */
-    case PlayStateInitial: _playState = PlayStatePlaying; break;
-    default: break; // TODO: support rewind/replay from stop/finished state?
-    }
+    assert(_player);
+    _player->Play();
 }
 
-void VideoPlayer::Pause()
+void BlockingVideoPlayer::Pause()
 {
-    if (_playState != PlayStatePlaying) return;
-
-    if (_audioOut)
-        _audioOut->Pause();
-    _playState = PlayStatePaused;
+    assert(_player);
+    _player->Pause();
 }
 
-void VideoPlayer::Resume()
+bool BlockingVideoPlayer::Poll()
 {
-    if (_playState != PlayStatePaused) return;
-
-    if (_audioOut)
-        _audioOut->Resume();
-    _playState = PlayStatePlaying;
-}
-
-int VideoPlayer::GetAudioPos()
-{
-    return _audioOut ? _audioOut->GetPositionMs() : 0;
-}
-
-bool VideoPlayer::Poll()
-{
-    if (_playState != PlayStatePlaying)
+    assert(_player);
+    if (!_player->Poll())
         return false;
-    // Acquire next video frame
-    if (!NextFrame() && !_audioFrame)
-    { // stop is no new frames, and no buffered frames left
-        _playState = PlayStateFinished;
-        return false;
-    }
-    // Render current frame
-    if (_audioFrame && !RenderAudio())
-    {
-        _playState = PlayStateError;
-        return false;
-    }
-    if (_videoFrame && !RenderVideo())
-    {
-        _playState = PlayStateError;
-        return false;
-    }
-    return true;
-}
 
-bool VideoPlayer::RenderAudio()
-{
-    assert(_audioFrame);
-    assert(_audioOut != nullptr);
-    _wantAudio = _audioOut->PutData(_audioFrame) > 0u;
-    _audioOut->Poll();
-    if (_wantAudio)
-        _audioFrame = SoundBuffer(); // clear received buffer
-    return true;
-}
+    if ((_flags & kVideo_EnableVideo) == 0)
+        return true;
 
-bool VideoPlayer::RenderVideo()
-{
-    assert(_videoFrame);
-    Bitmap *usebuf = _videoFrame.get();
+    const Bitmap *frame = _player->GetVideoFrame();
+    gfxDriver->UpdateDDBFromBitmap(_videoDDB, frame, false);
+    _videoDDB->SetStretch(_dstRect.GetWidth(), _dstRect.GetHeight(), false);
 
-    // Use intermediate hi-color buffer if necessary
-    if (_hicolBuf)
-    {
-        _hicolBuf->Blit(usebuf);
-        usebuf = _hicolBuf.get();
-    }
-
-    if ((_flags & kVideo_Stretch) != 0)
-    {
-        if (gfxDriver->HasAcceleratedTransform())
-        {
-            gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf, false);
-            _videoDDB->SetStretch(_dstRect.GetWidth(), _dstRect.GetHeight(), false);
-        }
-        else
-        {
-            _targetBitmap->StretchBlt(usebuf, RectWH(_dstRect.GetSize()));
-            gfxDriver->UpdateDDBFromBitmap(_videoDDB, _targetBitmap.get(), false);
-        }
-    }
-    else
-    {
-        gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf, false);
-    }
     gfxDriver->BeginSpriteBatch(play.GetMainViewport(), SpriteTransform());
     gfxDriver->DrawSprite(_dstRect.Left, _dstRect.Top, _videoDDB);
     gfxDriver->EndSpriteBatch();
@@ -232,254 +158,7 @@ bool VideoPlayer::RenderVideo()
     return true;
 }
 
-std::unique_ptr<VideoPlayer> gl_Video;
-
-//-----------------------------------------------------------------------------
-// FLIC video player implementation
-//-----------------------------------------------------------------------------
-
-class FlicPlayer : public VideoPlayer
-{
-public:
-    FlicPlayer() = default;
-    ~FlicPlayer();
-
-    bool IsValid() override { return _pf != nullptr; }
-    void Restore() override;
-
-private:
-    HError OpenImpl(const AGS::Common::String &name, int &flags) override;
-    void CloseImpl() override;
-    bool NextFrame() override;
-
-    PACKFILE *_pf = nullptr;
-    RGB _oldpal[256]{};
-};
-
-FlicPlayer::~FlicPlayer()
-{
-    CloseImpl();
-}
-
-void FlicPlayer::Restore()
-{
-    // If the FLIC video is playing, restore its palette
-    set_palette_range(fli_palette, 0, 255, 0);
-}
-
-HError FlicPlayer::OpenImpl(const AGS::Common::String &name, int& /*flags*/)
-{
-    std::unique_ptr<Stream> in(AssetMgr->OpenAsset(name));
-    if (!in)
-        return new Error(String::FromFormat("Failed to open file: %s", name.GetCStr()));
-    in->Seek(8);
-    const int fliwidth = in->ReadInt16();
-    const int fliheight = in->ReadInt16();
-    in.reset();
-
-    PACKFILE *pf = PackfileFromAsset(AssetPath(name, "*"));
-    if (open_fli_pf(pf) != FLI_OK)
-    {
-        pack_fclose(pf);
-        return new Error("Failed to open FLI/FLC animation; could be an invalid or unsupported format");
-    }
-    _pf = pf;
-
-    get_palette_range(_oldpal, 0, 255);
-
-    _videoFrame.reset(BitmapHelper::CreateClearBitmap(fliwidth, fliheight, 8));
-    _frameDepth = 8;
-    _frameSize = Size(fliwidth, fliheight);
-    _frameRate = 1000 / fli_speed;
-    return HError::None();
-}
-
-void FlicPlayer::CloseImpl()
-{
-    close_fli();
-    if (_pf)
-        pack_fclose(_pf);
-    _pf = nullptr;
-
-    set_palette_range(_oldpal, 0, 255, 0);
-}
-
-bool FlicPlayer::NextFrame()
-{
-    // actual FLI playback state, base on original Allegro 4's do_play_fli
-
-    /* get next frame */
-    if (next_fli_frame(IsLooping() ? 1 : 0) != FLI_OK)
-        return false;
-
-    /* update the palette */
-    if (fli_pal_dirty_from <= fli_pal_dirty_to)
-        set_palette_range(fli_palette, fli_pal_dirty_from, fli_pal_dirty_to, TRUE);
-
-    /* update the screen */
-    if (fli_bmp_dirty_from <= fli_bmp_dirty_to) {
-        blit(fli_bitmap, _videoFrame->GetAllegroBitmap(), 0, fli_bmp_dirty_from, 0, fli_bmp_dirty_from,
-            fli_bitmap->w, 1 + fli_bmp_dirty_to - fli_bmp_dirty_from);
-    }
-
-    reset_fli_variables();
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-// Theora video player implementation
-//-----------------------------------------------------------------------------
-
-class TheoraPlayer : public VideoPlayer
-{
-public:
-    TheoraPlayer() = default;
-    ~TheoraPlayer();
-
-    bool IsValid() override { return _apegStream != nullptr; }
-
-private:
-    HError OpenImpl(const AGS::Common::String &name, int &flags) override;
-    void CloseImpl() override;
-    bool NextFrame() override;
-
-    std::unique_ptr<Stream> _dataStream;
-    APEG_STREAM *_apegStream = nullptr;
-    // Optional wrapper around original buffer frame (in case we want to extract a portion of it)
-    std::unique_ptr<Bitmap> _theoraFrame;
-};
-
-TheoraPlayer::~TheoraPlayer()
-{
-    CloseImpl();
-}
-
-//
-// Theora stream reader callbacks. We need these because APEG library does not
-// provide means to supply user's PACKFILE directly.
-//
-// Open stream for reading (return suggested cache buffer size).
-int apeg_stream_init(void *ptr)
-{
-    if (!ptr) return 0;
-    ((Stream*)ptr)->Seek(0, kSeekBegin);
-    return F_BUF_SIZE;
-}
-// Read requested number of bytes into provided buffer,
-// return actual number of bytes managed to read.
-int apeg_stream_read(void *buffer, int bytes, void *ptr)
-{
-    return ((Stream*)ptr)->Read(buffer, bytes);
-}
-// Skip requested number of bytes
-void apeg_stream_skip(int bytes, void *ptr)
-{
-    ((Stream*)ptr)->Seek(bytes);
-}
-//
-
-HError TheoraPlayer::OpenImpl(const AGS::Common::String &name, int &flags)
-{
-    std::unique_ptr<Stream> video_stream(AssetMgr->OpenAsset(name));
-    if (!video_stream)
-    {
-        return new Error(String::FromFormat("Failed to open file: %s", name.GetCStr()));
-    }
-
-    apeg_set_stream_reader(apeg_stream_init, apeg_stream_read, apeg_stream_skip);
-    apeg_set_display_depth(game.GetColorDepth());
-    // we must disable length detection, otherwise it takes ages to start
-    // playing if the file is large because it seeks through the whole thing
-    apeg_disable_length_detection(TRUE);
-    apeg_ignore_audio((flags & kVideo_EnableAudio) == 0);
-
-    APEG_STREAM* apeg_stream = apeg_open_stream_ex(video_stream.get());
-    if (!apeg_stream)
-    {
-        return new Error(String::FromFormat("Failed to open theora video '%s'; could be an invalid or unsupported format", name.GetCStr()));
-    }
-    int video_w = apeg_stream->w, video_h = apeg_stream->h;
-    if (video_w <= 0 || video_h <= 0)
-    {
-        return new Error(String::FromFormat("Failed to run theora video '%s': invalid frame dimensions (%d x %d)", name.GetCStr(), video_w, video_h));
-    }
-
-    _apegStream = apeg_stream;
-
-    if (gfxDriver->UsesMemoryBackBuffer())
-        gfxDriver->GetMemoryBackBuffer()->Clear();
-
-    // Init APEG
-    _dataStream = std::move(video_stream);
-    _frameDepth = game.GetColorDepth();
-    _frameRate = _apegStream->frame_rate;
-    const Size video_size = Size(video_w, video_h);
-    // According to the documentation:
-    // encoded theora frames must be a multiple of 16 in width and height.
-    // Which means that the original content may end up positioned on a larger frame.
-    // In such case we store this surface in a separate wrapper for the reference,
-    // while the actual video frame is assigned a sub-bitmap (a portion of the full frame).
-    if (((flags & kVideo_LegacyFrameSize) == 0) &&
-        (Size(_apegStream->bitmap->w, _apegStream->bitmap->h) != video_size))
-    {
-        _theoraFrame.reset(BitmapHelper::CreateRawBitmapWrapper(_apegStream->bitmap));
-        _videoFrame.reset(BitmapHelper::CreateSubBitmap(_theoraFrame.get(), RectWH(video_size)));
-    }
-    else
-    {
-        _videoFrame.reset(BitmapHelper::CreateRawBitmapWrapper(_apegStream->bitmap));
-    }
-    _frameSize = _videoFrame->GetSize();
-
-    _audioChannels = _apegStream->audio.channels;
-    _audioFreq = _apegStream->audio.freq;
-    _audioFormat = AUDIO_S16SYS;
-    apeg_set_error(_apegStream, NULL);
-    return HError::None();
-}
-
-void TheoraPlayer::CloseImpl()
-{
-    apeg_close_stream(_apegStream);
-    _apegStream = nullptr;
-}
-
-bool TheoraPlayer::NextFrame()
-{
-    assert(_apegStream);
-    // reset some data
-    bool has_audio = false, has_video = false;
-    _apegStream->frame_updated = -1;
-    _apegStream->audio.flushed = FALSE;
-
-    if ((_apegStream->flags & APEG_HAS_AUDIO) && _wantAudio)
-    {
-        unsigned char *buf = nullptr;
-        int count = 0;
-        int ret = apeg_get_audio_frame(_apegStream, &buf, &count);
-        if (ret == APEG_ERROR)
-            return false;
-        _audioFrame = SoundBuffer(buf, count);
-        has_audio = ret != APEG_EOF;
-    }
-
-    if ((_apegStream->flags & APEG_HAS_VIDEO))
-    {
-        int ret = apeg_get_video_frame(_apegStream);
-        if (ret == APEG_ERROR)
-            return false;
-
-        // Update frame count
-        ++(_apegStream->frame);
-
-        // Update the display frame
-        _apegStream->frame_updated = 0;
-        ret = apeg_display_video_frame(_apegStream);
-        has_video = ret != APEG_EOF;
-    }
-
-    return has_audio || has_video;
-}
+std::unique_ptr<BlockingVideoPlayer> gl_Video;
 
 } // namespace Engine
 } // namespace AGS
@@ -516,9 +195,18 @@ static bool video_check_user_input(VideoSkipType skip)
     return false;
 }
 
-static void video_run(std::unique_ptr<VideoPlayer> video, int flags, VideoSkipType skip)
+static void video_run(std::unique_ptr<VideoPlayer> video, const String &asset_name, int flags, VideoSkipType skip)
 {
-    gl_Video = std::move(video);
+    assert(video);
+    if (!video)
+        return;
+
+    gl_Video.reset(new BlockingVideoPlayer());
+    HError err = gl_Video->Open(std::move(video), asset_name, flags);
+    if (!err)
+    {
+        debug_script_warn("Failed to run video %s: %s", asset_name.GetCStr(), err->FullMessage().GetCStr());
+    }
 
     // Clear the screen before starting playback
     // TODO: needed for FLIC, but perhaps may be done differently
@@ -526,14 +214,14 @@ static void video_run(std::unique_ptr<VideoPlayer> video, int flags, VideoSkipTy
     {
         if (gfxDriver->UsesMemoryBackBuffer())
         {
-            Bitmap *screen_bmp = gfxDriver->GetMemoryBackBuffer();
-            screen_bmp->Clear();
+            gfxDriver->GetMemoryBackBuffer()->Clear();
         }
         render_to_screen();
     }
     
     gl_Video->Play();
-    const int old_fps = setTimerFps(gl_Video->GetFramerate());
+    const int old_fps = get_game_fps();
+    set_game_speed(gl_Video->GetVideoPlayer()->GetFramerate());
     // Loop until finished or skipped by player
     while (gl_Video->GetPlayState() == PlayStatePlaying ||
            gl_Video->GetPlayState() == PlayStatePaused)
@@ -545,7 +233,7 @@ static void video_run(std::unique_ptr<VideoPlayer> video, int flags, VideoSkipTy
         gl_Video->Poll(); // update/render next frame
         UpdateGameAudioOnly(); // update the game and wait for next frame
     }
-    setTimerFps(old_fps);
+    set_game_speed(old_fps);
     gl_Video.reset();
 
     // Clear the screen after stopping playback
@@ -554,8 +242,7 @@ static void video_run(std::unique_ptr<VideoPlayer> video, int flags, VideoSkipTy
     {
         if (gfxDriver->UsesMemoryBackBuffer())
         {
-            Bitmap *screen_bmp = gfxDriver->GetMemoryBackBuffer();
-            screen_bmp->Clear();
+            gfxDriver->GetMemoryBackBuffer()->Clear();
         }
         render_to_screen();
     }
@@ -566,7 +253,6 @@ static void video_run(std::unique_ptr<VideoPlayer> video, int flags, VideoSkipTy
 
 HError play_flc_video(int numb, int flags, VideoSkipType skip)
 {
-    std::unique_ptr<FlicPlayer> video(new FlicPlayer());
     // Try couple of various filename formats
     String flicname = String::FromFormat("flic%d.flc", numb);
     if (!AssetMgr->DoesAssetExist(flicname))
@@ -575,22 +261,14 @@ HError play_flc_video(int numb, int flags, VideoSkipType skip)
         if (!AssetMgr->DoesAssetExist(flicname))
             return new Error(String::FromFormat("FLIC animation flic%d.flc nor flic%d.fli were found", numb, numb));
     }
-    HError err = video->Open(flicname, flags);
-    if (!err)
-        return err;
 
-    video_run(std::move(video), flags, skip);
+    video_run(std::make_unique<FlicPlayer>(), flicname, flags, skip);
     return HError::None();
 }
 
 HError play_theora_video(const char *name, int flags, VideoSkipType skip)
 {
-    std::unique_ptr<TheoraPlayer> video(new TheoraPlayer());
-    HError err = video->Open(name, flags);
-    if (!err)
-        return err;
-
-    video_run(std::move(video), flags, skip);
+    video_run(std::make_unique<TheoraPlayer>(), name, flags, skip);
     return HError::None();
 }
 
@@ -606,12 +284,6 @@ void video_resume()
         gl_Video->Play();
 }
 
-void video_on_gfxmode_changed()
-{
-    if (gl_Video)
-        gl_Video->Restore();
-}
-
 void video_shutdown()
 {
     gl_Video.reset();
@@ -623,7 +295,6 @@ void play_theora_video(const char *name, int flags, AGS::Engine::VideoSkipType s
 void play_flc_video(int numb, int flags, AGS::Engine::VideoSkipType skip) {}
 void video_pause() {}
 void video_resume() {}
-void video_on_gfxmode_changed() {}
 void video_shutdown() {}
 
 #endif

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -36,7 +36,9 @@ enum VideoStateFlags
     // Stretch video to the game screen
     kVideoState_Stretch        = 0x0002,
     // Keep game audio running while video is playing
-    kVideoState_KeepGameAudio  = 0x0004
+    kVideoState_KeepGameAudio  = 0x0004,
+    // Increase game FPS to match video's
+    kVideoState_SetGameFps     = 0x0008
 };
 
 // Flags which define a skipping method for the blocking video playback

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -35,8 +35,8 @@ enum VideoStateFlags
     kVideoState_ClearScreen    = 0x0001,
     // Stretch video to the game screen
     kVideoState_Stretch        = 0x0002,
-    // Keep game audio running while video is playing
-    kVideoState_KeepGameAudio  = 0x0004,
+    // Stop game audio and restore after video finishes playing
+    kVideoState_StopGameAudio  = 0x0004,
     // Increase game FPS to match video's
     kVideoState_SetGameFps     = 0x0008
 };

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -17,29 +17,29 @@
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__VIDEO_H
 #define __AGS_EE_MEDIA__VIDEO_H
-#include "media/audio/openalsource.h"
+
+#include "media/video/videoplayer.h"
 #include "util/geometry.h"
 #include "util/string.h"
 #include "util/error.h"
 
 namespace AGS
 {
-
-namespace Common { class Bitmap; }
-
 namespace Engine
 {
 
-enum VideoFlags
+// Flags which define behavior of a blocking video "game state"
+enum VideoStateFlags
 {
-    kVideo_EnableVideo    = 0x0001,
-    kVideo_Stretch        = 0x0002,
-    kVideo_ClearScreen    = 0x0004,
-    kVideo_LegacyFrameSize= 0x0008,
-    kVideo_EnableAudio    = 0x0010,
-    kVideo_KeepGameAudio  = 0x0020
+    // Force-clear screen on begin and end (meant for software render)
+    kVideoState_ClearScreen    = 0x0001,
+    // Stretch video to the game screen
+    kVideoState_Stretch        = 0x0002,
+    // Keep game audio running while video is playing
+    kVideoState_KeepGameAudio  = 0x0004
 };
 
+// Flags which define a skipping method for the blocking video playback
 enum VideoSkipType
 {
     VideoSkipNone         = 0,
@@ -52,8 +52,8 @@ enum VideoSkipType
 } // namespace AGS
 
 
-AGS::Common::HError play_theora_video(const char *name, int flags, AGS::Engine::VideoSkipType skip);
-AGS::Common::HError play_flc_video(int numb, int flags, AGS::Engine::VideoSkipType skip);
+AGS::Common::HError play_theora_video(const char *name, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip);
+AGS::Common::HError play_flc_video(int numb, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip);
 
 // Pause the active video
 void video_pause();

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -52,14 +52,20 @@ enum VideoSkipType
 } // namespace AGS
 
 
+// Blocking video API
+//
+// Start a blocking OGV playback
 AGS::Common::HError play_theora_video(const char *name, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip);
+// Start a blocking FLIC playback
 AGS::Common::HError play_flc_video(int numb, int video_flags, int state_flags, AGS::Engine::VideoSkipType skip);
+// Pause the active blocking video
+void video_single_pause();
+// Resume the active blocking video
+void video_single_resume();
+// Stop current blocking video playback and dispose all video resource
+void video_single_stop();
 
-// Pause the active video
-void video_pause();
-// Resume the active video
-void video_resume();
-// Stop current playback and dispose all video resource
+// Stop all videos and video thread
 void video_shutdown();
 
 #endif // __AGS_EE_MEDIA__VIDEO_H

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -12,18 +12,11 @@
 //
 //=============================================================================
 //
-// Video playback interface.
-//
-// TODO: good future changes:
-//  - do not render to the screen right inside the VideoPlayer class,
-//    instead write the frame into the bitmap or texture, and expose
-//    current frame in the interface to let the engine decide what to do
-//    with it.
+// Game-blocking video interface.
 //
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__VIDEO_H
 #define __AGS_EE_MEDIA__VIDEO_H
-#include <atomic>
 #include "media/audio/openalsource.h"
 #include "util/geometry.h"
 #include "util/string.h"
@@ -55,85 +48,6 @@ enum VideoSkipType
     VideoSkipKeyOrMouse   = 3
 };
 
-class IDriverDependantBitmap;
-using AGS::Common::Bitmap;
-using AGS::Common::String;
-
-// Parent video player class, provides basic playback logic,
-// queries audio and video frames from decoders, plays audio chunks,
-// renders the video frames on screen, according to the stretch flags.
-// Relies on frame decoding being implemented in derived classes.
-class VideoPlayer
-{
-public:
-    virtual ~VideoPlayer();
-    // Tries to open a video file of a given name
-    Common::HError Open(const Common::String &name, int flags);
-    virtual bool IsValid() { return false; }
-    // Stops the playback, releasing any resources
-    void Close();
-    // Begins or resumes playback
-    void Play();
-    // Pauses playback
-    void Pause();
-    // Restores the video after display switch
-    virtual void Restore() {};
-
-    // Get suggested video framerate (frames per second)
-    uint32_t GetFramerate() const { return _frameRate; }
-    // Tells if video playback is looping
-    bool IsLooping() const { return _loop; }
-    // Get current playback state
-    PlaybackState GetPlayState() const { return _playState; }
-
-    // Updates the video playback, renders next frame
-    bool Poll();
-
-protected:
-    // Opens the video, implementation-specific; allows to modify flags
-    virtual Common::HError OpenImpl(const String& /*name*/, int& /*flags*/)
-        { return new Common::Error("Internal error: operation not implemented"); };
-    // Closes the video, implementation-specific
-    virtual void CloseImpl() {};
-    // Retrieves next video frame, implementation-specific
-    virtual bool NextFrame() { return false; };
-
-    int GetAudioPos(); // in ms
-
-    int _audioChannels = 0;
-    int _audioFreq = 0;
-    SDL_AudioFormat _audioFormat = 0;
-    SoundBuffer _audioFrame{};
-    bool _wantAudio = false;
-
-    std::unique_ptr<Bitmap> _videoFrame;
-    int _frameDepth = 0; // bits per pixel
-    Size _frameSize{};
-    uint32_t _frameRate = 0u;
-
-private:
-    // Renders the current audio data
-    bool RenderAudio();
-    // Renders the current video frame
-    bool RenderVideo();
-    // Resumes after pausing
-    void Resume();
-
-    // Parameters
-    bool _loop = false;
-    int _flags = 0;
-    // Playback state
-    uint32_t _frameTime = 0u; // frame duration in ms
-    PlaybackState _playState = PlayStateInitial;
-    // Audio
-    std::unique_ptr<OpenAlSource> _audioOut;
-    // Video
-    Rect _dstRect{};
-    std::unique_ptr<Bitmap> _hicolBuf;
-    std::unique_ptr<Bitmap> _targetBitmap;
-    IDriverDependantBitmap *_videoDDB = nullptr;
-};
-
 } // namespace Engine
 } // namespace AGS
 
@@ -145,8 +59,6 @@ AGS::Common::HError play_flc_video(int numb, int flags, AGS::Engine::VideoSkipTy
 void video_pause();
 // Resume the active video
 void video_resume();
-// Update video playback if the display mode has changed
-void video_on_gfxmode_changed();
 // Stop current playback and dispose all video resource
 void video_shutdown();
 

--- a/Engine/media/video/videoplayer.cpp
+++ b/Engine/media/video/videoplayer.cpp
@@ -1,0 +1,217 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "media/video/videoplayer.h"
+
+#ifndef AGS_NO_VIDEO_PLAYER
+
+//-----------------------------------------------------------------------------
+// VideoPlayer
+//-----------------------------------------------------------------------------
+namespace AGS
+{
+namespace Engine
+{
+
+using namespace Common;
+
+VideoPlayer::~VideoPlayer()
+{
+    Stop();
+}
+
+HError VideoPlayer::Open(std::unique_ptr<Common::Stream> data_stream,
+    const String &name, int flags)
+{
+    return Open(std::move(data_stream), name, flags, Size(), 0);
+}
+
+HError VideoPlayer::Open(std::unique_ptr<Common::Stream> data_stream,
+    const String &name, int flags,
+    const Size &target_sz, int target_depth)
+{
+    // We request a target depth from decoder, but it may ignore our request,
+    // so we have to check actual "native" frame's depth after
+    HError err = OpenImpl(std::move(data_stream), name, flags, target_depth);
+    if (!err)
+        return err;
+
+    _name = name;
+    _flags = flags;
+    // Start the audio stream
+    if ((flags & kVideoPlayer_EnableAudio) != 0)
+    {
+        if ((_audioFormat > 0) && (_audioChannels > 0) && (_audioFreq > 0))
+        {
+            _audioOut.reset(new OpenAlSource(_audioFormat, _audioChannels, _audioFreq));
+            _audioOut->Play();
+            _wantAudio = true;
+        }
+    }
+    // Setup video
+    if ((flags & kVideoPlayer_EnableVideo) != 0)
+    {
+        _targetDepth = target_depth > 0 ? target_depth : _frameDepth;
+        SetTargetFrame(target_sz);
+    }
+
+    _frameTime = 1000 / _frameRate;
+    return HError::None();
+}
+
+void VideoPlayer::SetTargetFrame(const Size &target_sz)
+{
+    _targetSize = target_sz.IsNull() ? _frameSize : target_sz;
+
+    // Create helper bitmaps in case of stretching or color depth conversion
+    if ((_targetSize != _frameSize) || (_targetDepth != _frameDepth))
+    {
+        _targetBitmap.reset(BitmapHelper::CreateBitmap(_targetSize.Width, _targetSize.Height, _targetDepth));
+        _readyBitmap = _targetBitmap.get();
+    }
+    else
+    {
+        _targetBitmap.reset();
+        _readyBitmap = _videoFrame.get();
+    }
+
+    // If we are decoding a 8-bit frame in a hi-color game, and stretching,
+    // then create a hi-color buffer, as bitmap lib cannot stretch with depth change
+    if ((_targetSize != _frameSize) && (_frameDepth == 8) && (_targetDepth > 8))
+    {
+        _hicolBuf.reset(BitmapHelper::CreateBitmap(_frameSize.Width, _frameSize.Height, _targetDepth));
+    }
+    else
+    {
+        _hicolBuf.reset();
+    }
+}
+
+void VideoPlayer::Stop()
+{
+    if (IsPlaybackReady(_playState)) // keep any error state
+        _playState = PlayStateStopped;
+
+    // Shutdown openal source
+    _audioOut.reset();
+    // Close video decoder and free resources
+    CloseImpl();
+
+    _videoFrame.reset();
+    _hicolBuf.reset();
+    _targetBitmap.reset();
+    _readyBitmap = nullptr;
+}
+
+void VideoPlayer::Play()
+{
+    if (!IsValid())
+        return;
+
+    switch (_playState)
+    {
+    case PlayStatePaused: Resume(); /* fall-through */
+    case PlayStateInitial: _playState = PlayStatePlaying; break;
+    default: break; // TODO: support rewind/replay from stop/finished state?
+    }
+}
+
+void VideoPlayer::Pause()
+{
+    if (_playState != PlayStatePlaying) return;
+
+    if (_audioOut)
+        _audioOut->Pause();
+    _playState = PlayStatePaused;
+}
+
+void VideoPlayer::Resume()
+{
+    if (_playState != PlayStatePaused) return;
+
+    if (_audioOut)
+        _audioOut->Resume();
+    _playState = PlayStatePlaying;
+}
+
+void VideoPlayer::Seek(float pos_ms)
+{
+    // TODO
+}
+
+bool VideoPlayer::Poll()
+{
+    if (_playState != PlayStatePlaying)
+        return false;
+    // Acquire next video frame
+    if (!NextFrame() && !_audioFrame)
+    { // stop is no new frames, and no buffered frames left
+        _playState = PlayStateFinished;
+        return false;
+    }
+    // Render current frame
+    if (_audioFrame && !RenderAudio())
+    {
+        _playState = PlayStateError;
+        return false;
+    }
+    if (_videoFrame && !RenderVideo())
+    {
+        _playState = PlayStateError;
+        return false;
+    }
+    return true;
+}
+
+bool VideoPlayer::RenderAudio()
+{
+    assert(_audioFrame);
+    assert(_audioOut != nullptr);
+    _wantAudio = _audioOut->PutData(_audioFrame) > 0u;
+    _audioOut->Poll();
+    if (_wantAudio)
+        _audioFrame = SoundBuffer(); // clear received buffer
+    return true;
+}
+
+bool VideoPlayer::RenderVideo()
+{
+    assert(_videoFrame);
+    Bitmap *usebuf = _videoFrame.get();
+
+    // Use intermediate hi-color buffer if necessary
+    if (_hicolBuf)
+    {
+        _hicolBuf->Blit(usebuf);
+        usebuf = _hicolBuf.get();
+    }
+
+    if (_targetBitmap)
+    {
+        if (_targetSize == _frameSize)
+            _targetBitmap->Blit(usebuf);
+        else
+            _targetBitmap->StretchBlt(usebuf, RectWH(_targetSize));
+    }
+
+    return true;
+}
+
+} // namespace Engine
+} // namespace AGS
+
+#else // AGS_NO_VIDEO_PLAYER
+
+
+
+#endif // !AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/videoplayer.cpp
+++ b/Engine/media/video/videoplayer.cpp
@@ -72,7 +72,8 @@ void VideoPlayer::SetTargetFrame(const Size &target_sz)
     _targetSize = target_sz.IsNull() ? _frameSize : target_sz;
 
     // Create helper bitmaps in case of stretching or color depth conversion
-    if ((_targetSize != _frameSize) || (_targetDepth != _frameDepth))
+    if ((_targetSize != _frameSize) || (_targetDepth != _frameDepth)
+        || ((_flags & kVideo_AccumFrame) != 0))
     {
         _vframeBuf.reset(new Bitmap(_frameSize.Width, _frameSize.Height, _frameDepth));
     }
@@ -334,7 +335,8 @@ void VideoPlayer::BufferVideo()
     }
 
     // Try to retrieve one video frame from decoder
-    const bool must_conv = (_targetSize != _frameSize || _targetDepth != _frameDepth);
+    const bool must_conv = (_targetSize != _frameSize || _targetDepth != _frameDepth
+        || ((_flags & kVideo_AccumFrame) != 0));
     Bitmap *usebuf = must_conv ? _vframeBuf.get() : target_frame.get();
     if (!NextVideoFrame(usebuf))
     { // failed to get frame, so move prepared target frame into the pool for now

--- a/Engine/media/video/videoplayer.cpp
+++ b/Engine/media/video/videoplayer.cpp
@@ -411,8 +411,4 @@ bool VideoPlayer::ProcessAudio()
 } // namespace Engine
 } // namespace AGS
 
-#else // AGS_NO_VIDEO_PLAYER
-
-
-
-#endif // !AGS_NO_VIDEO_PLAYER
+#endif // AGS_NO_VIDEO_PLAYER

--- a/Engine/media/video/videoplayer.cpp
+++ b/Engine/media/video/videoplayer.cpp
@@ -49,7 +49,7 @@ HError VideoPlayer::Open(std::unique_ptr<Common::Stream> data_stream,
     _name = name;
     _flags = flags;
     // Start the audio stream
-    if ((flags & kVideoPlayer_EnableAudio) != 0)
+    if ((flags & kVideo_EnableAudio) != 0)
     {
         if ((_audioFormat > 0) && (_audioChannels > 0) && (_audioFreq > 0))
         {
@@ -59,7 +59,7 @@ HError VideoPlayer::Open(std::unique_ptr<Common::Stream> data_stream,
         }
     }
     // Setup video
-    if ((flags & kVideoPlayer_EnableVideo) != 0)
+    if ((flags & kVideo_EnableVideo) != 0)
     {
         _targetDepth = target_depth > 0 ? target_depth : _frameDepth;
         SetTargetFrame(target_sz);

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -54,6 +54,9 @@ enum VideoFlags
     kVideo_LegacyFrameSize= 0x0008,
     // Allow to drop late video frames in autoplay mode
     kVideo_DropFrames     = 0x0010,
+    // Must accumulate decoded frames, when format's frames
+    // do not have a full image, but diff from the previous frame
+    kVideo_AccumFrame     = 0x0020,
 };
 
 // Parent video player class, provides basic playback logic,

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -101,9 +101,9 @@ public:
     // Get current playback state
     PlaybackState GetPlayState() const { return _playState; }
     // Gets duration, in ms
-    float GetDurationMs() const { return 0 /* TODO */; }
+    float GetDurationMs() const { return _durationMs; }
     // Gets playback position, in ms
-    float GetPositionMs() const { return 0 /* TODO */; }
+    float GetPositionMs() const { return _posMs; }
 
     void  SetSpeed(float speed);
     void  SetVolume(float volume);
@@ -144,6 +144,9 @@ protected:
     int _frameDepth = 0; // bits per pixel
     Size _frameSize{};
     float _frameRate = 0.f;
+    float _frameTime = 0.f;
+    uint32_t _frameCount = 0;
+    float _durationMs = 0.f;
 
 private:
     // Resume after pause
@@ -166,10 +169,12 @@ private:
     Size _targetSize;
     int _targetDepth = 0;
     float _targetFPS = 0.f;
+    float _targetFrameTime = 0.f; // frame duration in ms for "target fps"
     uint32_t _videoQueueMax = 5u;
     uint32_t _audioQueueMax = 0u; // we don't have a real queue atm
     // Playback state
     PlaybackState _playState = PlayStateInitial;
+    float _posMs = 0.f;
     // Frames counter, increments with playback, resets on rewind or seek
     uint32_t _framesPlayed = 0u;
     // Stage timestamps, used to calculate the next frame timing;
@@ -183,7 +188,6 @@ private:
     // Audio output object
     std::unique_ptr<OpenAlSource> _audioOut;
     // Video
-    float _frameTime = 0.f; // frame duration in ms
     // Helper buffer for retrieving video frames of different size/depth;
     // should match "native" video frame size and color depth
     std::unique_ptr<Common::Bitmap> _vframeBuf;

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include "gfx/bitmap.h"
+#include "media/audio/audiodefines.h"
 #include "media/audio/openalsource.h"
 #include "util/error.h"
 #include "util/stream.h"
@@ -34,12 +35,12 @@ namespace AGS
 namespace Engine
 {
 
-enum VideoPlayerFlags
+enum VideoFlags
 {
-    kVideoPlayer_EnableVideo    = 0x0001,
-    kVideoPlayer_EnableAudio    = 0x0002,
-    kVideoPlayer_Loop           = 0x0004,
-    kVideoPlayer_LegacyFrameSize= 0x0008
+    kVideo_EnableVideo    = 0x0001,
+    kVideo_EnableAudio    = 0x0002,
+    kVideo_Loop           = 0x0004,
+    kVideo_LegacyFrameSize= 0x0008
 };
 
 // Parent video player class, provides basic playback logic,
@@ -76,7 +77,7 @@ public:
     // Get suggested video framerate (frames per second)
     uint32_t GetFramerate() const { return _frameRate; }
     // Tells if video playback is looping
-    bool IsLooping() const { return (_flags & kVideoPlayer_Loop) != 0; }
+    bool IsLooping() const { return (_flags & kVideo_Loop) != 0; }
     // Get current playback state
     PlaybackState GetPlayState() const { return _playState; }
     // Gets duration, in ms

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -1,0 +1,143 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Video playback interface.
+// Renders video frames onto bitmap buffer; supports double-buffering,
+// where active bitmap is switched each next time.
+// Renders audio frames using OpenAlSource output.
+//
+// TODO: separate Video Decoder class, would be useful e.g. for plugins.
+//
+//=============================================================================
+#ifndef __AGS_EE_MEDIA__VIDEOPLAYER_H
+#define __AGS_EE_MEDIA__VIDEOPLAYER_H
+
+#include <memory>
+#include "gfx/bitmap.h"
+#include "media/audio/openalsource.h"
+#include "util/error.h"
+#include "util/stream.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+enum VideoPlayerFlags
+{
+    kVideoPlayer_EnableVideo    = 0x0001,
+    kVideoPlayer_EnableAudio    = 0x0002,
+    kVideoPlayer_Loop           = 0x0004,
+    kVideoPlayer_LegacyFrameSize= 0x0008
+};
+
+// Parent video player class, provides basic playback logic,
+// queries audio and video frames from decoders, plays audio chunks,
+// renders the video frames on bitmap.
+// Relies on frame decoding being implemented in derived classes.
+class VideoPlayer
+{
+public:
+    virtual ~VideoPlayer();
+
+    // Tries to init a video playback reading from the given stream
+    Common::HError Open(std::unique_ptr<Common::Stream> data_stream,
+        const String &name, int flags);
+    Common::HError Open(std::unique_ptr<Common::Stream> data_stream,
+        const String &name, int flags,
+        const Size &target_sz, int target_depth);
+    // Tells if the videoplayer object is valid and ready to render
+    virtual bool IsValid() { return false; }
+    // Assigns a wanted target bitmap size
+    void SetTargetFrame(const Size &target_sz);
+    // Begins or resumes playback
+    void Play();
+    // Pauses playback
+    void Pause();
+    // Stops the playback, releasing any resources
+    void Stop();
+    // Seek to the given time position
+    void Seek(float pos_ms);
+
+    const String &GetName() const { return _name; }
+    const Size &GetFrameSize() const { return _frameSize; }
+    const int GetFrameDepth() const { return _frameDepth; }
+    // Get suggested video framerate (frames per second)
+    uint32_t GetFramerate() const { return _frameRate; }
+    // Tells if video playback is looping
+    bool IsLooping() const { return (_flags & kVideoPlayer_Loop) != 0; }
+    // Get current playback state
+    PlaybackState GetPlayState() const { return _playState; }
+    // Gets duration, in ms
+    float GetDurationMs() const { return 0 /* TODO */; }
+    // Gets playback position, in ms
+    float GetPositionMs() const { return 0 /* TODO */; }
+
+    // Get current video frame
+    const Common::Bitmap *GetVideoFrame() const { return _readyBitmap; }
+
+    // Updates the video playback, renders next frame
+    bool Poll();
+
+protected:
+    // Opens the video, implementation-specific; allows to modify flags
+    virtual Common::HError OpenImpl(std::unique_ptr<Common::Stream> /*data_stream*/,
+        const String &/*name*/, int& /*flags*/, int /*target_depth*/)
+        { return new Common::Error("Internal error: operation not implemented"); };
+    // Closes the video, implementation-specific
+    virtual void CloseImpl() {};
+    // Retrieves next video frame, implementation-specific
+    virtual bool NextFrame() { return false; };
+
+    // Audio internals
+    int _audioChannels = 0;
+    int _audioFreq = 0;
+    SDL_AudioFormat _audioFormat = 0;
+    SoundBuffer _audioFrame{};
+    bool _wantAudio = false;
+
+    // Video internals
+    std::unique_ptr<Common::Bitmap> _videoFrame;
+    int _frameDepth = 0; // bits per pixel
+    Size _frameSize{};
+    uint32_t _frameRate = 0u;
+
+private:
+    // Renders the current audio data
+    bool RenderAudio();
+    // Renders the current video frame
+    bool RenderVideo();
+    // Resumes after pausing
+    void Resume();
+
+    // Parameters
+    String _name;
+    int _flags = 0;
+    Size _targetSize;
+    int _targetDepth = 0;
+    // Playback state
+    uint32_t _frameTime = 0u; // frame duration in ms
+    PlaybackState _playState = PlayStateInitial;
+    // Audio
+    std::unique_ptr<OpenAlSource> _audioOut;
+    // Video
+    std::unique_ptr<Common::Bitmap> _hicolBuf;
+    std::unique_ptr<Common::Bitmap> _targetBitmap;
+    Common::Bitmap *_readyBitmap = nullptr;
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_MEDIA__VIDEOPLAYER_H

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -72,8 +72,10 @@ public:
     void Seek(float pos_ms);
 
     const String &GetName() const { return _name; }
+    int GetFrameDepth() const { return _frameDepth; }
     const Size &GetFrameSize() const { return _frameSize; }
-    const int GetFrameDepth() const { return _frameDepth; }
+    int GetTargetDepth() const { return _targetDepth; }
+    const Size &GetTargetSize() const { return _targetSize; }
     // Get suggested video framerate (frames per second)
     uint32_t GetFramerate() const { return _frameRate; }
     // Tells if video playback is looping

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -647,7 +647,10 @@
     <ClCompile Include="..\..\Engine\media\audio\sdldecoder.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\sound.cpp" />
     <ClCompile Include="..\..\Engine\media\audio\soundclip.cpp" />
+    <ClCompile Include="..\..\Engine\media\video\flic_player.cpp" />
+    <ClCompile Include="..\..\Engine\media\video\theora_player.cpp" />
     <ClCompile Include="..\..\Engine\media\video\video.cpp" />
+    <ClCompile Include="..\..\Engine\media\video\videoplayer.cpp" />
     <ClCompile Include="..\..\Engine\platform\base\agsplatformdriver.cpp" />
     <ClCompile Include="..\..\Engine\platform\base\sys_main.cpp" />
     <ClCompile Include="..\..\Engine\platform\windows\acplwin.cpp" />
@@ -915,7 +918,10 @@
     <ClInclude Include="..\..\Engine\media\audio\queuedaudioitem.h" />
     <ClInclude Include="..\..\Engine\media\audio\sound.h" />
     <ClInclude Include="..\..\Engine\media\audio\soundclip.h" />
+    <ClInclude Include="..\..\Engine\media\video\flic_player.h" />
+    <ClInclude Include="..\..\Engine\media\video\theora_player.h" />
     <ClInclude Include="..\..\Engine\media\video\video.h" />
+    <ClInclude Include="..\..\Engine\media\video\videoplayer.h" />
     <ClInclude Include="..\..\Engine\platform\base\agsplatformdriver.h" />
     <ClInclude Include="..\..\Engine\platform\base\sys_main.h" />
     <ClInclude Include="..\..\Engine\platform\windows\debug\namedpipesagsdebugger.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -807,6 +807,15 @@
     <ClCompile Include="..\..\Engine\media\audio\audioplayer.cpp">
       <Filter>Source Files\media\audio</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\media\video\videoplayer.cpp">
+      <Filter>Source Files\media\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\media\video\flic_player.cpp">
+      <Filter>Source Files\media\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\media\video\theora_player.cpp">
+      <Filter>Source Files\media\video</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1624,6 +1633,15 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\media\audio\audioplayer.h">
       <Filter>Header Files\media\audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\media\video\videoplayer.h">
+      <Filter>Header Files\media\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\media\video\flic_player.h">
+      <Filter>Header Files\media\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\media\video\theora_player.h">
+      <Filter>Header Files\media\video</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libsrc/allegro/include/allegro/fli.h
+++ b/libsrc/allegro/include/allegro/fli.h
@@ -49,6 +49,7 @@ AL_VAR(int, fli_pal_dirty_from);       /* what part of fli_palette is dirty */
 AL_VAR(int, fli_pal_dirty_to);
 
 AL_VAR(int, fli_frame);                /* current frame number */
+AL_VAR(int, fli_frame_count);          /* total number of frames */
 
 AL_VAR(int, fli_speed);                /* FLI playback speed factor, in milliseconds */
 

--- a/libsrc/allegro/src/fli.c
+++ b/libsrc/allegro/src/fli.c
@@ -84,6 +84,7 @@ int fli_pal_dirty_from = INT_MAX;      /* what part of fli_palette is dirty */
 int fli_pal_dirty_to = INT_MIN;
 
 int fli_frame = 0;                     /* current frame number in the FLI */
+int fli_frame_count = 0;               /* total number of frames in the FLI */
 
 int fli_speed = 0;                     /* speed of the fli playback */
 
@@ -857,6 +858,7 @@ static int do_open_fli(void)
    }
 
    reset_fli_variables();
+   fli_frame_count = fli_header.frame_count;
    fli_frame = 0;
    fli_status = FLI_OK;
 
@@ -921,6 +923,7 @@ int open_memory_fli(void *fli_data)
  */
 void close_fli(void)
 {
+   fli_frame_count = 0;
    fli_speed = 0;
 
    if (fli_file) {


### PR DESCRIPTION
This is a limited backport from #2338, containing only improved VideoPlayer class, but no changes to script API, and no global working thread for non-blocking videos. Its main purpose is to keep code in branches at least somewhat consistent, but also make it easier to do improvements to video playback.

* Separated VideoPlayer and BlockingVideoPlayer classes, where VideoPlayer is a generic player, while BlockingVideoPlayer defines a game state which runs VideoPlayer in particular way.
* Turned BlockingVideoPlayer as another GameState implementation (complementary to the recent #2332).
* VideoPlayer now has buffer queue for video frames, supports both autoplay and manual frame-by-frame work modes.
* No actual working thread is implemented in this PR, but it may be done later, to improve playing videos with higher framerates.

There's a potential issue with FLIC videos that I found. It looks like existing games that use FLIC has videos coded with 100 fps (!), but it's played at 60 fps as a effect from setting vsync in script, and that's how it matches the audio (which is played separately). This makes me concerned about maintaining compatibility with these games in case if a video will be run on a working thread on its true fps rate. I suppose this could be worked around by running the FLICs in manual mode using NextFrame() call from the main thread, rather than starting it with Play(). This is possible because FLICs don't have any audio in them.
**EDIT:** fixed this, but used an easier method.
