### PR TITLE
AGS4: 8bit fixes

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1644,7 +1644,7 @@ namespace AGS.Editor.Components
                 throw new ArgumentNullException(nameof(bmp));
             }
 
-            Bitmap newBmp = new Bitmap(bmp);
+            Bitmap newBmp = bmp.Clone() as Bitmap;
             bool hasResolutionChanged = _loadedRoom.Width != newBmp.Width || _loadedRoom.Height != newBmp.Height;
             _loadedRoom.Width = newBmp.Width;
             _loadedRoom.Height = newBmp.Height;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -280,12 +280,7 @@ namespace AGS.Editor
                 int xPos = state.RoomXToWindow(character.StartX) - spriteSize.Width / 2;
                 int yPos = state.RoomYToWindow(character.StartY) - spriteSize.Height;
 
-                using (Bitmap sprite = Factory.NativeProxy.GetBitmapForSprite(spriteNum))
-                using (Bitmap sprite32bppAlpha = new Bitmap(sprite.Width, sprite.Height, PixelFormat.Format32bppArgb))
-                {
-                    sprite32bppAlpha.SetRawData(sprite.GetRawData());
-                    graphics.DrawImage(sprite32bppAlpha, xPos, yPos, spriteSize.Width, spriteSize.Height);
-                }
+                Utilities.DrawSpriteOnGraphics(graphics, spriteNum, xPos, yPos, spriteSize.Width, spriteSize.Height);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -162,12 +162,7 @@ namespace AGS.Editor
                 int xpos = state.RoomXToWindow(obj.StartX);
                 int ypos = state.RoomYToWindow(obj.StartY) - spriteSize.Height;
 
-                using (Bitmap sprite = Factory.NativeProxy.GetBitmapForSprite(obj.Image))
-                using (Bitmap sprite32bppAlpha = new Bitmap(sprite.Width, sprite.Height, PixelFormat.Format32bppArgb))
-                {
-                    sprite32bppAlpha.SetRawData(sprite.GetRawData());
-                    graphics.DrawImage(sprite32bppAlpha, xpos, ypos, spriteSize.Width, spriteSize.Height);
-                }
+                Utilities.DrawSpriteOnGraphics(graphics, obj.Image, xpos, ypos, spriteSize.Width, spriteSize.Height);
             }
 
             if (!Enabled || _selectedObject == null)

--- a/Editor/AGS.Native/NativeRoom.cpp
+++ b/Editor/AGS.Native/NativeRoom.cpp
@@ -79,6 +79,9 @@ SysBitmap ^NativeRoom::GetBackground(int bgnum)
         throw gcnew AGSEditorException(System::String::Format(
             "Invalid background number {0}", bgnum));
     }
+    if (_rs->BackgroundBPP == 1)
+      return ConvertBlockToBitmap(_rs->BgFrames[bgnum].Graphic.get());
+
     return ConvertBlockToBitmap32(_rs->BgFrames[bgnum].Graphic.get(), _rs->Width, _rs->Height, true /* opaque */);
 }
 


### PR DESCRIPTION
- Preserve bit depth from crm to new room format
- Preserve bit depth for imported room background
- Fixes error in displaying object/characters in the room editor

Related to #2349 and #2218

This PR is missing the palette remapping for 8bit mode, I see there's a TODO comment that the feature was meant to be reimplemented but it was not done yet. Perhaps I'll look into it next.