### PR TITLE
3.6.1: remove "supersampling" setting from OpenGL renderer

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -144,14 +144,12 @@ The preferences modifies the `android.cfg` file, either the local or global one.
 
 #### Graphics `[graphics]`
 
-- **Renderer** : Software (SDL2) or Hardware (OpenGL ES2)  
-  `renderer = 0, 1`  
+- **Renderer** : Software (SDL2), Hardware (OpenGL ES2) with rendering to screen, Hardware with rendering to texture.
+  `renderer = 0, 1, 2`  
 - **Screen Scaling** : No scaling, Fullscreen Preserving Aspect Ration, Fullscreen Stretch.  
   `scaling = 0, 1`  
 - **Linear Filtering** :  yes or no  
   `smoothing = 0, 1`  
-- **Super Sampling** : yes or no
-  `super_sampling = 0, 1`
 - **Smooth Scaled Sprites** : yes or no  
   `smooth_sprites = 0, 1`
   

--- a/Android/README.md
+++ b/Android/README.md
@@ -135,12 +135,7 @@ The preferences modifies the `android.cfg` file, either the local or global one.
 #### Sound `[sound]`
 
 - **Enabled** : yes or no  
-  `enabled = 0, 1`  
-
-#### Video `[video]`
-
-- **Drop frames if necessary** : disabled, to be removed  
-  `framedrop = 0, 1`
+  `enabled = 0, 1`
 
 #### Graphics `[graphics]`
 

--- a/Android/library/runtime/src/main/res/values/strings.xml
+++ b/Android/library/runtime/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="CONFIG_GFX_RENDERER">9</string>
     <string name="CONFIG_GFX_SMOOTHING">10</string>
     <string name="CONFIG_GFX_SCALING">11</string>
-    <string name="CONFIG_GFX_SS">12</string>
+    <!--<string name="CONFIG_GFX_SS">12</string>-->
     <string name="CONFIG_ROTATION">13</string>
     <string name="CONFIG_ENABLED">14</string>
     <string name="CONFIG_DEBUG_FPS">15</string>

--- a/Android/library/runtime/src/main/res/values/strings.xml
+++ b/Android/library/runtime/src/main/res/values/strings.xml
@@ -3,11 +3,9 @@
     <string name="title_activity_ags_settings">AgsSettingsActivity</string>
 
     <string name="CONFIG_AUDIO_ENABLED">3</string>
-    <string name="CONFIG_VIDEO_FRAMEDROP">8</string>
     <string name="CONFIG_GFX_RENDERER">9</string>
     <string name="CONFIG_GFX_SMOOTHING">10</string>
     <string name="CONFIG_GFX_SCALING">11</string>
-    <!--<string name="CONFIG_GFX_SS">12</string>-->
     <string name="CONFIG_ROTATION">13</string>
     <string name="CONFIG_ENABLED">14</string>
     <string name="CONFIG_DEBUG_FPS">15</string>

--- a/Android/library/runtime/src/main/res/xml/preferences.xml
+++ b/Android/library/runtime/src/main/res/xml/preferences.xml
@@ -120,14 +120,6 @@
 
         <androidx.preference.CheckBoxPreference
             android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_GFX_SS"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="Use a higher resolution for scaling objects"
-            android:title="Supersampling" />
-
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
             android:key="@string/CONFIG_GFX_SMOOTH_SPRITES"
             android:persistent="false"
             android:shouldDisableView="true"

--- a/Android/library/runtime/src/main/res/xml/preferences.xml
+++ b/Android/library/runtime/src/main/res/xml/preferences.xml
@@ -76,18 +76,6 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
-        android:key="preference_key_video"
-        android:title="Video">
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_VIDEO_FRAMEDROP"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="On slow devices this can lead to all frames being skipped"
-            android:title="Drop frames if necessary" />
-    </androidx.preference.PreferenceCategory>
-
-    <androidx.preference.PreferenceCategory
         android:key="preference_key_graphics"
         android:title="Graphics">
         <androidx.preference.ListPreference

--- a/Android/misc/android.cfg
+++ b/Android/misc/android.cfg
@@ -17,7 +17,6 @@ framedrop = 0
 renderer = 2
 smoothing = 1
 scaling = 1
-super_sampling = 0
 smooth_sprites = 0
 [debug]
 show_fps = 0

--- a/Android/misc/android.cfg
+++ b/Android/misc/android.cfg
@@ -11,8 +11,6 @@ clear_cache_on_room_change = 0
 [sound]
 enabled = 1
 cache_size = 64
-[video]
-framedrop = 0
 [graphics]
 renderer = 2
 smoothing = 1

--- a/Android/mygame/app/src/main/assets/android.cfg
+++ b/Android/mygame/app/src/main/assets/android.cfg
@@ -17,7 +17,6 @@ framedrop = 0
 renderer = 2
 smoothing = 1
 scaling = 1
-super_sampling = 0
 smooth_sprites = 0
 [debug]
 show_fps = 0

--- a/Android/mygame/app/src/main/assets/android.cfg
+++ b/Android/mygame/app/src/main/assets/android.cfg
@@ -11,8 +11,6 @@ clear_cache_on_room_change = 0
 [sound]
 enabled = 1
 cache_size = 64
-[video]
-framedrop = 0
 [graphics]
 renderer = 2
 smoothing = 1

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -57,8 +57,6 @@ namespace AGS.Editor
             string clear_cache = Utilities.GetConfigString(cfg, "compatibility", "clear_cache_on_room_change", "0");
             string sound_enabled = Utilities.GetConfigString(cfg, "sound", "enabled", "1");
             string sound_cache_size = Utilities.GetConfigString(cfg, "sound", "cache_size", "32768");
-            string frame_drop = Utilities.GetConfigString(cfg, "video", "framedrop", "0");
-            string super_sampling = Utilities.GetConfigString(cfg, "graphics", "super_sampling", "0");
             string logging = Utilities.GetConfigString(cfg, "debug", "logging", "0");
 
             cfg = new Dictionary<string, Dictionary<string, string>>();
@@ -90,9 +88,6 @@ namespace AGS.Editor
             cfg["sound"]["enabled"] = sound_enabled;
             cfg["sound"]["cache_size"] = sound_cache_size;
 
-            // Video options
-            cfg["video"]["framedrop"] = frame_drop;
-
             // Graphic options
             if (setup.GraphicsDriver == GraphicsDriver.Software) {
                 cfg["graphics"]["renderer"] = "0";
@@ -114,7 +109,6 @@ namespace AGS.Editor
                 cfg["graphics"]["scaling"] = "0";
             }
 
-            cfg["graphics"]["super_sampling"] = super_sampling;
             cfg["graphics"]["smooth_sprites"] = setup.AAScaledSprites ? "1" : "0";
 
             // Debug options

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2735,7 +2735,7 @@ void construct_game_scene(bool full_redraw)
     play.UpdateViewports();
 
     gfxDriver->UseSmoothScaling(IS_ANTIALIAS_SPRITES);
-    gfxDriver->RenderSpritesAtScreenResolution(usetup.RenderAtScreenRes, usetup.Supersampling);
+    gfxDriver->RenderSpritesAtScreenResolution(usetup.RenderAtScreenRes);
 
     pl_run_plugin_hooks(AGSE_PRERENDER, 0);
 

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -31,7 +31,6 @@ GameSetup::GameSetup()
     touch_emulate_mouse = kTouchMouse_OneFingerDrag;
     touch_motion_relative = false;
     RenderAtScreenRes = false;
-    Supersampling = 1;
     clear_cache_on_room_change = false;
     load_latest_save = false;
     rotation = kScreenRotation_Unlocked;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -97,7 +97,6 @@ struct GameSetup
     bool  touch_motion_relative;
     //
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
-    int   Supersampling;
     size_t SpriteCacheSize = DefSpriteCacheSize; // in KB
     size_t TextureCacheSize = DefTexCacheSize; // in KB
     size_t SoundLoadAtOnceSize = DefSoundLoadAtOnce; // threshold for loading sounds immediately, in KB

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -265,7 +265,7 @@ public:
         bool at_native_res, GraphicResolution *want_fmt,
         uint32_t batch_skip_filter = 0u) override;
     bool DoesSupportVsyncToggle() override { return _capsVsync; }
-    void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override;
+    void RenderSpritesAtScreenResolution(bool enabled) override;
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue,
         uint32_t batch_skip_filter = 0u) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue,
@@ -325,14 +325,10 @@ private:
     // rendering to screen directly. This is known as supersampling mode
     bool _can_render_to_texture {};
     bool _do_render_to_texture {};
-    // Backbuffer texture multiplier, used to determine a size of texture
-    // relative to the native game size.
-    int _super_sampling {};
     unsigned int _backbuffer {};
     unsigned int _fbo {};
     GLint _screenFramebuffer = 0;
     // Size of the backbuffer drawing area, equals to native size
-    // multiplied by _super_sampling
     Size _backRenderSize {};
     // Actual size of the backbuffer texture, created by OpenGL
     Size _backTextureSize {};
@@ -370,8 +366,6 @@ private:
     void SetupDefaultVertices();
     // Test if rendering to texture is supported
     void TestRenderToTexture();
-    // Test if supersampling should be allowed with the current setup
-    void TestSupersampling();
     // Create shader programs for sprite tinting and changing light level
     bool CreateShaders();
     // Configure backbuffer texture, that is used in render-to-texture mode

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -212,7 +212,7 @@ public:
     void SetGamma(int newGamma) override;
     void UseSmoothScaling(bool /*enabled*/) override { }
     bool DoesSupportVsyncToggle() override { return (SDL_VERSION_ATLEAST(2, 0, 18)) && _capsVsync; }
-    void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
+    void RenderSpritesAtScreenResolution(bool /*enabled*/) override { }
     Bitmap *GetMemoryBackBuffer() override;
     void SetMemoryBackBuffer(Bitmap *backBuffer) override;
     Bitmap *GetStageBackBuffer(bool mark_dirty) override;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -222,7 +222,7 @@ public:
   // drawn with additional fractional scaling will appear more detailed than
   // the rest of the game. The effect is stronger for the low-res games being
   // rendered in the high-res mode.
-  virtual void RenderSpritesAtScreenResolution(bool enabled, int supersampling = 1) = 0;
+  virtual void RenderSpritesAtScreenResolution(bool enabled) = 0;
   // TODO: move fade-in/out/boxout functions out of the graphics driver!! make everything render through
   // main drawing procedure. Since currently it does not - we need to init our own sprite batch
   // internally to let it set up correct viewport settings instead of relying on a chance.

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -333,7 +333,6 @@ void apply_config(const ConfigTree &cfg)
         usetup.Screen.Params.VSync = CfgReadBoolInt(cfg, "graphics", "vsync");
         usetup.RenderAtScreenRes = CfgReadBoolInt(cfg, "graphics", "render_at_screenres");
         usetup.enable_antialiasing = CfgReadBoolInt(cfg, "graphics", "antialias", usetup.enable_antialiasing);
-        usetup.Supersampling = CfgReadInt(cfg, "graphics", "supersampling", 1);
         usetup.software_render_driver = CfgReadString(cfg, "graphics", "software_driver");
 
         usetup.rotation = (ScreenRotation)CfgReadInt(cfg, "graphics", "rotation", usetup.rotation);

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -81,7 +81,7 @@ const int CONFIG_VIDEO_FRAMEDROP = 8;
 const int CONFIG_GFX_RENDERER = 9;
 const int CONFIG_GFX_SMOOTHING = 10;
 const int CONFIG_GFX_SCALING = 11;
-const int CONFIG_GFX_SS = 12;
+const int CONFIG_GFX_SS = 12; // unused, maybe temporarily
 const int CONFIG_ROTATION = 13;
 const int CONFIG_ENABLED = 14;
 const int CONFIG_DEBUG_FPS = 15;
@@ -147,8 +147,6 @@ JNIEXPORT jint JNICALL
       return setup.gfx_smoothing;
     case CONFIG_GFX_SCALING:
       return setup.gfx_scaling;
-    case CONFIG_GFX_SS:
-      return setup.gfx_super_sampling;
     case CONFIG_GFX_SMOOTH_SPRITES:
       return setup.gfx_smooth_sprites;
     case CONFIG_ROTATION:
@@ -215,9 +213,6 @@ JNIEXPORT void JNICALL
       break;
     case CONFIG_GFX_SCALING:
       setup.gfx_scaling = value;
-      break;
-    case CONFIG_GFX_SS:
-      setup.gfx_super_sampling = value;
       break;
     case CONFIG_GFX_SMOOTH_SPRITES:
       setup.gfx_smooth_sprites = value;

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -77,11 +77,9 @@ const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
 const int CONFIG_AUDIO_ENABLED = 3;
 const int CONFIG_AUDIO_CACHESIZE = 5;
-const int CONFIG_VIDEO_FRAMEDROP = 8;
 const int CONFIG_GFX_RENDERER = 9;
 const int CONFIG_GFX_SMOOTHING = 10;
 const int CONFIG_GFX_SCALING = 11;
-const int CONFIG_GFX_SS = 12; // unused, maybe temporarily
 const int CONFIG_ROTATION = 13;
 const int CONFIG_ENABLED = 14;
 const int CONFIG_DEBUG_FPS = 15;
@@ -139,8 +137,6 @@ JNIEXPORT jint JNICALL
       return setup.audio_enabled;
     case CONFIG_AUDIO_CACHESIZE:
       return setup.audio_cachesize;
-    case CONFIG_VIDEO_FRAMEDROP:
-      return setup.video_framedrop;
     case CONFIG_GFX_RENDERER:
       return setup.gfx_renderer;
     case CONFIG_GFX_SMOOTHING:
@@ -201,9 +197,6 @@ JNIEXPORT void JNICALL
       break;
     case CONFIG_AUDIO_CACHESIZE:
       setup.audio_cachesize = value;
-      break;
-    case CONFIG_VIDEO_FRAMEDROP:
-      setup.video_framedrop = value;
       break;
     case CONFIG_GFX_RENDERER:
       setup.gfx_renderer = value;

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -40,7 +40,6 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
     CfgWriteInt(cfg, "graphics", "renderer", setup.gfx_renderer);
     CfgWriteInt(cfg, "graphics", "smoothing", setup.gfx_smoothing);
     CfgWriteInt(cfg, "graphics", "scaling", setup.gfx_scaling);
-    CfgWriteInt(cfg, "graphics", "super_sampling", setup.gfx_super_sampling);
     CfgWriteInt(cfg, "graphics", "smooth_sprites", setup.gfx_smooth_sprites);
 
     CfgWriteInt(cfg, "debug", "show_fps", setup.show_fps);
@@ -83,7 +82,6 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
     setup.gfx_renderer = CfgReadInt(cfg, "graphics", "renderer", 0, 2, 0);
     setup.gfx_smoothing = CfgReadBoolInt(cfg, "graphics", "smoothing", true);
     setup.gfx_scaling = CfgReadInt(cfg, "graphics", "scaling", 0, 2, 1);
-    setup.gfx_super_sampling = CfgReadBoolInt(cfg, "graphics", "super_sampling", true);
     setup.gfx_smooth_sprites = CfgReadBoolInt(cfg, "graphics", "smooth_sprites", true);
 
     setup.mouse_emulation = CfgReadInt(cfg, "controls", "mouse_emulation", 0, 2, 1);
@@ -131,15 +129,6 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
         CfgWriteString(cfg, "graphics", "filter", "StdScale");
     else
         CfgWriteString(cfg, "graphics", "filter", "Linear");
-
-    // gfx_super_sampling - enable super sampling,
-    //  - only for hardware renderer and when rendering to texture:
-    //    * 0 - x1
-    //    * 1 - x2
-    if (setup.gfx_renderer == 2)
-        CfgWriteInt(cfg, "graphics", "supersampling", setup.gfx_super_sampling + 1);
-    else
-        CfgWriteInt(cfg, "graphics", "supersampling", 0);
 
     // gfx_rotation - scaling style:
     //    * 0 - unlocked, let the user rotate as wished.

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -35,8 +35,6 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
     CfgWriteInt(cfg, "sound", "enabled", setup.audio_enabled);
     CfgWriteInt(cfg, "sound", "cache_size", setup.audio_cachesize);
 
-    CfgWriteInt(cfg, "video", "framedrop", setup.video_framedrop);
-
     CfgWriteInt(cfg, "graphics", "renderer", setup.gfx_renderer);
     CfgWriteInt(cfg, "graphics", "smoothing", setup.gfx_smoothing);
     CfgWriteInt(cfg, "graphics", "scaling", setup.gfx_scaling);
@@ -76,8 +74,6 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
 
     setup.audio_enabled = CfgReadBoolInt(cfg, "sound", "enabled", true);
     setup.audio_cachesize = CfgReadInt(cfg, "sound", "cache_size", 32 * 1024);
-
-    setup.video_framedrop = CfgReadBoolInt(cfg, "video", "framedrop", true);
 
     setup.gfx_renderer = CfgReadInt(cfg, "graphics", "renderer", 0, 2, 0);
     setup.gfx_smoothing = CfgReadBoolInt(cfg, "graphics", "smoothing", true);

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -38,7 +38,6 @@ struct MobileSetup
     int gfx_renderer = 0;
     int gfx_scaling = 0;
     int gfx_smoothing = 0;
-    int gfx_super_sampling = 0;
     int gfx_smooth_sprites = 0;
 
     // Audio options

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -44,9 +44,6 @@ struct MobileSetup
     int audio_enabled = 0;
     int audio_cachesize = 0;
 
-    // Video playback options
-    int video_framedrop = 0;
-
     // Debug options
     int debug_write_to_logcat = 0;
     int show_fps = 0;

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -44,11 +44,9 @@ const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
 const int CONFIG_AUDIO_ENABLED = 3;
 const int CONFIG_AUDIO_CACHESIZE = 5;
-const int CONFIG_VIDEO_FRAMEDROP = 8;
 const int CONFIG_GFX_RENDERER = 9;
 const int CONFIG_GFX_SMOOTHING = 10;
 const int CONFIG_GFX_SCALING = 11;
-const int CONFIG_GFX_SS = 12; // unused, maybe temporarily
 const int CONFIG_ROTATION = 13;
 const int CONFIG_ENABLED = 14;
 const int CONFIG_DEBUG_FPS = 15;
@@ -113,8 +111,6 @@ int readIntConfigValue(int id)
         return setup.audio_enabled;
       case CONFIG_AUDIO_CACHESIZE:
         return setup.audio_cachesize;
-      case CONFIG_VIDEO_FRAMEDROP:
-        return setup.video_framedrop;
       case CONFIG_GFX_RENDERER:
         return setup.gfx_renderer;
       case CONFIG_GFX_SMOOTHING:
@@ -173,9 +169,6 @@ void setIntConfigValue(int id, int value)
         break;
       case CONFIG_AUDIO_CACHESIZE:
         setup.audio_cachesize = value;
-        break;
-      case CONFIG_VIDEO_FRAMEDROP:
-        setup.video_framedrop = value;
         break;
       case CONFIG_GFX_RENDERER:
         setup.gfx_renderer = value;

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -48,7 +48,7 @@ const int CONFIG_VIDEO_FRAMEDROP = 8;
 const int CONFIG_GFX_RENDERER = 9;
 const int CONFIG_GFX_SMOOTHING = 10;
 const int CONFIG_GFX_SCALING = 11;
-const int CONFIG_GFX_SS = 12;
+const int CONFIG_GFX_SS = 12; // unused, maybe temporarily
 const int CONFIG_ROTATION = 13;
 const int CONFIG_ENABLED = 14;
 const int CONFIG_DEBUG_FPS = 15;
@@ -121,8 +121,6 @@ int readIntConfigValue(int id)
         return setup.gfx_smoothing;
       case CONFIG_GFX_SCALING:
         return setup.gfx_scaling;
-      case CONFIG_GFX_SS:
-        return setup.gfx_super_sampling;
       case CONFIG_GFX_SMOOTH_SPRITES:
         return setup.gfx_smooth_sprites;
       case CONFIG_ROTATION:
@@ -187,9 +185,6 @@ void setIntConfigValue(int id, int value)
         break;
       case CONFIG_GFX_SCALING:
         setup.gfx_scaling = value;
-        break;
-      case CONFIG_GFX_SS:
-        setup.gfx_super_sampling = value;
         break;
       case CONFIG_GFX_SMOOTH_SPRITES:
         setup.gfx_smooth_sprites = value;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -252,7 +252,7 @@ public:
         bool at_native_res, GraphicResolution *want_fmt,
         uint32_t batch_skip_filter = 0u) override;
     bool DoesSupportVsyncToggle() override { return _capsVsync; }
-    void RenderSpritesAtScreenResolution(bool enabled, int /*supersampling*/) override { _renderSprAtScreenRes = enabled; };
+    void RenderSpritesAtScreenResolution(bool enabled) override { _renderSprAtScreenRes = enabled; };
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue,
         uint32_t batch_skip_filter = 0u) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue,

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -48,7 +48,6 @@ Locations of two latter files differ between running platforms:
     * linear - anti-aliased scaling; not usable with software renderer.
   * refresh = \[integer\] - refresh rate for the display mode.
   * render_at_screenres = \[0; 1\] - whether the sprites are transformed and rendered in native game's or current display resolution;
-  * supersampling = \[integer\] - supersampling multiplier, default is 1, used with render_at_screenres = 0 (currently supported only by OpenGL renderer);
   * vsync = \[0; 1\] - enable or disable vertical sync.
   * rotation = \[string | integer\] - screen rotation. Possible values are:
     * unlocked (0) - device can be freely rotated if possible.

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -44,8 +44,6 @@ clear_cache_on_room_change = 0  ; For low-end devices, clear the cache when chan
 [sound]
 enabled = 1           ; Enable sound, default 0,
 cache_size = 64       ; Sound cache size in bytes, default 32 * 1024
-[video]
-framedrop = 0         ; Video framedrop, default 0
 [graphics]
 renderer = 1          ; Renderer type (0 = Software, 1 = Render to screen, 2 = Render to texture), default 0
 smoothing = 0         ; Scale smoothing (0 = nearest-neighbor, linear) enabled, default 0,

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -50,7 +50,6 @@ framedrop = 0         ; Video framedrop, default 0
 renderer = 1          ; Renderer type (0 = Software, 1 = Render to screen, 2 = Render to texture), default 0
 smoothing = 0         ; Scale smoothing (0 = nearest-neighbor, linear) enabled, default 0,
 scaling = 1           ; Scaling style (0 = none, 1 = stretch and preserve aspect ratio, 2 stretch to whole screen), default 0
-super_sampling = 0    ; Super sampling (only if renderer = 1 or 2) (0 = x1, 1 = x2), default 0,
 smooth_sprites = 0    ; Sprite anti-aliasing, default 0
 [debug]
 show_fps = 0          ; Show FPS overlay while running the game, default 0

--- a/iOS/misc/ios.cfg
+++ b/iOS/misc/ios.cfg
@@ -17,7 +17,6 @@ framedrop = 0
 renderer = 0
 smoothing = 1
 scaling = 1
-super_sampling = 0
 smooth_sprites = 0
 [debug]
 show_fps = 0

--- a/iOS/misc/ios.cfg
+++ b/iOS/misc/ios.cfg
@@ -11,8 +11,6 @@ clear_cache_on_room_change = 0
 [sound]
 enabled = 1
 cache_size = 64
-[video]
-framedrop = 0
 [graphics]
 renderer = 0
 smoothing = 1


### PR DESCRIPTION
This "supersampling" setting comes from the original mobile port of AGS, but it's not clear whether it was useful. My understanding is that it increases resolution in which game sprites are drawn to a fixed multiplier of 2, but there's already is a "Render in screen resolution" setting that does the similar thing.

More importantly, there are issues with this:
1. It was never implemented in another hardware accelerated driver (Direct3D), being exclusive to OpenGL.
2. It was never added to standard setup, so not very visible.
3. It's not clear whether it was working properly all this time. There have been multiple changes to graphic renderers, and some of them may assume that rendering at "native resolution" is done at exactly, well, native resolution.


UPDATE:
Also removed unused "video" "framedrop" setting.