### PR TITLE
Script API: implement System.GetEngineInteger() and GetEngineString()

### DIFF
--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -276,6 +276,7 @@ const char *GetScriptAPIName(ScriptAPIVersion v)
     case kScriptAPI_v360: return "v3.6.0-alpha";
     case kScriptAPI_v36026: return "v3.6.0-final";
     case kScriptAPI_v361: return "v3.6.1";
+    case kScriptAPI_v362: return "v3.6.2";
     default: return "unknown";
     }
 }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -195,7 +195,8 @@ enum ScriptAPIVersion
     kScriptAPI_v360 = 3060000,
     kScriptAPI_v36026 = 3060026,
     kScriptAPI_v361 = 3060100,
-    kScriptAPI_Current = kScriptAPI_v361
+    kScriptAPI_v362 = 3060200,
+    kScriptAPI_Current = kScriptAPI_v362
 };
 
 const char *GetScriptAPIName(ScriptAPIVersion v);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2283,6 +2283,34 @@ builtin managed struct AudioClip {
 #endif
 };
 
+
+#ifdef SCRIPT_API_v362
+// Engine value constant name pattern:
+// ENGINE_VALUE_<I,II,S,SI>_NAME, where
+//   I - integer, II - indexed integer, S - string, SI - indexed string.
+// When adding indexed values - make sure to also add a value that tells their count.
+
+enum EngineValueID {
+  ENGINE_VALUE_UNDEFINED = 0,            // formality...
+  ENGINE_VALUE_SI_VALUENAME,             // get engine value's own name, by its index
+  ENGINE_VALUE_S_ENGINE_NAME,
+  ENGINE_VALUE_S_ENGINE_VERSION,         // N.N.N.N (with an optional custom tag)
+  ENGINE_VALUE_S_ENGINE_VERSION_FULL,    // full, with bitness, endianess and any tag list
+  ENGINE_VALUE_S_DISPLAY_MODE_STR,
+  ENGINE_VALUE_S_GFXRENDERER,
+  ENGINE_VALUE_S_GFXFILTER,
+  ENGINE_VALUE_I_SPRCACHE_MAXNORMAL,
+  ENGINE_VALUE_I_SPRCACHE_NORMAL,
+  ENGINE_VALUE_I_SPRCACHE_LOCKED,
+  ENGINE_VALUE_I_SPRCACHE_EXTERNAL,
+  ENGINE_VALUE_I_TEXCACHE_MAXNORMAL,
+  ENGINE_VALUE_I_TEXCACHE_NORMAL,
+  ENGINE_VALUE_I_FPS_MAX,
+  ENGINE_VALUE_I_FPS,
+  ENGINE_VALUE_LAST                      // in case user wants to iterate them
+};
+#endif
+
 builtin struct System {
 #ifdef SCRIPT_COMPAT_v350
   readonly int  screen_width,screen_height;
@@ -2354,6 +2382,12 @@ builtin struct System {
 #ifdef SCRIPT_API_v360
   /// Prints message
   import static void Log(LogLevel level, const string format, ...);    // $AUTOCOMPLETESTATICONLY$
+#endif
+#ifdef SCRIPT_API_v362
+  /// Gets a runtime engine value represented as integer by the given identifier; is meant for diagnostic purposes only
+  import static int GetEngineInteger(EngineValueID value, int index = 0); // $AUTOCOMPLETESTATICONLY$
+  /// Gets a runtime engine string by the given identifier; is meant for diagnostic purposes only
+  import static String GetEngineString(EngineValueID value, int index = 0); // $AUTOCOMPLETESTATICONLY$
 #endif
 };
 

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -37,6 +37,8 @@ namespace AGS.Types
         v36026 = 3060026,
         [Description("3.6.1")]
         v361 = 3060100,
+        [Description("3.6.2")]
+        v362 = 3060200,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -15,19 +15,23 @@
 #include "ac/common.h"
 #include "ac/draw.h"
 #include "ac/dynobj/cc_audiochannel.h"
+#include "ac/game.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/global_debug.h"
 #include "ac/global_translation.h"
 #include "ac/mouse.h"
+#include "ac/spritecache.h"
 #include "ac/string.h"
 #include "ac/system.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "debug/debug_log.h"
 #include "debug/out.h"
 #include "gfx/graphicsdriver.h"
+#include "gfx/gfxfilter.h"
 #include "main/config.h"
+#include "main/game_run.h"
 #include "main/graphics_mode.h"
 #include "main/engine.h"
 #include "main/main.h"
@@ -216,6 +220,122 @@ void System_SetRenderAtScreenResolution(int enable)
     usetup.RenderAtScreenRes = enable != 0;
 }
 
+int System_GetEngineInteger(int value_id, int index)
+{
+    int value = 0;
+    if (!GetEngineInteger(value, static_cast<EngineValueID>(value_id), index))
+        debug_script_warn("System.GetEngineInteger: undefined engine value %d (#%d), or not an integer value", value_id, index);
+    return value;
+}
+
+const char* System_GetEngineString(int value_id, int index)
+{
+    String value;
+    if (!GetEngineString(value, static_cast<EngineValueID>(value_id), index))
+        debug_script_warn("System.GetEngineString: undefined engine value %d (#%d)", value_id, index);
+    return CreateNewScriptString(value.GetCStr());
+}
+
+bool GetEngineInteger(int &value, EngineValueID value_id, int index)
+{
+    switch (value_id)
+    {
+    case ENGINE_VALUE_I_SPRCACHE_MAXNORMAL:
+        value = static_cast<int>(spriteset.GetMaxCacheSize() / 1024u); return true;
+    case ENGINE_VALUE_I_SPRCACHE_NORMAL:
+        value = static_cast<int>(spriteset.GetCacheSize() / 1024u); return true;
+    case ENGINE_VALUE_I_SPRCACHE_LOCKED:
+        value = static_cast<int>(spriteset.GetLockedSize() / 1024u); return true;
+    case ENGINE_VALUE_I_SPRCACHE_EXTERNAL:
+        value = static_cast<int>(spriteset.GetExternalSize() / 1024u); return true;
+    case ENGINE_VALUE_I_TEXCACHE_MAXNORMAL: /* fall-through */
+    case ENGINE_VALUE_I_TEXCACHE_NORMAL:
+    {
+        size_t max_txcached, total_txcached, total_txlocked, total_txext;
+        texturecache_get_state(max_txcached, total_txcached, total_txlocked, total_txext);
+        switch (value_id)
+        {
+        case ENGINE_VALUE_I_TEXCACHE_MAXNORMAL: value = static_cast<int>(max_txcached / 1024u); return true;
+        case ENGINE_VALUE_I_TEXCACHE_NORMAL: value = static_cast<int>(total_txcached / 1024u); return true;
+        default: return false; // should not happen...
+        }
+    }
+    case ENGINE_VALUE_I_FPS_MAX:
+        value = isTimerFpsMaxed() ? -1 : frames_per_second; return true;
+    case ENGINE_VALUE_I_FPS:
+    {
+        float fps = get_real_fps();
+        value = std::isnan(fps) ? -1 : static_cast<int>(std::round(fps));
+        return true;
+    }
+    default: return false;
+    }
+}
+
+bool GetEngineString(AGS::Common::String &value, EngineValueID value_id, int index)
+{
+    switch (value_id)
+    {
+    case ENGINE_VALUE_SI_VALUENAME: value = GetEngineValueName(static_cast<EngineValueID>(index)); return true;
+    case ENGINE_VALUE_S_ENGINE_NAME: value = get_engine_name(); return true;
+    case ENGINE_VALUE_S_ENGINE_VERSION: value = EngineVersion.LongString; return true;
+    case ENGINE_VALUE_S_ENGINE_VERSION_FULL: value = get_engine_version_and_build(); return true;
+    case ENGINE_VALUE_S_DISPLAY_MODE_STR:
+        value = "";
+        if (gfxDriver)
+        {
+            DisplayMode mode = gfxDriver->GetDisplayMode();
+            value = String::FromFormat("%d x %d %d-bit %s", mode.Width, mode.Height, mode.ColorDepth,
+                (mode.IsWindowed() ? " W" : (mode.IsRealFullscreen() ? " F" : " FD")));
+        }
+        return true;
+    case ENGINE_VALUE_S_GFXRENDERER: value = (gfxDriver ? gfxDriver->GetDriverName() : ""); return true;
+    case ENGINE_VALUE_S_GFXFILTER:
+        value = "";
+        if (gfxDriver)
+        {
+            auto filter = gfxDriver->GetGraphicsFilter();
+            if (filter)
+                value = filter->GetInfo().Name;
+        }
+        return true;
+    default:
+        // Attempt to retrieve an integer value and print that into string
+        {
+            int ival = 0;
+            if (GetEngineInteger(ival, value_id, index))
+            {
+                value = String::FromFormat("%d", ival);
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+String GetEngineValueName(EngineValueID value_id)
+{
+    switch (value_id)
+    {
+    case ENGINE_VALUE_SI_VALUENAME: return "Engine Value Name";
+    case ENGINE_VALUE_S_ENGINE_NAME: return "Engine Name";
+    case ENGINE_VALUE_S_ENGINE_VERSION: return "Engine Version String";
+    case ENGINE_VALUE_S_ENGINE_VERSION_FULL: return "Engine Version String (Full)";
+    case ENGINE_VALUE_S_DISPLAY_MODE_STR: return "Display Mode String";
+    case ENGINE_VALUE_S_GFXRENDERER: return "Graphics Renderer Name";
+    case ENGINE_VALUE_S_GFXFILTER: return "Graphics Filter Name";
+    case ENGINE_VALUE_I_SPRCACHE_MAXNORMAL: return "Sprite cache: normal capacity (KB)";
+    case ENGINE_VALUE_I_SPRCACHE_NORMAL: return "Sprite cache: normal size (KB)";
+    case ENGINE_VALUE_I_SPRCACHE_LOCKED: return "Sprite cache: locked size (KB)";
+    case ENGINE_VALUE_I_SPRCACHE_EXTERNAL: return "Sprite cache: ext sprites size (KB)";
+    case ENGINE_VALUE_I_TEXCACHE_MAXNORMAL: return "Texture cache: normal capacity (KB)";
+    case ENGINE_VALUE_I_TEXCACHE_NORMAL: return "Texture cache: normal size (KB)";
+    case ENGINE_VALUE_I_FPS_MAX: return "FPS cap";
+    case ENGINE_VALUE_I_FPS: return "FPS real";
+    default: return "";
+    }
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -390,6 +510,16 @@ RuntimeScriptValue Sc_System_Log(const RuntimeScriptValue *params, int32_t param
     return RuntimeScriptValue((int32_t)0);
 }
 
+RuntimeScriptValue Sc_System_GetEngineInteger(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT2(System_GetEngineInteger);
+}
+
+RuntimeScriptValue Sc_System_GetEngineString(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT2(const char, myScriptStringImpl, System_GetEngineString);
+}
+
 //=============================================================================
 //
 // Exclusive variadic API implementation for Plugins
@@ -436,6 +566,8 @@ void RegisterSystemAPI()
         
         { "System::SaveConfigToFile",         Sc_System_SaveConfigToFile, save_config_file },
         { "System::Log^102",                  Sc_System_Log, ScPl_System_Log },
+        { "System::GetEngineInteger^2",       API_FN_PAIR(System_GetEngineInteger) },
+        { "System::GetEngineString^2",        API_FN_PAIR(System_GetEngineString) },
     };
 
     ccAddExternalFunctions(system_api);

--- a/Engine/ac/system.h
+++ b/Engine/ac/system.h
@@ -44,5 +44,37 @@ int     System_GetVolume();
 void    System_SetVolume(int newvol);
 const char *System_GetRuntimeInfo();
 
+// Engine value constants match the declarations in script API.
+// Constant name pattern:
+// ENGINE_VALUE_<I,II,S,SI>_NAME, where
+//   I - integer, II - indexed integer, S - string, SI - indexed string.
+// When adding indexed values - make sure to also add a value that tells their count.
+enum EngineValueID
+{
+    ENGINE_VALUE_UNDEFINED = 0,            // formality...
+    ENGINE_VALUE_SI_VALUENAME,
+    ENGINE_VALUE_S_ENGINE_NAME,
+    ENGINE_VALUE_S_ENGINE_VERSION,         // N.N.N.N (with an optional custom tag)
+    ENGINE_VALUE_S_ENGINE_VERSION_FULL,    // full, with bitness, endianess and any tag list
+    ENGINE_VALUE_S_DISPLAY_MODE_STR,
+    ENGINE_VALUE_S_GFXRENDERER,
+    ENGINE_VALUE_S_GFXFILTER,
+    ENGINE_VALUE_I_SPRCACHE_MAXNORMAL,
+    ENGINE_VALUE_I_SPRCACHE_NORMAL,
+    ENGINE_VALUE_I_SPRCACHE_LOCKED,
+    ENGINE_VALUE_I_SPRCACHE_EXTERNAL,
+    ENGINE_VALUE_I_TEXCACHE_MAXNORMAL,
+    ENGINE_VALUE_I_TEXCACHE_NORMAL,
+    ENGINE_VALUE_I_FPS_MAX,
+    ENGINE_VALUE_I_FPS,
+    ENGINE_VALUE_LAST                      // in case user wants to iterate them
+};
+
+// Returns a runtime engine integer parameter, identified by a constant, and an optional index
+bool GetEngineInteger(int &value, EngineValueID value_id, int index = 0);
+// Returns a runtime engine string parameter, identified by a constant, and an optional index
+bool GetEngineString(AGS::Common::String &value, EngineValueID value_id, int index = 0);
+// Returns a engine value's description
+AGS::Common::String GetEngineValueName(EngineValueID value_id);
 
 #endif // __AGS_EE_AC_SYSTEMAUDIO_H


### PR DESCRIPTION
This implements two script functions: System.GetEngineInteger() and System.GetEngineString(), which return some runtime engine parameter by its ID (and an optional index).

The idea of this is to be able to get a number of predefined types of parameters from the engine in script, meant mainly for diagnostic purposes (logging, debugging, performance testing, etc). Because this purpose is not related to a game's logic, I believe that it does not make sense to litter script API with properties, but instead have just a couple of functions that return a value by id.

This is sort of inspired by similar cases in some popular APIs, such as OpenGL, OpenAL, and some others.
The reasons why I did not want to use strings as IDs is that the list of value IDs for those functions will likely be persistent, and also that strings won't autocomplete in script editor. If there will be a need to support some non-standard values, we could add a new function that would accept a String ID instead.

The functions are declared as members of `System` struct as:
```
/// Gets a runtime engine value represented as integer by the given identifier; is meant for diagnostic purposes only
import static int GetEngineInteger(EngineValueID value, int index = 0);
/// Gets a runtime engine string by the given identifier; is meant for diagnostic purposes only
import static String GetEngineString(EngineValueID value, int index = 0);
```

Where first function returns only parameters that are integers by nature, and the second returns those that are strings and also can return integer parameters formatted in a string. The optional "index" argument is meant for values that are arrays.

Currently supported following value IDs:
```
enum EngineValueID {
  ENGINE_VALUE_UNDEFINED = 0,            // formality...
  ENGINE_VALUE_SI_VALUENAME,             // get engine value's own name, by its index
  ENGINE_VALUE_S_ENGINE_NAME,
  ENGINE_VALUE_S_ENGINE_VERSION,         // N.N.N.N (with an optional custom tag)
  ENGINE_VALUE_S_ENGINE_VERSION_FULL,    // full, with bitness, endianess and any tag list
  ENGINE_VALUE_S_DISPLAY_MODE_STR,
  ENGINE_VALUE_S_GFXRENDERER,
  ENGINE_VALUE_S_GFXFILTER,
  ENGINE_VALUE_I_SPRCACHE_MAXNORMAL,
  ENGINE_VALUE_I_SPRCACHE_NORMAL,
  ENGINE_VALUE_I_SPRCACHE_LOCKED,
  ENGINE_VALUE_I_SPRCACHE_EXTERNAL,
  ENGINE_VALUE_I_TEXCACHE_MAXNORMAL,
  ENGINE_VALUE_I_TEXCACHE_NORMAL,
  ENGINE_VALUE_I_FPS_MAX,
  ENGINE_VALUE_I_FPS,
  ENGINE_VALUE_LAST                      // in case user wants to iterate them
};
```

This enumeration may be expanded easily in the future.
Note that the constant name contains a hint of how this value should be retrieved: I - integer, II - indexed integer, S - string, SI - indexed string.

Quick example of use:
```
// Print all supported engine values as strings
for (int i = ENGINE_VALUE_UNDEFINED + 1; i < ENGINE_VALUE_LAST; i++)
{
    Display("(%d) %s =\n%s", i, System.GetEngineString(ENGINE_VALUE_SI_VALUENAME, i), System.GetEngineString(i));
}
```

A more practical example:
```
lblSpriteCache.Text = String.Format("%d / %d (KB)",
    System.GetEngineInteger(ENGINE_VALUE_I_SPRCACHE_NORMAL),
    System.GetEngineInteger(ENGINE_VALUE_I_SPRCACHE_MAXNORMAL));

lblFPS.Text = String.Format("FPS: %d / %d",
    System.GetEngineInteger(ENGINE_VALUE_I_FPS),
    System.GetEngineInteger(ENGINE_VALUE_I_FPS_MAX));
```