### PR TITLE
Editor: add room description in tab name

### DIFF
--- a/Editor/AGS.Editor/Components/BaseComponentWithScripts.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithScripts.cs
@@ -55,7 +55,7 @@ namespace AGS.Editor.Components
 
         protected void UpdateScriptWindowTitle(ScriptEditor editor)
         {
-            string newTitle = editor.Script.FileName + (editor.IsModified ? " *" : "");
+            string newTitle = editor.GetScriptTabName();
             ContentDocument document = GetDocument(editor);            
             if (document != null && document.Name != newTitle)
             {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -695,7 +695,7 @@ namespace AGS.Editor.Components
                 scriptEditor.Room = _loadedRoom;
             }
             _roomScriptEditors[selectedRoom.Number] = new ContentDocument(scriptEditor,
-                selectedRoom.Script.FileName, this, SCRIPT_ICON);
+                scriptEditor.GetScriptTabName(), this, SCRIPT_ICON);
             _roomScriptEditors[selectedRoom.Number].ToolbarCommands = scriptEditor.ToolbarIcons;
             _roomScriptEditors[selectedRoom.Number].MainMenu = scriptEditor.ExtraMenu; 
         }
@@ -1101,6 +1101,12 @@ namespace AGS.Editor.Components
                 room.Description = _loadedRoom.Description;
                 RePopulateTreeView(GetItemNodeID(room));
                 RoomListTypeConverter.RefreshRoomList();
+                ContentDocument doc;
+                if (_roomScriptEditors.TryGetValue(_loadedRoom.Number, out doc) && doc != null)
+                {
+                    ScriptEditor scriptEditor = ((ScriptEditor)doc.Control);
+                    UpdateScriptWindowTitle(scriptEditor);
+                }
             }
 
 			if ((propertyName == UnloadedRoom.PROPERTY_NAME_NUMBER) && (_loadedRoom != null))

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1039,9 +1039,19 @@ namespace AGS.Editor.Components
 			}
         }
 
+        private string GetRoomSettingsTabName()
+        {
+            if(!string.IsNullOrEmpty(_loadedRoom.Description))
+            {
+                return "Room " + _loadedRoom.Number.ToString() + (_loadedRoom.Modified ? " *" : "") + ": " + _loadedRoom.Description;
+            }
+
+            return "Room " + _loadedRoom.Number + (_loadedRoom.Modified ? " *" : "");
+        }
+
         private void CreateRoomSettings(DockData previousDockData)
         {
-            string paneTitle = "Room " + _loadedRoom.Number + (_loadedRoom.Modified ? " *" : "");
+            string paneTitle = GetRoomSettingsTabName();
 
             RoomSettingsEditor editor = new RoomSettingsEditor(_loadedRoom);
             _roomSettings = new ContentDocument(editor,
@@ -1079,7 +1089,7 @@ namespace AGS.Editor.Components
                 // Prompt it to check out if necessary
                 _agsEditor.AttemptToGetWriteAccess(_loadedRoom.FileName);
             }
-            _roomSettings.Name = "Room " + _loadedRoom.Number + (isModified ? " *" : "");
+            _roomSettings.Name = GetRoomSettingsTabName();
             _guiController.DocumentTitlesChanged();
         }
 

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -505,6 +505,24 @@ namespace AGS.Editor.Preferences
         }
 
         [Browsable(true)]
+        [DisplayName("Show icons in panel tabs")]
+        [Description("Wheter icons from the project explorer also appears in tabs.")]
+        [Category("Editor Appearance")]
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("False")]
+        public bool ShowIconInTab
+        {
+            get
+            {
+                return (bool)(this["ShowIconInTab"]);
+            }
+            set
+            {
+                this["ShowIconInTab"] = value;
+            }
+        }
+
+        [Browsable(true)]
         [DisplayName("Default image editor")]
         [Description("When you double-click a sprite, what program do you want to use to edit it? This program must support PNG and BMP files.")]
         [Category("Sprite Editor")]

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -488,7 +488,7 @@ namespace AGS.Editor.Preferences
 
         [Browsable(true)]
         [DisplayName("Show view preview by default in view editors")]
-        [Description("Wheter view preview is always showing when a view editor is loaded.")]
+        [Description("Whether view preview is always showing when a view editor is loaded.")]
         [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]
@@ -506,7 +506,7 @@ namespace AGS.Editor.Preferences
 
         [Browsable(true)]
         [DisplayName("Show icons in panel tabs")]
-        [Description("Wheter icons from the project explorer also appears in tabs.")]
+        [Description("Whether icons from the project explorer also appear in tabs.")]
         [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1630,6 +1630,11 @@ namespace AGS.Editor
         {
             RePopulateTreeView(component, null);
         }
+        public bool ShowTabIcons
+        {
+            get { return _mainForm.ShowTabIcons; }
+            set { _mainForm.ShowTabIcons = value; }
+        }
 
 
         void IGUIController.SetStatusBarText(string text)

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -158,6 +158,7 @@ namespace AGS.Editor
 
             Factory.AGSEditor.Settings.Apply(_settings);
             UpdateFontSettings();
+            Factory.GUIController.ShowTabIcons = Factory.AGSEditor.Settings.ShowIconInTab;
         }
 
         private void btnApply_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -414,6 +414,7 @@ namespace AGS.Editor
         {
             this.tabbedDocumentContainer1.Init();
 
+            ShowTabIcons = Factory.AGSEditor.Settings.ShowIconInTab;
             Factory.GUIController.ShowWelcomeScreen();
         }
 
@@ -502,6 +503,12 @@ namespace AGS.Editor
 			// you click in the tree. It's an unpopular feature!
             //SetPropertyObjectList(null);
             //SetPropertyObject(null);
+        }
+
+        public bool ShowTabIcons
+        {
+            get { return mainContainer.ShowDocumentIcon; }
+            set { mainContainer.ShowDocumentIcon = value; }
         }
 
         private void LoadColorTheme(ColorTheme t)

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -49,11 +49,24 @@ namespace AGS.Editor
             _agsEditor = agsEditor;
             _showMatchingScript = showMatchingScript;
             _room = null;
-            _roomNumber = 0;
+            _roomNumber = -1;
             Init(scriptToEdit);
 
             this.Load += new EventHandler(ScriptEditor_Load);
             this.Resize += new EventHandler(ScriptEditor_Resize);
+        }
+
+        public string GetScriptTabName()
+        {
+            if (_roomNumber >= 0)
+            {
+                UnloadedRoom room = Factory.AGSEditor.CurrentGame.FindRoomByID(_roomNumber);
+                if(room != null && room.Number == _roomNumber && !string.IsNullOrEmpty(room.Description))
+                {
+                    return Script.FileName + (IsModified ? " *" : "") + ": " + room.Description;
+                }
+            }
+            return Script.FileName + (IsModified ? " *" : "");
         }
 
         private void Init(Script scriptToEdit)


### PR DESCRIPTION
fix #1066 

~~I didn't add the icon as requested, it would be good to disambiguate between room and script, but I didn't want to deal with ALL possible tabs.~~ Welp, turns out someone already did that in the past, added a way to turn it on.

It also looked interesting to have some method to deal with the tab name, that could perhaps be overriden in some way, but I didn't figure a common place to them.

![image](https://github.com/adventuregamestudio/ags/assets/2244442/81927fae-0763-442f-8447-e8075d01d303)

Please evaluate.