### PR TITLE
Editor: move folders between folders and move item downwards in Project Explorer

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -191,6 +191,9 @@
     <Compile Include="GUI\ImportTTFDialog.Designer.cs">
       <DependentUpon>ImportTTFDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\LineInBetween.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="GUI\LogPanel.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -256,7 +256,7 @@ namespace AGS.Editor.Components
                     (commandId == TOP_LEVEL_COMMAND_ID));
         }
 
-        private bool ProjectTreeItem_CanDropHere(ProjectTreeItem source, ProjectTreeItem target)
+        private bool ProjectTreeItem_CanDropHere(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone)
         {
             FolderType targetFolder;
             ItemType targetItem;
@@ -305,7 +305,7 @@ namespace AGS.Editor.Components
             }
         }
 
-        private void ProjectTreeItem_DropHere(ProjectTreeItem source, ProjectTreeItem target)
+        private void ProjectTreeItem_DropHere(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone)
         {            
             FolderType targetFolder;
             ItemType targetItem;
@@ -328,7 +328,16 @@ namespace AGS.Editor.Components
             {
                 if (targetFolder == null)
                 {
-                    DragItemToBeBeforeItem(sourceItem, targetItem);
+                    if (dropZone == TargetDropZone.Bottom || dropZone == TargetDropZone.MiddleBottom)
+                    {
+                        DragItemToBeAfterItem(sourceItem, targetItem);
+                        //Console.WriteLine("drop after");
+                    }
+                    else
+                    {
+                      //  Console.WriteLine("drop before");
+                        DragItemToBeBeforeItem(sourceItem, targetItem);
+                    }
                 }
                 else
                 {

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -354,7 +354,7 @@ namespace AGS.Editor.Components
             folder.ShouldSkipChangeNotifications = skipNotification;
         }
 
-        private void DragItemToBeBeforeItem(ItemType itemToMove, ItemType targetItem)
+        private void DragItemRelativeToItemImpl(ItemType itemToMove, ItemType targetItem, bool after)
         {
             FolderType sourceFolder = FindFolderThatContainsItem(this.GetRootFolder(), itemToMove);
             if (sourceFolder == null)
@@ -374,33 +374,20 @@ namespace AGS.Editor.Components
 
             PerformActionWithoutNotification(sourceFolder, folder => folder.Items.Remove(itemToMove));
 
-            targetIndex = targetFolder.Items.IndexOf(targetItem);
-            PerformActionWithoutNotification(targetFolder, folder => folder.Items.Insert(targetIndex, itemToMove));            
+            targetIndex = targetFolder.Items.IndexOf(targetItem);  // removal may have changed index
+            if(after) targetIndex++;                               // inserts before if 'after' is false
+
+            PerformActionWithoutNotification(targetFolder, folder => folder.Items.Insert(targetIndex, itemToMove));
+        }
+
+        private void DragItemToBeBeforeItem(ItemType itemToMove, ItemType targetItem)
+        {
+            DragItemRelativeToItemImpl(itemToMove, targetItem, false);
         }
 
         private void DragItemToBeAfterItem(ItemType itemToMove, ItemType targetItem)
         {
-            FolderType sourceFolder = FindFolderThatContainsItem(this.GetRootFolder(), itemToMove);
-            if (sourceFolder == null)
-            {
-                throw new AGSEditorException("Source item was not in a folder");
-            }
-            FolderType targetFolder = FindFolderThatContainsItem(this.GetRootFolder(), targetItem);
-            if (targetFolder == null)
-            {
-                throw new AGSEditorException("Target item was not in a folder");
-            }
-            int targetIndex = targetFolder.Items.IndexOf(targetItem);
-            if (targetIndex == -1)
-            {
-                throw new AGSEditorException("Target item was not found in folder");
-            }
-
-            PerformActionWithoutNotification(sourceFolder, folder => folder.Items.Remove(itemToMove));
-
-            targetIndex = targetFolder.Items.IndexOf(targetItem);
-            targetIndex++;
-            PerformActionWithoutNotification(targetFolder, folder => folder.Items.Insert(targetIndex, itemToMove));
+            DragItemRelativeToItemImpl(itemToMove, targetItem, true);
         }
 
         private void DragItemToFolder(ItemType itemToMove, FolderType targetFolder)

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -266,6 +266,12 @@ namespace AGS.Editor.Components
             ItemType sourceItem;
             GetDropItemOrFolder(source, out sourceFolder, out sourceItem);
 
+
+            if ((sourceFolder == null && sourceItem == null) || (targetItem == null && targetFolder == null))
+            {
+                return false;
+            }
+
             if (sourceFolder != null && targetFolder == null) return false;
             if (sourceFolder != null && !IsValidFolderMove(sourceFolder, targetFolder)) return false;
             if (sourceItem != null && targetItem != null && sourceItem.Equals(targetItem)) return false;
@@ -293,7 +299,10 @@ namespace AGS.Editor.Components
 
             if (!IsFolderNode(treeItem.ID))
             {
-                item = _items[treeItem.ID];
+                if (_items.ContainsKey(treeItem.ID))
+                {
+                    item = _items[treeItem.ID];
+                }
             }
             else if (treeItem.ID == TOP_LEVEL_COMMAND_ID)
             {
@@ -314,6 +323,11 @@ namespace AGS.Editor.Components
             FolderType sourceFolder;
             ItemType sourceItem;
             GetDropItemOrFolder(source, out sourceFolder, out sourceItem);
+
+            if((sourceFolder == null && sourceItem == null) || (targetItem == null && targetFolder == null))
+            {
+                return;
+            }
 
             if (sourceFolder != null)
             {
@@ -386,7 +400,7 @@ namespace AGS.Editor.Components
             {
                 throw new AGSEditorException("Folder being moved has no parent");
             }
-            if (parentOfSource == targetFolder)
+            if (folderToMove == targetFolder)
             {
                 throw new AGSEditorException("Source folder and target folder are the same");
             }

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -256,7 +256,7 @@ namespace AGS.Editor.Components
                     (commandId == TOP_LEVEL_COMMAND_ID));
         }
 
-        private bool ProjectTreeItem_CanDropHere(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone)
+        private bool ProjectTreeItem_CanDropHere(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone, out bool showLine)
         {
             FolderType targetFolder;
             ItemType targetItem;
@@ -265,17 +265,51 @@ namespace AGS.Editor.Components
             FolderType sourceFolder;
             ItemType sourceItem;
             GetDropItemOrFolder(source, out sourceFolder, out sourceItem);
-
+            showLine = !((dropZone == TargetDropZone.Top || dropZone == TargetDropZone.Bottom) && 
+                ((sourceFolder != null && targetItem != null) || (sourceItem != null && targetFolder != null)));
 
             if ((sourceFolder == null && sourceItem == null) || (targetItem == null && targetFolder == null))
             {
+                showLine = false;
                 return false;
             }
 
-            if (sourceFolder != null && targetFolder == null) return false;
-            if (sourceFolder != null && !IsValidFolderMove(sourceFolder, targetFolder)) return false;
-            if (sourceItem != null && targetItem != null && sourceItem.Equals(targetItem)) return false;
-                        
+            if (sourceFolder != null && targetFolder == null)
+            {
+                showLine = false;
+                return false;
+            }
+            if (sourceFolder != null && !IsValidFolderMove(sourceFolder, targetFolder))
+            {
+                showLine = false;
+                return false;
+            }
+            if (sourceItem != null && targetItem != null && sourceItem.Equals(targetItem))
+            {
+                showLine = false;
+                return false;
+            }
+            if(sourceFolder != null && targetFolder != null)
+            {
+                // the GetRootFolder will be the same, so if a target has null parent, it's probably from a different "type"
+                FolderType parentOfSource = FindParentFolder(GetRootFolder(), sourceFolder);
+                FolderType parentOfTarget = FindParentFolder(GetRootFolder(), targetFolder);
+                if(parentOfSource == null || parentOfTarget == null)
+                {
+                    showLine = false;
+                    return false;
+                }
+            }
+            if (sourceItem != null && targetFolder != null)
+            {
+                FolderType parentOfSource = FindFolderThatContainsItem(GetRootFolder(), sourceItem);
+                if(parentOfSource == targetFolder)
+                {
+                    showLine = false;
+                    return false;
+                }
+            }
+
             return true;
         }
         

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -373,7 +373,34 @@ namespace AGS.Editor.Components
             }
 
             PerformActionWithoutNotification(sourceFolder, folder => folder.Items.Remove(itemToMove));
+
+            targetIndex = targetFolder.Items.IndexOf(targetItem);
             PerformActionWithoutNotification(targetFolder, folder => folder.Items.Insert(targetIndex, itemToMove));            
+        }
+
+        private void DragItemToBeAfterItem(ItemType itemToMove, ItemType targetItem)
+        {
+            FolderType sourceFolder = FindFolderThatContainsItem(this.GetRootFolder(), itemToMove);
+            if (sourceFolder == null)
+            {
+                throw new AGSEditorException("Source item was not in a folder");
+            }
+            FolderType targetFolder = FindFolderThatContainsItem(this.GetRootFolder(), targetItem);
+            if (targetFolder == null)
+            {
+                throw new AGSEditorException("Target item was not in a folder");
+            }
+            int targetIndex = targetFolder.Items.IndexOf(targetItem);
+            if (targetIndex == -1)
+            {
+                throw new AGSEditorException("Target item was not found in folder");
+            }
+
+            PerformActionWithoutNotification(sourceFolder, folder => folder.Items.Remove(itemToMove));
+
+            targetIndex = targetFolder.Items.IndexOf(targetItem);
+            targetIndex++;
+            PerformActionWithoutNotification(targetFolder, folder => folder.Items.Insert(targetIndex, itemToMove));
         }
 
         private void DragItemToFolder(ItemType itemToMove, FolderType targetFolder)

--- a/Editor/AGS.Editor/GUI/LineInBetween.cs
+++ b/Editor/AGS.Editor/GUI/LineInBetween.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Drawing;
+using System.Collections;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    class LineInBetween : Control
+    {
+        public LineInBetween()
+        {            
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            // see https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest
+            const int WM_NCHITTEST = 0x0084;
+            const int HTTRANSPARENT = -1;
+
+            // Ensure clicks go through
+            if (m.Msg == WM_NCHITTEST)
+            {
+                m.Result = new IntPtr(HTTRANSPARENT);
+                return;
+            }
+
+            base.WndProc(ref m);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            SolidBrush fore_brush = new SolidBrush(ForeColor);
+            Pen fore_pen = new Pen(fore_brush);
+            fore_pen.Width = 3;
+
+            SolidBrush back_brush = new SolidBrush(BackColor);
+
+            Pen back_pen = new Pen(back_brush);
+            back_pen.Width = 5;
+
+            e.Graphics.DrawLine(back_pen, 0, Height / 2, Width, Height / 2);
+            e.Graphics.DrawLine(back_pen, 0, 0, 0, Height);
+            e.Graphics.DrawLine(back_pen, Width, 0, Width, Height);
+
+            e.Graphics.DrawLine(fore_pen, 0, Height / 2, Width, Height / 2);
+            e.Graphics.DrawLine(fore_pen, 0, 0, 0, Height);
+            e.Graphics.DrawLine(fore_pen, Width, 0, Width, Height);
+        }
+
+        public void ShowAndHideAt(int x, int y, int w, int h)
+        {
+            Top = y;
+            Left = x;
+            Size = new Size(w, h);
+
+            Show();
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/ProjectTree.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTree.cs
@@ -542,7 +542,6 @@ namespace AGS.Editor
             return dropZone;
         }
 
-
         private TargetDropZone GetDropZone(ProjectTreeItem target, Point locationInControl)
         {
             int node_h = target.TreeNode.Bounds.Height;
@@ -591,23 +590,24 @@ namespace AGS.Editor
 				{
 					ProjectTreeItem target = (ProjectTreeItem)dragTarget.Tag;
                     TargetDropZone dropZone = GetDropZone(target, locationInControl);
+                    bool showLine;
 
                     if (source.CanDropHere == null)
 					{
 						throw new AGSEditorException("Node has not populated CanDropHere handler for draggable node");
 					}
-                    if (source.CanDropHere(source, target, dropZone))
+                    if (source.CanDropHere(source, target, dropZone, out showLine))
                     {
                         int node_h = target.TreeNode.Bounds.Height;
                         int node_y = target.TreeNode.Bounds.Y;
                         int line_h = node_h / 5;
                         int width = GetLineInBetweenWidth(target);
 
-                        if (dropZone == TargetDropZone.Top)
+                        if (dropZone == TargetDropZone.Top && showLine)
                         {
                             ShowMiddleLineProjectTree(target.TreeNode.Bounds.X, node_y - line_h / 2, width, line_h);
                         }
-                        else if (dropZone == TargetDropZone.Bottom)
+                        else if (dropZone == TargetDropZone.Bottom && showLine)
                         {
                             ShowMiddleLineProjectTree(target.TreeNode.Bounds.X, node_y + node_h - line_h / 2, width, line_h);
                         }

--- a/Editor/AGS.Editor/GUI/ProjectTreeItem.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTreeItem.cs
@@ -9,7 +9,7 @@ namespace AGS.Editor
 {
     public class ProjectTreeItem : IProjectTreeItem
     {
-		public delegate bool CanDropHereDelegate(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone);
+		public delegate bool CanDropHereDelegate(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone, out bool showLine);
 		public delegate void DropHereDelegate(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone);
 
         public bool AllowLabelEdit = false;

--- a/Editor/AGS.Editor/GUI/ProjectTreeItem.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTreeItem.cs
@@ -9,8 +9,8 @@ namespace AGS.Editor
 {
     public class ProjectTreeItem : IProjectTreeItem
     {
-		public delegate bool CanDropHereDelegate(ProjectTreeItem source, ProjectTreeItem target);
-		public delegate void DropHereDelegate(ProjectTreeItem source, ProjectTreeItem target);
+		public delegate bool CanDropHereDelegate(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone);
+		public delegate void DropHereDelegate(ProjectTreeItem source, ProjectTreeItem target, TargetDropZone dropZone);
 
         public bool AllowLabelEdit = false;
         public bool AllowDoubleClickWhenExpanding = false;

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -144,6 +144,7 @@
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
     <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\InputMotionMode.cs" />
+    <Compile Include="Enums\TargetDropZone.cs" />
     <Compile Include="Enums\TouchToMouseEmulationType.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />

--- a/Editor/AGS.Types/Enums/TargetDropZone.cs
+++ b/Editor/AGS.Types/Enums/TargetDropZone.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public enum TargetDropZone
+    {
+        Top,
+        MiddleTop,
+        Middle,
+        MiddleBottom,
+        Bottom
+    }
+}


### PR DESCRIPTION
Edit: I copied the things I haven't checked yet to the bottom of this.

fix #1526 

Please test this, also any tips on the things that are problematic let me know.

**NOTE:** This won't fix moving _items_ BETWEEN _folders_. This would require much bigger changes. TBH, I don't even think this is a good idea.

I think the commits would be better if they all got squashed in a single commit, but leaving as is currently. In the PR the files changed tab can show the changes squashed.

https://github.com/adventuregamestudio/ags/assets/2244442/9ac7f6fe-ab3c-4ae8-a768-3dba963114c4

- My own feeling is that this makes dragging and dropping a bit finnicky, because the nodes are very small, the tree nodes could be made slightly bigger in height, I think it would work better for this interaction.
- There is some autoscroll that happens that I don't know what causes.
- [x] The length of the "insert line" depends on the length of a item name, if item's name is short then this line also becomes very short, which is not very convenient. I think it would be nice to have it either fixed length (maybe something like half of explorer's width) or at least have a minimal length.
- [x] As you stated, dragging an item between folders is not supported, but the "insert line" still shows up. This causes wrong expectations: user may think that they are going to place item between folders, but in reality it will get inside the folder.
- [x] It looks like the "insert line" can also place itself above or below the parent node if you hover a cursor over it while dragging.
- [x] Dragging any item at the parent node will make it move to the bottom of the list.
- [ ] If you select an item A by clicking, then hold and drag another item B, the selection returns to item A (but you still drag B successfully).