### PR TITLE
Editor: add feature add existing ash/asc files

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Components\ViewsComponent.cs" />
     <Compile Include="Entities\LogBufferEventArgs.cs" />
     <Compile Include="Entities\MultiSelectAction.cs" />
+    <Compile Include="Entities\ScriptModuleDef.cs" />
     <Compile Include="GUI\AssignToView.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -151,6 +151,8 @@
     <Compile Include="Components\SpriteManagerComponent.cs" />
     <Compile Include="Components\TextParserComponent.cs" />
     <Compile Include="Components\ViewsComponent.cs" />
+    <Compile Include="Entities\ExistingScriptHeaderToAdd.cs" />
+    <Compile Include="Entities\ExistingFileToAdd.cs" />
     <Compile Include="Entities\LogBufferEventArgs.cs" />
     <Compile Include="Entities\MultiSelectAction.cs" />
     <Compile Include="Entities\ScriptModuleDef.cs" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -405,6 +405,7 @@
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\MathExtra.cs" />
+    <Compile Include="Utils\ScriptFileUtilities.cs" />
     <Compile Include="Utils\ScriptGeneration.cs" />
     <Compile Include="Utils\StdConsoleWriter.cs" />
     <Compile Include="Utils\Validation.cs" />

--- a/Editor/AGS.Editor/Entities/ExistingFileToAdd.cs
+++ b/Editor/AGS.Editor/Entities/ExistingFileToAdd.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// A file that should be added to the game project, represented by its source (from anywhere) and destination in the game project.
+    /// </summary>
+    struct ExistingFileToAdd : IEquatable<ExistingFileToAdd>
+    {
+        public string SrcFileName;
+        public string DstFileName;
+
+        public bool Equals(ExistingFileToAdd other)
+        {
+            return this.SrcFileName == other.SrcFileName && this.DstFileName == other.DstFileName;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Entities/ExistingScriptHeaderToAdd.cs
+++ b/Editor/AGS.Editor/Entities/ExistingScriptHeaderToAdd.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// A script and header pair that exists as a file somewhere and should be added to the game project.
+    /// </summary>
+    struct ExistingScriptHeaderToAdd : IEquatable<ExistingScriptHeaderToAdd>
+    {
+        public ExistingFileToAdd Header;
+        public ExistingFileToAdd Script;
+
+        public bool Equals(ExistingScriptHeaderToAdd other)
+        {
+            return this.Header.Equals(other.Header) && this.Script.Equals(other.Script);
+        }
+    }
+}

--- a/Editor/AGS.Editor/Entities/ScriptModuleDef.cs
+++ b/Editor/AGS.Editor/Entities/ScriptModuleDef.cs
@@ -1,0 +1,13 @@
+﻿namespace AGS.Editor
+{
+    public struct ScriptModuleDef
+    {
+        public string Name;
+        public string Author;
+        public string Description;
+        public string Version;
+        public string Script;
+        public string Header;
+        public int UniqueKey;
+    }
+}

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -732,14 +732,19 @@ namespace AGS.Editor
 
         public string[] ShowOpenFileDialogMultipleFiles(string title, string fileFilter)
         {
-			EnsureLastImportDirectoryIsSet(true);
+            EnsureLastImportDirectoryIsSet(true);
 
+            return ShowOpenFileDialogMultipleFiles(title, fileFilter, _lastImportDirectory);
+        }
+
+        public string[] ShowOpenFileDialogMultipleFiles(string title, string fileFilter, string initialDirectory)
+        {
             OpenFileDialog dialog = new OpenFileDialog();
             dialog.Title = title;
             dialog.RestoreDirectory = true;
             dialog.CheckFileExists = true;
             dialog.CheckPathExists = true;
-            dialog.InitialDirectory = _lastImportDirectory;
+            dialog.InitialDirectory = initialDirectory;
             dialog.ValidateNames = true;
             dialog.Filter = fileFilter;
             dialog.Multiselect = true;

--- a/Editor/AGS.Editor/ImportExport.cs
+++ b/Editor/AGS.Editor/ImportExport.cs
@@ -311,6 +311,24 @@ namespace AGS.Editor
             return importErrors;
         }
 
+        public static List<Script> AddImportedScriptModule(ScriptModuleDef module)
+        {
+            string author = module.Author;
+            string description = module.Description;
+            string name = module.Name;
+            string version = module.Version;
+            string scriptText = module.Script;
+            string headerText = module.Header;
+            int uniqueKey = module.UniqueKey;
+
+            List<Script> scriptsImported = new List<Script>();
+            Script header = new Script(null, headerText, name, description, author, version, uniqueKey, true);
+            Script mainScript = new Script(null, scriptText, name, description, author, version, uniqueKey, false);
+            scriptsImported.Add(header);
+            scriptsImported.Add(mainScript);
+            return scriptsImported;
+        }
+
         public static List<Script> ImportScriptModule(string fileName, Encoding defEncoding)
         {
             BinaryReader reader = new BinaryReader(new FileStream(fileName, FileMode.Open, FileAccess.Read));
@@ -328,9 +346,9 @@ namespace AGS.Editor
 
             Encoding enc = defEncoding;
 
-            var author = ReadNullTerminatedStringAsBytes(reader);
-            var description = ReadNullTerminatedStringAsBytes(reader);
-            var name = ReadNullTerminatedStringAsBytes(reader);
+            var bAuthor = ReadNullTerminatedStringAsBytes(reader);
+            var bDescription = ReadNullTerminatedStringAsBytes(reader);
+            var bName = ReadNullTerminatedStringAsBytes(reader);
             var version = ReadNullTerminatedString(reader);
 
             int scriptLength = reader.ReadInt32();
@@ -361,15 +379,24 @@ namespace AGS.Editor
             }
             catch (ArgumentException) { }
 
-            List<Script> scriptsImported = new List<Script>();
-            Script header = new Script(null, enc.GetString(headerBytes), enc.GetString(name),
-                enc.GetString(description), enc.GetString(author), version, uniqueKey, true);
-            Script mainScript = new Script(null, enc.GetString(scriptBytes), enc.GetString(name),
-                enc.GetString(description), enc.GetString(author), version, uniqueKey, false);
-            scriptsImported.Add(header);
-            scriptsImported.Add(mainScript);
-            return scriptsImported;
+            string author = enc.GetString(bAuthor);
+            string description = enc.GetString(bDescription);
+            string name = enc.GetString(bName);
+            string script = enc.GetString(scriptBytes);
+            string header = enc.GetString(headerBytes);
+
+            ScriptModuleDef module;
+            module.Author = author;
+            module.Description = description;
+            module.Name = name;
+            module.Version = version;
+            module.Script = script;
+            module.Header = header;
+            module.UniqueKey = uniqueKey;
+
+            return AddImportedScriptModule(module);
         }
+
 
         public static void ExportScriptModule(Script header, Script script, string fileName, Encoding defEncoding)
         {

--- a/Editor/AGS.Editor/Utils/ScriptFileUtilities.cs
+++ b/Editor/AGS.Editor/Utils/ScriptFileUtilities.cs
@@ -1,0 +1,123 @@
+﻿using AGS.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AGS.Editor.Utils
+{
+    /// <summary>
+    /// These are stateless utility methods for handling script, used by ScriptComponent.
+    /// They are separated here for easy testing and possible reusability.
+    /// </summary>
+    internal class ScriptFileUtilities
+    {
+        /// <summary>
+        /// Filters file names to include only those with ".as{hc}" (header, script) extensions.
+        /// </summary>
+        /// <param name="fileNames">Array of file names to filter.</param>
+        /// <returns>A copy of the input without any non ags script extension files.</returns>
+        public static string[] FilterNonScriptFileNames(string[] fileNames, out string[] deleted)
+        {
+            string[] r = fileNames.Where(fileName => fileName.EndsWith(".asc", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".ash", StringComparison.OrdinalIgnoreCase)).ToArray();
+            deleted = fileNames.Except(r).ToArray();
+            return r;
+
+        }
+
+        /// <summary>
+        /// Filters file names to include only those that aren't named "roomX.asc", presumably room scripts.
+        /// </summary>
+        /// <param name="fileNames">Array of file names to filter.</param>
+        /// <returns>A copy of the input without any room script files.</returns>
+        public static string[] FilterOutRoomScriptFileNames(string[] fileNames, out string[] deleted)
+        {
+            string[] r = fileNames.Where(fileName => !(Regex.Match(fileName, @"(?:.*[/\\])?room(\d+)\.asc$").Success)).ToArray();
+            deleted = fileNames.Except(r).ToArray();
+            return r;
+        }
+
+        /// <summary>
+        /// Helper to check if a file exists in the provided collection of game scripts and headers.
+        /// </summary>
+        /// <param name="fileName">Filename to check.</param>
+        /// <param name="gameScripts">Collection of game scripts and headers to search in.</param>
+        /// <returns>True if the file exists in the game scripts or headers.</returns>
+        private static bool IsFileInGameScripts(string fileName, ScriptsAndHeaders gameScripts)
+        {
+            for (int i = 0; i < gameScripts.Count; i++)
+            {
+                ScriptAndHeader scriptAndHeader = gameScripts[i];
+                string gameScriptFileName = scriptAndHeader.Script.FileName;
+                string gameHeaderFileName = scriptAndHeader.Header.FileName;
+
+                if (Utilities.AnyPathsAreEqual(fileName, gameScriptFileName))
+                    return true;
+                if (Utilities.AnyPathsAreEqual(fileName, gameHeaderFileName))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Filters out files that are already present in the provided collection of game scripts and headers.
+        /// </summary>
+        /// <param name="fileNames">Array of file names to filter.</param>
+        /// <param name="gameScripts">Collection of game scripts and headers to check against.</param>
+        /// <returns>A copy of the input, without the files already in the provided collection of game scripts and headers.</returns>
+        public static string[] FilterAlreadyInGameScripts(string[] fileNames, ScriptsAndHeaders gameScripts, out string[] deleted)
+        {
+            string[] r = fileNames.Where(fileName => !IsFileInGameScripts(fileName, gameScripts)).ToArray();
+            deleted = fileNames.Except(r).ToArray();
+            return r;
+        }
+
+        /// <summary>
+        /// Pairs header files ("*.ash") with corresponding script files ("*.asc") from the provided array of file names, using the full path.
+        /// Unpaired files will be returning an empty string.
+        /// </summary>
+        /// <param name="fileNames">Array of file names containing both header and script files.</param>
+        /// <returns>A list of tuples where each tuple contains header and script file name, in this order, or an empty string if no corresponding header or script file is found.</returns>
+        public static List<Tuple<string, string>> PairHeadersAndScriptFiles(string[] fileNames)
+        {
+            Dictionary<string, string> ashFiles = fileNames.Where(f => f.EndsWith(".ash"))
+                                    .ToDictionary(f => f.Substring(0, f.Length - 4), f => f);
+
+            Dictionary<string, string> ascFiles = fileNames.Where(f => f.EndsWith(".asc"))
+                                    .ToDictionary(f => f.Substring(0, f.Length - 4), f => f);
+
+            List<Tuple<string, string>> pairs = ashFiles.Select(ash =>
+            {
+                string ascValue = ascFiles.ContainsKey(ash.Key) ? ascFiles[ash.Key] : "";
+
+                return new Tuple<string, string>(ash.Value, ascValue);
+            }).ToList();
+
+            foreach (var asc in ascFiles)
+            {
+                if (!ashFiles.ContainsKey(asc.Key))
+                {
+                    pairs.Add(new Tuple<string, string>("", asc.Value));
+                }
+            }
+
+            return pairs;
+        }
+
+        /// <summary>
+        /// Checks if a uniqueKey is already present in any of the script modules in the provided collection.
+        /// </summary>
+        /// <param name="uniqueKey">A script module uniqueKey, presumably a new one.</param>
+        /// <param name="gameScripts">Collection of game scripts and headers to search in.</param>
+        /// <returns>True if the script module uniqueKey doesn't exist in provided collection.</returns>
+        public static bool IsKeyUnique(int uniqueKey, ScriptsAndHeaders gameScripts)
+        {
+            for (int i = 0; i < gameScripts.Count; i++)
+            {
+                ScriptAndHeader scriptAndHeader = gameScripts[i];
+                if (scriptAndHeader.Script.UniqueKey == uniqueKey) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -187,6 +187,11 @@ namespace AGS.Editor
             return uri1.Equals(uri2);
         }
 
+        public static bool AnyPathsAreEqual(string path1, string path2)
+        {
+            return PathsAreEqual(ResolveSourcePath(path1), ResolveSourcePath(path2));
+        }
+
         /// <summary>
         /// Tells if the given path equals to or subdirectory of a basepath.
         /// </summary>

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -157,6 +157,16 @@ namespace AGS.Editor
             return Uri.UnescapeDataString(currentProjectUri.MakeRelativeUri(currentPathUri).OriginalString);
         }
 
+        public static string[] GetRelativeToProjectPath(string[] absolutePaths)
+        {
+            string[] normalizedPaths = new string[absolutePaths.Length];
+            for (int i = 0; i < absolutePaths.Length; i++)
+            {
+                normalizedPaths[i] = GetRelativeToProjectPath(absolutePaths[i]);
+            }
+            return normalizedPaths;
+        }
+
         public static string ResolveSourcePath(string sourcePath)
         {
             Uri baseUri = new Uri(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar);


### PR DESCRIPTION
fix #589

This took way more lines of code than I thought it would. I broke things down in multiple steps and when I went to implement there was a lot that I thought would be written that just wasn't.

<details><summary>Hidden completed checklist because it's not as relevant now!</summary>

- I think I can't figure the encoding from the file itself, so I am using the one set in the project.
- ~Are special characters in file names allowed? (Specifically basename)~ I think the filesystem already took care of this
- [x] Are special character in the script name allowed? ~~(Is there a function for this?)~~ There is a function but turns out they are already checked by the filesystem itself, so no need to call it again
- [x] ~~I still need to~~ test this a bit more for spaces in filenames. Apparently they don't matter
- [x] I think if a person is adding an existing script file that is in the game project directory  and it has a header there that pairs but they didn't select, it should magically figure it out and pick it up, otherwise their content may be deleted in the process (need to check)
- [x] Same as before but switch script for header and header for script.
- [x] forgot to refresh the project tree after adding scripts, doing that correctly now!

~~Leaving as a draft until I can test a bit more.~~ 

</details>

Tested and it appears to work alright!