### PR TITLE
Editor: fix script editor fold in comment in scintilla lexxer

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -324,6 +324,8 @@ namespace AGS.Editor
             // to make this work properly we need to supply keywords for preprocessor,
             // otherwise lexer will not know about external defines.
             scintillaControl1.SetProperty("lexer.cpp.track.preprocessor", "0");
+            // avoid confusing comment fold feature, see https://github.com/adventuregamestudio/ags/issues/2323
+            scintillaControl1.SetProperty("fold.cpp.comment.explicit", "0");
 
             Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             UpdateAllStyles();


### PR DESCRIPTION
fix #2323

The issue here is if foldExplicitStart is empty it is defined as `"//{"`  and foldExplicitEnd it is defined as `"//}"`.

This causes the confusing behavior that if foldCommentExplicit  is true, the scintilla cpp lexxer can fold in comments following the previously defined start and terminator string. We are setting it to false to disable this unexpected behavior.