### PR TITLE
Editor: fix welcome pane scaling under dpiaware

### DIFF
--- a/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
@@ -29,136 +29,203 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WelcomePane));
-            this.panel1 = new System.Windows.Forms.Panel();
+            this.panelTitle = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.label3 = new System.Windows.Forms.Label();
+            this.panelWelcomeToAgs = new System.Windows.Forms.Panel();
+            this.tableWelcomeToAgs = new System.Windows.Forms.TableLayoutPanel();
             this.lnkTutorial = new System.Windows.Forms.LinkLabel();
+            this.label3 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.pnlRight = new System.Windows.Forms.Panel();
+            this.tableRight = new System.Windows.Forms.TableLayoutPanel();
             this.lblUpgradingInfo3 = new System.Windows.Forms.Label();
-            this.lblUpgradingInfo = new System.Windows.Forms.Label();
-            this.lnkUpgrading = new System.Windows.Forms.LinkLabel();
             this.label5 = new System.Windows.Forms.Label();
+            this.lnkUpgrading = new System.Windows.Forms.LinkLabel();
+            this.lblUpgradingInfo = new System.Windows.Forms.Label();
             this.pnlTipOfTheDay = new System.Windows.Forms.Panel();
-            this.lnkTipText = new System.Windows.Forms.LinkLabel();
+            this.tableTipOfTheDay = new System.Windows.Forms.TableLayoutPanel();
             this.lnkNextTip = new System.Windows.Forms.LinkLabel();
+            this.lnkTipText = new System.Windows.Forms.LinkLabel();
             this.label6 = new System.Windows.Forms.Label();
-            this.panel1.SuspendLayout();
-            this.panel2.SuspendLayout();
+            this.flowLayoutPanelBase = new System.Windows.Forms.FlowLayoutPanel();
+            this.flowLayoutPanelLeft = new System.Windows.Forms.FlowLayoutPanel();
+            this.panelBaseAll = new System.Windows.Forms.Panel();
+            this.panelTitle.SuspendLayout();
+            this.panelWelcomeToAgs.SuspendLayout();
+            this.tableWelcomeToAgs.SuspendLayout();
             this.pnlRight.SuspendLayout();
+            this.tableRight.SuspendLayout();
             this.pnlTipOfTheDay.SuspendLayout();
+            this.tableTipOfTheDay.SuspendLayout();
+            this.flowLayoutPanelBase.SuspendLayout();
+            this.flowLayoutPanelLeft.SuspendLayout();
+            this.panelBaseAll.SuspendLayout();
             this.SuspendLayout();
             // 
-            // panel1
+            // panelTitle
             // 
-            this.panel1.BackColor = System.Drawing.Color.RoyalBlue;
-            this.panel1.Controls.Add(this.label1);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel1.ForeColor = System.Drawing.Color.White;
-            this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(697, 68);
-            this.panel1.TabIndex = 0;
+            this.panelTitle.AutoSize = true;
+            this.panelTitle.BackColor = System.Drawing.Color.RoyalBlue;
+            this.panelTitle.Controls.Add(this.label1);
+            this.panelTitle.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelTitle.ForeColor = System.Drawing.Color.White;
+            this.panelTitle.Location = new System.Drawing.Point(0, 0);
+            this.panelTitle.Name = "panelTitle";
+            this.panelTitle.Padding = new System.Windows.Forms.Padding(18, 8, 18, 8);
+            this.panelTitle.Size = new System.Drawing.Size(900, 69);
+            this.panelTitle.TabIndex = 0;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.Font = new System.Drawing.Font("Tahoma", 26F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(19, 10);
+            this.label1.Location = new System.Drawing.Point(18, 8);
+            this.label1.Margin = new System.Windows.Forms.Padding(15, 10, 15, 10);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(384, 42);
+            this.label1.Size = new System.Drawing.Size(485, 53);
             this.label1.TabIndex = 0;
             this.label1.Text = "Adventure Game Studio";
             // 
-            // panel2
+            // panelWelcomeToAgs
             // 
-            this.panel2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(201)))), ((int)(((byte)(231)))), ((int)(((byte)(252)))));
-            this.panel2.Controls.Add(this.label3);
-            this.panel2.Controls.Add(this.lnkTutorial);
-            this.panel2.Controls.Add(this.label2);
-            this.panel2.Location = new System.Drawing.Point(11, 79);
-            this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(207, 154);
-            this.panel2.TabIndex = 1;
+            this.panelWelcomeToAgs.AutoSize = true;
+            this.panelWelcomeToAgs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(201)))), ((int)(((byte)(231)))), ((int)(((byte)(252)))));
+            this.panelWelcomeToAgs.Controls.Add(this.tableWelcomeToAgs);
+            this.panelWelcomeToAgs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelWelcomeToAgs.Location = new System.Drawing.Point(10, 10);
+            this.panelWelcomeToAgs.Margin = new System.Windows.Forms.Padding(10);
+            this.panelWelcomeToAgs.MinimumSize = new System.Drawing.Size(240, 177);
+            this.panelWelcomeToAgs.Name = "panelWelcomeToAgs";
+            this.panelWelcomeToAgs.Size = new System.Drawing.Size(252, 177);
+            this.panelWelcomeToAgs.TabIndex = 1;
             // 
-            // label3
+            // tableWelcomeToAgs
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(9, 96);
-            this.label3.MaximumSize = new System.Drawing.Size(180, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(178, 42);
-            this.label3.TabIndex = 2;
-            this.label3.Text = "The tree in the top-right is the main way you\'ll be navigating around the editor." +
-                "";
+            this.tableWelcomeToAgs.AutoSize = true;
+            this.tableWelcomeToAgs.ColumnCount = 1;
+            this.tableWelcomeToAgs.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableWelcomeToAgs.Controls.Add(this.lnkTutorial, 0, 2);
+            this.tableWelcomeToAgs.Controls.Add(this.label3, 0, 1);
+            this.tableWelcomeToAgs.Controls.Add(this.label2, 0, 0);
+            this.tableWelcomeToAgs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableWelcomeToAgs.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.tableWelcomeToAgs.Location = new System.Drawing.Point(0, 0);
+            this.tableWelcomeToAgs.Name = "tableWelcomeToAgs";
+            this.tableWelcomeToAgs.Padding = new System.Windows.Forms.Padding(3);
+            this.tableWelcomeToAgs.RowCount = 4;
+            this.tableWelcomeToAgs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableWelcomeToAgs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableWelcomeToAgs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableWelcomeToAgs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableWelcomeToAgs.Size = new System.Drawing.Size(252, 177);
+            this.tableWelcomeToAgs.TabIndex = 0;
             // 
             // lnkTutorial
             // 
             this.lnkTutorial.AutoSize = true;
             this.lnkTutorial.LinkArea = new System.Windows.Forms.LinkArea(57, 8);
-            this.lnkTutorial.Location = new System.Drawing.Point(12, 39);
-            this.lnkTutorial.MaximumSize = new System.Drawing.Size(180, 0);
+            this.lnkTutorial.Location = new System.Drawing.Point(6, 87);
+            this.lnkTutorial.MaximumSize = new System.Drawing.Size(240, 0);
             this.lnkTutorial.Name = "lnkTutorial";
-            this.lnkTutorial.Size = new System.Drawing.Size(160, 48);
+            this.lnkTutorial.Padding = new System.Windows.Forms.Padding(3);
+            this.lnkTutorial.Size = new System.Drawing.Size(240, 66);
             this.lnkTutorial.TabIndex = 1;
             this.lnkTutorial.TabStop = true;
             this.lnkTutorial.Text = "If this is your first time with AGS, be sure to read the Tutorial to get you star" +
-                "ted.";
+    "ted.";
             this.lnkTutorial.UseCompatibleTextRendering = true;
             this.lnkTutorial.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkTutorial_LinkClicked);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(6, 27);
+            this.label3.MaximumSize = new System.Drawing.Size(240, 0);
+            this.label3.Name = "label3";
+            this.label3.Padding = new System.Windows.Forms.Padding(3);
+            this.label3.Size = new System.Drawing.Size(216, 60);
+            this.label3.TabIndex = 2;
+            this.label3.Text = "The tree in the top-right is the main way you\'ll be navigating around the editor." +
+    "";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(12, 10);
+            this.label2.Location = new System.Drawing.Point(6, 3);
+            this.label2.MaximumSize = new System.Drawing.Size(240, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(113, 14);
+            this.label2.Padding = new System.Windows.Forms.Padding(3);
+            this.label2.Size = new System.Drawing.Size(141, 24);
             this.label2.TabIndex = 0;
             this.label2.Text = "Welcome to AGS!";
             // 
             // pnlRight
             // 
+            this.pnlRight.AutoSize = true;
             this.pnlRight.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(201)))), ((int)(((byte)(231)))), ((int)(((byte)(252)))));
-            this.pnlRight.Controls.Add(this.lblUpgradingInfo3);
-            this.pnlRight.Controls.Add(this.lblUpgradingInfo);
-            this.pnlRight.Controls.Add(this.lnkUpgrading);
-            this.pnlRight.Controls.Add(this.label5);
-            this.pnlRight.Location = new System.Drawing.Point(236, 79);
-            this.pnlRight.Margin = new System.Windows.Forms.Padding(3, 30, 3, 3);
+            this.pnlRight.Controls.Add(this.tableRight);
+            this.pnlRight.Location = new System.Drawing.Point(266, 10);
+            this.pnlRight.Margin = new System.Windows.Forms.Padding(10);
+            this.pnlRight.MinimumSize = new System.Drawing.Size(443, 362);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(443, 236);
+            this.pnlRight.Size = new System.Drawing.Size(612, 362);
             this.pnlRight.TabIndex = 2;
+            // 
+            // tableRight
+            // 
+            this.tableRight.AutoSize = true;
+            this.tableRight.ColumnCount = 1;
+            this.tableRight.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableRight.Controls.Add(this.lblUpgradingInfo3, 0, 3);
+            this.tableRight.Controls.Add(this.label5, 0, 0);
+            this.tableRight.Controls.Add(this.lnkUpgrading, 0, 2);
+            this.tableRight.Controls.Add(this.lblUpgradingInfo, 0, 1);
+            this.tableRight.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableRight.Location = new System.Drawing.Point(0, 0);
+            this.tableRight.Name = "tableRight";
+            this.tableRight.Padding = new System.Windows.Forms.Padding(3);
+            this.tableRight.RowCount = 5;
+            this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableRight.Size = new System.Drawing.Size(612, 362);
+            this.tableRight.TabIndex = 6;
             // 
             // lblUpgradingInfo3
             // 
             this.lblUpgradingInfo3.AutoSize = true;
-            this.lblUpgradingInfo3.Location = new System.Drawing.Point(15, 150);
-            this.lblUpgradingInfo3.MaximumSize = new System.Drawing.Size(340, 0);
+            this.lblUpgradingInfo3.Location = new System.Drawing.Point(6, 117);
+            this.lblUpgradingInfo3.MaximumSize = new System.Drawing.Size(600, 0);
             this.lblUpgradingInfo3.Name = "lblUpgradingInfo3";
-            this.lblUpgradingInfo3.Size = new System.Drawing.Size(261, 140);
+            this.lblUpgradingInfo3.Padding = new System.Windows.Forms.Padding(3);
+            this.lblUpgradingInfo3.Size = new System.Drawing.Size(311, 186);
             this.lblUpgradingInfo3.TabIndex = 3;
             this.lblUpgradingInfo3.Text = resources.GetString("lblUpgradingInfo3.Text");
             // 
-            // lblUpgradingInfo
+            // label5
             // 
-            this.lblUpgradingInfo.AutoSize = true;
-            this.lblUpgradingInfo.Location = new System.Drawing.Point(12, 39);
-            this.lblUpgradingInfo.MaximumSize = new System.Drawing.Size(300, 0);
-            this.lblUpgradingInfo.Name = "lblUpgradingInfo";
-            this.lblUpgradingInfo.Size = new System.Drawing.Size(273, 14);
-            this.lblUpgradingInfo.TabIndex = 2;
-            this.lblUpgradingInfo.Text = "With AGS 3.6 you can build your game for Web!";
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(6, 3);
+            this.label5.Name = "label5";
+            this.label5.Padding = new System.Windows.Forms.Padding(3);
+            this.label5.Size = new System.Drawing.Size(191, 24);
+            this.label5.TabIndex = 0;
+            this.label5.Text = "What\'s new in AGS 3.6?";
             // 
             // lnkUpgrading
             // 
             this.lnkUpgrading.AutoSize = true;
             this.lnkUpgrading.LinkArea = new System.Windows.Forms.LinkArea(103, 22);
-            this.lnkUpgrading.Location = new System.Drawing.Point(15, 77);
-            this.lnkUpgrading.MaximumSize = new System.Drawing.Size(400, 0);
+            this.lnkUpgrading.Location = new System.Drawing.Point(6, 51);
+            this.lnkUpgrading.MaximumSize = new System.Drawing.Size(600, 0);
             this.lnkUpgrading.Name = "lnkUpgrading";
-            this.lnkUpgrading.Size = new System.Drawing.Size(400, 48);
+            this.lnkUpgrading.Padding = new System.Windows.Forms.Padding(3);
+            this.lnkUpgrading.Size = new System.Drawing.Size(600, 66);
             this.lnkUpgrading.TabIndex = 1;
             this.lnkUpgrading.TabStop = true;
             this.lnkUpgrading.Text = "If you\'ve come from an older version of AGS be sure to read \"Upgrading to ...\" ar" +
@@ -167,96 +234,171 @@ namespace AGS.Editor
             this.lnkUpgrading.UseCompatibleTextRendering = true;
             this.lnkUpgrading.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkUpgrading_LinkClicked);
             // 
-            // label5
+            // lblUpgradingInfo
             // 
-            this.label5.AutoSize = true;
-            this.label5.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(12, 10);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(154, 14);
-            this.label5.TabIndex = 0;
-            this.label5.Text = "What\'s new in AGS 3.6?";
+            this.lblUpgradingInfo.AutoSize = true;
+            this.lblUpgradingInfo.Location = new System.Drawing.Point(6, 27);
+            this.lblUpgradingInfo.MaximumSize = new System.Drawing.Size(600, 0);
+            this.lblUpgradingInfo.Name = "lblUpgradingInfo";
+            this.lblUpgradingInfo.Padding = new System.Windows.Forms.Padding(3);
+            this.lblUpgradingInfo.Size = new System.Drawing.Size(329, 24);
+            this.lblUpgradingInfo.TabIndex = 2;
+            this.lblUpgradingInfo.Text = "With AGS 3.6 you can build your game for Web!";
             // 
             // pnlTipOfTheDay
             // 
+            this.pnlTipOfTheDay.AutoSize = true;
             this.pnlTipOfTheDay.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(201)))), ((int)(((byte)(231)))), ((int)(((byte)(252)))));
-            this.pnlTipOfTheDay.Controls.Add(this.lnkTipText);
-            this.pnlTipOfTheDay.Controls.Add(this.lnkNextTip);
-            this.pnlTipOfTheDay.Controls.Add(this.label6);
-            this.pnlTipOfTheDay.Location = new System.Drawing.Point(11, 248);
+            this.pnlTipOfTheDay.Controls.Add(this.tableTipOfTheDay);
+            this.pnlTipOfTheDay.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlTipOfTheDay.Location = new System.Drawing.Point(10, 207);
+            this.pnlTipOfTheDay.Margin = new System.Windows.Forms.Padding(10);
+            this.pnlTipOfTheDay.MinimumSize = new System.Drawing.Size(240, 166);
             this.pnlTipOfTheDay.Name = "pnlTipOfTheDay";
-            this.pnlTipOfTheDay.Size = new System.Drawing.Size(207, 166);
+            this.pnlTipOfTheDay.Size = new System.Drawing.Size(252, 166);
             this.pnlTipOfTheDay.TabIndex = 3;
+            // 
+            // tableTipOfTheDay
+            // 
+            this.tableTipOfTheDay.AutoSize = true;
+            this.tableTipOfTheDay.ColumnCount = 1;
+            this.tableTipOfTheDay.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableTipOfTheDay.Controls.Add(this.lnkNextTip, 0, 3);
+            this.tableTipOfTheDay.Controls.Add(this.lnkTipText, 0, 1);
+            this.tableTipOfTheDay.Controls.Add(this.label6, 0, 0);
+            this.tableTipOfTheDay.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableTipOfTheDay.Location = new System.Drawing.Point(0, 0);
+            this.tableTipOfTheDay.Name = "tableTipOfTheDay";
+            this.tableTipOfTheDay.Padding = new System.Windows.Forms.Padding(3);
+            this.tableTipOfTheDay.RowCount = 4;
+            this.tableTipOfTheDay.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableTipOfTheDay.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableTipOfTheDay.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableTipOfTheDay.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableTipOfTheDay.Size = new System.Drawing.Size(252, 166);
+            this.tableTipOfTheDay.TabIndex = 0;
+            // 
+            // lnkNextTip
+            // 
+            this.lnkNextTip.AutoSize = true;
+            this.lnkNextTip.LinkArea = new System.Windows.Forms.LinkArea(0, 16);
+            this.lnkNextTip.Location = new System.Drawing.Point(6, 139);
+            this.lnkNextTip.MaximumSize = new System.Drawing.Size(240, 0);
+            this.lnkNextTip.Name = "lnkNextTip";
+            this.lnkNextTip.Padding = new System.Windows.Forms.Padding(3);
+            this.lnkNextTip.Size = new System.Drawing.Size(123, 24);
+            this.lnkNextTip.TabIndex = 5;
+            this.lnkNextTip.TabStop = true;
+            this.lnkNextTip.Text = "Show another tip";
+            this.lnkNextTip.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkNextTip_LinkClicked);
             // 
             // lnkTipText
             // 
             this.lnkTipText.AutoSize = true;
             this.lnkTipText.LinkArea = new System.Windows.Forms.LinkArea(0, 16);
-            this.lnkTipText.Location = new System.Drawing.Point(12, 33);
-            this.lnkTipText.MaximumSize = new System.Drawing.Size(180, 0);
+            this.lnkTipText.Location = new System.Drawing.Point(6, 27);
+            this.lnkTipText.MaximumSize = new System.Drawing.Size(240, 0);
             this.lnkTipText.Name = "lnkTipText";
-            this.lnkTipText.Size = new System.Drawing.Size(151, 34);
+            this.lnkTipText.Padding = new System.Windows.Forms.Padding(3);
+            this.lnkTipText.Size = new System.Drawing.Size(195, 48);
             this.lnkTipText.TabIndex = 6;
             this.lnkTipText.TabStop = true;
             this.lnkTipText.Text = "** TIP OF THE DAY GOES HERE**";
             this.lnkTipText.UseCompatibleTextRendering = true;
             this.lnkTipText.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkTipText_LinkClicked);
             // 
-            // lnkNextTip
-            // 
-            this.lnkNextTip.AutoSize = true;
-            this.lnkNextTip.LinkArea = new System.Windows.Forms.LinkArea(0, 16);
-            this.lnkNextTip.Location = new System.Drawing.Point(12, 138);
-            this.lnkNextTip.MaximumSize = new System.Drawing.Size(400, 0);
-            this.lnkNextTip.Name = "lnkNextTip";
-            this.lnkNextTip.Size = new System.Drawing.Size(103, 14);
-            this.lnkNextTip.TabIndex = 5;
-            this.lnkNextTip.TabStop = true;
-            this.lnkNextTip.Text = "Show another tip";
-            this.lnkNextTip.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkNextTip_LinkClicked);
-            // 
             // label6
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(12, 10);
+            this.label6.Location = new System.Drawing.Point(6, 3);
+            this.label6.MaximumSize = new System.Drawing.Size(240, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(99, 14);
+            this.label6.Padding = new System.Windows.Forms.Padding(3);
+            this.label6.Size = new System.Drawing.Size(123, 24);
             this.label6.TabIndex = 0;
             this.label6.Text = "Did you know?";
             // 
+            // flowLayoutPanelBase
+            // 
+            this.flowLayoutPanelBase.AutoSize = true;
+            this.flowLayoutPanelBase.Controls.Add(this.flowLayoutPanelLeft);
+            this.flowLayoutPanelBase.Controls.Add(this.pnlRight);
+            this.flowLayoutPanelBase.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanelBase.MinimumSize = new System.Drawing.Size(900, 600);
+            this.flowLayoutPanelBase.Name = "flowLayoutPanelBase";
+            this.flowLayoutPanelBase.Size = new System.Drawing.Size(900, 600);
+            this.flowLayoutPanelBase.TabIndex = 4;
+            this.flowLayoutPanelBase.WrapContents = false;
+            // 
+            // flowLayoutPanelLeft
+            // 
+            this.flowLayoutPanelLeft.AutoSize = true;
+            this.flowLayoutPanelLeft.Controls.Add(this.panelWelcomeToAgs);
+            this.flowLayoutPanelLeft.Controls.Add(this.pnlTipOfTheDay);
+            this.flowLayoutPanelLeft.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanelLeft.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanelLeft.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanelLeft.MaximumSize = new System.Drawing.Size(256, 1024);
+            this.flowLayoutPanelLeft.MinimumSize = new System.Drawing.Size(256, 600);
+            this.flowLayoutPanelLeft.Name = "flowLayoutPanelLeft";
+            this.flowLayoutPanelLeft.Size = new System.Drawing.Size(256, 600);
+            this.flowLayoutPanelLeft.TabIndex = 5;
+            this.flowLayoutPanelLeft.WrapContents = false;
+            // 
+            // panelBaseAll
+            // 
+            this.panelBaseAll.AutoScroll = true;
+            this.panelBaseAll.Controls.Add(this.flowLayoutPanelBase);
+            this.panelBaseAll.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelBaseAll.Location = new System.Drawing.Point(0, 69);
+            this.panelBaseAll.Name = "panelBaseAll";
+            this.panelBaseAll.Size = new System.Drawing.Size(900, 600);
+            this.panelBaseAll.TabIndex = 6;
+            // 
             // WelcomePane
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.Controls.Add(this.pnlTipOfTheDay);
-            this.Controls.Add(this.pnlRight);
-            this.Controls.Add(this.panel2);
-            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.panelBaseAll);
+            this.Controls.Add(this.panelTitle);
             this.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "WelcomePane";
-            this.Size = new System.Drawing.Size(697, 502);
+            this.Size = new System.Drawing.Size(900, 669);
             this.Load += new System.EventHandler(this.WelcomePane_Load);
-            this.Resize += new System.EventHandler(this.WelcomePane_Resize);
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
+            this.panelTitle.ResumeLayout(false);
+            this.panelTitle.PerformLayout();
+            this.panelWelcomeToAgs.ResumeLayout(false);
+            this.panelWelcomeToAgs.PerformLayout();
+            this.tableWelcomeToAgs.ResumeLayout(false);
+            this.tableWelcomeToAgs.PerformLayout();
             this.pnlRight.ResumeLayout(false);
             this.pnlRight.PerformLayout();
+            this.tableRight.ResumeLayout(false);
+            this.tableRight.PerformLayout();
             this.pnlTipOfTheDay.ResumeLayout(false);
             this.pnlTipOfTheDay.PerformLayout();
+            this.tableTipOfTheDay.ResumeLayout(false);
+            this.tableTipOfTheDay.PerformLayout();
+            this.flowLayoutPanelBase.ResumeLayout(false);
+            this.flowLayoutPanelBase.PerformLayout();
+            this.flowLayoutPanelLeft.ResumeLayout(false);
+            this.flowLayoutPanelLeft.PerformLayout();
+            this.panelBaseAll.ResumeLayout(false);
+            this.panelBaseAll.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
-        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Panel panelTitle;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Panel panelWelcomeToAgs;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.LinkLabel lnkTutorial;
         private System.Windows.Forms.Label label3;
@@ -269,6 +411,11 @@ namespace AGS.Editor
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.LinkLabel lnkNextTip;
         private System.Windows.Forms.LinkLabel lnkTipText;
-
+        private System.Windows.Forms.TableLayoutPanel tableWelcomeToAgs;
+        private System.Windows.Forms.TableLayoutPanel tableTipOfTheDay;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelBase;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelLeft;
+        private System.Windows.Forms.TableLayoutPanel tableRight;
+        private System.Windows.Forms.Panel panelBaseAll;
     }
 }

--- a/Editor/AGS.Editor/Panes/WelcomePane.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.cs
@@ -49,19 +49,6 @@ namespace AGS.Editor
             _guiContoller.LaunchHelpForKeyword("Upgrading to AGS 3.6");
         }
 
-        private void WelcomePane_Resize(object sender, EventArgs e)
-        {
-            int newWidth = this.ClientRectangle.Width - pnlRight.Left;
-            if (newWidth < 25) newWidth = 25;
-            pnlRight.Width = newWidth - 10;
-            lblUpgradingInfo.MaximumSize = new Size(pnlRight.ClientRectangle.Width - lblUpgradingInfo.Left - 10, 0);
-            lnkUpgrading.MaximumSize = new Size(pnlRight.ClientRectangle.Width - lnkUpgrading.Left - 10, 0);
-            lnkUpgrading.Top = lblUpgradingInfo.Bottom + 10;
-            lblUpgradingInfo3.MaximumSize = new Size(pnlRight.ClientRectangle.Width - lblUpgradingInfo3.Left - 10, 0);
-            lblUpgradingInfo3.Top = lnkUpgrading.Bottom + 10;
-            pnlRight.Height = lblUpgradingInfo3.Bottom + 10;
-        }
-
         private void WelcomePane_Load(object sender, EventArgs e)
         {
             if (!DesignMode)
@@ -90,6 +77,8 @@ namespace AGS.Editor
 
         private void ShowTipOfTheDay(int tipIndex)
         {
+            pnlTipOfTheDay.SuspendDrawing();
+            pnlTipOfTheDay.SuspendLayout();
             string tipText = TIPS_OF_THE_DAY[tipIndex];
             lnkTipText.LinkArea = new LinkArea(0, 0);
             _currentTipLinkTarget = null;
@@ -110,8 +99,11 @@ namespace AGS.Editor
                 lnkTipText.LinkArea = new LinkArea(linkOffset, linkEnd - linkOffset);
             }
             lnkTipText.Text = tipText;
-            lnkNextTip.Top = lnkTipText.Bottom + 10;
-            pnlTipOfTheDay.Height = lnkNextTip.Bottom + 15;
+            pnlTipOfTheDay.ResumeLayout();
+            pnlTipOfTheDay.ResumeDrawing();
+            pnlTipOfTheDay.Refresh();
+            // we refresh the entire flowpanel because the pnl may have reduced in size because the tip is very small and we are at a very big OS scaling
+            flowLayoutPanelLeft.Refresh();
         }
 
         private void lnkTipText_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -130,10 +122,10 @@ namespace AGS.Editor
         {
             t.SetColor("welcome/background", c => BackColor = c);
             t.SetColor("welcome/foreground", c => ForeColor = c);
-            t.SetColor("welcome/panel1/background", c => panel1.BackColor = c);
-            t.SetColor("welcome/panel1/foreground", c => panel1.ForeColor = c);
-            t.SetColor("welcome/panel2/background", c => panel2.BackColor = c);
-            t.SetColor("welcome/panel2/foreground", c => panel2.ForeColor = c);
+            t.SetColor("welcome/panel1/background", c => panelTitle.BackColor = c);
+            t.SetColor("welcome/panel1/foreground", c => panelTitle.ForeColor = c);
+            t.SetColor("welcome/panel2/background", c => panelWelcomeToAgs.BackColor = c);
+            t.SetColor("welcome/panel2/foreground", c => panelWelcomeToAgs.ForeColor = c);
             t.SetColor("welcome/pnlTipOfTheDay/background", c => pnlTipOfTheDay.BackColor = c);
             t.SetColor("welcome/pnlTipOfTheDay/foreground", c => pnlTipOfTheDay.ForeColor = c);
             t.SetColor("welcome/pnlRight/background", c => pnlRight.BackColor = c);
@@ -144,17 +136,17 @@ namespace AGS.Editor
             try
             {
                 Color linkColor = t.GetColor("welcome/panel2/link");
-                foreach (LinkLabel link in panel2.Controls.OfType<LinkLabel>())
+                foreach (LinkLabel link in tableWelcomeToAgs.Controls.OfType<LinkLabel>())
                 {
                     link.LinkColor = linkColor;
                 }
                 linkColor = t.GetColor("welcome/pnlTipOfTheDay/link");
-                foreach (LinkLabel link in pnlTipOfTheDay.Controls.OfType<LinkLabel>())
+                foreach (LinkLabel link in tableTipOfTheDay.Controls.OfType<LinkLabel>())
                 {
                     link.LinkColor = linkColor;
                 }
                 linkColor = t.GetColor("welcome/pnlRight/link");
-                foreach (LinkLabel link in pnlRight.Controls.OfType<LinkLabel>())
+                foreach (LinkLabel link in tableRight.Controls.OfType<LinkLabel>())
                 {
                     link.LinkColor = linkColor;
                 }


### PR DESCRIPTION
Allow scaling of the Welcome Pane, this is step 1/7, partial of #2087

I plan to work on each pane slowly when I find time, in separate PRs, also because these panes have lots of specific details, I think it's better to work them one by one.

<details>
<summary>Editor at 125% scaling</summary>

![image](https://github.com/adventuregamestudio/ags/assets/2244442/6b7e7ccd-821e-4fc5-8ead-c9b24af31963)

</details>


<details>
<summary>Editor at 200% scaling</summary>

![image](https://github.com/adventuregamestudio/ags/assets/2244442/402b3660-e8dc-458c-bf3f-5fd4385630d0)

</details>

To test this PR I recommend editing the `Editor/AGS.Editor/app.manifest` and uncommenting the dpi aware setting (lines 52 to 58).