### PR TITLE
Editor: create a parent class for Object and Character room filters

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -60,7 +60,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <LangVersion>6</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>    
+    <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -252,6 +252,7 @@
       <DependentUpon>NumberEntryDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="Entities\LogBuffer.cs" />
+    <Compile Include="Panes\Room\RoomEditFilters\BaseThingEditorFilter.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\CharactersEditorFilter.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\DesignTimeProperties.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\RoomFilterContextMenuArgs.cs" />
@@ -1242,22 +1243,22 @@
   <ItemGroup Condition="'$(OS)' != 'Unix' And $(Platform) == 'x86'">
     <NativeDLL Include="..\..\Solutions\packages\Magick.NET-Q8-AnyCPU.7.10.0\runtimes\win-x86\native\*.Native.dll" />
     <Content Include="@(NativeDLL)">
-        <Link>%(FileName)%(Extension)</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' != 'Unix' And $(Platform) == 'x64'">
     <NativeDLL Include="..\..\Solutions\packages\Magick.NET-Q8-AnyCPU.7.10.0\runtimes\win-x64\native\*.Native.dll" />
     <Content Include="@(NativeDLL)">
-        <Link>%(FileName)%(Extension)</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Unix'">
-      <NativeDLL Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*.Native.dll.so" />
-      <Content Include="@(NativeDLL)">
-          <Copy>%(FileName)%(Extension)</Copy>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
+    <NativeDLL Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*.Native.dll.so" />
+    <Content Include="@(NativeDLL)">
+      <Copy>%(FileName)%(Extension)</Copy>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// BaseThingEditorFilter is a parent filter for room layers, which manage
+    /// individual "things": something that has exact coordinates, simple visual
+    /// representation, and may be moved around.
+    /// </summary>
+    public abstract class BaseThingEditorFilter<TThing> : IRoomEditorFilter
+    {
+        private bool _isOn = false;
+        protected Room _room;
+        protected Panel _panel;
+        protected RoomSettingsEditor _editor;
+        private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
+
+        public BaseThingEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
+        {
+            _room = room;
+            _panel = displayPanel;
+            _editor = editor;
+            _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+        }
+
+        #region IDisposable implementation
+
+        public void Dispose()
+        {
+        }
+
+        #endregion // IDisposable
+
+        #region IRoomEditorFilter implementation
+
+        public abstract string Name { get; }
+        public abstract string DisplayName { get; }
+
+        public RoomAreaMaskType MaskToDraw
+        {
+            get { return RoomAreaMaskType.None; }
+        }
+
+        public abstract int ItemCount { get; }
+
+        public int SelectedArea
+        {
+            get { return 0; } // not supported
+        }
+
+        public abstract string HelpKeyword { get; }
+
+        public bool ShowTransparencySlider
+        {
+            get { return false; }
+        }
+
+        public bool SupportVisibleItems
+        {
+            get { return true; }
+        }
+
+        public bool Modified { get; set; }
+        public bool Enabled { get { return _isOn; } }
+        public bool Visible { get; set; }
+        public bool Locked { get; set; }
+
+        public SortedDictionary<string, DesignTimeProperties> DesignItems { get; protected set; }
+
+        public void Invalidate()
+        {
+            _panel.Invalidate();
+        }
+
+        public void FilterOn()
+        {
+            SetPropertyGridList();
+            Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            _isOn = true;
+            FilterActivated();
+        }
+
+        public void FilterOff()
+        {
+            FilterDeactivated();
+            Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            _isOn = false;
+        }
+
+        // Following IRoomEditorFilter members are left for descendants to implement
+        public abstract void PaintToHDC(IntPtr hdc, RoomEditorState state);
+        public abstract void Paint(Graphics graphics, RoomEditorState state);
+        public abstract bool MouseDown(MouseEventArgs e, RoomEditorState state);
+        public abstract bool MouseUp(MouseEventArgs e, RoomEditorState state);
+        public abstract bool DoubleClick(RoomEditorState state);
+        public abstract bool MouseMove(int x, int y, RoomEditorState state);
+        public abstract void CommandClick(string command);
+        public abstract bool KeyPressed(Keys keyData);
+        public abstract bool KeyReleased(Keys keyData);
+        public abstract string GetItemName(string id);
+        public abstract void SelectItem(string id);
+        public abstract Cursor GetCursor(int x, int y, RoomEditorState state);
+        public abstract bool AllowClicksInterception();
+
+        public abstract event EventHandler OnItemsChanged;
+        public abstract event EventHandler<SelectedRoomItemEventArgs> OnSelectedItemChanged;
+        public abstract event EventHandler<RoomFilterContextMenuArgs> OnContextMenu;
+
+        #endregion // IRoomEditorFilter
+
+        protected virtual void SetPropertyGridList()
+        {
+        }
+
+        protected virtual void GUIController_OnPropertyObjectChanged(object newPropertyObject)
+        {
+        }
+
+        protected virtual void FilterActivated()
+        {
+        }
+
+        protected virtual void FilterDeactivated()
+        {
+        }
+    }
+}

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -52,7 +52,7 @@ namespace AGS.Editor
 
         protected override string GetItemName(int id)
         {
-            return _room.Hotspots[id].Name;
+            return _room.Hotspots[id].PropertyGridTitle; // NOTE: ScriptName is not obligatory at the moment!
         }
 
         protected override SortedDictionary<string, int> InitItemRefs()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -17,11 +17,30 @@ namespace AGS.Editor
         /// Displayed name of the filter.
         /// </summary>
         string DisplayName { get; }
+        /// <summary>
+        /// Which room's mask is associated with this filter.
+        /// </summary>
         RoomAreaMaskType MaskToDraw { get; }
+        /// <summary>
+        /// Number of items.
+        /// </summary>
         int ItemCount { get; }
+        /// <summary>
+        /// Which area is selected (if applicable).
+        /// </summary>
         int SelectedArea { get; }
+        /// <summary>
+        /// Keyword to use when displaying F1 help for this filter.
+        /// </summary>
         string HelpKeyword { get; }
+        /// <summary>
+        /// Whether to show "transparency" slider control for this filter.
+        /// This lets to display filter contents with a level of transparency.
+        /// </summary>
         bool ShowTransparencySlider { get; }
+        /// <summary>
+        /// Whether filter items may be shown/hidden in the editor.
+        /// </summary>
         bool SupportVisibleItems { get; }
 
         /// <summary>


### PR DESCRIPTION
Resolves #2230

Introduces BaseThingEditorFilter<TThing>, a generic parent class for room filters which handle "things": objects which have precise coordinates and are drawn individually.
Picks out much of the shared code out from ObjectsEditorFilter and CharactersEditorFilter classes.

Although BaseThingEditorFilter is generic, it cannot access actual object properties, because, unfortunately, Character and RoomObject do not have a base class which would share common properties... This is why when there's a need to get something out of them, such as position or a script name, it has to call a virtual method to let child class handle this.

This does not have to be seen as a "final" implementation; as interfaces are not modified, and all classes are internal to the editor, these classes may be changed and optimized further.