### PR TITLE
3.6.1: rewrote dynamic sprite to texture notification mechanism

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -246,7 +246,8 @@ struct SpriteInfo
         : Width(w), Height(h), Flags(flags) {}
 
     inline Size GetResolution() const { return Size(Width, Height); }
-
+    // Gets if sprite is created at runtime (by engine, or a script command)
+    inline bool IsDynamicSprite() const { return (Flags & SPF_DYNAMICALLOC) != 0; }
     //
     // Legacy game support
     //

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -101,6 +101,16 @@ struct DrawState
     WalkBehindMethodEnum WalkBehindMethod = DrawAsSeparateSprite;
     // Whether there are currently remnants of a on-screen effect
     bool ScreenIsDirty = false;
+
+    // A map of shared "control blocks" per each sprite used
+    // when preparing object textures. "Control block" is currently just
+    // an integer which lets to check whether the object texture is in sync
+    // with the sprite. When the dynamic sprite is updated or deleted,
+    // the control block is marked as invalid and removed from the map;
+    // but certain objects may keep the shared ptr to the old block with
+    // "invalid" mark, thus they know that they must reset their texture.
+    std::unordered_map<sprkey_t, std::shared_ptr<uint32_t>>
+        SpriteNotifyMap;
 };
 
 DrawState drawstate;
@@ -122,6 +132,9 @@ struct ObjTexture
     std::unique_ptr<Bitmap> Bmp;
     // Corresponding texture, created by renderer
     IDriverDependantBitmap *Ddb = nullptr;
+    // Sprite notification block: becomes invalid to notify an updated
+    // or deleted sprtie
+    std::shared_ptr<uint32_t> SpriteNotify;
     // Sprite's position
     Point Pos;
     // Texture's offset, *relative* to the logical sprite's position;
@@ -141,6 +154,13 @@ struct ObjTexture
             assert(gfxDriver);
             gfxDriver->DestroyDDB(Ddb);
         }
+    }
+
+    // Tests the sprite notification block to ensure that the texture
+    // is synchronized with the latest sprite version
+    inline bool IsSynced() const
+    {
+        return SpriteNotify && (*SpriteNotify == SpriteID);
     }
 
     ObjTexture &operator =(ObjTexture &&o)
@@ -762,8 +782,6 @@ void init_game_drawdata()
         guio_num += gui.GetControlCount();
     }
     guiobjbg.resize(guio_num);
-
-    play.spritemodified.resize(game.SpriteInfos.size());
 }
 
 void dispose_game_drawdata()
@@ -784,9 +802,6 @@ void dispose_game_drawdata()
     gui_render_tex.clear();
     guiobjbg.clear();
     guiobjddbref.clear();
-
-    play.spritemodified.clear();
-    play.spritemodifiedlist.clear();
 }
 
 static void dispose_debug_room_drawdata()
@@ -830,9 +845,8 @@ void clear_drawobj_cache()
     for (auto &o : guiobjbg) o = ObjTexture();
     overtxs.clear();
 
-    // Clear "modified sprite" flags
-    play.spritemodifiedlist.clear();
-    std::fill(play.spritemodified.begin(), play.spritemodified.end(), false);
+    // Clear sprite update notification blocks
+    drawstate.SpriteNotifyMap.clear();
 
     dispose_debug_room_drawdata();
 }
@@ -1047,14 +1061,19 @@ void notify_sprite_changed(int sprnum, bool deleted)
         update_shared_texture(sprnum);
 
     // For texture-based renderers updating a shared texture will already
-    // update all the related drawn objects on screen.
-    // For software renderer we should notify drawables that currently
-    // reference this sprite.
-    if (drawstate.SoftwareRender && !play.spritemodified.empty())
+    // update all the related drawn objects on screen; software renderer
+    // will need to know to redraw active cached sprite for objects.
+    // We have this notification for both kinds of renderers though,
+    // because it makes the code simpler, and also it makes it simpler to
+    // notify texture-based ones in a specific case when a deleted sprite
+    // was replaced by another of same ID.
     {
-        assert(static_cast<uint32_t>(sprnum) < play.spritemodified.size());
-        play.spritemodified[sprnum] = true;
-        play.spritemodifiedlist.push_back(sprnum);
+        auto it_notify = drawstate.SpriteNotifyMap.find(sprnum);
+        if (it_notify != drawstate.SpriteNotifyMap.end())
+        {
+            *it_notify->second = UINT32_MAX;
+            drawstate.SpriteNotifyMap.erase(sprnum);
+        }
     }
 }
 
@@ -1352,6 +1371,21 @@ IDriverDependantBitmap* recycle_render_target(IDriverDependantBitmap *ddb, int w
 static void sync_object_texture(ObjTexture &obj, bool has_alpha = false, bool opaque = false)
 {
     obj.Ddb = recycle_ddb_sprite(obj.Ddb, obj.SpriteID, obj.Bmp.get(), has_alpha, opaque);
+    // If this is a sprite-referencing texture, then assign a control block,
+    // let the object receive notification of sprite updates.
+    if ((obj.SpriteID != UINT32_MAX) && (!obj.IsSynced()))
+    {
+        auto it_notify = drawstate.SpriteNotifyMap.find(obj.SpriteID);
+        if (it_notify != drawstate.SpriteNotifyMap.end())
+        { // assign existing
+            obj.SpriteNotify = it_notify->second;
+        }
+        else
+        { // if does not exist, then create and share one
+            obj.SpriteNotify = std::make_shared<uint32_t>(obj.SpriteID);
+            drawstate.SpriteNotifyMap.insert(std::make_pair(obj.SpriteID, obj.SpriteNotify));
+        }
+    }
 }
 
 //------------------------------------------------------------------------
@@ -1810,7 +1844,8 @@ static bool construct_object_gfx(const ViewFrame *vf, int pic,
     if (use_hw_transform)
     {
         // HW acceleration
-        const bool is_texture_intact = objsav.sppic == specialpic;
+        const bool is_texture_intact =
+            (objsav.sppic == specialpic) && actsp.IsSynced();
         objsav.sppic = specialpic;
         objsav.tintamnt = tint_level;
         objsav.tintr = tint_red;
@@ -1836,7 +1871,7 @@ static bool construct_object_gfx(const ViewFrame *vf, int pic,
     if ((objsav.image != nullptr) &&
         (objsav.sppic == specialpic) &&
         // not a dynamic sprite, or not sprite modified lately
-        (!play.spritemodified[pic]) &&
+        (actsp.IsSynced()) &&
         (objsav.tintamnt == tint_level) &&
         (objsav.tintlight == tint_light) &&
         (objsav.tintr == tint_red) &&
@@ -2676,7 +2711,7 @@ static void construct_overlays()
         if (over.transparency == 255) continue; // skip fully transparent
 
         auto &overtx = overtxs[i];
-        bool has_changed = over.HasChanged() || play.spritemodified[over.GetSpriteNum()];
+        bool has_changed = over.HasChanged();
         // If walk behinds are drawn over the cached object sprite, then check if positions were updated
         if (crop_walkbehinds && over.IsRoomLayer())
         {
@@ -2685,7 +2720,7 @@ static void construct_overlays()
             overcache[i].X = pos.X; overcache[i].Y = pos.Y;
         }
 
-        if (has_changed)
+        if (has_changed || !overtx.IsSynced())
         {
             overtx.SpriteID = over.GetSpriteNum();
             // For software mode - prepare transformed bitmap if necessary;
@@ -2717,21 +2752,6 @@ static void construct_overlays()
         if (!overtx.Ddb) continue;
         overtx.Ddb->SetStretch(over.scaleWidth, over.scaleHeight);
         overtx.Ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
-    }
-}
-
-static void reset_spritemodified()
-{
-    if (play.spritemodifiedlist.size() > 0)
-    {
-        // Sort and remove duplicates;
-        // CHECKME: or is it more optimal to just run over raw list?
-        std::sort(play.spritemodifiedlist.begin(), play.spritemodifiedlist.end());
-        play.spritemodifiedlist.erase(
-            std::unique(play.spritemodifiedlist.begin(), play.spritemodifiedlist.end()), play.spritemodifiedlist.end());
-        for (auto sprnum : play.spritemodifiedlist)
-            play.spritemodified[sprnum] = false;
-        play.spritemodifiedlist.clear();
     }
 }
 
@@ -2794,9 +2814,6 @@ void construct_game_scene(bool full_redraw)
 
     // End the parent scene node
     gfxDriver->EndSpriteBatch();
-
-    // Clear "modified sprite" flags
-    reset_spritemodified();
 }
 
 void construct_game_screen_overlay(bool draw_mouse)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -109,6 +109,11 @@ struct DrawState
     // the control block is marked as invalid and removed from the map;
     // but certain objects may keep the shared ptr to the old block with
     // "invalid" mark, thus they know that they must reset their texture.
+    //
+    // TODO: investigate an alternative of having a equivalent of
+    // "shared texture" with sprite ID ref in Software renderer too,
+    // which would allow to use same method of testing DDB ID for both
+    // kinds of renderers, thus saving on 1 extra notification mechanism.
     std::unordered_map<sprkey_t, std::shared_ptr<uint32_t>>
         SpriteNotifyMap;
 };

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -469,9 +469,6 @@ int add_dynamic_sprite(int slot, std::unique_ptr<Bitmap> image, bool has_alpha, 
     uint32_t flags = SPF_DYNAMICALLOC | (SPF_ALPHACHANNEL * has_alpha) | extra_flags;
     if (!spriteset.SetSprite(slot, std::move(image), flags))
         return 0; // failed to add the sprite, bad image or realloc failed
-
-    if (play.spritemodified.size() < game.SpriteInfos.size())
-        play.spritemodified.resize(game.SpriteInfos.size());
     return slot;
 }
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -294,14 +294,6 @@ struct GameState
     // y offset of the shaking screen
     int shake_screen_yoff = 0;
 
-    // CHECKME: we might consider hiding these in draw unit, but then,
-    // because the drawing system still has standalone parts (GUIs...)
-    // there still may be cases when we may require these accessed elsewhere.
-    // Sprite modified flag, used to detect dynamic sprite modifications
-    std::vector<bool> spritemodified;
-    // Which sprites were modified since the recent drawing pass
-    std::vector<int> spritemodifiedlist;
-
 
     GameState();
 


### PR DESCRIPTION
The previous attempt, using a boolean `spritemodified` array, proved to be having logical loopholes. In simple words, because `spritemodified` flag was resetting each draw pass, it won't affect objects that are temporarily not visible, and they failed to reupdate when becoming visible again. This affected Software renderer.

Texture-based renderers have a different problem, where they fail to recognize when an old sprite was deleted and a completely new dynamic sprite created accidentally with the same ID. The cause was simply that the check for this is done inside sync_object_texture(), but sync_object_texture itself is not called unless draw() function thought that object had changed. So there has to be a check outside too...

Here I decided to reimplement notification mechanism, and use it for both types of renderers, for the sake of more straightforward code logic. (Although, strictly speaking, texture-based renderers could check their texture's "ref id" instead.)

Anyway, the idea of a new implementation is this:
1. There's a map of "control blocks" per each active sprite (that is - sprite that was drawn as a part of object). The "control block" is simply a integer with a sprite ID in it, allocated and wrapped by shared_ptr.
2. When the ObjectTexture syncs its texture with a new sprite, the control block is retrieved (or new created), and from now on it may be shared among multiple objects which display same sprite.
3. When the sprite gets either updated or deleted two things happen: the previous control block is assigned an "invalid value", serving as a marker, and then it is removed from the map, left only if referenced by any ObjectTexture.
4. When checking whether texture needs to be re-synced we test the control block too, to see if it was invalidated. In such case this tells us to call sync_object_texture() again.

NOTE that dynamic sprites that do not appear on screen, and are only used for drawing on another surface, do not allocate control blocks, nor notify anything.

---

This mechanism was, ironically, similar to the first idea I had when doing #2117, and is mentioned in following commit:
https://github.com/adventuregamestudio/ags/pull/2117#issuecomment-1705778549
unfortunately, I had a change of mind and did this "spritemodified" array solution instead:
https://github.com/adventuregamestudio/ags/pull/2117#issuecomment-1717920385
But, looking at my oldest implementation saved in my repository here: https://github.com/ivan-mogilko/ags-refactoring/commit/7c4fcdc3e787fce738d7ca07c8ee11ccf6a99231 it appears that I did not do it completely right, so it would have same problem as there's now.

Something that I might try to change in this PR, is only create notification block for **dynamic** sprites. That will change few conditions, but might save memory.

But first I need to be sure that this works overall.

And of course I would need to do performance tests again, just in case.