### PR TITLE
Editor: implement "Controls transparency" slider in GUI Editor

### DIFF
--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -281,7 +281,11 @@ void GUIMain::DrawWithControls(Bitmap *ds)
 {
     ds->ResetClip();
     DrawSelf(ds);
+    DrawControls(ds);
+}
 
+void GUIMain::DrawControls(Bitmap *ds)
+{
     if ((GUI::Context.DisabledState != kGuiDis_Undefined) && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
         return; // don't draw GUI controls
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -162,6 +162,7 @@ public:
     bool    BringControlToFront(int index);
     void    DrawSelf(Bitmap *ds);
     void    DrawWithControls(Bitmap *ds);
+    void    DrawControls(Bitmap *ds);
     // Polls GUI state, providing current cursor (mouse) coordinates
     void    Poll(int mx, int my);
     // Reconnects this GUIMain with the child controls from the global guiobject collection

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -89,9 +89,9 @@ namespace AGS.Editor
             }
         }
 
-        public void DrawGUI(IntPtr hdc, int x, int y, GUI gui, int resolutionFactor, float scale, int selectedControl)
+        public void DrawGUI(IntPtr hdc, int x, int y, GUI gui, int resolutionFactor, float scale, int ctrlTransparency, int selectedControl)
         {
-            _native.DrawGUI((int)hdc, x, y, gui, resolutionFactor, scale, selectedControl);
+            _native.DrawGUI((int)hdc, x, y, gui, resolutionFactor, scale, ctrlTransparency, selectedControl);
         }
 
         public void DrawSprite(IntPtr hdc, int x, int y, int spriteNum)

--- a/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
@@ -29,16 +29,23 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.ctrlPanel = new System.Windows.Forms.Panel();
+            this.lblTransparency = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.sldTransparency = new System.Windows.Forms.TrackBar();
             this.lblZoomInfo = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.sldZoomLevel = new System.Windows.Forms.TrackBar();
             this.bgPanel = new AGS.Editor.BufferedPanel();
             this.ctrlPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
             this.SuspendLayout();
             // 
             // ctrlPanel
             // 
+            this.ctrlPanel.Controls.Add(this.lblTransparency);
+            this.ctrlPanel.Controls.Add(this.label2);
+            this.ctrlPanel.Controls.Add(this.sldTransparency);
             this.ctrlPanel.Controls.Add(this.lblZoomInfo);
             this.ctrlPanel.Controls.Add(this.label3);
             this.ctrlPanel.Controls.Add(this.sldZoomLevel);
@@ -47,6 +54,36 @@ namespace AGS.Editor
             this.ctrlPanel.Name = "ctrlPanel";
             this.ctrlPanel.Size = new System.Drawing.Size(702, 51);
             this.ctrlPanel.TabIndex = 0;
+            // 
+            // lblTransparency
+            // 
+            this.lblTransparency.AutoSize = true;
+            this.lblTransparency.Location = new System.Drawing.Point(560, 15);
+            this.lblTransparency.Name = "lblTransparency";
+            this.lblTransparency.Size = new System.Drawing.Size(33, 13);
+            this.lblTransparency.TabIndex = 5;
+            this.lblTransparency.Text = "100%";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(282, 15);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(112, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Controls transparency:";
+            // 
+            // sldTransparency
+            // 
+            this.sldTransparency.LargeChange = 20;
+            this.sldTransparency.Location = new System.Drawing.Point(400, 6);
+            this.sldTransparency.Maximum = 100;
+            this.sldTransparency.Name = "sldTransparency";
+            this.sldTransparency.Size = new System.Drawing.Size(154, 42);
+            this.sldTransparency.SmallChange = 5;
+            this.sldTransparency.TabIndex = 4;
+            this.sldTransparency.TickFrequency = 20;
+            this.sldTransparency.Scroll += new System.EventHandler(this.sldTransparency_Scroll);
             // 
             // lblZoomInfo
             // 
@@ -108,6 +145,7 @@ namespace AGS.Editor
             this.Load += new System.EventHandler(this.GUIEditor_Load);
             this.ctrlPanel.ResumeLayout(false);
             this.ctrlPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();
             this.ResumeLayout(false);
 
@@ -120,5 +158,8 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblZoomInfo;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TrackBar sldZoomLevel;
+        private System.Windows.Forms.Label lblTransparency;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TrackBar sldTransparency;
     }
 }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -59,7 +59,7 @@ extern bool measure_font_height(const AGSString &filename, int pixel_height, int
 // may be called with hdc = 0 to get required height without drawing anything
 extern int drawFontAt (int hdc, int fontnum, int x, int y, int width);
 extern Dictionary<int, Sprite^>^ load_sprite_dimensions();
-extern void drawGUI(int hdc, int x,int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl);
+extern void drawGUI(int hdc, int x, int y, GUI^ gui, int resolutionFactor, float scale, int control_transparency, int selectedControl);
 extern void drawSprite(int hdc, int x,int y, int spriteNum, bool flipImage);
 extern void drawSpriteStretch(int hdc, int x,int y, int width, int height, int spriteNum, bool flipImage);
 extern void drawBlockOfColour(int hdc, int x,int y, int width, int height, int colNum);
@@ -305,9 +305,9 @@ namespace AGS
 			GameUpdated(game, false);
 		}
 
-		void NativeMethods::DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl)
+		void NativeMethods::DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int controlTransparency, int selectedControl)
 		{
-			drawGUI(hDC, x, y, gui, resolutionFactor, scale, selectedControl);
+			drawGUI(hDC, x, y, gui, resolutionFactor, scale, controlTransparency, selectedControl);
 		}
 
 		void NativeMethods::DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -47,7 +47,7 @@ namespace AGS
 			void SaveGame(Game^ game);
 			void GameSettingsChanged(Game^ game);
 			void PaletteColoursUpdated(Game ^game);
-			void DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl);
+			void DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int controlTransparency, int selectedControl);
 			void DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage);
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
 			// Draws font char sheet on the provided context and returns the height of drawn object;


### PR DESCRIPTION
Resolves #2379.

Adds a "Controls transparency" slider to the GUI Editor, lets draw controls in semi-transparent way or hide them completely.