### PR TITLE
call ReadPlugin already with version 2.55

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -948,7 +948,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, std::unique_ptr<Stream> &&
         return new MainGameFileError(kMGFErr_GameEntityFailed, err2);
     game.numgui = ents.Guis.size();
 
-    if (data_ver >= kGameVersion_260)
+    if (data_ver >= kGameVersion_255)
     {
         err = ReadPlugins(ents.PluginInfos, in);
         if (!err)


### PR DESCRIPTION
Zak McKraken 2 is game version 2.55 and uses the ags flashlight plugin. using this patch it successfully parses the plugin data.

https://www.maniac-mansion-mania.com/index.php/en/resources-mainmenu-76/downloads/episoden/fanadventures/95-the-new-adventures-of-zak-mckracken/file.html