### PR TITLE
room file: fix loading of zak mckraken 2

### DIFF
--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -316,7 +316,7 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
         room->BgFrames[0].Graphic = load_rle_bitmap8(in);
 
     // Area masks
-    if (data_ver >= kRoomVersion_255b)
+    if (data_ver >= kRoomVersion_253)
         room->RegionMask = load_rle_bitmap8(in);
     else if (data_ver >= kRoomVersion_114)
         skip_rle_bitmap8(in); // an old version - clear the 'shadow' area into a blank regions bmp (???)


### PR DESCRIPTION
roomver is 2.53, and the skip_rle code skips way too many bytes way over the script data, this change fixes the game.