### PR TITLE
fix build error with musl libc

### DIFF
--- a/Common/libinclude/ogg/config_types.h
+++ b/Common/libinclude/ogg/config_types.h
@@ -4,7 +4,7 @@
 /* these are filled in by configure */
 typedef int16_t ogg_int16_t;
 typedef int32_t ogg_int32_t;
-typedef u_int32_t ogg_uint32_t;
+typedef uint32_t ogg_uint32_t;
 typedef int64_t ogg_int64_t;
 
 #endif


### PR DESCRIPTION
u_int_32t is not a standard type, it's from legacy sys/types.h and mixed in here with stdint.h types. fix it by also using stdint.h type instead.