### PR TITLE
Calculate real TTF glyphs extent, fix fonts cut from the top

### DIFF
--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -11,9 +11,10 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_AGSFONTRENDERER_H
 #define __AC_AGSFONTRENDERER_H
+
+#include "util/string.h"
 
 struct BITMAP;
 
@@ -101,8 +102,8 @@ public:
     // Tells if this is a bitmap font (otherwise it's a vector font)
     virtual bool IsBitmapFont() = 0;
     // Load font, applying extended font rendering parameters
-    virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
-        FontMetrics *metrics) = 0;
+    virtual bool LoadFromDiskEx(int fontNumber, int fontSize, AGS::Common::String *src_filename,
+        const FontRenderParams *params, FontMetrics *metrics) = 0;
     // Fill FontMetrics struct; note that it may be left cleared if this is not supported
     virtual void GetFontMetrics(int fontNumber, FontMetrics *metrics) = 0;
     // Perform any necessary adjustments when the AA mode is toggled

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -92,6 +92,8 @@ struct FontMetrics
     // have individual glyphs exceeding these bounds, in both directions.
     // Note that "top" may be negative!
     std::pair<int, int> VExtent;
+
+    inline int ExtentHeight() const { return VExtent.second - VExtent.first; }
 };
 
 // The strictly internal font renderer interface, not to use in plugin API.

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -73,9 +73,24 @@ struct FontRenderParams
 // Describes loaded font's properties
 struct FontMetrics
 {
-    int Height = 0; // formal font height value
-    int RealHeight = 0; // real graphical height of a font
-    int CompatHeight = 0; // either formal or real height, depending on compat settings
+    // Nominal font's height, equals to the game-requested size of the font.
+    // This may or not be equal to font's face height; sometimes a font cannot
+    // be scaled exactly to particular size, and then nominal height appears different
+    // (usually - smaller) than the real one.
+    int NominalHeight = 0;
+    // Real font's height, equals to reported ascender + descender.
+    // This is what you normally think as a font's height.
+    int RealHeight = 0;
+    // Compatible height, equals to either NominalHeight or RealHeight,
+    // selected depending on the game settings.
+    // This property is used in calculating linespace, etc.
+    int CompatHeight = 0;
+    // Maximal vertical extent of a font (top; bottom), this tells the actual
+    // graphical bounds that may be occupied by font's glyphs.
+    // In a "proper" font this extent is (0; RealHeight-1), but "bad" fonts may
+    // have individual glyphs exceeding these bounds, in both directions.
+    // Note that "top" may be negative!
+    std::pair<int, int> VExtent;
 };
 
 // The strictly internal font renderer interface, not to use in plugin API.

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -332,8 +332,7 @@ int get_font_surface_height(size_t fontNumber)
 {
     if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
         return 0;
-    return fonts[fontNumber].Metrics.VExtent.second -
-        fonts[fontNumber].Metrics.VExtent.first;
+    return fonts[fontNumber].Metrics.ExtentHeight();
 }
 
 std::pair<int, int> get_font_surface_extent(size_t fontNumber)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -17,6 +17,7 @@
 #include <alfont.h>
 #include "ac/common.h" // set_our_eip
 #include "ac/gamestructdefines.h"
+#include "debug/out.h"
 #include "font/fonts.h"
 #include "font/ttffontrenderer.h"
 #include "font/wfnfontrenderer.h"
@@ -549,25 +550,31 @@ bool load_font_size(size_t fontNumber, const FontInfo &font_info)
   params.LoadMode = (font_info.Flags & FFLG_LOADMODEMASK);
   FontMetrics metrics;
 
-  if (ttfRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &params, &metrics))
+  Font &font = fonts[fontNumber];
+  String src_filename;
+  if (ttfRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &src_filename, &params, &metrics))
   {
-    fonts[fontNumber].Renderer    = &ttfRenderer;
-    fonts[fontNumber].Renderer2   = &ttfRenderer;
-    fonts[fontNumber].RendererInt = &ttfRenderer;
+    font.Renderer    = &ttfRenderer;
+    font.Renderer2   = &ttfRenderer;
+    font.RendererInt = &ttfRenderer;
   }
-  else if (wfnRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &params, &metrics))
+  else if (wfnRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &src_filename, &params, &metrics))
   {
-    fonts[fontNumber].Renderer    = &wfnRenderer;
-    fonts[fontNumber].Renderer2   = &wfnRenderer;
-    fonts[fontNumber].RendererInt = &wfnRenderer;
+    font.Renderer    = &wfnRenderer;
+    font.Renderer2   = &wfnRenderer;
+    font.RendererInt = &wfnRenderer;
   }
 
-  if (!fonts[fontNumber].Renderer)
+  if (!font.Renderer)
       return false;
 
-  fonts[fontNumber].Info = font_info;
-  fonts[fontNumber].Metrics = metrics;
+  font.Info = font_info;
+  font.Metrics = metrics;
   font_post_init(fontNumber);
+
+  Debug::Printf("Loaded font %d: %s, req size: %d; nominal h: %d, real h: %d, extent: %d,%d",
+      fontNumber, src_filename.GetCStr(), font_info.Size, font.Metrics.NominalHeight, font.Metrics.RealHeight,
+      font.Metrics.VExtent.first, font.Metrics.VExtent.second);
   return true;
 }
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -111,7 +111,7 @@ static void font_post_init(size_t fontNumber)
     Font &font = fonts[fontNumber];
     // If no font height property was provided, then try several methods,
     // depending on which interface is available
-    if ((font.Metrics.Height == 0) && font.Renderer)
+    if ((font.Metrics.NominalHeight == 0) && font.Renderer)
     {
         int height = 0;
         if (font.Renderer2)
@@ -125,14 +125,15 @@ static void font_post_init(size_t fontNumber)
             const char *height_test_string = "ZHwypgfjqhkilIK";
             height = font.Renderer->GetTextHeight(height_test_string, fontNumber);
         }
-        
-        font.Metrics.Height = std::max(0, height);
-        font.Metrics.RealHeight = font.Metrics.Height;
+
+        font.Metrics.NominalHeight = std::max(0, height);
+        font.Metrics.RealHeight = font.Metrics.NominalHeight;
+        font.Metrics.VExtent = std::make_pair(0, font.Metrics.RealHeight);
     }
     // Use either nominal or real pixel height to define font's logical height
     // and default linespacing; logical height = nominal height is compatible with the old games
     font.Metrics.CompatHeight = (font.Info.Flags & FFLG_REPORTNOMINALHEIGHT) != 0 ?
-        font.Metrics.Height : font.Metrics.RealHeight;
+        font.Metrics.NominalHeight : font.Metrics.RealHeight;
 
     if (font.Info.Outline != FONT_OUTLINE_AUTO)
     {
@@ -330,7 +331,15 @@ int get_font_surface_height(size_t fontNumber)
 {
     if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
         return 0;
-    return fonts[fontNumber].Metrics.RealHeight;
+    return fonts[fontNumber].Metrics.VExtent.second -
+        fonts[fontNumber].Metrics.VExtent.first;
+}
+
+std::pair<int, int> get_font_surface_extent(size_t fontNumber)
+{
+    if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
+        return std::make_pair(0, 0);
+    return fonts[fontNumber].Metrics.VExtent;
 }
 
 int get_font_linespacing(size_t fontNumber)

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -15,6 +15,7 @@
 #define __AC_FONT_H
 
 #include <string>
+#include <utility>
 #include <vector>
 #include "ac/gamestructdefines.h"
 #include "util/string.h"
@@ -66,6 +67,10 @@ int get_font_height_outlined(size_t fontNumber);
 // Get font's surface height: this always returns the height enough to accomodate
 // font letters on a bitmap or a texture; the distinction is needed for compatibility reasons
 int get_font_surface_height(size_t fontNumber);
+// Get font's maximal graphical extent: this means the farthest vertical positions of glyphs,
+// relative to the "pen" position. Besides letting to calculate the surface height,
+// this information also lets to detect if some of the glyphs may appear above y0.
+std::pair<int, int> get_font_surface_extent(size_t fontNumber);
 // Get font's line spacing
 int get_font_linespacing(size_t fontNumber);
 // Set font's line spacing

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -78,6 +78,8 @@ static int GetAlfontFlags(int load_mode)
   if (((load_mode & FFLG_ASCENDERFIXUP) != 0) &&
       !(ShouldAntiAliasText() && (loaded_game_file_version < kGameVersion_341)))
       flags |= ALFONT_FLG_ASCENDER_EQ_HEIGHT;
+  // Precalculate real glyphs extent (will make loading fonts relatively slower)
+  flags |= ALFONT_FLG_PRECALC_MAX_CBOX;
   return flags;
 }
 
@@ -103,9 +105,13 @@ static ALFONT_FONT *LoadTTF(const String &filename, int fontSize, int alfont_fla
 // Fill the FontMetrics struct from the given ALFONT
 static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics)
 {
-    metrics->Height = alfont_get_font_height(alfptr);
+    metrics->NominalHeight = alfont_get_font_height(alfptr);
     metrics->RealHeight = alfont_get_font_real_height(alfptr);
-    metrics->CompatHeight = metrics->Height; // just set to default here
+    metrics->CompatHeight = metrics->NominalHeight; // just set to default here
+    alfont_get_font_real_vextent(alfptr, &metrics->VExtent.first, &metrics->VExtent.second);
+    // fixup vextent to be *not less* than realheight
+    metrics->VExtent.first = std::min(0, metrics->VExtent.first);
+    metrics->VExtent.second = std::max(metrics->RealHeight, metrics->VExtent.second);
 }
 
 bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -61,7 +61,7 @@ void TTFFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 
 bool TTFFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
 {
-  return LoadFromDiskEx(fontNumber, fontSize, nullptr, nullptr);
+  return LoadFromDiskEx(fontNumber, fontSize, nullptr, nullptr, nullptr);
 }
 
 bool TTFFontRenderer::IsBitmapFont()
@@ -114,7 +114,7 @@ static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics)
     metrics->VExtent.second = std::max(metrics->RealHeight, metrics->VExtent.second);
 }
 
-bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
+bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, String *src_filename,
     const FontRenderParams *params, FontMetrics *metrics)
 {
     String filename = String::FromFormat("agsfnt%d.ttf", fontNumber);
@@ -132,6 +132,8 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
 
     _fontData[fontNumber].AlFont = alfptr;
     _fontData[fontNumber].Params = f_params;
+    if (src_filename)
+        *src_filename = filename;
     if (metrics)
         FillMetrics(alfptr, metrics);
     return true;

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -41,8 +41,8 @@ public:
 
   // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
-  bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
-      FontMetrics *metrics) override;
+  bool LoadFromDiskEx(int fontNumber, int fontSize, AGS::Common::String *src_filename,
+      const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
 

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -114,7 +114,7 @@ static int RenderChar(Bitmap *ds, const int at_x, const int at_y, Rect clip,
 
 bool WFNFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
 {
-  return LoadFromDiskEx(fontNumber, fontSize, nullptr, nullptr);
+  return LoadFromDiskEx(fontNumber, fontSize, nullptr, nullptr, nullptr);
 }
 
 bool WFNFontRenderer::IsBitmapFont()
@@ -123,7 +123,7 @@ bool WFNFontRenderer::IsBitmapFont()
 }
 
 bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
-    const FontRenderParams *params, FontMetrics *metrics)
+    String *src_filename, const FontRenderParams *params, FontMetrics *metrics)
 {
   String file_name;
   Stream *ffi = nullptr;
@@ -133,6 +133,8 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
   if (ffi == nullptr)
   {
     // actual font not found, try font 0 instead
+    // FIXME: this should not be done here in this font renderer implementation,
+    // but somewhere outside, when whoever calls this method
     file_name = "agsfnt0.wfn";
     ffi = AssetMgr->OpenAsset(file_name);
     if (ffi == nullptr)
@@ -151,6 +153,8 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
   }
   _fontData[fontNumber].Font = font;
   _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+  if (src_filename)
+    *src_filename = file_name;
   if (metrics)
     *metrics = FontMetrics();
   return true;

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -41,8 +41,8 @@ public:
 
   // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
-  bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
-      FontMetrics *metrics) override;
+  bool LoadFromDiskEx(int fontNumber, int fontSize, AGS::Common::String *src_filename,
+      const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override { *metrics = FontMetrics(); }
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
 

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -725,12 +725,15 @@ GuiVersion GameGuiVersion = kGuiVersion_Initial;
 Line CalcFontGraphicalVExtent(int font)
 {
     // Following factors are affecting the graphical vertical metrics:
+    // * font's real graphical extent (top and bottom offsets relative to the "pen")
     // * custom vertical offset set by user (if non-zero),
-    // * font's real graphical height
-    int font_yoffset = get_fontinfo(font).YOffset;
-    int yoff = std::min(0, font_yoffset); // only if yoff is negative
-    int height_off = std::max(0, font_yoffset); // only if yoff is positive
-    return Line(0, yoff, 0, get_font_surface_height(font) + height_off);
+    const auto finfo = get_fontinfo(font);
+    const auto fextent = get_font_surface_extent(font);
+    int top = fextent.first +
+        std::min(0, finfo.YOffset); // apply YOffset only if negative
+    int bottom = fextent.second +
+        std::max(0, finfo.YOffset); // apply YOffset only if positive
+    return Line(0, top, 0, bottom);
 }
 
 Point CalcTextPosition(const char *text, int font, const Rect &frame, FrameAlignment align, Rect *gr_rect)

--- a/Common/libsrc/alfont-2.0.9/alfont.c
+++ b/Common/libsrc/alfont-2.0.9/alfont.c
@@ -34,6 +34,8 @@ struct ALFONT_FONT {
   int face_h;             /* face height */
   int real_face_h;        /* real face height */
   int face_ascender;      /* face ascender */
+  int real_face_extent_asc; /* calculated max extent of glyphs (ascender) */
+  int real_face_extent_desc; /* calculated max extent of glyphs (descender) */
   char *data;             /* if loaded from memory, the data chunk */
   int data_size;          /* and its size */
   int ch_spacing;         /* extra spacing */
@@ -407,6 +409,32 @@ static void _alfont_new_cache_glyph(ALFONT_FONT *f) {
   }
 }
 
+static void _alfont_calculate_max_cbox(ALFONT_FONT *f) {
+  int i;
+  int max_box_top = 0, min_box_bottom = 0;
+  FT_Glyph glyph;
+  FT_BBox box;
+
+  for (i = 0; i < f->face->num_glyphs; i++) {
+    // CHECKME: is FT_LOAD_DEFAULT optimal here? there are various load modes
+    FT_Load_Glyph(f->face, i, FT_LOAD_DEFAULT);
+    FT_Get_Glyph(f->face->glyph, &glyph);
+
+    FT_Glyph_Get_CBox(glyph, ft_glyph_bbox_pixels, &box);
+    if (max_box_top < box.yMax) {
+      max_box_top = box.yMax;
+    }
+    if (min_box_bottom > box.yMin) {
+      min_box_bottom = box.yMin;
+    }
+
+    FT_Done_Glyph(glyph);
+  }
+
+  f->real_face_extent_asc = max_box_top;
+  f->real_face_extent_desc = -min_box_bottom;
+}
+
 
 /* API */
 
@@ -482,10 +510,15 @@ int alfont_set_font_size_ex(ALFONT_FONT *f, int h, int flags) {
     f->real_face_h = real_height;
     f->face_ascender = f->face->size->metrics.ascender >> 6;
 
-    // AGS COMPAT HACK: set ascender to the formal font height
+    /* Precalculate actual glyphs vertical extent */
+    if ((flags & ALFONT_FLG_PRECALC_MAX_CBOX) != 0) {
+      _alfont_calculate_max_cbox(f);
+    }
+
+    /* AGS COMPAT HACK: set ascender to the formal font height */
     if ((flags & ALFONT_FLG_ASCENDER_EQ_HEIGHT) != 0) {
-       f->face_ascender = test_h;
-       f->real_face_h = test_h + abs(f->face->size->metrics.descender >> 6);
+      f->face_ascender = test_h;
+      f->real_face_h = test_h + abs(f->face->size->metrics.descender >> 6);
     }
 
     return ALFONT_OK;
@@ -503,7 +536,12 @@ int alfont_get_font_height(ALFONT_FONT *f) {
 
 /* Return font height based on ascender + descender summation */
 int alfont_get_font_real_height(ALFONT_FONT *f) {
-    return f->real_face_h;
+  return f->real_face_h;
+}
+
+ALFONT_DLL_DECLSPEC void alfont_get_font_real_vextent(ALFONT_FONT *f, int *top, int *bottom) {
+  *top = f->face_ascender - f->real_face_extent_asc; // may be negative
+  *bottom = f->face_ascender + f->real_face_extent_desc;
 }
 
 void alfont_exit(void) {

--- a/Common/libsrc/alfont-2.0.9/alfont.h
+++ b/Common/libsrc/alfont-2.0.9/alfont.h
@@ -48,6 +48,10 @@ extern "C" {
 // otherwise will search for the point size which results in pixel
 // height closest to the requested size.
 #define ALFONT_FLG_SELECT_NOMINAL_SZ  0x04
+// Precalculate maximal glyph control box, that is maximal graphical
+// extent of any glyph in the font (which may exceed font's height).
+// Note that this requires FreeType to load each glyph one by one.
+#define ALFONT_FLG_PRECALC_MAX_CBOX   0x08
 
 
 /* includes */
@@ -72,6 +76,8 @@ ALFONT_DLL_DECLSPEC int alfont_set_font_size_ex(ALFONT_FONT *f, int h, int flags
 ALFONT_DLL_DECLSPEC int alfont_get_font_height(ALFONT_FONT *f);
 /* Returns the real font graphical height */
 ALFONT_DLL_DECLSPEC int alfont_get_font_real_height(ALFONT_FONT *f);
+/* Returns the real font graphical extent (top, bottom) */
+ALFONT_DLL_DECLSPEC void alfont_get_font_real_vextent(ALFONT_FONT *f, int *top, int *bottom);
 
 ALFONT_DLL_DECLSPEC int alfont_text_mode(int mode);
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -361,7 +361,7 @@ namespace AGS
         {
             throw gcnew AGSEditorException(String::Format("Unable to load font {0}. Not a TTF font, or there an error occured while loading it.", fileName));
         }
-        return metrics.Height;
+        return metrics.NominalHeight;
     }
 
     void NativeMethods::OnGameFontUpdated(Game^ game, int fontSlot, bool forceUpdate)

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -529,17 +529,20 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
         color |= makeacol32(0, 0, 0, 0xff);
 
     size_t const t_width = get_text_width(texx, font);
-    size_t const t_height = get_font_surface_height(font);
+    const auto t_extent = get_font_surface_extent(font);
+    size_t const t_height = t_extent.second - t_extent.first;
     if (t_width == 0 || t_height == 0)
         return;
     // Prepare stencils
+    size_t const t_yoff = t_extent.first;
     Bitmap *texx_stencil, *outline_stencil;
     alloc_font_outline_buffers(font, &texx_stencil, &outline_stencil,
         t_width, t_height, stencil_cd);
     texx_stencil->ClearTransparent();
     outline_stencil->ClearTransparent();
     // Ready text stencil
-    wouttextxy(texx_stencil, 0, 0, font, color, texx);
+    // Note we are drawing with y off, in case some font's glyphs exceed font's ascender
+    wouttextxy(texx_stencil, 0, -t_yoff, font, color, texx);
     // Anti-aliased TTFs require to be alpha-blended, not blit,
     // or the alpha values will be plain copied and final image will be broken.
     void(Bitmap::*pfn_drawstencil)(Bitmap *src, int dst_x, int dst_y);
@@ -555,7 +558,7 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
 
     // move start of text so that the outline doesn't drop off the bitmap
     xxp += thickness;
-    int const outline_y = yyp;
+    int const outline_y = yyp + t_yoff;
     yyp += thickness;
     
     // What we do here: first we paint text onto outline_stencil offsetting vertically;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -788,6 +788,8 @@ void init_game_drawdata()
     guiobjbg.resize(guio_num);
 }
 
+extern void dispose_engine_overlay();
+
 void dispose_game_drawdata()
 {
     clear_drawobj_cache();
@@ -806,6 +808,8 @@ void dispose_game_drawdata()
     gui_render_tex.clear();
     guiobjbg.clear();
     guiobjddbref.clear();
+
+    dispose_engine_overlay();
 }
 
 static void dispose_debug_room_drawdata()
@@ -2352,20 +2356,34 @@ PBitmap draw_room_background(Viewport *view)
 }
 
 
+struct DrawFPS
+{
+    IDriverDependantBitmap* ddb = nullptr;
+    std::unique_ptr<Bitmap> bmp;
+    int font = -1; // in case normal font changes at runtime
+} gl_DrawFPS;
+
+void dispose_engine_overlay()
+{
+    gl_DrawFPS.bmp.reset();
+    if (gl_DrawFPS.ddb)
+        gfxDriver->DestroyDDB(gl_DrawFPS.ddb);
+    gl_DrawFPS.ddb = nullptr;
+    gl_DrawFPS.font = -1;
+}
+
 void draw_fps(const Rect &viewport)
 {
-    // TODO: make allocated "fps struct" instead of using static vars!!
-    static IDriverDependantBitmap* ddb = nullptr;
-    static Bitmap *fpsDisplay = nullptr;
     const int font = FONT_NORMAL;
-    if (fpsDisplay == nullptr)
+    auto &fpsDisplay = gl_DrawFPS.bmp;
+    if (fpsDisplay == nullptr || gl_DrawFPS.font != font)
     {
-        fpsDisplay = CreateCompatBitmap(viewport.GetWidth(), (get_font_surface_height(font) + get_fixed_pixel_size(5)));
+        recycle_bitmap(fpsDisplay, game.GetColorDepth(), viewport.GetWidth(), (get_font_surface_height(font) + get_fixed_pixel_size(5)));
+        gl_DrawFPS.font = font;
     }
-    fpsDisplay->ClearTransparent();
-    
-    color_t text_color = fpsDisplay->GetCompatibleColor(14);
 
+    fpsDisplay->ClearTransparent();
+    const color_t text_color = fpsDisplay->GetCompatibleColor(14);
     char base_buffer[20];
     if (!isTimerFpsMaxed()) {
         snprintf(base_buffer, sizeof(base_buffer), "%d", frames_per_second);
@@ -2381,19 +2399,17 @@ void draw_fps(const Rect &viewport)
     } else {
         snprintf(fps_buffer, sizeof(fps_buffer), "FPS: --.- / %s", base_buffer);
     }
-    wouttext_outline(fpsDisplay, 1, 1, font, text_color, fps_buffer);
-
     char loop_buffer[60];
     snprintf(loop_buffer, sizeof(loop_buffer), "Loop %u", loopcounter);
-    wouttext_outline(fpsDisplay, viewport.GetWidth() / 2, 1, font, text_color, loop_buffer);
 
-    if (ddb)
-        gfxDriver->UpdateDDBFromBitmap(ddb, fpsDisplay, false);
-    else
-        ddb = gfxDriver->CreateDDBFromBitmap(fpsDisplay, false);
+    int text_off = get_font_surface_extent(font).first; // TODO: a generic function that accounts for this?
+    wouttext_outline(fpsDisplay.get(), 1, 1 - text_off, font, text_color, fps_buffer);
+    wouttext_outline(fpsDisplay.get(), viewport.GetWidth() / 2, 1 - text_off, font, text_color, loop_buffer);
+
+    gl_DrawFPS.ddb = recycle_ddb_bitmap(gl_DrawFPS.ddb, gl_DrawFPS.bmp.get());
     int yp = viewport.GetHeight() - fpsDisplay->GetHeight();
-    gfxDriver->DrawSprite(1, yp, ddb);
-    invalidate_sprite_glob(1, yp, ddb);
+    gfxDriver->DrawSprite(1, yp, gl_DrawFPS.ddb);
+    invalidate_sprite_glob(1, yp, gl_DrawFPS.ddb);
 }
 
 // Draw GUI controls as separate sprites, each on their own texture


### PR DESCRIPTION
This is an attempt to fix certain fonts getting "cut off" from the top when being drawn on a limited size texture or bitmap, such as Labels (when run with texture-based renderer - Direct3D / OpenGL).

The reason for such behavior is that fonts may include glyphs which topmost extent is higher than the reported "ascender". In this case the engine simply does not know that glyphs may be drawn higher, and the prepared texture is not accommodated for that.

**Example font(s)**

[Pixel-Noir Skinny Short.zip](https://github.com/adventuregamestudio/ags/files/15044400/Pixel-Noir.Skinny.Short.zip)


**How we fix this:**

1. Following a caller's instruction (a new flag ALFONT_FLG_PRECALC_MAX_CBOX), alfont preloads all glyphs one by one and records the maximal extents of their "control boxes". These values are saved and returned on demand.
This operation is done only once the font is loaded, on game launch.
2. Our FontMetrics struct has a new VExtent field, that keeps these values (converted to top-down Y axis) for the reference.
3. get_font_surface_height() now returns a surface height calculated from these extent values.
4. CalcFontGraphicalVExtent() now uses the extent values when telling how the text will be graphically positioned, relative to the requested "text position".

**Testing**

This issue, and a fix, are best tested with "Clip gui controls" setting **DISABLED** (because otherwise the text may be simply clipped by the control's rectangle).

What to test: items that display texts *automatically* (as opposed to user drawing it on DrawingSurface):
- Any GUI that can display a text.
~- Textual overlays of any kind (Overlay.CreateTextual, Say, Display).~ looks like not necessary (?)
~- Dialog options (I don't think I ever tested these for font issues...)~ EDIT: probably should not do this here, because that might conflict with options drawing logic, or make it inconsistent with the rest. This is the same issue as happens if you draw text at 0,0 on a drawing surface: the text renderer assumes that the top of ascender should be at 0,0, and if glyphs are higher, then they are naturally cut.
- Automatic font outline.
- FPS counter.

Also:
- Automatic outline (!) preferably with big thickness, to have a larger offset.