### PR TITLE
Editor: no need to use shell in our started process

### DIFF
--- a/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
+++ b/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
@@ -123,6 +123,7 @@ namespace AGS.Editor
 
                 ProcessStartInfo startInfo = new ProcessStartInfo
                 {
+                    UseShellExecute = false,
                     Arguments = DiskDir,
                     FileName = "explorer.exe"
                 };

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -1051,6 +1051,7 @@ namespace AGS.Editor
         {
             string fileName = (string)parameter;
             Process imageEditor = new Process();
+            imageEditor.StartInfo.UseShellExecute = false;
 
             string paintProgramPath = Factory.AGSEditor.Settings.PaintProgramPath;
             if (string.IsNullOrEmpty(paintProgramPath))

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -607,6 +607,7 @@ namespace AGS.Editor
                 }
 
                 _testGameProcess = new Process();
+                _testGameProcess.StartInfo.UseShellExecute = false;
                 _testGameProcess.StartInfo.FileName = exeName;
                 _testGameProcess.StartInfo.Arguments = parameter;
                 if (raiseEventOnExit)


### PR DESCRIPTION
I think everywhere we start a new process from the Editor the process doesn't need a shell, as we aren't using commands from those, so it should be alright to set `UseShellExecute` to false in all of them.

I have a guess that this would not cause the Defender to trigger in this specific case reported in the forums : https://www.adventuregamestudio.co.uk/forums/beginners-technical-questions/ags-3-6-0-crashing-when-i-hit-f5-to-launch-the-game/msg636662661/#msg636662661