### PR TITLE
AGS 4.0: Fix room background import in 8-bit games

### DIFF
--- a/Common/util/wgt2allg.cpp
+++ b/Common/util/wgt2allg.cpp
@@ -94,12 +94,11 @@ using namespace AGS::Common;
 
   int __wremap_keep_transparent = 1;
 
-  void wremap(RGB * pal1, Bitmap *picc, RGB * pal2)
+  void wremap(const RGB * pal1, Bitmap *picc, const RGB * pal2)
   {
-    int jj;
     unsigned char color_mapped_table[256];
 
-    for (jj = 0; jj < 256; jj++)
+    for (int jj = 0; jj < 256; jj++)
     {
       if ((pal1[jj].r == 0) && (pal1[jj].g == 0) && (pal1[jj].b == 0))
       {
@@ -115,21 +114,21 @@ using namespace AGS::Common;
       // keep transparency
       color_mapped_table[0] = 0;
       // any other pixels which are being mapped to 0, map to 16 instead
-      for (jj = 1; jj < 256; jj++) {
+      for (int jj = 1; jj < 256; jj++) {
         if (color_mapped_table[jj] == 0)
           color_mapped_table[jj] = 16;
       }
     }
 
     int pic_size = picc->GetWidth() * picc->GetHeight();
-    for (jj = 0; jj < pic_size; jj++) {
+    for (int jj = 0; jj < pic_size; jj++) {
       int xxl = jj % (picc->GetWidth()), yyl = jj / (picc->GetWidth());
       int rr = picc->GetPixel(xxl, yyl);
       picc->PutPixel(xxl, yyl, color_mapped_table[rr]);
     }
   }
 
-  void wremapall(RGB * pal1, Bitmap *picc, RGB * pal2)
+  void wremapall(const RGB * pal1, Bitmap *picc, const RGB * pal2)
   {
     __wremap_keep_transparent--;
     wremap(pal1, picc, pal2);

--- a/Common/util/wgt2allg.cpp
+++ b/Common/util/wgt2allg.cpp
@@ -92,9 +92,7 @@ using namespace AGS::Common;
     0xA0A0A0, 0xB0B0B0, 0xC0C0C0, 0xD0D0D0, 0xE0E0E0, 0xF0F0F0
   };
 
-  int __wremap_keep_transparent = 1;
-
-  void wremap(const RGB * pal1, Bitmap *picc, const RGB * pal2)
+  void wremap(const RGB * pal1, Bitmap *picc, const RGB * pal2, bool keep_transparent)
   {
     unsigned char color_mapped_table[256];
 
@@ -110,7 +108,7 @@ using namespace AGS::Common;
       }
     }
 
-    if (__wremap_keep_transparent > 0) {
+    if (keep_transparent) {
       // keep transparency
       color_mapped_table[0] = 0;
       // any other pixels which are being mapped to 0, map to 16 instead
@@ -130,7 +128,5 @@ using namespace AGS::Common;
 
   void wremapall(const RGB * pal1, Bitmap *picc, const RGB * pal2)
   {
-    __wremap_keep_transparent--;
-    wremap(pal1, picc, pal2);
-    __wremap_keep_transparent++;
+    wremap(pal1, picc, pal2, false);
   }

--- a/Common/util/wgt2allg.h
+++ b/Common/util/wgt2allg.h
@@ -40,8 +40,8 @@ extern void __my_setcolor(int *ctset, int newcol, int wantColDep);
 
     // TODO: these are used only in the Editor's agsnative.cpp
     extern int __wremap_keep_transparent;
-    extern void wremap(RGB * pal1, Common::Bitmap *picc, RGB * pal2);
-    extern void wremapall(RGB * pal1, Common::Bitmap *picc, RGB * pal2);
+    extern void wremap(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2);
+    extern void wremapall(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2);
 
 
 #endif // __WGT4_H

--- a/Common/util/wgt2allg.h
+++ b/Common/util/wgt2allg.h
@@ -39,8 +39,7 @@ extern void __my_setcolor(int *ctset, int newcol, int wantColDep);
     extern const int col_lookups[32];
 
     // TODO: these are used only in the Editor's agsnative.cpp
-    extern int __wremap_keep_transparent;
-    extern void wremap(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2);
+    extern void wremap(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2, bool keep_transparent = true);
     extern void wremapall(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2);
 
 

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -425,6 +425,7 @@
     <Compile Include="Utils\DirectoryInfoExtensions.cs" />
     <Compile Include="Utils\FileWatcher.cs" />
     <Compile Include="Utils\MathExtra.cs" />
+    <Compile Include="Utils\PaletteUtilities.cs" />
     <Compile Include="Utils\ScriptFileUtilities.cs" />
     <Compile Include="Utils\ScriptGeneration.cs" />
     <Compile Include="Utils\StdConsoleWriter.cs" />

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1727,7 +1727,7 @@ namespace AGS.Editor.Components
                 }
                 newBmp.Palette = palette;
 
-                newBmp.SetGlobalPaletteFromPalette();
+                newBmp.CopyToAGSBackgroundPalette(Factory.AGSEditor.CurrentGame.Palette);
                 // TODO Implement remap_background from AGS.Native
             }
 
@@ -2055,7 +2055,7 @@ namespace AGS.Editor.Components
         {
             double scale = _loadedRoom.GetMaskScale(mask);
             var bitmap = new Bitmap((int)(width * scale), (int)(height * scale), PixelFormat.Format8bppIndexed);
-            bitmap.SetPaletteFromGlobalPalette();
+            bitmap.SetFromAGSPalette(Factory.AGSEditor.CurrentGame.Palette);
             return bitmap;
         }
 
@@ -2086,7 +2086,7 @@ namespace AGS.Editor.Components
             var temp_bitmap = new Bitmap(1, 1, PixelFormat.Format8bppIndexed); // needed to create a fresh 256 palette, ColorPalette can't be created alone
             newMask.Palette = temp_bitmap.Palette;
             temp_bitmap.Dispose();
-            newMask.SetPaletteFromGlobalPalette(); // enforce default mask palette
+            newMask.SetFromAGSPalette(Factory.AGSEditor.CurrentGame.Palette); // enforce default mask palette
 
             int maxColor = Room.GetMaskMaxColor(type);
             bool invalidPixel = false;

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1722,7 +1722,10 @@ namespace AGS.Editor.Components
             {
                 int colorsImage, colorsLimit;
                 PaletteUtilities.RemapBackground(newBmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, out colorsImage, out colorsLimit);
-                newBmp.CopyToAGSBackgroundPalette(Factory.AGSEditor.CurrentGame.Palette);
+                if (background == 0)
+                {
+                    newBmp.CopyToAGSBackgroundPalette(Factory.AGSEditor.CurrentGame.Palette);
+                }
 
                 // TODO: not sure if it's good to report error here, in the interface impl,
                 // but the existing method does not provide a "CompileMessages" arg
@@ -2041,7 +2044,21 @@ namespace AGS.Editor.Components
             _guiController.RefreshPropertyGrid();
         }
 
-        private Bitmap LoadBackground(int i) => BitmapExtensions.LoadNonLockedBitmap(_loadedRoom.GetBackgroundFileName(i));
+        private Bitmap LoadBackground(int i)
+        {
+            Bitmap newBmp = BitmapExtensions.LoadNonLockedBitmap(_loadedRoom.GetBackgroundFileName(i));
+            // For 8-bit rooms - remap loaded background images
+            if (_loadedRoom.ColorDepth == 8)
+            {
+                int colorsImage, colorsLimit;
+                PaletteUtilities.RemapBackground(newBmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, out colorsImage, out colorsLimit);
+                if (i == 0)
+                {
+                    newBmp.CopyToAGSBackgroundPalette(Factory.AGSEditor.CurrentGame.Palette);
+                }
+            }
+            return newBmp;
+        }
 
         private void RefreshBackground(int i)
         {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1720,15 +1720,18 @@ namespace AGS.Editor.Components
 
             if (_loadedRoom.ColorDepth == 8)
             {
-                ColorPalette palette = newBmp.Palette;
-                foreach (var color in _agsEditor.CurrentGame.Palette.Where(p => p.ColourType == PaletteColourType.Locked))
-                {
-                    palette.Entries[color.Index] = color.Colour;
-                }
-                newBmp.Palette = palette;
-
+                int colorsImage, colorsLimit;
+                PaletteUtilities.RemapBackground(newBmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, out colorsImage, out colorsLimit);
                 newBmp.CopyToAGSBackgroundPalette(Factory.AGSEditor.CurrentGame.Palette);
-                // TODO Implement remap_background from AGS.Native
+
+                // TODO: not sure if it's good to report error here, in the interface impl,
+                // but the existing method does not provide a "CompileMessages" arg
+                if (Factory.AGSEditor.Settings.RemapPalettizedBackgrounds &&
+                    (colorsImage > colorsLimit))
+                {
+                    _guiController.ShowMessage($"The image uses more colors ({colorsImage}) than palette slots allocated to backgrounds ({colorsLimit}). Some colours will be lost.",
+                        MessageBoxIconType.Information);
+                }
             }
 
             if (background >= _backgroundCache.Count)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2388,8 +2388,6 @@ namespace AGS.Editor.Components
             }
 
             // Sync native palette before writing
-            // TODO: revise this later; at the time of writing nativeRoom.SetBackground
-            // did full background remap once more, which seems like a duplicated effort
             if ((_loadedRoom.ColorDepth == 8) && (_loadedRoom.BackgroundCount > 0))
             {
                 CopyGamePalette(); // in case they had changes to game colors in the meantime
@@ -2400,8 +2398,7 @@ namespace AGS.Editor.Components
             var nativeRoom = new Native.NativeRoom(_loadedRoom);
             for (int i = 0; i < _loadedRoom.BackgroundCount; i++)
             {
-                nativeRoom.SetBackground(
-                    i, _backgroundCache[i].Image, _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false);
+                nativeRoom.SetBackground(i, _backgroundCache[i].Image);
             }
 
             foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -73,6 +73,11 @@ namespace AGS.Editor
             _native.PaletteColoursUpdated(game);
         }
 
+        public void ApplyPalette(PaletteEntry[] palette)
+        {
+            _native.ApplyPalette(palette);
+        }
+
         public void SaveGame(Game game)
         {
 			lock (_spriteSetLock)

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -159,7 +159,7 @@ namespace AGS.Editor
                 {
                     Color thisColor = game.Palette[i].Colour;
                     e.Graphics.FillRectangle(new SolidBrush(thisColor), x, y, 20, 20);
-/*
+                    /*
                     if (game.Palette[i].ColourType == PaletteColourType.Locked)
                     {
                         Brush textCol = Brushes.White;

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -536,7 +536,7 @@ namespace AGS.Editor
 				Bitmap bmp = null;
                 try
                 {
-                    bmp = new Bitmap(selectedFile);
+                    bmp = BitmapExtensions.LoadNonLockedBitmap(selectedFile);
                     bmp = ExtendBitmapIfSmallerThanScreen(bmp);
                     bool doImport = true;
                     bool deleteExtraFrames = false;

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -541,7 +541,12 @@ namespace AGS.Editor
                     bool doImport = true;
                     bool deleteExtraFrames = false;
 
-					if ((bmp.Width != _room.Width) || (bmp.Height != _room.Height))
+                    if ((Factory.AGSEditor.CurrentGame.Settings.ColorDepth == GameColorDepth.Palette) && (bmp.GetColorDepth() > 8))
+                    {
+                        Factory.GUIController.ShowMessage("You cannot import a hi-colour or true-colour image into a 256-colour game.", MessageBoxIcon.Warning);
+                        doImport = false;
+                    }
+					else if ((bmp.Width != _room.Width) || (bmp.Height != _room.Height))
                     {
                         if (bgIndex > 0)
                         {

--- a/Editor/AGS.Editor/Utils/PaletteUtilities.cs
+++ b/Editor/AGS.Editor/Utils/PaletteUtilities.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// PaletteUtilities is meant to be a group of methods which handle AGS Game Palette,
+    /// and perform various operations over it, or between AGS Palette and Image's Palette.
+    /// </summary>
+    class PaletteUtilities
+    {
+        static PaletteUtilities()
+        {
+            BestFitInit();
+        }
+
+        public static void RemapBackground(Bitmap scene, bool exactPal, out int colorsImage, out int colorsLimit)
+        {
+            PaletteEntry[] gamePalette = Factory.AGSEditor.CurrentGame.Palette;
+            ColorPalette palette = scene.Palette;
+            /*
+            // Unconditionally copy any Locked colors to the bitmap palette
+            foreach (var color in gamePalette.Where(p => p.ColourType == PaletteColourType.Locked))
+            {
+                palette.Entries[color.Index] = color.Colour;
+            }
+            */
+
+            // Exact palette: keep any color of Background indexes as-is
+            if (exactPal)
+            {
+                // CHECKME: should we also clear or copy all the Game-wide slots here?
+                // This was not entirely clear from the original code in AGS.Native
+                colorsImage = 0; // just reset them, no use in this case
+                colorsLimit = 0;
+                return;
+            }
+
+            // Now do palette remap...
+            // Find how many slots there are reserved for backgrounds
+            // NOTE: this was counting non-Gamewide in original code, meaning this counts Bg + Locked
+            int bgSlotCount = gamePalette.Count(p => p.ColourType != PaletteColourType.Gamewide);
+            // Find which colours from the image palette are actually used
+            var pixels = scene.GetRawData();
+            int[] slotUsed = new int[256];
+            int usedSlotCount = 0;
+            for (int p = 0; p < pixels.Length; ++p)
+            {
+                slotUsed[pixels[p]]++;
+            }
+            for (int i = 0; i < 256; ++i)
+            {
+                if (slotUsed[i] > 0)
+                    usedSlotCount++;
+            }
+
+            // Nativize RGB, clamp to 64-unit format to match historical engine's palette restriction
+            Color[] srcColors = new Color[256];
+            for (int i = 0; i < 256; ++i)
+            {
+                srcColors[i] = Color.FromArgb(0xFF, palette.Entries[i].R / 4, palette.Entries[i].G / 4, palette.Entries[i].B / 4);
+            }
+
+            // Count and remember the unique colours in the image
+            // We have to do this separately, because some of the palette colors could be duplicates.
+            Color[] uniqueColors = new Color[256];
+            int uniqueColorCount = 0;
+            for (int i = 0; i < 256; ++i)
+            {
+                // slot not used
+                if (slotUsed[i] == 0)
+                {
+                    continue;
+                }
+
+                // full-black color, skip it
+                if ((srcColors[i].R == 0) & (srcColors[i].G == 0) & (srcColors[i].B == 0))
+                {
+                    continue;
+                }
+
+                bool foundRepeat = false;
+                for (int j = 0; j < uniqueColorCount; ++j)
+                {
+                    if ((srcColors[i].R == uniqueColors[j].R) &
+                        (srcColors[i].G == uniqueColors[j].G) &
+                        (srcColors[i].B == uniqueColors[j].B))
+                    {
+                        foundRepeat = true;
+                        break;
+                    }
+                }
+
+                if (foundRepeat)
+                {
+                    continue;
+                }
+
+                // Save new unique color
+                uniqueColors[uniqueColorCount++] = srcColors[i];
+            }
+
+            // Create new set of colors for the final mapping
+            Color[] finalColors = new Color[256];
+            // Clear the game-wide color slots, so that they are not used during following remap
+            foreach (var color in gamePalette.Where(p => p.ColourType == PaletteColourType.Gamewide))
+            {
+                finalColors[color.Index] = Color.Black;
+            }
+            // Fill the background slots in the palette with the unique colours
+            // Start from end of palette and work backwards
+            for (int uc = 0, slot = 255; (uc < uniqueColorCount) && (slot >= 0); ++uc, --slot)
+            {
+                // find the next background slot for this unique color
+                for (; (slot >= 0) &&
+                    (gamePalette[slot].ColourType != PaletteColourType.Background);
+                    --slot) ;
+
+                if (slot >= 0)
+                {
+                    finalColors[slot] = uniqueColors[uc];
+                }
+            }
+
+            /*
+            // Copy any Locked colors over the final palette
+            foreach (var color in gamePalette.Where(p => p.ColourType == PaletteColourType.Locked))
+            {
+                finalColors[color.Index] = color.Colour;
+            }
+            */
+
+            // Use the final color list to remap the palette
+            RemapPixels(pixels, srcColors, finalColors, false /* don't keep transparency */);
+
+            // Assign resulting pixel array and new palette to the bitmap;
+            // Un-nativize RGB from 64-unit format
+            for (int i = 0; i < 256; ++i)
+            {
+                palette.Entries[i] = Color.FromArgb(0xFF, finalColors[i].R * 4, finalColors[i].G * 4, finalColors[i].B * 4);
+            }
+            scene.SetRawData(pixels);
+            scene.Palette = palette;
+            colorsImage = uniqueColorCount;
+            colorsLimit = bgSlotCount;
+        }
+
+        /// <summary>
+        /// Remaps pixel values from old palette to the new palette,
+        /// by finding the "best match" colors in the new palette.
+        /// </summary>
+        private static void RemapPixels(byte[] pixels, Color[] oldPal, Color[] newPal, bool keepTransparency)
+        {
+            byte[] colorMap = new byte[256];
+            for (int i = 0; i < 256; ++i)
+            {
+                if ((oldPal[i].R == 0) && (oldPal[i].G == 0) && (oldPal[i].B == 0))
+                {
+                    colorMap[i] = 0;
+                }
+                else
+                {
+                    colorMap[i] = BestFitColor(newPal, oldPal[i].R, oldPal[i].G, oldPal[i].B);
+                }
+            }
+
+            if (keepTransparency)
+            {
+                colorMap[0] = 0;
+                // Any other pixels which are being mapped to 0, map to 16 instead
+                // TODO: find out why "16" (was in the old code) and comment here;
+                // probably a "magic" color value...
+                for (int i = 1; i < 256; ++i)
+                {
+                    if (colorMap[i] == 0)
+                        colorMap[i] = 16;
+                }
+            }
+
+            for (int p = 0; p < pixels.Length; ++p)
+            {
+                pixels[p] = colorMap[pixels[p]];
+            }
+        }
+
+        // 1.5k lookup table for color matching
+        private static uint[] ColDiffTable = new uint[3 * 128];
+
+        /// <summary>
+        /// Color matching is done with weighted squares, which are much faster
+        /// if we pregenerate a little lookup table...
+        /// </summary>
+        private static void BestFitInit()
+        {
+            for (uint i = 1; i < 64; i++)
+            {
+                uint k = i * i;
+                ColDiffTable[0 + i] = ColDiffTable[0 + 128 - i] = k * (59 * 59);
+                ColDiffTable[128 + i] = ColDiffTable[128 + 128 - i] = k * (30 * 30);
+                ColDiffTable[256 + i] = ColDiffTable[256 + 128 - i] = k * (11 * 11);
+            }
+        }
+
+        /// <summary>
+        /// Searches a palette for the color closest to the requested R, G, B value.
+        /// </summary>
+        private static byte BestFitColor(Color[] pal, int r, int g, int b)
+        {
+            //ASSERT(r >= 0 && r <= 63);
+            //ASSERT(g >= 0 && g <= 63);
+            //ASSERT(b >= 0 && b <= 63);
+
+            // only the transparent (pink) color can be mapped to index 0
+            uint slot;
+            if ((r == 63) && (g == 0) && (b == 63))
+                slot = 0;
+            else
+                slot = 1;
+
+            uint bestfit = 0;
+            uint lowest = uint.MaxValue;
+
+            for (; slot < 256; ++slot)
+            {
+                Color col = pal[slot];
+                uint coldiff = ColDiffTable[0 + ((col.G - g) & 0x7F)];
+                if (coldiff < lowest)
+                {
+                    coldiff += ColDiffTable[128 + ((col.R - r) & 0x7F)];
+                    if (coldiff < lowest)
+                    {
+                        coldiff += ColDiffTable[256 + ((col.B - b) & 0x7F)];
+                        if (coldiff < lowest)
+                        {
+                            bestfit = slot;
+                            if (coldiff == 0)
+                                return (byte)bestfit;
+                            lowest = coldiff;
+                        }
+                    }
+                }
+            }
+
+            return (byte)bestfit;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/PaletteUtilities.cs
+++ b/Editor/AGS.Editor/Utils/PaletteUtilities.cs
@@ -20,9 +20,8 @@ namespace AGS.Editor
             BestFitInit();
         }
 
-        public static void RemapBackground(Bitmap scene, bool exactPal, out int colorsImage, out int colorsLimit)
+        public static void RemapBackground(Bitmap scene, bool exactPal, PaletteEntry[] gamePalette, out int colorsImage, out int colorsLimit)
         {
-            PaletteEntry[] gamePalette = Factory.AGSEditor.CurrentGame.Palette;
             ColorPalette palette = scene.Palette;
             /*
             // Unconditionally copy any Locked colors to the bitmap palette

--- a/Editor/AGS.Editor/Utils/PaletteUtilities.cs
+++ b/Editor/AGS.Editor/Utils/PaletteUtilities.cs
@@ -34,8 +34,13 @@ namespace AGS.Editor
             // Exact palette: keep any color of Background indexes as-is
             if (exactPal)
             {
-                // CHECKME: should we also clear or copy all the Game-wide slots here?
-                // This was not entirely clear from the original code in AGS.Native
+                // We should still copy all the Game-wide slots over,
+                // otherwise the user will get false picture in the Editor.
+                foreach (var color in gamePalette.Where(p => p.ColourType == PaletteColourType.Gamewide))
+                {
+                    palette.Entries[color.Index] = color.Colour;
+                }
+                scene.Palette = palette;
                 colorsImage = 0; // just reset them, no use in this case
                 colorsLimit = 0;
                 return;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -86,7 +86,7 @@ extern void change_sprite_number(int oldNumber, int newNumber);
 extern void SaveNativeSprites(Settings^ gameSettings);
 extern void ReplaceSpriteFile(const AGSString &new_spritefile, const AGSString &new_indexfile, bool fallback_tempfiles);
 extern HAGSError reset_sprite_file();
-extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
+extern void ApplyPalette(cli::array<PaletteEntry^>^ newPalette);
 extern void GameDirChanged(String ^workingDir);
 extern void GameUpdated(Game ^game, bool forceUpdate);
 extern void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
@@ -277,15 +277,20 @@ namespace AGS
 		void NativeMethods::NewGameLoaded(Game ^game, CompileMessages ^errors)
 		{
             _gameTextConverter = gcnew TextConverter(game->TextEncoding);
-			this->PaletteColoursUpdated(game);
+			PaletteColoursUpdated(game);
 			GameUpdated(game, true);
 			UpdateNativeSpritesToGame(game, errors);
 		}
 
 		void NativeMethods::PaletteColoursUpdated(Game ^game)
 		{
-			lastPaletteSet = game->Palette;
-			PaletteUpdated(game->Palette);
+            ApplyPalette(game->Palette);
+		}
+
+        void NativeMethods::ApplyPalette(cli::array<PaletteEntry^> ^palette)
+		{
+			lastPaletteSet = palette;
+			::ApplyPalette(palette);
 		}
 
 		void NativeMethods::LoadNewSpriteFile() 

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -47,7 +47,8 @@ namespace Native
 			void NewGameLoaded(Game^ game, CompileMessages ^errors);
 			void SaveGame(Game^ game);
 			void GameSettingsChanged(Game^ game);
-			void PaletteColoursUpdated(Game ^game);
+            void PaletteColoursUpdated(Game ^game);
+			void ApplyPalette(cli::array<PaletteEntry^> ^palette);
 			void DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl);
 			void DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage);
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);

--- a/Editor/AGS.Native/NativeRoom.cpp
+++ b/Editor/AGS.Native/NativeRoom.cpp
@@ -31,8 +31,7 @@ extern void convert_room_from_native(const RoomStruct &rs, AGS::Types::Room ^roo
 extern void convert_room_to_native(Room ^room, RoomStruct &rs);
 extern AGSString load_room_file(RoomStruct &rs, const AGSString &filename);
 extern void save_room_file(RoomStruct &rs, const AGSString &path);
-extern void SetNativeRoomBackground(RoomStruct &room, int backgroundNumber,
-    SysBitmap ^bmp, bool useExactPalette, bool sharePalette);
+extern void SetNativeRoomBackground(RoomStruct &room, int backgroundNumber, SysBitmap ^bmp);
 extern void validate_mask(AGSBitmap *toValidate, const char *name, int maxColour);
 
 
@@ -105,9 +104,9 @@ SysBitmap ^NativeRoom::GetAreaMask(AGS::Types::RoomAreaMaskType maskType)
     return managedMask;
 }
 
-void NativeRoom::SetBackground(int bgnum, SysBitmap ^bmp, bool useExactPalette, bool sharePalette)
-{ // NOTE: this operation uses too much from the native code to completely move here 
-    SetNativeRoomBackground(*_rs, bgnum, bmp, useExactPalette, sharePalette);
+void NativeRoom::SetBackground(int bgnum, SysBitmap ^bmp)
+{
+    SetNativeRoomBackground(*_rs, bgnum, bmp);
 }
 
 void NativeRoom::SetAreaMask(AGS::Types::RoomAreaMaskType maskType, SysBitmap ^bmp)

--- a/Editor/AGS.Native/NativeRoom.cpp
+++ b/Editor/AGS.Native/NativeRoom.cpp
@@ -24,7 +24,6 @@ using AGS::Types::AGSEditorException;
 using SysBitmap = System::Drawing::Bitmap;
 
 
-AGSBitmap *CreateBlockFromBitmap(SysBitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth);
 extern SysBitmap^ ConvertBlockToBitmap32(AGSBitmap *todraw, int width, int height, bool opaque);
 extern SysBitmap^ ConvertBlockToBitmap(AGSBitmap *todraw);
 AGSBitmap *CreateOpaqueNativeBitmap(SysBitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth);

--- a/Editor/AGS.Native/NativeRoom.h
+++ b/Editor/AGS.Native/NativeRoom.h
@@ -40,7 +40,7 @@ public:
     // Gets respective area mask as a .NET Bitmap
     System::Drawing::Bitmap ^GetAreaMask(AGS::Types::RoomAreaMaskType maskType);
     // Sets/replaces room background, converting from .NET Bitmap
-    void SetBackground(int bgnum, System::Drawing::Bitmap ^bmp, bool useExactPalette, bool sharePalette);
+    void SetBackground(int bgnum, System::Drawing::Bitmap ^bmp);
     // Sets/replaces area mask, converting from .NET Bitmap
     void SetAreaMask(AGS::Types::RoomAreaMaskType maskType, System::Drawing::Bitmap ^bmp);
     // Saves current room object to the file (CRM)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1060,7 +1060,6 @@ void sort_out_palette(Common::Bitmap *toimp, RGB*itspal, bool useBgSlots, int tr
     if (transcol!=0)
       itspal[transcol] = itspal[0];
     wsetrgb(0,0,0,0,itspal); // set index 0 to black
-    __wremap_keep_transparent = 1;
     RGB oldpale[256];
     for (int uu=0;uu<255;uu++) {
       if (useBgSlots)  //  use background scene palette

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2144,7 +2144,7 @@ System::Drawing::Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int he
   return ConvertBlockToBitmap32(todraw, width, height, false /* keep alpha */);
 }
 
-void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette) 
+void ApplyPalette(cli::array<PaletteEntry^>^ newPalette) 
 {  
 	for each (PaletteEntry ^colour in newPalette) 
 	{
@@ -2153,8 +2153,6 @@ void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette)
 		palette[colour->Index].b = colour->Colour.B / 4;
 	}
 	set_palette(palette);
-	RoomStruct dummy; // FIXME: not working since open room format
-	copy_global_palette_to_room_palette(dummy);
 }
 
 void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui) 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1187,12 +1187,11 @@ void free_old_game_data()
 }
 
 // remap the scene, from its current palette oldpale to palette
-void remap_background (Common::Bitmap *scene, RGB *oldpale, RGB*palette, int exactPal) {
-  int a;  
+void remap_background (Common::Bitmap *scene, const RGB *oldpale, RGB*palette, int exactPal) {
 
   if (exactPal) {
     // exact palette import (for doing palette effects, don't change)
-    for (a=0;a<256;a++) 
+    for (int a=0;a<256;a++) 
     {
       if (thisgame.paluses[a] == PAL_BACKGROUND)
       {
@@ -1204,23 +1203,23 @@ void remap_background (Common::Bitmap *scene, RGB *oldpale, RGB*palette, int exa
 
   // find how many slots there are reserved for backgrounds
   int numbgslots=0;
-  for (a=0;a<256;a++) { oldpale[a].filler=0;
+  for (int a=0;a<256;a++) {
     if (thisgame.paluses[a]!=PAL_GAMEWIDE) numbgslots++;
   }
   // find which colours from the image palette are actually used
   int imgpalcnt[256],numimgclr=0;
   memset(&imgpalcnt[0],0,sizeof(int)*256);
 
-  for (a=0;a<(scene->GetWidth()) * (scene->GetHeight());a++) {
+  for (int a=0;a<(scene->GetWidth()) * (scene->GetHeight());a++) {
     imgpalcnt[scene->GetScanLine(0)[a]]++;
   }
-  for (a=0;a<256;a++) {
+  for (int a=0;a<256;a++) {
     if (imgpalcnt[a]>0) numimgclr++;
   }
   // count up the number of unique colours in the image
   int numclr=0,bb;
   RGB tpal[256];
-  for (a=0;a<256;a++) {
+  for (int a=0;a<256;a++) {
     if (thisgame.paluses[a]==PAL_BACKGROUND)
       wsetrgb(a,0,0,0,palette);  // black out the bg slots before starting
     if ((oldpale[a].r==0) & (oldpale[a].g==0) & (oldpale[a].b==0)) {
@@ -1247,7 +1246,7 @@ void remap_background (Common::Bitmap *scene, RGB *oldpale, RGB*palette, int exa
 
   // fill the background slots in the palette with the colours
   int palslt=255;  // start from end of palette and work backwards
-  for (a=0;a<numclr;a++) {
+  for (int a=0;a<numclr;a++) {
     while (thisgame.paluses[palslt]!=PAL_BACKGROUND) {
       palslt--;
       if (palslt<0) break;
@@ -1258,7 +1257,7 @@ void remap_background (Common::Bitmap *scene, RGB *oldpale, RGB*palette, int exa
     if (palslt<0) break;
   }
   // blank out the sprite colours, then remap the picture
-  for (a=0;a<256;a++) {
+  for (int a=0;a<256;a++) {
     if (thisgame.paluses[a]==PAL_GAMEWIDE) {
       tpal[a].r=0;
       tpal[a].g=0; tpal[a].b=0; 

--- a/Editor/AGS.Types/Enums/PaletteColourType.cs
+++ b/Editor/AGS.Types/Enums/PaletteColourType.cs
@@ -7,7 +7,7 @@ namespace AGS.Types
     public enum PaletteColourType
     {
         Gamewide = 0,
-        Locked = 1,
+        //Locked = 1, // not used since AGS 3.*
         Background = 2
     }
 }


### PR DESCRIPTION
Fixes #2218

Reimplemented palette remap on the managed side, where it is applied to the Bitmaps as they are imported to the room.
Confirmed that backgrounds now look in the Editor as they should after remap (compared with ags3 branch), and look the same in the Engine.

Introduced a separate Palette in RoomComponent, which merges default palette from Game, and palette from the last imported primary background (index 0). This prevents Game's palette from being modified by room bgs.

Make sure the native palette is also synchronized when a primary room background is imported or reloaded. Native-side palette is still used when importing 8-bit sprites.

NOTES:
* couple of first commits in AGS.Native is a small code cleanup, to help myself understand the meaning of function arguments.
