### PR TITLE
Fix editor android keystore gen

### DIFF
--- a/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.cs
+++ b/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.cs
@@ -192,6 +192,11 @@ namespace AGS.Editor
 
         private void buttonGenerate_Click(object sender, EventArgs e)
         {
+            if (!AndroidUtilities.IsKeytoolAvailable())
+            {
+                Factory.GUIController.ShowMessage("Failed to find KeyTool. Please verify the JDK path in the Editor Preferences is correct.", MessageBoxIcon.Error);
+            }
+
             string errors = String.Join("\n", AndroidUtilities.GetKeystoreErrors(_ks));
 
             if (!string.IsNullOrEmpty(errors))
@@ -202,7 +207,7 @@ namespace AGS.Editor
                 return;
             }
 
-            if(AndroidUtilities.RunGenerateKeystore(_ks))
+            if (AndroidUtilities.RunGenerateKeystore(_ks))
             {
                 _lastGeneratedKS = _ks.Copy();
                 buttonOK.Enabled = true;

--- a/Editor/AGS.Editor/Utils/AndroidUtilities.cs
+++ b/Editor/AGS.Editor/Utils/AndroidUtilities.cs
@@ -384,9 +384,10 @@ namespace AGS.Editor.Utils
 
             if (string.IsNullOrEmpty(d.Password)) errors.Add("Password can't be empty.");
             if (string.IsNullOrEmpty(d.KeyPassword)) errors.Add("Key Password can't be empty.");
-            if (d.KeyPassword != d.Password) errors.Add("Passwords don't match.");
             if (string.IsNullOrEmpty(d.KeyAlias)) errors.Add("Key alias cannot be empty.");
-
+            if (d.Password.Length < 6) errors.Add("Password must be at least 6 characters.");
+            if (d.KeyPassword.Length < 6) errors.Add("Key password must be at least 6 characters.");
+            if (d.KeyPassword != d.Password) errors.Add("Passwords don't match.");
             if (d.ValidityInYears < 1) errors.Add("Validity cannot be lower than 1 year.");
 
             return errors;

--- a/Editor/AGS.Editor/Utils/AndroidUtilities.cs
+++ b/Editor/AGS.Editor/Utils/AndroidUtilities.cs
@@ -285,6 +285,8 @@ namespace AGS.Editor.Utils
 
         public static bool IsKeytoolAvailable()
         {
+            if (string.IsNullOrEmpty(GetJavaHome())) 
+                return false;
             return IsExecutableAvailable(GetKeytoolPath());
         }
 


### PR DESCRIPTION
fixing a few errors in the android keystore gen process.

doing this as a quick answer to the issue here: https://www.adventuregamestudio.co.uk/forums/advanced-technical-forum/generate-android-keystore-error/msg636662764/#msg636662764

I would like to add a few more things to make it visually more obvious in the preferences screen and maybe block keygen screen until jdk path is properly filled but I don't have a good idea on that side yet and the things I am fixing here felt quite obvious to fix.