### PR TITLE
4.0: Overlays always store their explicit position, reimplemented autopositioning

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2575,10 +2575,10 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     int tdxp = xx,tdyp = yy;
     int oldview=-1, oldloop = -1;
     int ovr_type = 0;
+    int autoplace_at_char = -1; // depends on speech style below
     text_lips_offset = 0;
     text_lips_text = texx;
     Bitmap *closeupface = nullptr;
-    bool overlayPositionFixed = false;
     int charFrameWas = 0;
     int viewWasLocked = 0;
     if (speakingChar->flags & CHF_FIXVIEW)
@@ -2851,7 +2851,6 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             if (facetalkchar->blinktimer < 0)
                 facetalkchar->blinktimer = facetalkchar->blinkinterval;
             textcol=-textcol;
-            overlayPositionFixed = true;
             // Process the first portrait view frame
             const int frame_vol = charextra[facetalkchar->index_id].GetFrameSoundVolume(facetalkchar);
             CheckViewFrame(facetalkview, facetalkloop, facetalkframe, frame_vol);
@@ -2859,6 +2858,9 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         else if (useview >= 0) {
             // Lucasarts-style speech
             set_our_eip(154);
+
+            // autoplace at character
+            autoplace_at_char = aschar;
 
             oldview = speakingChar->view;
             oldloop = speakingChar->loop;
@@ -2903,8 +2905,9 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
         }
     }
-    else
+    else {
         allowShrink = 1;
+    }
 
     // it wants the centred position, so make it so
     if ((xx >= 0) && (tdxp < 0))
@@ -2918,7 +2921,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         char_thinking = aschar;
 
     set_our_eip(155);
-    display_main(tdxp, tdyp, bwidth, texx, nullptr, DISPLAYTEXT_SPEECH, FONT_SPEECH, textcol, isThought, allowShrink, overlayPositionFixed);
+    display_main(tdxp, tdyp, bwidth, texx, nullptr, DISPLAYTEXT_SPEECH, FONT_SPEECH, textcol, isThought, allowShrink, autoplace_at_char);
     set_our_eip(156);
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
         closeupface = nullptr;

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -73,12 +73,13 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
 //   != 0 - text color for a speech or a regular textual overlay, where
 //     < 0 - use text window if applicable
 //     > 0 - suppose it's a classic LA-style speech above character's head
+// autoplace_at_char - tells whether overlay should autoposition itself whenever game updates.
 // NOTE: this function treats the text as-is; it assumes that any processing
 // (translation, parsing voice token) was done prior to its call.
 // TODO: refactor this collection of args into few args + 1-2 structs with extended params.
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
     const TopBarSettings *topbar, int disp_type, int usingfont,
-    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
+    int asspch, int isThought, int allowShrink, int autoplace_at_char = -1, bool roomlayer = false);
 // Displays a standard blocking message box at a given position
 void display_at(int xx, int yy, int wii, const char *text, const TopBarSettings *topbar);
 // Cleans up display message state

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2800,7 +2800,7 @@ static void construct_overlays()
         // If walk behinds are drawn over the cached object sprite, then check if positions were updated
         if (crop_walkbehinds && over.IsRoomLayer())
         {
-            Point pos = get_overlay_position(over);
+            Point pos = get_overlay_display_pos(over);
             has_changed |= (pos.X != overcache[i].X || pos.Y != overcache[i].Y);
             overcache[i].X = pos.X; overcache[i].Y = pos.Y;
         }
@@ -2830,7 +2830,7 @@ static void construct_overlays()
                         recycle_bitmap(use_cache, use_bmp->GetColorDepth(), use_bmp->GetWidth(), use_bmp->GetHeight(), true);
                         use_cache->Blit(use_bmp);
                     }
-                    Point pos = get_overlay_position(over);
+                    Point pos = get_overlay_display_pos(over);
                     walkbehinds_cropout(use_cache.get(), pos.X, pos.Y, over.zorder);
                     use_bmp = use_cache.get();
                 }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2868,11 +2868,6 @@ void construct_game_scene(bool full_redraw)
     // Overlays may be both in rooms and ui layer, prepare their textures beforehand
     construct_overlays();
 
-    // TODO: move to game update! don't call update during rendering pass!
-    // IMPORTANT: keep the order same because sometimes script may depend on it
-    if (displayed_room >= 0)
-        play.UpdateRoomCameras();
-
     // Begin with the parent scene node, defining global offset and flip
     gfxDriver->BeginSpriteBatch(play.GetMainViewport(),
         play.GetGlobalTransform(drawstate.FullFrameRedraw),

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -234,13 +234,12 @@ void DisplaySpeechAt (int xx, int yy, int wii, int aschar, const char*spch) {
 }
 
 // [DEPRECATED] left only for use in Display, replace/merge with modern function
-static int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, int disp_type) {
+static int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, int disp_type, int speech_for_char) {
     int allowShrink = 0;
-
-    if (xx == OVR_AUTOPLACE) // allow DisplaySpeechBackground to be shrunk
+    if (speech_for_char >= 0) // allow DisplaySpeechBackground to be shrunk
         allowShrink = 1;
 
-    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, disp_type, allowShrink);
+    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, disp_type, allowShrink, speech_for_char);
     return over ? over->type : 0;
 }
 
@@ -251,18 +250,18 @@ int DisplaySpeechBackground(int charid, const char*speel) {
     const auto &overs = get_overlays();
     for (size_t i = 0; i < overs.size(); ++i)
     {
-        if (overs[i].bgSpeechForChar == charid)
+        if (overs[i].speechForChar == charid)
         {
             remove_screen_overlay(i);
             break;
         }
     }
 
-    int ovrl=CreateTextOverlay(OVR_AUTOPLACE,charid,play.GetUIViewport().GetWidth()/2,FONT_SPEECH,
-        -game.chars[charid].talkcolor, get_translation(speel), DISPLAYTEXT_NORMALOVERLAY);
+    int ovrl = CreateTextOverlay(0, 0, play.GetUIViewport().GetWidth() / 2, FONT_SPEECH,
+        -game.chars[charid].talkcolor, get_translation(speel), DISPLAYTEXT_NORMALOVERLAY, charid);
 
     auto *over = get_overlay(ovrl);
-    over->bgSpeechForChar = charid;
+    over->speechForChar = charid;
     over->timeout = GetTextDisplayTime(speel, 1);
     return ovrl;
 }

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -36,11 +36,13 @@ ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool clone);
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
 ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool clone = false);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int disp_type, int allow_shrink);
+    const char *text, int disp_type, int allow_shrink, int speech_for_char = -1);
 
 ScreenOverlay *get_overlay(int type);
-// Calculates overlay position in its respective layer (screen or room)
-Point get_overlay_position(const ScreenOverlay &over);
+// Gets overlay position for drawing in its respective layer (screen or room)
+Point get_overlay_display_pos(const ScreenOverlay &over);
+// Autopositions overlay, that is linked to a character
+void autoposition_overlay(ScreenOverlay &over);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy);

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -95,8 +95,6 @@ enum LegacyScriptAlignment
 #define OVER_TEXTSPEECH 4
 #define OVER_FIRSTFREE 5
 #define OVER_CUSTOM   -1
-// Overlay parameters
-#define OVR_AUTOPLACE 30000
 
 // These are possibly actions scheduled to run after "wait";
 // but only FOR_EXITLOOP is used currently;

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -103,7 +103,7 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
     x = in->ReadInt32();
     y = in->ReadInt32();
     timeout = in->ReadInt32();
-    bgSpeechForChar = in->ReadInt32();
+    speechForChar = in->ReadInt32();
     associatedOverlayHandle = in->ReadInt32();
     if (cmp_ver >= kOverSvgVersion_36025)
     {
@@ -112,8 +112,9 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
     else
     {
         in->ReadBool(); // [DEPRECATED] has alpha
-        if (!(in->ReadBool())) // screen relative position
-            _flags |= kOver_PositionAtRoomXY;
+        // "is screen relative pos" flag; historically room relative == autopos
+        if (!(in->ReadBool()))
+            _flags |= kOver_AutoPosition;
     }
 
     if (cmp_ver >= kOverSvgVersion_35028)
@@ -172,7 +173,7 @@ void ScreenOverlay::WriteToSavegame(Stream *out) const
     out->WriteInt32(x);
     out->WriteInt32(y);
     out->WriteInt32(timeout);
-    out->WriteInt32(bgSpeechForChar);
+    out->WriteInt32(speechForChar);
     out->WriteInt32(associatedOverlayHandle);
     out->WriteInt16(_flags);
     // since cmp_ver = 1

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -40,7 +40,7 @@ using namespace AGS; // FIXME later
 
 enum OverlayFlags
 {
-    kOver_PositionAtRoomXY = 0x0002, // room-relative position, may be in ui
+    kOver_AutoPosition     = 0x0002, // autoposition over a linked Character (speech)
     kOver_RoomLayer        = 0x0004, // work in room layer (as opposed to UI)
     kOver_SpriteShared     = 0x0008, // reference shared sprite (as opposed to exclusive)
 };
@@ -70,7 +70,8 @@ struct ScreenOverlay
     int offsetX = 0, offsetY = 0;
     // Width and height to stretch the texture to
     int scaleWidth = 0, scaleHeight = 0;
-    int bgSpeechForChar = -1;
+    // Character index, if this overlay serves as a speech (blocking or bg)
+    int speechForChar = -1;
     int associatedOverlayHandle = 0; // script obj handle
     int zorder = INT_MIN;
     float rotation = 0.f;
@@ -87,13 +88,23 @@ struct ScreenOverlay
     // Returns Overlay's graphic space params
     inline const Common::GraphicSpace &GetGraphicSpace() const { return _gs; }
     bool IsSpriteShared() const { return (_flags & kOver_SpriteShared) != 0; }
-    bool IsRoomRelative() const { return (_flags & kOver_PositionAtRoomXY) != 0; }
+    bool IsAutoPosition() const { return (_flags & kOver_AutoPosition) != 0; }
     bool IsRoomLayer() const { return (_flags & kOver_RoomLayer) != 0; }
-    void SetRoomRelative(bool on) { on ? _flags |= kOver_PositionAtRoomXY : _flags &= ~kOver_PositionAtRoomXY; }
+    void SetAutoPosition(int for_character)
+    {
+        _flags |= kOver_AutoPosition;
+        speechForChar = for_character;
+    }
+    void SetFixedPosition(int x_, int y_)
+    {
+        _flags &= ~kOver_AutoPosition;
+        x = x_; y = y_;
+        speechForChar = -1;
+    }
     void SetRoomLayer(bool on)
     {
-        on ? _flags |= (kOver_RoomLayer | kOver_PositionAtRoomXY) :
-             _flags &= ~(kOver_RoomLayer | kOver_PositionAtRoomXY);
+        on ? _flags |= (kOver_RoomLayer) :
+             _flags &= ~(kOver_RoomLayer);
     }
     // Gets actual overlay's image, whether owned by overlay or by a sprite reference
     Common::Bitmap *GetImage() const;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -188,20 +188,26 @@ void update_following_exactly_characters(const std::vector<int> &followingAsShee
   }
 }
 
-void update_overlay_timers()
+void update_overlays()
 {
-	// update overlay timers
-  auto &overs = get_overlays();
-  for (auto &over : overs)
-  {
-    if (over.timeout > 0) {
-      over.timeout--;
-      if (over.timeout == 0)
-      {
-        remove_screen_overlay(over.type);
-      }
+    // update overlay timers and positions
+    auto &overs = get_overlays();
+    for (auto &over : overs)
+    {
+        if (over.IsAutoPosition())
+        {
+            autoposition_overlay(over);
+        }
+
+        if (over.timeout > 0)
+        {
+            over.timeout--;
+            if (over.timeout == 0)
+            {
+                remove_screen_overlay(over.type);
+            }
+        }
     }
-  }
 }
 
 void update_speech_and_messages()
@@ -444,7 +450,7 @@ void update_stuff() {
 
   set_our_eip(23);
 
-  update_overlay_timers();
+  update_overlays();
 
   update_speech_and_messages();
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -188,17 +188,12 @@ void update_following_exactly_characters(const std::vector<int> &followingAsShee
   }
 }
 
-void update_overlays()
+void update_overlay_timers()
 {
     // update overlay timers and positions
     auto &overs = get_overlays();
     for (auto &over : overs)
     {
-        if (over.IsAutoPosition())
-        {
-            autoposition_overlay(over);
-        }
-
         if (over.timeout > 0)
         {
             over.timeout--;
@@ -450,7 +445,7 @@ void update_stuff() {
 
   set_our_eip(23);
 
-  update_overlays();
+  update_overlay_timers();
 
   update_speech_and_messages();
 


### PR DESCRIPTION
This fixes #1180 for AGS 4. Initially I had a deeper reimplementation in mind for ags4, where not overlays keep links to characters, but characters have a link to their speech overlays, but then decided to step back for a simpler one for a time being.
I also think that this is safe to be backported to ags3, as this is really a bug fix, does not modify a save format; and the only thing different will be returned property values, which may be wrapped in a "script api" check. But I'll look into that separately.

---

The purpose of this change is to have x,y parameters of ScreenOverlay to contain explicit coordinates at all times, and use coordinates strictly depending on the Overlay's layer (screen or room).

Historically, non-blocking character speech overlays stored a magic OVR_AUTOPLACE value in their x parameter, and character's index in y parameter. This told the engine to calculate this overlay's drawing position based on linked character's position. Furthermore, for blocking speech the flag kOver_PositionAtRoomXY told to assume Overlay stores its position in room coordinates, even though it's an overlay on a screen layer.

This made the meaning of x,y parameters complicated, and contributed to discrepancy between values set to Overlay.X and Y properties, and values returned by reading them.

In this change:
* Magical OVR_AUTOPLACE value is removed.
* Overlay's flag kOver_PositionAtRoomXY is replaced with kOver_AutoPosition; - that is safe to do, because PositionAtRoomXY was ever only set along with OVR_AUTOPLACE.
* bgSpeechForChar parameter is renamed to speechForChar, and is assigned regardless of whether speech is blocking or non-blocking.
* Overlays now always store explicit position in x,y.
* Auto-positioning is performed during game update, and new x,y parameters are assigned.
* Overlay.X,Y properties now get and set same values, corresponding to overlay's layer (screen or room).



**POTENTIAL TODO:**
- I suppose the next logical step could be to remove dependency on "offsets". Right now the assigned position corresponds to the position of "text" in textual overlays, and any borders (from TextWindow) are positioned "outside". Historical reference: #1098, #1104.
So the question is whether this should be changed to have position mark exactly top-left corner of the generated image, including borders, or not.
**Regardless**, X,Y properties must assign and return same position (either accounting or not accounting these borders).

EDIT: sudden thought: maybe these offsets could be redesigned as "origin" parameter, which was planned (potentially) for all objects in the future ags4.


**TESTING**
- [ ] Display boxes should not have any changes in behavior.
- [ ] Non-blocking speech should position correctly above character even if it walks around; also - in scrolling rooms.
- [ ] Blocking speech should position correctly above character; also - in scrolling rooms.
- [ ] Setting X or Y property to a autopositioned overlay should disable its automatic behavior. **I forgot to do this**, needs to be amended.
- [ ] Overlay.X and Y properties must always return the value that was set to it by user, and always in coordinates consistent with the overlay's layer: screen overlays use screen coords, room overlays use room coords.
