### PR TITLE
3.6.1: fix unsafe buffer use in String.Replace and removed result limit of 2048 bytes

### DIFF
--- a/libsrc/allegro/include/allegro/unicode.h
+++ b/libsrc/allegro/include/allegro/unicode.h
@@ -83,6 +83,7 @@ AL_FUNC(char *, ustrupr, (char *s));
 AL_FUNC(char *, ustrchr, (AL_CONST char *s, int c));
 AL_FUNC(char *, ustrrchr, (AL_CONST char *s, int c));
 AL_FUNC(char *, ustrstr, (AL_CONST char *s1, AL_CONST char *s2));
+AL_FUNC(char *, ustrcasestr, (AL_CONST char *s1, AL_CONST char *s2));
 AL_FUNC(char *, ustrpbrk, (AL_CONST char *s, AL_CONST char *set));
 AL_FUNC(char *, ustrtok, (char *s, AL_CONST char *set));
 AL_FUNC(char *, ustrtok_r, (char *s, AL_CONST char *set, char **last));

--- a/libsrc/allegro/src/unicode.c
+++ b/libsrc/allegro/src/unicode.c
@@ -2205,7 +2205,29 @@ char *ustrstr(AL_CONST char *s1, AL_CONST char *s2)
    len = ustrlen(s2);
    while (ugetc(s1)) {
       if (ustrncmp(s1, s2, len) == 0)
-	 return (char *)s1;
+         return (char *)s1;
+
+      s1 += uwidth(s1);
+   }
+
+   return NULL;
+}
+
+
+
+/* ustrcasestr:
+ *  Unicode-aware version of the GNU ustrcasestr() function.
+ */
+char *ustrcasestr(AL_CONST char *s1, AL_CONST char *s2)
+{
+   int len;
+   ASSERT(s1);
+   ASSERT(s2);
+
+   len = ustrlen(s2);
+   while (ugetc(s1)) {
+      if (ustrnicmp(s1, s2, len) == 0)
+         return (char *)s1;
 
       s1 += uwidth(s1);
    }


### PR DESCRIPTION
Somehow this problem was ignored after all these years (even though the String API was updated with Unicode support).

The implementation of script function String.Replace was limiting resulting string to 2048 bytes, and furthermore used that buffer without any size checks. This may potentially lead to a buffer overflow and memory corruption.

NOTE: buffer limit has been 3000 originally, but reduced to 2048 in the latest master branch.

Example test case:
```
function TestLongReplace()
{
  String source = "REPLACE THIS BIT"; // test replace in the beginning
  while (source.Length < 4096)
  {
    source = source.Append("xxxxxxxxxxxxxxxx REPLACE THIS BIT xxxxxxxxxxxxxxxx");
  }
  source = source.Append("REPLACE THIS BIT"); // test replace in the end
  
  String dest1 = source.Replace("REPLACE THIS BIT", "THIS IS A NEW BIT", eCaseSensitive);
  String dest2 = source.Replace("replace this bit", "this is a new bit", eCaseInsensitive);
  
  File *f = File.Open("$SAVEGAMEDIR$/replace.txt", eFileWrite);
  f.WriteRawLine(source);
  f.WriteRawLine(dest1);
  f.WriteRawLine(dest2);
  f.Close();
}
```

Above will crash the engine in any past version of AGS (most likely).

This PR should fix the above for both ASCII and Unicode text format setting.