### PR TITLE
ags4: add string trim (remove trailing and leading whitespace in string)

### DIFF
--- a/Common/util/utf8.h
+++ b/Common/util/utf8.h
@@ -106,6 +106,14 @@ inline size_t GetLength(const char *c)
     return len;
 }
 
+// Takes a utf8 string pointer and rolls it back one char, unless it hits the head of same string
+inline const char* BackOneChar(const char* c, const char* front)
+{
+    if(c <= front) return front;
+    for (--c; c > front && ((*c & 0xC0) == 0x80); --c);
+    return c;
+}
+
 } // namespace Utf8
 
 #endif // __AGS_CN_UTIL__UTF8_H

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -536,6 +536,10 @@ internalstring autoptr builtin managed struct String {
   import String  Substring(int index, int length);
   /// Truncates the string down to the specified length by removing characters from the end.
   import String  Truncate(int length);
+#ifdef SCRIPT_API_v400
+  /// Returns a new string without any leading or trailing whitespace.
+  import String  Trim();
+#endif
   /// Returns an upper-cased version of this string.
   import String  UpperCase();
 #ifdef SCRIPT_API_v350


### PR DESCRIPTION
There is always a time where I need to use this when reading from a custom file, I have it done in AGS Script, but it really should be right there in the String itself, as it exists in Javascript, C# and all other languages I use.

An example of place where I would like to use this would be in something like [dicttoini](https://github.com/ericoporto/dont-give-up-the-cat/blob/main/dont-give-up-the-cat/dicttoini.asc).

Edit: had to push force minor [utf-8 proper fix](https://github.com/adventuregamestudio/ags/compare/67557870484852e26e7367f04aceb6b098eee0e6..3549ae856845ad58395519e6b1960cb5066476b5).