### PR TITLE
Hotfix function pointer assignment in String_Replace independent of libc

### DIFF
--- a/Common/util/string_compat.h
+++ b/Common/util/string_compat.h
@@ -30,4 +30,10 @@ char *ags_strdup(const char *s);
 }
 #endif
 
+#if defined (__MINGW32__)
+typedef char* (*PfnStrStr)(const char *, const char *);
+#else
+typedef const char* (*PfnStrStr)(const char *, const char *);
+#endif
+
 #endif // __AGS_CN_UTIL__STRINGCOMPAT_H

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 #include <algorithm>
-#include <cstdio>
+#include <string.h>
 #include <allegro.h>
 #include "ac/string.h"
 #include "ac/common.h"
@@ -162,9 +162,9 @@ const char* String_Replace(const char *thisString, const char *lookForText, cons
     const auto &this_header = ScriptString::GetHeader(thisString);
     // For case-sensitive search select simple ascii "strstr", for strict byte-to-byte comparison;
     // For case-insensitive search select no-case unicode-compatible variant
-    typedef const char* (*fn_strstr)(const char *, const char *);
-    fn_strstr pfn_strstr = 
-        caseSensitive ? static_cast<fn_strstr>(strstr) : reinterpret_cast<fn_strstr>(ustrcasestr);
+    PfnStrStr pfn_strstr = caseSensitive ?
+        static_cast<PfnStrStr>(strstr) :
+        reinterpret_cast<PfnStrStr>(ustrcasestr);
     int match_len, match_ulen;
     ustrlen2(lookForText, &match_len, &match_ulen);
 


### PR DESCRIPTION
Various implementations of libc may have non-standard overloads of `strstr`, making it impossible to use static_cast or reinterpret_cast with them directly (either would work with one libc, but may fail with another).

Experiment to see which approach may work here.