### PR TITLE
(2) Hotfix function pointer assignment in String_Replace independent of libc 

### DIFF
--- a/Common/util/string_compat.c
+++ b/Common/util/string_compat.c
@@ -58,3 +58,8 @@ char *ags_strdup(const char *s)
     memcpy(result, s, len + 1);
     return result;
 }
+
+char *ags_strstr(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle);
+}

--- a/Common/util/string_compat.h
+++ b/Common/util/string_compat.h
@@ -25,6 +25,7 @@ char *ags_strupr(char *s);
 int ags_stricmp(const char *, const char *);
 int ags_strnicmp(const char *, const char *, size_t);
 char *ags_strdup(const char *s);
+char *ags_strstr(const char *haystack, const char *needle);
 
 #ifdef __cplusplus
 }

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 #include <algorithm>
-#include <cstdio>
 #include <allegro.h>
 #include "ac/string.h"
 #include "ac/common.h"
@@ -164,7 +163,7 @@ const char* String_Replace(const char *thisString, const char *lookForText, cons
     // For case-insensitive search select no-case unicode-compatible variant
     typedef const char* (*fn_strstr)(const char *, const char *);
     fn_strstr pfn_strstr = 
-        caseSensitive ? static_cast<fn_strstr>(strstr) : reinterpret_cast<fn_strstr>(ustrcasestr);
+        caseSensitive ? reinterpret_cast<fn_strstr>(ags_strstr) : reinterpret_cast<fn_strstr>(ustrcasestr);
     int match_len, match_ulen;
     ustrlen2(lookForText, &match_len, &match_ulen);
 


### PR DESCRIPTION
Another attempt on this...
Trying to make it work across different implementations of libc, including ones with non-standard overloads.

Declare a C standard compatible variant of strstr in our string_compat file, and assign that to a pointer instead.