### PR TITLE
Implement `--no-plugins` command arg and config setting

### DIFF
--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -113,6 +113,7 @@ struct GameSetup
     // User's overrides and hacks
     int   override_script_os; // pretend engine is running on this eScriptSystemOSID
     char  override_multitasking; // -1 for none, 0 or 1 to lock in the on/off mode
+    bool  override_noplugins = false; // disable loading plugins
     bool  override_upscale; // whether upscale old games that supported that
     // Optional keys for calling built-in save/restore dialogs;
     // primarily meant for the test runs of the games where save functionality

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -569,7 +569,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     //
     // 7. Start up plugins
     //
-    pl_register_plugins(ents.PluginInfos);
+    pl_register_plugins(ents.PluginInfos, !usetup.override_noplugins);
     pl_startup_plugins();
 
     //

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -382,6 +382,7 @@ void apply_config(const ConfigTree &cfg)
 
         // User's overrides and hacks
         usetup.override_multitasking = CfgReadInt(cfg, "override", "multitasking", -1);
+        usetup.override_noplugins = CfgReadInt(cfg, "override", "noplugins", 0);
         String override_os = CfgReadString(cfg, "override", "os");
         usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(override_os,
             CstrArr<eNumOS>{"", "dos", "win", "linux", "mac", "android", "ios", "psp", "web", "freebsd"}, eOS_Unknown);

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -157,6 +157,7 @@ void main_print_help() {
            "  --log-file-path=PATH         Define custom path for the log file\n"
           //--------------------------------------------------------------------------------|
            "  --no-message-box             Disable alerts as modal message boxes\n"
+           "  --no-plugins                 Disable plugin loading\n"
            "  --no-translation             Use default game language on start\n"
            "  --noiface                    Don't draw game GUI\n"
            "  --noscript                   Don't run room scripts; *WARNING:* unreliable\n"
@@ -314,6 +315,8 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             cfg["language"]["translation"] = "";
         else if (ags_stricmp(arg, "--background") == 0)
             cfg["override"]["multitasking"] = "1";
+        else if (ags_stricmp(arg, "--no-plugins") == 0)
+            cfg["override"]["noplugins"] = "1";
         else if (ags_stricmp(arg, "--fps") == 0)
             cfg["misc"]["show_fps"] = "1";
         else if (ags_stricmp(arg, "--test") == 0) debug_flags |= DBG_DEBUGMODE;

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -52,7 +52,7 @@ int  pl_run_plugin_hook_by_index(int pl_index, int event, int data);
 int  pl_run_plugin_hook_by_name(AGS::Common::String &pl_name, int event, int data);
 
 // Tries to register plugins, either by loading dynamic libraries, or getting any kind of replacement
-AGS::Engine::GameInitError pl_register_plugins(const std::vector<AGS::Common::PluginInfo> &infos);
+AGS::Engine::GameInitError pl_register_plugins(const std::vector<AGS::Common::PluginInfo> &infos, bool enable_load);
 bool pl_is_plugin_loaded(const char *pl_name);
 
 //returns whether _any_ plugins want a particular event

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -24,11 +24,6 @@
 #include "game/plugininfo.h"
 #include "util/string.h"
 
-class IAGSEngine;
-namespace AGS { namespace Common { class Stream; }}
-using namespace AGS; // FIXME later
-
-
 //
 // PluginObjectReader is a managed object unserializer registered by plugin.
 //
@@ -50,14 +45,14 @@ int  pl_run_plugin_debug_hooks(const char *scriptfile, int linenum);
 // Finds a plugin that wants this event, starting with pl_index;
 // returns TRUE on success and fills its index and name;
 // returns FALSE if no more suitable plugins found.
-bool pl_query_next_plugin_for_event(int event, int &pl_index, Common::String &pl_name);
+bool pl_query_next_plugin_for_event(int event, int &pl_index, AGS::Common::String &pl_name);
 // Runs event for a plugin identified by an index it was registered under.
 int  pl_run_plugin_hook_by_index(int pl_index, int event, int data);
 // Runs event for a plugin identified by its name.
-int  pl_run_plugin_hook_by_name(Common::String &pl_name, int event, int data);
+int  pl_run_plugin_hook_by_name(AGS::Common::String &pl_name, int event, int data);
 
 // Tries to register plugins, either by loading dynamic libraries, or getting any kind of replacement
-Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> &infos);
+AGS::Engine::GameInitError pl_register_plugins(const std::vector<AGS::Common::PluginInfo> &infos);
 bool pl_is_plugin_loaded(const char *pl_name);
 
 //returns whether _any_ plugins want a particular event

--- a/Engine/plugin/plugin_stubs.cpp
+++ b/Engine/plugin/plugin_stubs.cpp
@@ -65,10 +65,11 @@ bool RegisterPluginStubs(const char* name)
   else if (ags_stricmp(name, "agsappopenurl") == 0)
   {
     // agsappopenurl.dll
-    ccAddExternalStaticFunction("AppOpenURL",                 Sc_PluginStub_Int0);
-   return true;
+    ccAddExternalStaticFunction("AppOpenURL",                   Sc_PluginStub_Int0);
+    return true;
   }
-  else if (ags_stricmp(name, "ags_snowrain") == 0)
+  else if (ags_stricmp(name, "ags_snowrain") == 0 ||
+           ags_stricmp(name, "ags_SnowRain20") == 0)
   {
     // ags_snowrain.dll
     ccAddExternalStaticFunction("srSetSnowDriftRange",          Sc_PluginStub_Void);

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -112,6 +112,7 @@ Locations of two latter files differ between running platforms:
   * sdl = LEVEL - setup SDL's own logging level, defined either by name or numeric ID:
     * verbose (1), debug (2), info (3), warn (4), error (5), critical (6).
 * **\[override\]** - special options, overriding game behavior.
+  * noplugins = \[0; 1\] - disable plugin loading. Engine will fallback to built-in plugins or stubs, if they are available.
   * multitasking = \[0; 1\] - lock the game in the "single-tasking" or "multitasking" mode. In the nutshell, "multitasking" here means that the game will continue running when player switched away from game window; otherwise it will freeze until player switches back.
   * os = \[string\] - trick the game to think that it runs on a particular operating system. This may come handy if the game is scripted to play differently depending on OS. Possible choices are:
     * dos - MS DOS;
@@ -171,6 +172,7 @@ Following OPTIONS are supported when running from command line:
     * --log-stdout=+mg:debug
 * --log-file-path=PATH - define custom path for the log file.
 * --no-message-box - disable alerts as modal message boxes (on platforms that support them in the first place).
+* --no-plugins - disable plugin loading.
 * --no-translation - use default game language on start.
 * --noiface - don't draw game GUI (for test purposes).
 * --noscript - don't run room scripts (for test purposes); *WARNING:* unreliable.


### PR DESCRIPTION
Add `--no-plugins` command line argument, and related config setting, which tells to **not** load plugins from dynamic libraries.
Built-in plugins and stubs are still going to be used in this case (if they are available).

This may be used to either force engine to use built-in plugins, or as a safety measure to run engine without loading any extra binary.
