### PR TITLE
Engine: replace a "plugin return value" hack with something appropriate

### DIFF
--- a/Engine/ac/dynobj/dynobj_manager.cpp
+++ b/Engine/ac/dynobj/dynobj_manager.cpp
@@ -108,6 +108,15 @@ ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&ob
     return obj_type;
 }
 
+ScriptValueType ccTryGetObjectManagerFromAddress(void *address, IScriptObject *&manager)
+{
+    if (address == nullptr) {
+        manager = nullptr;
+        return kScValUndefined;
+    }
+    return pool.FindManagerForAddress(address, manager);
+}
+
 int ccAddObjectReference(int32_t handle) {
     if (handle == 0)
         return 0;

--- a/Engine/ac/dynobj/dynobj_manager.h
+++ b/Engine/ac/dynobj/dynobj_manager.h
@@ -30,25 +30,28 @@ using namespace AGS; // FIXME later
 
 // register a memory handle for the object and allow script
 // pointers to point to it
-extern int32_t ccRegisterManagedObject(void *object, IScriptObject *, ScriptValueType obj_type = kScValScriptObject);
+int32_t ccRegisterManagedObject(void *object, IScriptObject *, ScriptValueType obj_type = kScValScriptObject);
 // register a de-serialized object
-extern int32_t ccRegisterUnserializedObject(int index, void *object, IScriptObject *, ScriptValueType obj_type = kScValScriptObject);
+int32_t ccRegisterUnserializedObject(int index, void *object, IScriptObject *, ScriptValueType obj_type = kScValScriptObject);
 // unregister a particular object
-extern int   ccUnRegisterManagedObject(void *object);
+int   ccUnRegisterManagedObject(void *object);
 // remove all registered objects
-extern void  ccUnregisterAllObjects();
+void  ccUnregisterAllObjects();
 // serialize all objects to disk
-extern void  ccSerializeAllObjects(Common::Stream *out);
+void  ccSerializeAllObjects(Common::Stream *out);
 // un-serialise all objects (will remove all currently registered ones)
-extern int   ccUnserializeAllObjects(Common::Stream *in, ICCObjectCollectionReader *callback);
+int   ccUnserializeAllObjects(Common::Stream *in, ICCObjectCollectionReader *callback);
 // dispose the object if RefCount==0
-extern void  ccAttemptDisposeObject(int32_t handle);
+void  ccAttemptDisposeObject(int32_t handle);
 // translate between object handles and memory addresses
-extern int32_t ccGetObjectHandleFromAddress(void *address);
-extern void *ccGetObjectAddressFromHandle(int32_t handle);
-extern ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&object, IScriptObject *&manager);
+int32_t ccGetObjectHandleFromAddress(void *address);
+void *ccGetObjectAddressFromHandle(int32_t handle);
+ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&object, IScriptObject *&manager);
+// Tries to return a dynamic object manager for the given object's address;
+// does not set a script error in case it was not found
+ScriptValueType ccTryGetObjectManagerFromAddress(void *address, IScriptObject *&manager);
 
-extern int ccAddObjectReference(int32_t handle);
-extern int ccReleaseObjectReference(int32_t handle);
+int ccAddObjectReference(int32_t handle);
+int ccReleaseObjectReference(int32_t handle);
 
 #endif // __AGS_EE_DYNOBJ__DYNOBJMANAGER_H

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -103,6 +103,15 @@ ScriptValueType ManagedObjectPool::HandleToAddressAndManager(int32_t handle, voi
     return o.obj_type;
 }
 
+ScriptValueType ManagedObjectPool::FindManagerForAddress(void *addr, IScriptObject *&manager)
+{
+    if (addr == nullptr) { manager = nullptr; return kScValUndefined; }
+    auto it = handleByAddress.find(addr);
+    if (it == handleByAddress.end()) { manager = nullptr; return kScValUndefined; }
+    manager = objects[it->second].callback;
+    return objects[it->second].obj_type;
+}
+
 int ManagedObjectPool::RemoveObject(void *address) {
     if (address == nullptr) { return 0; }
     auto it = handleByAddress.find(address);

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -63,6 +63,7 @@ public:
     int32_t AddressToHandle(void *addr);
     void* HandleToAddress(int32_t handle);
     ScriptValueType HandleToAddressAndManager(int32_t handle, void *&object, IScriptObject *&manager);
+    ScriptValueType FindManagerForAddress(void *addr, IScriptObject *&manager);
     int RemoveObject(void *address);
     void RunGarbageCollectionIfAppropriate();
     int AddObject(void *address, IScriptObject *callback, ScriptValueType obj_type);

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -92,7 +92,6 @@ extern RGB palette[256];
 extern int displayed_room;
 extern RoomStruct thisroom;
 extern RoomStatus *croom;
-extern RuntimeScriptValue GlobalReturnValue;
 
 
 // **************** PLUGIN IMPLEMENTATION ****************
@@ -674,7 +673,6 @@ void IAGSEngine::QueueGameScriptFunction(const char *name, int32 globalScript, i
 }
 
 int IAGSEngine::RegisterManagedObject(void *object, IAGSScriptManagedObject *callback) {
-    GlobalReturnValue.SetPluginObject(object, (IScriptObject*)callback);
     return ccRegisterManagedObject(object, (IScriptObject*)callback, kScValPluginObject);
 }
 
@@ -691,7 +689,6 @@ void IAGSEngine::AddManagedObjectReader(const char *typeName, IAGSManagedObjectR
 }
 
 void IAGSEngine::RegisterUnserializedObject(int key, void *object, IAGSScriptManagedObject *callback) {
-    GlobalReturnValue.SetPluginObject((void*)object, (IScriptObject*)callback);
     ccRegisterUnserializedObject(key, object, (IScriptObject*)callback, kScValPluginObject);
 }
 
@@ -700,18 +697,11 @@ int IAGSEngine::GetManagedObjectKeyByAddress(void *address) {
 }
 
 void* IAGSEngine::GetManagedObjectAddressByKey(int key) {
-    void *object;
-    IScriptObject *manager;
-    ScriptValueType obj_type = ccGetObjectAddressAndManagerFromHandle(key, object, manager);
-    GlobalReturnValue.SetScriptObject(obj_type, object, manager);
-    return object;
+    return ccGetObjectAddressFromHandle(key);
 }
 
 const char* IAGSEngine::CreateScriptString(const char *fromText) {
-    const char *string = CreateNewScriptString(fromText);
-    // Should be still standard dynamic object, because not managed by plugin
-    GlobalReturnValue.SetScriptObject((void*)string, &myScriptStringImpl);
-    return string;
+    return CreateNewScriptString(fromText);
 }
 
 int IAGSEngine::IncrementManagedObjectRefCount(void *address) {

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -133,17 +133,17 @@ void ccSetDebugHook(new_line_hook_type jibble)
     new_line_hook = jibble;
 }
 
-int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms)
+intptr_t call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms)
 {
     if (!fn_addr)
     {
         cc_error("null function pointer in call_function");
-        return -1;
+        return 0;
     }
     if (numparm > 0 && !parms)
     {
         cc_error("invalid parameters array in call_function");
-        return -1;
+        return 0;
     }
 
     intptr_t parm_value[9];
@@ -161,7 +161,6 @@ int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, 
         case kScValFloat:   // AGS passes floats, copying their values into long variable
         case kScValPluginArg:
             parm_value[ival] = (intptr_t)parms[iparm].IValue;
-            break;
             break;
         default:
             parm_value[ival] = (intptr_t)parms[iparm].GetPtrWithOffset();
@@ -207,70 +206,41 @@ int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, 
     // time and energy should be allocated for this task.
     //
 
+    typedef intptr_t (*fntype0) ();
+    typedef intptr_t (*fntype1) (intptr_t);
+    typedef intptr_t (*fntype2) (intptr_t, intptr_t);
+    typedef intptr_t (*fntype3) (intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype4) (intptr_t, intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype5) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype6) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype7) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype8) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
+    typedef intptr_t (*fntype9) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
+
     switch (numparm)
     {
     case 0:
-        {
-            int (*fparam) ();
-            fparam = (int (*)())fn_addr;
-            return fparam();
-        }
+        return reinterpret_cast<fntype0>(fn_addr)();
     case 1:
-        {
-            int (*fparam) (intptr_t);
-            fparam = (int (*)(intptr_t))fn_addr;
-            return fparam(parm_value[0]);
-        }
+        return reinterpret_cast<fntype1>(fn_addr)(parm_value[0]);
     case 2:
-        {
-            int (*fparam) (intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1]);
-        }
+        return reinterpret_cast<fntype2>(fn_addr)(parm_value[0], parm_value[1]);
     case 3:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2]);
-        }
+        return reinterpret_cast<fntype3>(fn_addr)(parm_value[0], parm_value[1], parm_value[2]);
     case 4:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3]);
-        }
+        return reinterpret_cast<fntype4>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3]);
     case 5:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4]);
-        }
+        return reinterpret_cast<fntype5>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4]);
     case 6:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5]);
-        }
+        return reinterpret_cast<fntype6>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5]);
     case 7:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6]);
-        }
+        return reinterpret_cast<fntype7>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6]);
     case 8:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7]);
-        }
+        return reinterpret_cast<fntype8>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7]);
     case 9:
-        {
-            int (*fparam) (intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t);
-            fparam = (int (*)(intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t))fn_addr;
-            return fparam(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7], parm_value[8]);
-        }
+        return reinterpret_cast<fntype9>(fn_addr)(parm_value[0], parm_value[1], parm_value[2], parm_value[3], parm_value[4], parm_value[5], parm_value[6], parm_value[7], parm_value[8]);
     }
 
     cc_error("too many arguments in call to function");
-    return -1;
+    return 0;
 }

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -97,6 +97,6 @@ void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout, un
 // reset the current while loop counter
 void ccNotifyScriptStillAlive();
 // for calling exported plugin functions old-style
-int call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
+intptr_t call_function(void *fn_addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
 
 #endif // __AGS_EE_CC__SCRIPTRUNTIME_H


### PR DESCRIPTION
Necessary for #2313 (indirectly).

There is this very old hack which I invented while porting script VM to 64-bit back in 2012. When I've been rewriting script VM to work with RuntimeScriptValue struct, instead of a plain int32, plugins were becoming an issue, because there was no way to change the return values of their functions without modifying plugin API (and each existing plugin). And if we keep plugin functions cast to something returning an int, then we cannot know if that's a pointer, and which kind of a pointer that is (which exactly dynamic object type).

Back then I introduced a "temporary" hack: have a GlobalReturnValue object, which is assigned whenever plugin does *anything* related to the managed objects: create, register, resolve a handle, add reference, and so forth. Then *hope* that it is the value that the plugin is intending to return from its function. Silly as it is, this naive solution actually worked, for the actively used plugins at least. That's why it was forgotten about and never replaced.

But of course this is not a correct solution, simply because a plugin does not have to return a dynamic object that it touched last, it may return something completely different, previously saved instead.

The new solution I'm trying here is based on a simple but more logical assumption:
1. A plugin's return value is either a primitive type (int or float) or a memory address.
2. If it's a memory address, then this must be a managed object's address, as AGS script does not support plain pointers returned from a function (at least as of now).
3. If it's a managed object, then we may quickly search for it in the dynamic memory manager (it has a hashtable that resolves addresses to handles).

Therefore, we try the plugin function's return value as a address, and ask for its respective IScriptObject (dynamic object manager). If we succeeded, then we may assign a RuntimeScriptValue as a "Script Object". If we fail, we assign one as a "Plugin Argument", which may be anything else.

---

TEST LIST:

- [x] Win x32 engine
- [ ] Win x64 engine
- [ ] Linux x64 engine
- [ ] OSX x64 engine
- [ ] Android
- [ ] Performance test
