### PR TITLE
Update innosetup version to 6.2.2

### DIFF
--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -14,7 +14,7 @@ RUN pushd %TEMP% && \
   rd /s /q empty
 
 ARG NUGET_VERSION=5.7.0
-ARG INNO_SETUP_VERSION=6.0.5
+ARG INNO_SETUP_VERSION=6.2.2
 RUN cinst nuget.commandline --version %NUGET_VERSION% -y && \
   cinst innosetup --version %INNO_SETUP_VERSION% -y && \
   mkdir empty && \


### PR DESCRIPTION
While updating #2404, I tested Innosetup with 6.2.2, and there were no problems installing or uninstalling. The only visible change is that installer icons have been modernized, mainly.

Changes:

https://jrsoftware.org/files/is6-whatsnew.htm

6.1: Many improvements to the Compiler IDE including support for [editing and debugging of #include files](https://i.imgur.com/iDrhOSs.png) and [viewing the preprocessor output](https://i.imgur.com/IVI2nk3.png) directly.
6.1: Support for downloading files without using a third-party tool and easily [showing the download progress](https://i.imgur.com/deliPb8.png) to the user.
6.1: Support for per-user fonts if Setup is running on Windows 10 Version 1803 and later.
6.2: Graphics modernized, including the automatic use of higher quality images (which were not available before) on higher DPI settings.