### PR TITLE
fix[Common/util/stdio_compat.c]: This commit fixes the use of *NIX pr…

### DIFF
--- a/Common/util/stdio_compat.c
+++ b/Common/util/stdio_compat.c
@@ -192,7 +192,7 @@ int ags_file_copy(const char *src, const char *dst, int overwrite)
     int fd_src, fd_dst;
     int dst_flags;
     char buf[4096]; // CHECKME: larger buffer? malloc a bigger one on heap?
-    size_t read_num;
+    ssize_t read_num; // read returns -1 if there was an error, so we need a signed type.
 
     fd_src = open(src, O_RDONLY);
     if (fd_src < 0)
@@ -208,7 +208,7 @@ int ags_file_copy(const char *src, const char *dst, int overwrite)
 
     while ((read_num = read(fd_src, buf, sizeof(buf))) > 0) {
         char *out_ptr = buf;
-        size_t wrote_num;
+        ssize_t wrote_num; // write returns -1 if there was an error, so we need a signed type.
         do {
             wrote_num = write(fd_dst, out_ptr, read_num);
             if (wrote_num >= 0) {


### PR DESCRIPTION
…imitive I/O functions read and write.

The types of read_num and wrote_num in ags_file_copy were changed from the unsigned type size_t to the signed type ssize_t because read and write return -1 on an error and therefore the variables which hold the return values must be signed or errors will not be caught.