### PR TITLE
AGS 4: remake ExtendedCompiler setting into ScriptCompiler selection

### DIFF
--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -288,12 +288,12 @@ namespace AGS.Editor
 
         public List<string> GetCompilerExtensions(Game game)
         {
-            return _native.GetCompilerExtensions(game.Settings.ExtendedCompiler);
+            return _native.GetCompilerExtensions(game.Settings.ScriptCompiler == AGSEditor.DEFAULT_SCRIPT_COMPILER);
         }
 
         public void CompileScript(Script script, string[] preProcessedData, Game game, CompileMessages messages)
         {
-            _native.CompileScript(script, preProcessedData, game, messages);
+            _native.CompileScript(script, preProcessedData, game, game.Settings.ScriptCompiler == AGSEditor.DEFAULT_SCRIPT_COMPILER, messages);
         }
 
         public void CreateDebugMiniEXE(string[] fileList, string exeFileName)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -474,6 +474,12 @@ namespace AGS.Editor
                 game.Settings.ScaleCharacterSpriteOffsets = false;
             }
 
+            if (xmlVersionIndex < 4000005)
+            {
+                game.Settings.ScriptCompiler = game.Settings.ExtendedCompiler ?
+                    AGSEditor.DEFAULT_SCRIPT_COMPILER : AGSEditor.DEFAULT_LEGACY_SCRIPT_COMPILER;
+            }
+
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);
             System.Version projectVersion = game.SavedXmlEditorVersion != null ? Types.Utilities.TryParseVersion(game.SavedXmlEditorVersion) : null;
             if (projectVersion == null || projectVersion < editorVersion)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -84,7 +84,7 @@ namespace Native
             void SaveDefaultRoomFile(Room ^roomToSave);
 			String ^LoadRoomScript(String ^roomFileName);
             List<String^>^ GetCompilerExtensions(bool new_compiler);
-			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, CompileMessages ^errors);
+			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, bool new_compiler, CompileMessages ^errors);
 			GameTemplate^ LoadTemplateFile(String ^fileName);
       RoomTemplate^ LoadRoomTemplateFile(String ^fileName);
 			void ExtractTemplateFiles(String ^templateFileName);

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -59,7 +59,7 @@ namespace AGS
     }
 
     void NativeMethods::CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts,
-        Game ^game, CompileMessages ^messages)
+        Game ^game, bool new_compiler, CompileMessages ^messages)
     {
         if (script->CompiledData != nullptr)
             script->CompiledData = nullptr; // clear up previous data, if present
@@ -77,7 +77,7 @@ namespace AGS
                 SCOPT_RTTIOPS |
                 false;
 
-        if (game->Settings->ExtendedCompiler)
+        if (new_compiler)
         {
             // Concatenate the whole thing together
             String^ all_the_script = "";

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -222,6 +222,7 @@
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />
     <Compile Include="PropertyGridExtras\ReadOnlyConverter .cs" />
     <Compile Include="PropertyGridExtras\RoomMaskResolutionTypeConverter.cs" />
+    <Compile Include="PropertyGridExtras\ScriptCompilerTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\SpriteFileNameEditor.cs" />
     <Compile Include="PropertyGridExtras\SpriteSelectUIEditor.cs" />
     <Compile Include="PropertyGridExtras\TextEncodingTypeConverter.cs" />

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptCompilerTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptCompilerTypeConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AGS.Types
+{
+    public class ScriptCompilerTypeConverter : BaseListSelectTypeConverter<string, string>
+    {
+        private static Dictionary<string, string> _possibleValues = new Dictionary<string, string>();
+
+        protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _possibleValues;
+        }
+
+        /// <summary>
+        /// Assigns a dictionary of "id / display name".
+        /// </summary>
+        public static void SetCompilerList(IDictionary<string, string> compilers)
+        {
+            _possibleValues = new Dictionary<string, string>(compilers);
+        }
+    }
+}

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -66,6 +66,7 @@ namespace AGS.Types
         private SpriteCompression _compressSprites = SpriteCompression.None;
         private bool _optimizeSpriteStorage = true;
         private bool _experimentalCompiler = false;
+        private string _scriptCompiler = "";
         private bool _inventoryCursors = true;
         private bool _handleInvInScript = false;
         private bool _displayMultipleInv = false;
@@ -315,14 +316,21 @@ namespace AGS.Types
             set { _optimizeSpriteStorage = value; }
         }
 
-        [DisplayName("Use extended script compiler")]
-        [Description("The extended script compiler has more features but may still have some bugs, too")]
-        [DefaultValue(false)]
-        [Category("Compiler")]
+        [Obsolete]
+        [Browsable(false)]
         public bool ExtendedCompiler
         {
-            get { return _experimentalCompiler; }
-            set { _experimentalCompiler = value; }
+            get; set; // need setter to load old value and upgrade the older projects
+        }
+
+        [DisplayName("Script compiler")]
+        [Description("Select the script compiler that will be used when compiling your game scripts")]
+        [Category("Compiler")]
+        [TypeConverter(typeof(ScriptCompilerTypeConverter))]
+        public string ScriptCompiler
+        {
+            get { return _scriptCompiler; }
+            set { _scriptCompiler = value; }
         }
 
         [DisplayName("Save screenshots in save games")]


### PR DESCRIPTION
As suggested few time before, this remakes the "Use extended compiler" property in General Settings to "Script compiler" with a list of compilers to choose from.

At first I wanted to get compiler names (IDs) out of compiler libraries, but then met 2 issues:
1) I was not sure how to distinguish the "new" and "old" one, to choose one when upgrading a project.
2) I was not sure if their "displayed name" should be also defined by them, or left for the Editor.

At the moment I'm hardcoding their names in the AGSEditor class, but that is frankly not good.
I also would like to make this future compatible with potentially supporting standalone compiler(s).