### PR TITLE
AGS 4: replace "Remap 8-bit backgrounds" preference with Room property

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -112,9 +112,10 @@ namespace AGS.Editor
          * 4.00.00.00     - Raised for org purposes without project changes
          * 4.00.00.03     - Distinct Character and Object Enabled and Visible properties;
          *                - FaceDirectionRatio
-         *
+         * 4.00.00.05     - Settings.DefaultRemap8bitRoomBackgrounds
+         * 
         */
-        public const int    LATEST_XML_VERSION_INDEX = 4000003;
+        public const int    LATEST_XML_VERSION_INDEX = 4000005;
         /// <summary>
         /// XML version index on the release of AGS 4.0.0, this constant be used to determine
         /// if upgrade of Rooms/Sprites/etc. to new format have been performed.

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -557,6 +557,7 @@ namespace AGS.Editor.Components
             room.Width = gameSettings.CustomResolution.Width;
             room.Height = gameSettings.CustomResolution.Height;
             room.MaskResolution = gameSettings.DefaultRoomMaskResolution;
+            room.Remap8bitBackgrounds = gameSettings.DefaultRemap8bitRoomBackgrounds;
             room.ColorDepth = (int)gameSettings.ColorDepth * 8; // from bytes to bits per pixel
             room.BackgroundCount = 1;
             room.RightEdgeX = room.Width - 1;
@@ -1726,7 +1727,7 @@ namespace AGS.Editor.Components
             {
                 int colorsImage, colorsLimit;
                 CopyGamePalette(); // in case they had changes to game colors in the meantime
-                PaletteUtilities.RemapBackground(newBmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, _roomPalette, out colorsImage, out colorsLimit);
+                PaletteUtilities.RemapBackground(newBmp, !_loadedRoom.Remap8bitBackgrounds, _roomPalette, out colorsImage, out colorsLimit);
                 if (background == 0)
                 {
                     newBmp.CopyToAGSBackgroundPalette(_roomPalette); // update current room palette
@@ -1735,8 +1736,7 @@ namespace AGS.Editor.Components
 
                 // TODO: not sure if it's good to report error here, in the interface impl,
                 // but the existing method does not provide a "CompileMessages" arg
-                if (Factory.AGSEditor.Settings.RemapPalettizedBackgrounds &&
-                    (colorsImage > colorsLimit))
+                if (_loadedRoom.Remap8bitBackgrounds && (colorsImage > colorsLimit))
                 {
                     _guiController.ShowMessage($"The image uses more colors ({colorsImage}) than palette slots allocated to backgrounds ({colorsLimit}). Some colours will be lost.",
                         MessageBoxIconType.Information);
@@ -2065,7 +2065,7 @@ namespace AGS.Editor.Components
             {
                 int colorsImage, colorsLimit;
                 CopyGamePalette(); // in case they had changes to game colors in the meantime
-                PaletteUtilities.RemapBackground(newBmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, _roomPalette, out colorsImage, out colorsLimit);
+                PaletteUtilities.RemapBackground(newBmp, !_loadedRoom.Remap8bitBackgrounds, _roomPalette, out colorsImage, out colorsLimit);
                 if (i == 0)
                 {
                     newBmp.CopyToAGSBackgroundPalette(_roomPalette); // update current room palette
@@ -2337,6 +2337,8 @@ namespace AGS.Editor.Components
             Room room = nativeRoom.ConvertToManagedRoom(unloadedRoom.Number, null);
             room.Description = unloadedRoom.Description;
             room.Script = unloadedRoom.Script;
+            // Force-disable background remap for imported CRMs, because their backgrounds are already remapped.
+            room.Remap8bitBackgrounds = false;
 
             for (int i = 0; i < room.BackgroundCount; i++)
                 yield return SaveAndDisposeBitmapAsync(nativeRoom.GetBackground(i), room.GetBackgroundFileName(i));

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -636,24 +636,6 @@ namespace AGS.Editor.Preferences
             }
         }
 
-        [Browsable(true)]
-        [DisplayName("Remap palette of room backgrounds")]
-        [Description("Remap paletter of room background into allocated background palette slots (8-bit games only).")]
-        [Category("Import of 8-bit background")]
-        [UserScopedSettingAttribute()]
-        [DefaultSettingValueAttribute("True")]
-        public bool RemapPalettizedBackgrounds
-        {
-            get
-            {
-                return (bool)(this["RemapPalettizedBackgrounds"]);
-            }
-            set
-            {
-                this["RemapPalettizedBackgrounds"] = value;
-            }
-        }
-
         [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]

--- a/Editor/AGS.Editor/Entities/IAppSettings.cs
+++ b/Editor/AGS.Editor/Entities/IAppSettings.cs
@@ -24,7 +24,6 @@ namespace AGS.Editor.Preferences
         BindingList<RecentGame> RecentGames { get; }
         BindingList<string> RecentSearches { get; }
         ReloadScriptOnExternalChange ReloadScriptOnExternalChange { get; set; }
-        bool RemapPalettizedBackgrounds { get; set; }
         bool SendAnonymousStats { get; set; }
         bool ShowViewPreviewByDefault { get; set; }
         SpriteImportMethod SpriteImportMethod { get; set; }

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -34,8 +34,6 @@ namespace AGS.Editor
             this.tabPageLast = new System.Windows.Forms.TabPage();
             this.propertyGridPreferences = new System.Windows.Forms.PropertyGrid();
             this.tabPageFirst = new System.Windows.Forms.TabPage();
-            this.groupBox9 = new System.Windows.Forms.GroupBox();
-            this.chkRemapBgImport = new System.Windows.Forms.CheckBox();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.cmbSpriteImportTransparency = new System.Windows.Forms.ComboBox();
             this.label12 = new System.Windows.Forms.Label();
@@ -95,19 +93,26 @@ namespace AGS.Editor
             this.tabPage3 = new System.Windows.Forms.TabPage();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.groupBoxAndroidJdkPath = new System.Windows.Forms.GroupBox();
+            this.labelJdkOk = new System.Windows.Forms.Label();
             this.btnAndChooseJavaHomePath = new System.Windows.Forms.Button();
             this.txtAndJavaHomePath = new System.Windows.Forms.TextBox();
             this.label16 = new System.Windows.Forms.Label();
             this.radAndJavaHomePath = new System.Windows.Forms.RadioButton();
             this.radAndJavaHomeEnv = new System.Windows.Forms.RadioButton();
             this.groupBoxAndroidSdkPath = new System.Windows.Forms.GroupBox();
+            this.labelSdkOk = new System.Windows.Forms.Label();
             this.btnAndChooseAndroidHomePath = new System.Windows.Forms.Button();
             this.txtAndAndroidHomePath = new System.Windows.Forms.TextBox();
             this.label15 = new System.Windows.Forms.Label();
             this.radAndAndroidHomePath = new System.Windows.Forms.RadioButton();
             this.radAndAndroidHomeEnv = new System.Windows.Forms.RadioButton();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.groupBoxKeystore = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.checkBoxAndroidShowPassword = new System.Windows.Forms.CheckBox();
+            this.buttonAndroidGenerateKeystore = new System.Windows.Forms.Button();
+            this.label17 = new System.Windows.Forms.Label();
+            this.buttonAndroidChooseKeystore = new System.Windows.Forms.Button();
             this.labelAndKey_File = new System.Windows.Forms.Label();
             this.textBoxAndKeystoreFile = new System.Windows.Forms.TextBox();
             this.labelAndKey_Pass = new System.Windows.Forms.Label();
@@ -116,16 +121,8 @@ namespace AGS.Editor
             this.textBoxAndKeystoreKeyAlias = new System.Windows.Forms.TextBox();
             this.labelAndKey_KeyPass = new System.Windows.Forms.Label();
             this.textBoxAndKeystoreKeyPassword = new System.Windows.Forms.TextBox();
-            this.checkBoxAndroidShowPassword = new System.Windows.Forms.CheckBox();
-            this.label17 = new System.Windows.Forms.Label();
-            this.buttonAndroidGenerateKeystore = new System.Windows.Forms.Button();
-            this.buttonAndroidChooseKeystore = new System.Windows.Forms.Button();
-            this.groupBoxKeystore = new System.Windows.Forms.GroupBox();
-            this.labelJdkOk = new System.Windows.Forms.Label();
-            this.labelSdkOk = new System.Windows.Forms.Label();
             this.tabPageLast.SuspendLayout();
             this.tabPageFirst.SuspendLayout();
-            this.groupBox9.SuspendLayout();
             this.groupBox5.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.groupBox8.SuspendLayout();
@@ -146,8 +143,8 @@ namespace AGS.Editor
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
             this.groupBoxKeystore.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnApply
@@ -207,7 +204,6 @@ namespace AGS.Editor
             // 
             // tabPageFirst
             // 
-            this.tabPageFirst.Controls.Add(this.groupBox9);
             this.tabPageFirst.Controls.Add(this.groupBox5);
             this.tabPageFirst.Controls.Add(this.groupBox1);
             this.tabPageFirst.Controls.Add(this.groupBox8);
@@ -222,27 +218,6 @@ namespace AGS.Editor
             this.tabPageFirst.TabIndex = 0;
             this.tabPageFirst.Text = "Main Preferences";
             this.tabPageFirst.UseVisualStyleBackColor = true;
-            // 
-            // groupBox9
-            // 
-            this.groupBox9.Controls.Add(this.chkRemapBgImport);
-            this.groupBox9.Location = new System.Drawing.Point(370, 357);
-            this.groupBox9.Name = "groupBox9";
-            this.groupBox9.Size = new System.Drawing.Size(361, 52);
-            this.groupBox9.TabIndex = 10;
-            this.groupBox9.TabStop = false;
-            this.groupBox9.Text = "8-bit background import";
-            // 
-            // chkRemapBgImport
-            // 
-            this.chkRemapBgImport.Location = new System.Drawing.Point(14, 16);
-            this.chkRemapBgImport.Name = "chkRemapBgImport";
-            this.chkRemapBgImport.Size = new System.Drawing.Size(346, 30);
-            this.chkRemapBgImport.TabIndex = 8;
-            this.chkRemapBgImport.Text = "Remap palette of room backgrounds into allocated background palette slots (8-bit " +
-    "games only)";
-            this.chkRemapBgImport.UseVisualStyleBackColor = true;
-            this.chkRemapBgImport.CheckedChanged += new System.EventHandler(this.chkRemapBgImport_CheckedChanged);
             // 
             // groupBox5
             // 
@@ -959,6 +934,17 @@ namespace AGS.Editor
             this.groupBoxAndroidJdkPath.TabStop = false;
             this.groupBoxAndroidJdkPath.Text = "JDK Path";
             // 
+            // labelJdkOk
+            // 
+            this.labelJdkOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelJdkOk.AutoSize = true;
+            this.labelJdkOk.Location = new System.Drawing.Point(476, 21);
+            this.labelJdkOk.Name = "labelJdkOk";
+            this.labelJdkOk.Size = new System.Drawing.Size(113, 13);
+            this.labelJdkOk.TabIndex = 5;
+            this.labelJdkOk.Text = "JDK Found On Config!";
+            this.labelJdkOk.Visible = false;
+            // 
             // btnAndChooseJavaHomePath
             // 
             this.btnAndChooseJavaHomePath.Location = new System.Drawing.Point(321, 60);
@@ -1026,6 +1012,16 @@ namespace AGS.Editor
             this.groupBoxAndroidSdkPath.TabIndex = 12;
             this.groupBoxAndroidSdkPath.TabStop = false;
             this.groupBoxAndroidSdkPath.Text = "SDK Path";
+            // 
+            // labelSdkOk
+            // 
+            this.labelSdkOk.AutoSize = true;
+            this.labelSdkOk.Location = new System.Drawing.Point(474, 21);
+            this.labelSdkOk.Name = "labelSdkOk";
+            this.labelSdkOk.Size = new System.Drawing.Size(114, 13);
+            this.labelSdkOk.TabIndex = 6;
+            this.labelSdkOk.Text = "SDK Found On Config!";
+            this.labelSdkOk.Visible = false;
             // 
             // btnAndChooseAndroidHomePath
             // 
@@ -1096,6 +1092,18 @@ namespace AGS.Editor
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 0;
             // 
+            // groupBoxKeystore
+            // 
+            this.groupBoxKeystore.AutoSize = true;
+            this.groupBoxKeystore.Controls.Add(this.tableLayoutPanel1);
+            this.groupBoxKeystore.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBoxKeystore.Location = new System.Drawing.Point(0, 0);
+            this.groupBoxKeystore.Name = "groupBoxKeystore";
+            this.groupBoxKeystore.Size = new System.Drawing.Size(460, 233);
+            this.groupBoxKeystore.TabIndex = 0;
+            this.groupBoxKeystore.TabStop = false;
+            this.groupBoxKeystore.Text = "Keystore";
+            // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
@@ -1116,7 +1124,7 @@ namespace AGS.Editor
             this.tableLayoutPanel1.Controls.Add(this.labelAndKey_KeyPass, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.textBoxAndKeystoreKeyPassword, 1, 3);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(2, 16);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 17);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 7;
@@ -1127,8 +1135,51 @@ namespace AGS.Editor
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(456, 215);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(454, 213);
             this.tableLayoutPanel1.TabIndex = 1;
+            // 
+            // checkBoxAndroidShowPassword
+            // 
+            this.checkBoxAndroidShowPassword.AutoSize = true;
+            this.checkBoxAndroidShowPassword.Location = new System.Drawing.Point(105, 110);
+            this.checkBoxAndroidShowPassword.Name = "checkBoxAndroidShowPassword";
+            this.checkBoxAndroidShowPassword.Size = new System.Drawing.Size(101, 17);
+            this.checkBoxAndroidShowPassword.TabIndex = 0;
+            this.checkBoxAndroidShowPassword.Text = "Show Password";
+            this.checkBoxAndroidShowPassword.UseVisualStyleBackColor = true;
+            this.checkBoxAndroidShowPassword.CheckStateChanged += new System.EventHandler(this.checkBoxAndroidShowPassword_CheckStateChanged);
+            // 
+            // buttonAndroidGenerateKeystore
+            // 
+            this.buttonAndroidGenerateKeystore.Location = new System.Drawing.Point(105, 181);
+            this.buttonAndroidGenerateKeystore.MinimumSize = new System.Drawing.Size(180, 26);
+            this.buttonAndroidGenerateKeystore.Name = "buttonAndroidGenerateKeystore";
+            this.buttonAndroidGenerateKeystore.Size = new System.Drawing.Size(180, 26);
+            this.buttonAndroidGenerateKeystore.TabIndex = 4;
+            this.buttonAndroidGenerateKeystore.Text = "Generate Keystore";
+            this.buttonAndroidGenerateKeystore.UseVisualStyleBackColor = true;
+            this.buttonAndroidGenerateKeystore.Click += new System.EventHandler(this.buttonAndroidGenerateKeystore_Click);
+            // 
+            // label17
+            // 
+            this.label17.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(105, 152);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(199, 26);
+            this.label17.TabIndex = 5;
+            this.label17.Text = "If you don\'t have a Keystore, generate one";
+            // 
+            // buttonAndroidChooseKeystore
+            // 
+            this.buttonAndroidChooseKeystore.Location = new System.Drawing.Point(322, 4);
+            this.buttonAndroidChooseKeystore.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonAndroidChooseKeystore.Name = "buttonAndroidChooseKeystore";
+            this.buttonAndroidChooseKeystore.Size = new System.Drawing.Size(34, 24);
+            this.buttonAndroidChooseKeystore.TabIndex = 6;
+            this.buttonAndroidChooseKeystore.Text = "...";
+            this.buttonAndroidChooseKeystore.UseVisualStyleBackColor = true;
+            this.buttonAndroidChooseKeystore.Click += new System.EventHandler(this.buttonAndroidChooseKeystore_Click);
             // 
             // labelAndKey_File
             // 
@@ -1155,7 +1206,7 @@ namespace AGS.Editor
             // 
             this.labelAndKey_Pass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.labelAndKey_Pass.AutoSize = true;
-            this.labelAndKey_Pass.Location = new System.Drawing.Point(43, 25);
+            this.labelAndKey_Pass.Location = new System.Drawing.Point(43, 32);
             this.labelAndKey_Pass.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelAndKey_Pass.Name = "labelAndKey_Pass";
             this.labelAndKey_Pass.Size = new System.Drawing.Size(57, 13);
@@ -1164,11 +1215,11 @@ namespace AGS.Editor
             // 
             // textBoxAndKeystorePassword
             // 
-            this.textBoxAndKeystorePassword.Location = new System.Drawing.Point(104, 27);
+            this.textBoxAndKeystorePassword.Location = new System.Drawing.Point(104, 34);
             this.textBoxAndKeystorePassword.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxAndKeystorePassword.MinimumSize = new System.Drawing.Size(209, 24);
             this.textBoxAndKeystorePassword.Name = "textBoxAndKeystorePassword";
-            this.textBoxAndKeystorePassword.Size = new System.Drawing.Size(209, 24);
+            this.textBoxAndKeystorePassword.Size = new System.Drawing.Size(209, 21);
             this.textBoxAndKeystorePassword.TabIndex = 3;
             this.textBoxAndKeystorePassword.Validated += new System.EventHandler(this.textBoxAndKeystorePassword_Validated);
             // 
@@ -1176,7 +1227,7 @@ namespace AGS.Editor
             // 
             this.labelAndKey_KeyAlias.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.labelAndKey_KeyAlias.AutoSize = true;
-            this.labelAndKey_KeyAlias.Location = new System.Drawing.Point(46, 53);
+            this.labelAndKey_KeyAlias.Location = new System.Drawing.Point(46, 57);
             this.labelAndKey_KeyAlias.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelAndKey_KeyAlias.Name = "labelAndKey_KeyAlias";
             this.labelAndKey_KeyAlias.Size = new System.Drawing.Size(54, 13);
@@ -1185,7 +1236,7 @@ namespace AGS.Editor
             // 
             // textBoxAndKeystoreKeyAlias
             // 
-            this.textBoxAndKeystoreKeyAlias.Location = new System.Drawing.Point(104, 55);
+            this.textBoxAndKeystoreKeyAlias.Location = new System.Drawing.Point(104, 59);
             this.textBoxAndKeystoreKeyAlias.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxAndKeystoreKeyAlias.MinimumSize = new System.Drawing.Size(209, 24);
             this.textBoxAndKeystoreKeyAlias.Name = "textBoxAndKeystoreKeyAlias";
@@ -1197,7 +1248,7 @@ namespace AGS.Editor
             // 
             this.labelAndKey_KeyPass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.labelAndKey_KeyPass.AutoSize = true;
-            this.labelAndKey_KeyPass.Location = new System.Drawing.Point(22, 81);
+            this.labelAndKey_KeyPass.Location = new System.Drawing.Point(22, 82);
             this.labelAndKey_KeyPass.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelAndKey_KeyPass.Name = "labelAndKey_KeyPass";
             this.labelAndKey_KeyPass.Size = new System.Drawing.Size(78, 13);
@@ -1206,89 +1257,13 @@ namespace AGS.Editor
             // 
             // textBoxAndKeystoreKeyPassword
             // 
-            this.textBoxAndKeystoreKeyPassword.Location = new System.Drawing.Point(104, 83);
+            this.textBoxAndKeystoreKeyPassword.Location = new System.Drawing.Point(104, 84);
             this.textBoxAndKeystoreKeyPassword.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxAndKeystoreKeyPassword.MinimumSize = new System.Drawing.Size(209, 24);
             this.textBoxAndKeystoreKeyPassword.Name = "textBoxAndKeystoreKeyPassword";
             this.textBoxAndKeystoreKeyPassword.Size = new System.Drawing.Size(209, 24);
             this.textBoxAndKeystoreKeyPassword.TabIndex = 7;
             this.textBoxAndKeystoreKeyPassword.Validated += new System.EventHandler(this.textBoxAndKeystoreKeyPassword_Validated);
-            // 
-            // checkBoxAndroidShowPassword
-            // 
-            this.checkBoxAndroidShowPassword.AutoSize = true;
-            this.checkBoxAndroidShowPassword.Location = new System.Drawing.Point(131, 125);
-            this.checkBoxAndroidShowPassword.Name = "checkBoxAndroidShowPassword";
-            this.checkBoxAndroidShowPassword.Size = new System.Drawing.Size(126, 21);
-            this.checkBoxAndroidShowPassword.TabIndex = 0;
-            this.checkBoxAndroidShowPassword.Text = "Show Password";
-            this.checkBoxAndroidShowPassword.UseVisualStyleBackColor = true;
-            this.checkBoxAndroidShowPassword.CheckStateChanged += new System.EventHandler(this.checkBoxAndroidShowPassword_CheckStateChanged);
-            // 
-            // label17
-            // 
-            this.label17.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(131, 176);
-            this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(249, 34);
-            this.label17.TabIndex = 5;
-            this.label17.Text = "If you don\'t have a Keystore, generate one";
-            // 
-            // buttonAndroidGenerateKeystore
-            // 
-            this.buttonAndroidGenerateKeystore.Location = new System.Drawing.Point(131, 213);
-            this.buttonAndroidGenerateKeystore.MinimumSize = new System.Drawing.Size(180, 26);
-            this.buttonAndroidGenerateKeystore.Name = "buttonAndroidGenerateKeystore";
-            this.buttonAndroidGenerateKeystore.Size = new System.Drawing.Size(180, 26);
-            this.buttonAndroidGenerateKeystore.TabIndex = 4;
-            this.buttonAndroidGenerateKeystore.Text = "Generate Keystore";
-            this.buttonAndroidGenerateKeystore.UseVisualStyleBackColor = true;
-            this.buttonAndroidGenerateKeystore.Click += new System.EventHandler(this.buttonAndroidGenerateKeystore_Click);
-            // 
-            // buttonAndroidChooseKeystore
-            // 
-            this.buttonAndroidChooseKeystore.Location = new System.Drawing.Point(402, 4);
-            this.buttonAndroidChooseKeystore.Margin = new System.Windows.Forms.Padding(4);
-            this.buttonAndroidChooseKeystore.Name = "buttonAndroidChooseKeystore";
-            this.buttonAndroidChooseKeystore.Size = new System.Drawing.Size(34, 24);
-            this.buttonAndroidChooseKeystore.TabIndex = 6;
-            this.buttonAndroidChooseKeystore.Text = "...";
-            this.buttonAndroidChooseKeystore.UseVisualStyleBackColor = true;
-            this.buttonAndroidChooseKeystore.Click += new System.EventHandler(this.buttonAndroidChooseKeystore_Click);
-            // 
-            // groupBoxKeystore
-            // 
-            this.groupBoxKeystore.AutoSize = true;
-            this.groupBoxKeystore.Controls.Add(this.tableLayoutPanel1);
-            this.groupBoxKeystore.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxKeystore.Location = new System.Drawing.Point(0, 0);
-            this.groupBoxKeystore.Name = "groupBoxKeystore";
-            this.groupBoxKeystore.Size = new System.Drawing.Size(460, 291);
-            this.groupBoxKeystore.TabIndex = 0;
-            this.groupBoxKeystore.TabStop = false;
-            this.groupBoxKeystore.Text = "Keystore";
-            // 
-            // labelJdkOk
-            // 
-            this.labelJdkOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelJdkOk.AutoSize = true;
-            this.labelJdkOk.Location = new System.Drawing.Point(476, 21);
-            this.labelJdkOk.Name = "labelJdkOk";
-            this.labelJdkOk.Size = new System.Drawing.Size(144, 17);
-            this.labelJdkOk.TabIndex = 5;
-            this.labelJdkOk.Text = "JDK Found On Config!";
-            this.labelJdkOk.Visible = false;
-            // 
-            // labelSdkOk
-            // 
-            this.labelSdkOk.AutoSize = true;
-            this.labelSdkOk.Location = new System.Drawing.Point(474, 21);
-            this.labelSdkOk.Name = "labelSdkOk";
-            this.labelSdkOk.Size = new System.Drawing.Size(146, 17);
-            this.labelSdkOk.TabIndex = 6;
-            this.labelSdkOk.Text = "SDK Found On Config!";
-            this.labelSdkOk.Visible = false;
             // 
             // PreferencesEditor
             // 
@@ -1310,7 +1285,6 @@ namespace AGS.Editor
             this.Text = "Preferences";
             this.tabPageLast.ResumeLayout(false);
             this.tabPageFirst.ResumeLayout(false);
-            this.groupBox9.ResumeLayout(false);
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
             this.groupBox1.ResumeLayout(false);
@@ -1342,9 +1316,9 @@ namespace AGS.Editor
             this.splitContainer1.Panel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            this.groupBoxKeystore.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
-            this.groupBoxKeystore.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -1357,8 +1331,6 @@ namespace AGS.Editor
         private System.Windows.Forms.TabPage tabPageLast;
         private System.Windows.Forms.PropertyGrid propertyGridPreferences;
         private System.Windows.Forms.TabPage tabPageFirst;
-        private System.Windows.Forms.GroupBox groupBox9;
-        private System.Windows.Forms.CheckBox chkRemapBgImport;
         private System.Windows.Forms.GroupBox groupBox5;
         private System.Windows.Forms.ComboBox cmbSpriteImportTransparency;
         private System.Windows.Forms.Label label12;

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -103,7 +103,6 @@ namespace AGS.Editor
             udBackupInterval.Value = (_settings.BackupWarningInterval > 0) ? _settings.BackupWarningInterval : 1;
             chkBackupReminders.Checked = (_settings.BackupWarningInterval != 0);
             udBackupInterval.Enabled = chkBackupReminders.Checked;
-            chkRemapBgImport.Checked = _settings.RemapPalettizedBackgrounds;
             chkKeepHelpOnTop.Checked = _settings.KeepHelpOnTop;
             chkPromptDialogOnTabsClose.Checked = _settings.DialogOnMultipleTabsClose;
             cmbScriptReloadOnExternalChange.SelectedIndex = (int)_settings.ReloadScriptOnExternalChange;
@@ -324,11 +323,6 @@ namespace AGS.Editor
         private void chkUsageInfo_CheckedChanged(object sender, EventArgs e)
         {
             _settings.SendAnonymousStats = chkUsageInfo.Checked;
-        }
-
-        private void chkRemapBgImport_CheckedChanged(object sender, EventArgs e)
-        {
-            _settings.RemapPalettizedBackgrounds = chkRemapBgImport.Checked;
         }
 
         private void chkKeepHelpOnTop_CheckedChanged(object sender, EventArgs e)

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -46,6 +46,7 @@ namespace AGS.Types
         private int _backgroundAnimationDelay = 5;
         private bool _backgroundAnimEnabled = true;
         private int _backgroundCount;
+        private bool _remap8bitBackgrounds = false;
         private int _gameId;
         private bool _modified;
         private CustomProperties _properties = new CustomProperties();
@@ -171,7 +172,6 @@ namespace AGS.Types
         }
 
         [Description("Width of the room, in game units")]
-        //[DisplayName("WidthInGameUnits")]
         [Category("Visual")]
         [ReadOnly(true)]
         public int Width
@@ -181,13 +181,22 @@ namespace AGS.Types
         }
 
         [Description("Height of the room, in game units")]
-        //[DisplayName("HeightInGameUnits")]
         [Category("Visual")]
         [ReadOnly(true)]
         public int Height
         {
             get { return _height; }
             set { _height = value; }
+        }
+
+        [Category("Design")]
+        [DisplayName("Remap 8-bit backgrounds palette")]
+        [Description("Remap palette of room backgrounds into allocated background palette slots (8-bit games only)")]
+        [DefaultValue(false)]
+        public bool Remap8bitBackgrounds
+        {
+            get { return _remap8bitBackgrounds; }
+            set { _remap8bitBackgrounds = value; }
         }
 
         [Obsolete]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -100,8 +100,9 @@ namespace AGS.Types
         private bool _runGameLoopsWhileDialogOptionsDisplayed = false;
         private InventoryHotspotMarker _inventoryHotspotMarker = new InventoryHotspotMarker();
         private int _defRoomMaskResolution = 1;
+        private bool _defRemap8bitBackgrounds = false;
         // Game Description fields
-		private string _description = string.Empty;
+        private string _description = string.Empty;
 		private DateTime _releaseDate = DateTime.Now;
 		private string _genre = DEFAULT_GENRE;
 		private string _version = DEFAULT_VERSION;
@@ -910,6 +911,16 @@ namespace AGS.Types
         {
             get { return _defRoomMaskResolution; }
             set { _defRoomMaskResolution = value; }
+        }
+
+        [DisplayName("Default remap 8-bit room backgrounds")]
+        [Description("Remap palette of room backgrounds into allocated background palette slots (8-bit games only)")]
+        [Category("Rooms")]
+        [DefaultValue(false)]
+        public bool DefaultRemap8bitRoomBackgrounds
+        {
+            get { return _defRemap8bitBackgrounds; }
+            set { _defRemap8bitBackgrounds = value; }
         }
 
         [Obsolete]


### PR DESCRIPTION
After making #2393 I realized that the option of remapping 8-bit backgrounds no longer works well if it's located in the Editor Preferences. That is because room backgrounds are stored unremapped in folders, and remapped each time they are loaded into the editor, or a room is compiled for packaging. This means that rooms need persistent "import settings" for their backgrounds, similar to sprite import settings.

In this PR I removed "remap 8-bit backgrounds" from Editor Preferences, and added two settings:
1. DefaultRemap8bitRoomBackgrounds to the General Settings.
2. Remap8bitBackgrounds to the Room properties.

DefaultRemap8bitRoomBackgrounds is assigned to the room whenever a new room is created.
Importing a room from CRM forces this option to false, because the existing backgrounds presumably are already remapped.
When loading a background from the room's folder, Editor uses room's property instead of one from the preferences (which is now removed).

REMAINING ISSUES:
1. I noticed that Room data xml never had its version updated, and does not have a version check at all. It has to have something similar to game.agf version check, but it was never implemented apparently. This may be done separately from this PR though.
2. There's an unfortunate problem: ConvertRoomFromCrmToOpenFormat is also used when creating a room from template, even after generating an empty room programmatically... Possibly I'll have to set Remap8bitBackgrounds property per-case.
