### PR TITLE
Compiler: preprocessor can build without compiler

### DIFF
--- a/Compiler/preproc/preprocessor.cpp
+++ b/Compiler/preproc/preprocessor.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include <algorithm>
+#include "script/cs_parser_common.h"
 #include "preproc/preprocessor.h"
 #include "script/cc_common.h"
 #include "util/textstreamwriter.h"
@@ -34,6 +35,11 @@ namespace Preprocessor {
 #else
     static const char * li_end = "\n";
 #endif
+
+    bool IsScriptWordChar(int c)
+    {
+        return std::isalnum(c) || c == '_';
+    }
 
     class StringBuilder : TextWriter {
     private:
@@ -167,7 +173,7 @@ namespace Preprocessor {
     String Preprocessor::GetNextWord(String &text, bool trimText, bool includeDots) {
         size_t i = 0;
         while ((i < text.GetLength()) &&
-               (is_alphanum(text[i]) ||
+               (IsScriptWordChar(text[i]) ||
                 (includeDots && (text[i] == '.')))
                 ) {
             i++;
@@ -284,7 +290,7 @@ namespace Preprocessor {
                 LogError(ErrorCode::MacroNameMissing);
                 return String("");
             }
-            else if (is_digit(macroName[0]))
+            else if (std::isdigit(macroName[0]))
             {
                 LogError(ErrorCode::MacroNameInvalid, String::FromFormat("Macro name '%s' cannot start with a digit", macroName.GetCStr()));
             }
@@ -353,7 +359,7 @@ namespace Preprocessor {
         while (line.GetLength() > 0)
         {
             size_t i = 0;
-            while ((i < line.GetLength()) && (!is_alphanum(line[i])))
+            while ((i < line.GetLength()) && (!std::isalnum(line[i])))
             {
                 if ((line[i] == '"') || (line[i] == '\''))
                 {

--- a/Compiler/preproc/preprocessor.cpp
+++ b/Compiler/preproc/preprocessor.cpp
@@ -28,7 +28,7 @@ extern int currentline; // in script/script_common
 namespace AGS {
 namespace Preprocessor {
 
-    static const size_t NOT_FOUND = -1;
+    static const size_t NOT_FOUND = String::NoIndex;
 
 #if AGS_PLATFORM_OS_WINDOWS
     static const char * li_end = "\r\n";
@@ -39,6 +39,26 @@ namespace Preprocessor {
     bool IsScriptWordChar(int c)
     {
         return std::isalnum(c) || c == '_';
+    }
+
+    size_t FindIndexOfMatchingCharacter(String text, size_t indexOfFirstSpeechMark, int charToMatch)
+    {
+        size_t endOfString = NOT_FOUND;
+        size_t checkFrom = indexOfFirstSpeechMark + 1;
+        for (size_t i = checkFrom; i < text.GetLength(); i++)
+        {
+            if (text[i] == '\\')
+            {
+                i++;  // ignore next char
+            }
+            else if (text[i] == charToMatch)
+            {
+                endOfString = i;
+                break;
+            }
+        }
+
+        return endOfString;
     }
 
     class StringBuilder : TextWriter {
@@ -206,7 +226,7 @@ namespace Preprocessor {
             {
                 if ((text[i] == '"') || (text[i] == '\''))
                 {
-                    size_t endOfString = text.FindChar(text[i],i);
+                    size_t endOfString = FindIndexOfMatchingCharacter(text, i, text[i]);
                     if (endOfString == NOT_FOUND) //size_t is unsigned but it's alright
                     {
                         LogError(ErrorCode::UnterminatedString, "Unterminated string");
@@ -363,7 +383,7 @@ namespace Preprocessor {
             {
                 if ((line[i] == '"') || (line[i] == '\''))
                 {
-                    i = line.FindChar(line[i],i);
+                    i = FindIndexOfMatchingCharacter(line, i, line[i]);
                     if (i == NOT_FOUND)
                     {
                         i = line.GetLength();

--- a/Compiler/preproc/preprocessor.cpp
+++ b/Compiler/preproc/preprocessor.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include <algorithm>
+#include <cctype>
 #include "script/cs_parser_common.h"
 #include "preproc/preprocessor.h"
 #include "script/cc_common.h"

--- a/Compiler/preproc/preprocessor.h
+++ b/Compiler/preproc/preprocessor.h
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 #include <stack>
-#include "script/cs_parser_common.h"
 #include "preproc/cc_macrotable.h"
 #include "util/string.h"
 #include "util/version.h"

--- a/Compiler/test/preprocessor_test.cpp
+++ b/Compiler/test/preprocessor_test.cpp
@@ -378,6 +378,63 @@ Display("This doesn't");
 }
 
 
+TEST(Preprocess, IfDefNestedElseIfDef) {
+        Preprocessor pp = Preprocessor();
+        const char* inpl = R"EOS(
+#define FOO
+#define BAR
+#ifdef FOO
+#ifdef BAR
+Display("FOO and BAR are defined");
+#else
+Display("Only FOO is defined");
+#endif
+#endif
+)EOS";
+
+    clear_error();
+    String res = pp.Preprocess(inpl, "IfDefNestedElseIfDef");
+
+    EXPECT_STREQ(last_seen_cc_error(), "");
+
+    std::vector<AGSString> lines = SplitLines(res);
+    ASSERT_EQ(lines.size(), 12);
+
+    ASSERT_STREQ(lines[0].GetCStr(), "\"__NEWSCRIPTSTART_IfDefNestedElseIfDef\"");
+    ASSERT_STREQ(lines[1].GetCStr(), "");
+    ASSERT_STREQ(lines[2].GetCStr(), "");
+    ASSERT_STREQ(lines[3].GetCStr(), "");
+    ASSERT_STREQ(lines[4].GetCStr(), "");
+    ASSERT_STREQ(lines[5].GetCStr(), "");
+    ASSERT_STREQ(lines[6].GetCStr(), "Display(\"FOO and BAR are defined\");");
+    ASSERT_STREQ(lines[7].GetCStr(), "");
+    ASSERT_STREQ(lines[8].GetCStr(), "");
+    ASSERT_STREQ(lines[9].GetCStr(), "");
+    ASSERT_STREQ(lines[10].GetCStr(), "");
+}
+
+TEST(Preprocess, EscapeCharacters) {
+    Preprocessor pp = Preprocessor();
+    const char* inpl = R"EOS(
+#define ESCAPE_SEQUENCE_STRING "This string has escape characters: \n\t\r\\\""
+Display(ESCAPE_SEQUENCE_STRING);
+)EOS";
+
+    clear_error();
+    String res = pp.Preprocess(inpl, "EscapeCharacters");
+
+    EXPECT_STREQ(last_seen_cc_error(), "");
+
+    std::vector<AGSString> lines = SplitLines(res);
+    ASSERT_EQ(lines.size(), 5);
+
+    ASSERT_STREQ(lines[0].GetCStr(), "\"__NEWSCRIPTSTART_EscapeCharacters\"");
+    ASSERT_STREQ(lines[1].GetCStr(), "");
+    ASSERT_STREQ(lines[2].GetCStr(), "");
+    ASSERT_STREQ(lines[3].GetCStr(), "Display(\"This string has escape characters: \\n\\t\\r\\\\\\\"\");");
+    ASSERT_STREQ(lines[4].GetCStr(), "");
+}
+
 TEST(Preprocess, IfVer) {
     Preprocessor pp = Preprocessor();
     pp.SetAppVersion("3.6.0.5");

--- a/Editor/AGS.Editor.Tests/ScriptCompiler/PreprocessorTests.cs
+++ b/Editor/AGS.Editor.Tests/ScriptCompiler/PreprocessorTests.cs
@@ -324,6 +324,51 @@ Display(""This displays!"");
             AssertStringEqual(res, script_res);
         }
 
+
+        [Test]
+        public void IfDefNestedElseIfDef()
+        {
+            IPreprocessor preprocessor = CompilerFactory.CreatePreprocessor(AGS.Types.Version.AGS_EDITOR_VERSION);
+            string script = $@"
+#define FOO
+#define BAR
+#ifdef FOO
+#ifdef BAR
+Display(""FOO and BAR are defined"");
+#else
+Display(""Only FOO is defined"");
+#endif
+#endif
+";
+            string res = preprocessor.Preprocess(script, "IfDefNestedElseIfDef");
+            Assert.That(preprocessor.Results.Count == 0);
+            string script_res = $@"""__NEWSCRIPTSTART_IfDefNestedElseIfDef""
+
+
+
+
+
+Display(""FOO and BAR are defined"");
+
+
+
+
+";
+
+            AssertStringEqual(res, script_res);
+        }
+
+        [Test]
+        public void EscapeCharacters()
+        {
+            IPreprocessor preprocessor = CompilerFactory.CreatePreprocessor(AGS.Types.Version.AGS_EDITOR_VERSION);
+            string script = "#define ESCAPE_SEQUENCE_STRING \"This string has escape characters: \\n\\t\\r\\\\\\\"\"\r\nDisplay(ESCAPE_SEQUENCE_STRING);";
+            string res = preprocessor.Preprocess(script, "EscapeCharacters");
+            Assert.That(preprocessor.Results.Count == 0);
+            string script_res = "\"__NEWSCRIPTSTART_EscapeCharacters\"\r\n\r\nDisplay(\"This string has escape characters: \\n\\t\\r\\\\\\\"\");\r\n";
+            AssertStringEqual(res, script_res);
+        }
+
         [Test]
         public void IfVer()
         {


### PR DESCRIPTION
This PR is targeting master branch but it is actually useful in ags4 and part of #2328 as it enables building the preprocessor with both the legacy compiler but also the new ags4 compiler.

- is_digit and is_alphanum are replaced by standard functions
- Fixes preprocessor not properly picking up escaped characters
- the preprocessor also needs the `NEW_SCRIPT_TOKEN_PREFIX` from that header.

With these changes I can build the preprocessor independently of the compiler.