### PR TITLE
AGS 3: replace C arrays in ccScript with std containers

### DIFF
--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -31,7 +31,6 @@ namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
 struct CharacterInfo;
-struct ccScript;
 
 
 struct GameSetupStructBase

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -18,7 +18,9 @@
 #ifndef __CC_INTERNAL_H
 #define __CC_INTERNAL_H
 
-#define SCOM_VERSION 90
+#define SCOM_VERSION_SECTIONS 83
+#define SCOM_VERSION_321  90
+#define SCOM_VERSION_CURRENT SCOM_VERSION_321
 #define SCOM_VERSIONSTR "0.90"
 
 // virtual CPU registers

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -39,167 +39,56 @@ ccScript *ccScript::CreateFromStream(Stream *in)
     return scri;
 }
 
-ccScript::ccScript()
-{
-    globaldata          = nullptr;
-    globaldatasize      = 0;
-    code                = nullptr;
-    codesize            = 0;
-    strings             = nullptr;
-    stringssize         = 0;
-    fixuptypes          = nullptr;
-    fixups              = nullptr;
-    numfixups           = 0;
-    importsCapacity     = 0;
-    imports             = nullptr;
-    numimports          = 0;
-    exportsCapacity     = 0;
-    exports             = nullptr;
-    export_addr         = nullptr;
-    numexports          = 0;
-    instances           = 0;
-    sectionNames        = nullptr;
-    sectionOffsets      = nullptr;
-    numSections         = 0;
-    capacitySections    = 0;
-}
-
 ccScript::ccScript(const ccScript &src)
 {
-    globaldatasize = src.globaldatasize;
-    if (globaldatasize > 0)
-    {
-        globaldata = (char*)malloc(globaldatasize);
-        memcpy(globaldata, src.globaldata, globaldatasize);
-    }
-    else
-    {
-        globaldata = nullptr;
-    }
+    globaldata = src.globaldata;
+    code = src.code;
+    strings = src.strings;
+    fixuptypes = src.fixuptypes;
+    fixups = src.fixups;
 
-    codesize = src.codesize;
-    if (codesize > 0)
-    {
-        code = (int32_t*)malloc(codesize * sizeof(int32_t));
-        memcpy(code, src.code, sizeof(int32_t) * codesize);
-    }
-    else
-    {
-        code = nullptr;
-    }
+    imports = src.imports;
+    exports = src.exports;
+    export_addr = src.export_addr;
 
-    stringssize = src.stringssize;
-    if (stringssize > 0)
-    {
-        strings = (char*)malloc(stringssize);
-        memcpy(strings, src.strings, stringssize);
-    }
-    else
-    {
-        strings = nullptr;
-    }
+    sectionNames = src.sectionNames;
+    sectionOffsets = src.sectionOffsets;
 
-    numfixups = src.numfixups;
-    if (numfixups > 0)
-    {
-        fixuptypes = (char*)malloc(numfixups);
-        fixups = (int32_t*)malloc(numfixups * sizeof(int32_t));
-        memcpy(fixuptypes, src.fixuptypes, numfixups);
-        memcpy(fixups, src.fixups, numfixups * sizeof(int32_t));
-    }
-    else
-    {
-        fixups = nullptr;
-        fixuptypes = nullptr;
-    }
-
-    importsCapacity = src.numimports;
-    numimports = src.numimports;
-    if (numimports > 0)
-    {
-        imports = (char**)malloc(sizeof(char*) * numimports);
-        for (int i = 0; i < numimports; ++i)
-            imports[i] = ags_strdup(src.imports[i]);
-    }
-    else
-    {
-        imports = nullptr;
-    }
-
-    exportsCapacity = src.numexports;
-    numexports = src.numexports;
-    if (numexports > 0)
-    {
-        exports = (char**)malloc(sizeof(char*) * numexports);
-        export_addr = (int32_t*)malloc(sizeof(int32_t) * numexports);
-        for (int i = 0; i < numexports; ++i)
-        {
-            exports[i] = ags_strdup(src.exports[i]);
-            export_addr[i] = src.export_addr[i];
-        }
-    }
-    else
-    {
-        exports = nullptr;
-        export_addr = nullptr;
-    }
-
-    capacitySections = src.numSections;
-    numSections = src.numSections;
-    if (numSections > 0)
-    {
-        sectionNames = (char**)malloc(numSections * sizeof(char*));
-        sectionOffsets = (int32_t*)malloc(numSections * sizeof(int32_t));
-        for (int i = 0; i < numSections; ++i)
-        {
-            sectionNames[i] = ags_strdup(src.sectionNames[i]);
-            sectionOffsets[i] = src.sectionOffsets[i];
-        }
-    }
-    else
-    {
-        numSections = 0;
-        sectionNames = nullptr;
-        sectionOffsets = nullptr;
-    }
-
-    instances = 0;
+    instances = 0; // don't copy reference count, since it's a new object
 }
 
-ccScript::~ccScript()
+void ccScript::Write(Stream *out)
 {
-    Free();
-}
-
-void ccScript::Write(Stream *out) {
-    int n;
     out->Write(scfilesig,4);
-    out->WriteInt32(SCOM_VERSION);
-    out->WriteInt32(globaldatasize);
-    out->WriteInt32(codesize);
-    out->WriteInt32(stringssize);
-    if (globaldatasize > 0)
-        out->WriteArray(globaldata,globaldatasize,1);
-    if (codesize > 0)
-        out->WriteArrayOfInt32(code,codesize);
-    if (stringssize > 0)
-        out->WriteArray(strings,stringssize,1);
-    out->WriteInt32(numfixups);
-    if (numfixups > 0) {
-        out->WriteArray(fixuptypes,numfixups,1);
-        out->WriteArrayOfInt32(fixups,numfixups);
+    out->WriteInt32(SCOM_VERSION_CURRENT);
+    out->WriteInt32(globaldata.size());
+    out->WriteInt32(code.size());
+    out->WriteInt32(strings.size());
+    if (globaldata.size() > 0)
+        out->Write(&globaldata.front(), globaldata.size());
+    if (code.size() > 0)
+        out->WriteArrayOfInt32(&code.front(), code.size());
+    if (strings.size() > 0)
+        out->Write(&strings.front(), strings.size());
+    out->WriteInt32(fixups.size());
+    if (fixups.size() > 0)
+    {
+        out->Write(&fixuptypes.front(), fixups.size());
+        out->WriteArrayOfInt32(&fixups.front(), fixups.size());
     }
-    out->WriteInt32(numimports);
-    for (n=0;n<numimports;n++)
-        StrUtil::WriteCStr(imports[n], out);
-    out->WriteInt32(numexports);
-    for (n=0;n<numexports;n++) {
-        StrUtil::WriteCStr(exports[n], out);
+    out->WriteInt32(imports.size());
+    for (size_t n = 0; n < imports.size(); ++n)
+        StrUtil::WriteCStr(imports[n].c_str(), out);
+    out->WriteInt32(exports.size());
+    for (size_t n = 0; n < exports.size(); ++n)
+    {
+        StrUtil::WriteCStr(exports[n].c_str(), out);
         out->WriteInt32(export_addr[n]);
     }
-    out->WriteInt32(numSections);
-    for (n = 0; n < numSections; n++) {
-        StrUtil::WriteCStr(sectionNames[n], out);
+    out->WriteInt32(sectionNames.size());
+    for (size_t n = 0; n < sectionNames.size(); ++n)
+    {
+        StrUtil::WriteCStr(sectionNames[n].c_str(), out);
         out->WriteInt32(sectionOffsets[n]);
     }
     out->WriteInt32(ENDFILESIG);
@@ -207,164 +96,100 @@ void ccScript::Write(Stream *out) {
 
 bool ccScript::Read(Stream *in)
 {
-  instances = 0;
-  int n;
-  char gotsig[5];
-  currentline = -1;
-  in->Read(gotsig, 4);
-  gotsig[4] = 0;
+    instances = 0;
+    currentline = -1;
 
-  int fileVer = in->ReadInt32();
+    char gotsig[5]{};
+    in->Read(gotsig, 4);
 
-  if ((strcmp(gotsig, scfilesig) != 0) || (fileVer > SCOM_VERSION)) {
-    cc_error("file was not written by ccScript::Write or seek position is incorrect");
-    return false;
-  }
-
-  globaldatasize = in->ReadInt32();
-  codesize = in->ReadInt32();
-  stringssize = in->ReadInt32();
-
-  if (globaldatasize > 0) {
-    globaldata = (char *)malloc(globaldatasize);
-    in->Read(globaldata, globaldatasize);
-  }
-  else
-    globaldata = nullptr;
-
-  if (codesize > 0) {
-    code = (int32_t *)malloc(codesize * sizeof(int32_t));
-    in->ReadArrayOfInt32(code, codesize);
-  }
-  else
-    code = nullptr;
-
-  if (stringssize > 0) {
-    strings = (char *)malloc(stringssize);
-    in->Read(strings, stringssize);
-  } 
-  else
-    strings = nullptr;
-
-  numfixups = in->ReadInt32();
-  if (numfixups > 0) {
-    fixuptypes = (char *)malloc(numfixups);
-    fixups = (int32_t *)malloc(numfixups * sizeof(int32_t));
-    in->Read(fixuptypes, numfixups);
-    in->ReadArrayOfInt32(fixups, numfixups);
-  }
-  else {
-    fixups = nullptr;
-    fixuptypes = nullptr;
-  }
-
-  numimports = in->ReadInt32();
-
-  imports = (char**)malloc(sizeof(char*) * numimports);
-  for (n = 0; n < numimports; n++)
-    imports[n] = StrUtil::ReadMallocCStrOrNull(in);
-
-  numexports = in->ReadInt32();
-  exports = (char**)malloc(sizeof(char*) * numexports);
-  export_addr = (int32_t*)malloc(sizeof(int32_t) * numexports);
-  for (n = 0; n < numexports; n++) {
-    exports[n] = StrUtil::ReadMallocCStrOrNull(in);
-    export_addr[n] = in->ReadInt32();
-  }
-
-  if (fileVer >= 83) {
-    // read in the Sections
-    numSections = in->ReadInt32();
-    sectionNames = (char**)malloc(numSections * sizeof(char*));
-    sectionOffsets = (int32_t*)malloc(numSections * sizeof(int32_t));
-    for (n = 0; n < numSections; n++) {
-      sectionNames[n] = StrUtil::ReadMallocCStrOrNull(in);
-      sectionOffsets[n] = in->ReadInt32();
+    int fileVer = in->ReadInt32();
+    if ((strcmp(gotsig, scfilesig) != 0) || (fileVer > SCOM_VERSION_CURRENT))
+    {
+        cc_error("file was not written by ccScript::Write or seek position is incorrect");
+        return false;
     }
-  }
-  else
-  {
-    numSections = 0;
-    sectionNames = nullptr;
-    sectionOffsets = nullptr;
-  }
 
-  if (static_cast<uint32_t>(in->ReadInt32()) != ENDFILESIG) {
-    cc_error("internal error rebuilding script");
-    return false;
-  }
-  return true;
+    const uint32_t globaldatasize = in->ReadInt32();
+    const uint32_t codesize = in->ReadInt32();
+    const uint32_t stringssize = in->ReadInt32();
+
+    globaldata.resize(globaldatasize);
+    if (globaldatasize > 0)
+    {
+        in->Read(&globaldata.front(), globaldata.size());
+    }
+
+    code.resize(codesize);
+    if (codesize > 0)
+    {
+        in->ReadArrayOfInt32(&code.front(), code.size());
+    }
+
+    strings.resize(stringssize);
+    if (strings.size() > 0)
+    {
+        in->Read(&strings.front(), strings.size());
+    }
+
+    const uint32_t numfixups = in->ReadInt32();
+    fixuptypes.resize(numfixups);
+    fixups.resize(numfixups);
+    if (numfixups > 0)
+    {
+        in->Read(&fixuptypes.front(), numfixups);
+        in->ReadArrayOfInt32(&fixups.front(), numfixups);
+    }
+
+    const uint32_t numimports = in->ReadInt32();
+    imports.resize(numimports);
+    for (uint32_t n = 0; n < numimports; ++n)
+    {
+        imports[n] = StrUtil::ReadCStrAsStdString(in);
+    }
+
+    const uint32_t numexports = in->ReadInt32();
+    exports.resize(numexports);
+    export_addr.resize(numexports);
+    for (uint32_t n = 0; n < numexports; ++n)
+    {
+        exports[n] = StrUtil::ReadCStrAsStdString(in);
+        export_addr[n] = in->ReadInt32();
+    }
+
+    if (fileVer >= SCOM_VERSION_SECTIONS)
+    {
+        // read in the Sections
+        const uint32_t numsections = in->ReadInt32();
+        sectionNames.resize(numsections);
+        sectionOffsets.resize(numsections);
+        for (uint32_t n = 0; n < numsections; ++n)
+        {
+            sectionNames[n] = StrUtil::ReadCStrAsStdString(in);
+            sectionOffsets[n] = in->ReadInt32();
+        }
+    }
+
+    if (static_cast<uint32_t>(in->ReadInt32()) != ENDFILESIG)
+    {
+        cc_error("!internal error reading script: end file signature not found");
+        return false;
+    }
+    return true;
 }
 
-void ccScript::Free()
+const char* ccScript::GetSectionName(int32_t offs) const
 {
-    if (globaldata != nullptr)
-        free(globaldata);
-
-    if (code != nullptr)
-        free(code);
-
-    if (strings != nullptr)
-        free(strings);
-
-    if (fixups != nullptr && numfixups > 0)
-        free(fixups);
-
-    if (fixuptypes != nullptr && numfixups > 0)
-        free(fixuptypes);
-
-    globaldata = nullptr;
-    code = nullptr;
-    strings = nullptr;
-    fixups = nullptr;
-    fixuptypes = nullptr;
-
-    int aa;
-    for (aa = 0; aa < numimports; aa++) {
-        if (imports[aa] != nullptr)
-            free(imports[aa]);
-    }
-
-    for (aa = 0; aa < numexports; aa++)
-        free(exports[aa]);
-
-    for (aa = 0; aa < numSections; aa++)
-        free(sectionNames[aa]);
-
-    if (sectionNames != nullptr)
+    size_t sect_idx = 0;
+    for (; sect_idx < sectionOffsets.size(); ++sect_idx)
     {
-        free(sectionNames);
-        free(sectionOffsets);
-        sectionNames = nullptr;
-        sectionOffsets = nullptr;
-    }
-
-    if (imports != nullptr)
-    {
-        free(imports);
-        free(exports);
-        free(export_addr);
-        imports = nullptr;
-        exports = nullptr;
-        export_addr = nullptr;
-    }
-    numimports = 0;
-    numexports = 0;
-    numSections = 0;
-}
-
-const char* ccScript::GetSectionName(int32_t offs) const {
-
-    int i;
-    for (i = 0; i < numSections; i++) {
-        if (sectionOffsets[i] < offs)
+        if (sectionOffsets[sect_idx] < offs)
             continue;
         break;
     }
 
     // if no sections in script, return unknown
-    if (i == 0)
+    if (sect_idx == 0)
         return "(unknown section)";
 
-    return sectionNames[i - 1];
+    return sectionNames[sect_idx - 1].c_str();
 }

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -12,7 +12,8 @@
 //
 //=============================================================================
 //
-// 'C'-style script compiler
+// Compiled script object. A result of AGS script compilation,
+// loaded and run by the engine. A single game may have multiple scripts.
 //
 //=============================================================================
 
@@ -20,6 +21,8 @@
 #define __CC_SCRIPT_H
 
 #include <memory>
+#include <string>
+#include <vector>
 #include "core/types.h"
 
 namespace AGS { namespace Common { class Stream; } }
@@ -28,46 +31,33 @@ using namespace AGS; // FIXME later
 struct ccScript
 {
 public:
-    char *globaldata;
-    int32_t globaldatasize;
-    int32_t *code;                // executable byte-code, 32-bit per op or arg
-    int32_t codesize; // TODO: find out if we can make it size_t
-    char *strings;
-    int32_t stringssize;
-    char *fixuptypes;             // global data/string area/ etc
-    int32_t *fixups;              // code array index to fixup (in ints)
-    int numfixups;
-    int importsCapacity;
-    char **imports;
-    int numimports;
-    int exportsCapacity;
-    char **exports;   // names of exports
-    int32_t *export_addr; // high byte is type; low 24-bits are offset
-    int numexports;
-    int instances;
+    std::vector<char> globaldata;
+    std::vector<int32_t> code;    // executable byte-code, 32-bit per op or arg
+    std::vector<char> strings;
+    std::vector<char> fixuptypes; // global data/string area/ etc
+    std::vector<int32_t> fixups;  // code array index to fixup (in ints)
+    std::vector<std::string> imports; // names of imports
+    std::vector<std::string> exports; // names of exports
+    std::vector<int32_t> export_addr; // export addresses: high byte is type; low 24-bits are offset
     // 'sections' allow the interpreter to find out which bit
     // of the code came from header files, and which from the main file
-    char **sectionNames;
-    int32_t *sectionOffsets;
-    int numSections;
-    int capacitySections;
+    std::vector<std::string> sectionNames;
+    std::vector<int32_t> sectionOffsets;
+    // Extended information
+
+    int instances = 0; // reference count for this script object
 
     static ccScript *CreateFromStream(Common::Stream *in);
 
-    ccScript();
+    ccScript() = default;
     ccScript(const ccScript &src);
-    virtual ~ccScript(); // there are few derived classes, so dtor should be virtual
+    virtual ~ccScript() = default; // there are few derived classes, so dtor should be virtual
 
     // write the script to disk (after compiling)
     void        Write(Common::Stream *out);
     // read back a script written with Write
     bool        Read(Common::Stream *in);
     const char* GetSectionName(int32_t offset) const;
-
-protected:
-    // free the memory occupied by the script - do NOT attempt to run the
-    // script after calling this function
-    void        Free();
 };
 
 typedef std::shared_ptr<ccScript> PScript;

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -198,14 +198,16 @@ void StrUtil::ReadCStr(char *buf, Stream *in, size_t buf_limit)
     auto last = buf + buf_limit - 1;
     for (;;)
     {
-        if (ptr >= last) {
+        if (ptr >= last)
+        {
             *ptr = 0;
             while (in->ReadByte() > 0); // must still read until 0
             break;
         }
 
         auto ichar = in->ReadByte();
-        if (ichar <= 0) {
+        if (ichar <= 0)
+        {
             *ptr = 0;
             break;
         }
@@ -223,17 +225,15 @@ void StrUtil::ReadCStrCount(char *buf, Stream *in, size_t count)
 char *StrUtil::ReadMallocCStrOrNull(Stream *in)
 {
     char buf[1024];
-    for (auto ptr = buf; (ptr < buf + sizeof(buf)); ++ptr)
-    {
-        auto ichar = in->ReadByte();
-        if (ichar <= 0)
-        {
-            *ptr = 0;
-            break;
-        }
-        *ptr = static_cast<char>(ichar);
-    }
+    ReadCStr(buf, in, sizeof(buf));
     return buf[0] != 0 ? ags_strdup(buf) : nullptr;
+}
+
+std::string StrUtil::ReadCStrAsStdString(Stream *in)
+{
+    char buf[1024];
+    ReadCStr(buf, in, sizeof(buf));
+    return buf;
 }
 
 void StrUtil::SkipCStr(Stream *in)

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -82,6 +82,9 @@ namespace StrUtil
     // Buffer is hard-limited to 1024 bytes, including null-terminator.
     // Strictly for compatibility with the C lib code!
     char *          ReadMallocCStrOrNull(Stream *in);
+    // Variant of above, that allocates std::string.
+    // Buffer is hard-limited to 1024 bytes, including null-terminator.
+    std::string     ReadCStrAsStdString(Stream *in);
     void            SkipCStr(Stream *in);
     void            WriteCStr(const char *cstr, Stream *out);
     void            WriteCStr(const String &s, Stream *out);

--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -49,15 +49,6 @@ void ccCompiledScript::pop_reg(int regg) {
     cur_sp -= 4;
 }
 
-ccCompiledScript::ccCompiledScript() {
-    init();
-    ax_val_type = 0;
-    ax_val_scope = 0;
-}
-ccCompiledScript::~ccCompiledScript() {
-    shutdown();
-}
-
 int ccCompiledScript::add_global(int size, const char*vall) {
     size_t old_size = globaldata.size();
     globaldata.resize(old_size + size);
@@ -99,16 +90,11 @@ void ccCompiledScript::fixup_previous(char ftype) {
 }
 
 int ccCompiledScript::add_new_function(const char*namm, int *idx) {
-    if (numfunctions >= MAX_FUNCTIONS) return -1;
-    //  if (remove_any_import (namm)) return -2;
-    functions[numfunctions] = (char*)malloc(strlen(namm)+20);
-    strcpy(functions[numfunctions],namm);
-    funccodeoffs[numfunctions] = code.size();
-    funcnumparams[numfunctions] = 0;
-    //  code = (int32_t*)realloc(code, codesize + 5000);
+    functions.push_back(namm);
+    funccodeoffs.push_back(code.size());
+    funcnumparams.push_back(0);
     if (idx)
-        *idx = numfunctions;
-    numfunctions++;
+        *idx = functions.size() - 1;
     return code.size();
 }
 
@@ -239,26 +225,8 @@ void ccCompiledScript::start_new_section(const char *name) {
     }
 }
 
-void ccCompiledScript::init() {
-    codeallocated = 0;
-    numfunctions = 0;
-    cur_sp=0;
-    next_line = 0;
-    ax_val_type = 0;
-    ax_val_scope = 0;
-    memset(functions, 0, sizeof(functions));
-    memset(funccodeoffs, 0, sizeof(funccodeoffs));
-    memset(funcnumparams, 0, sizeof(funcnumparams));
-}
-
-// free the extra bits that ccScript doesn't have
 void ccCompiledScript::free_extra() {
-    int aa;
-	for (aa=0;aa<numfunctions;aa++) {
-        free(functions[aa]);
-	}
-    numfunctions=0;
-}
-void ccCompiledScript::shutdown() {
-    free_extra();
+    functions = {};
+    funccodeoffs = {};
+    funcnumparams = {};
 }

--- a/Compiler/script/cc_compiledscript.h
+++ b/Compiler/script/cc_compiledscript.h
@@ -15,7 +15,6 @@
 #define __CC_COMPILEDSCRIPT_H
 
 #include <cstdint>
-#include <string>
 #include "script/cc_script.h"       // ccScript
 #include "cs_parser_common.h"   // macro definitions
 #include "cc_symboldef.h"       // SymbolDef

--- a/Compiler/script/cc_compiledscript.h
+++ b/Compiler/script/cc_compiledscript.h
@@ -21,18 +21,17 @@
 
 
 struct ccCompiledScript: public ccScript {
-    int32_t codeallocated;
-    char*functions[MAX_FUNCTIONS];
-    int32_t funccodeoffs[MAX_FUNCTIONS];
-    int16_t funcnumparams[MAX_FUNCTIONS];
-    int32_t numfunctions;
-    int32_t cur_sp;
-    int  next_line;  // line number of next code
-    int  ax_val_type;  // type of value in AX
-    int  ax_val_scope;  // SYM_LOCALVAR or SYM_GLOBALAVR
+    std::vector<std::string> functions;
+    std::vector<int32_t> funccodeoffs;
+    std::vector<int16_t> funcnumparams;
+    int32_t codeallocated = 0;
+    int32_t cur_sp = 0;
+    int  next_line = 0;     // line number of next code
+    int  ax_val_type = 0;   // type of value in AX
+    int  ax_val_scope = 0;  // SYM_LOCALVAR or SYM_GLOBALAVR
 
-    void init();
-    void shutdown();
+    // free the extra bits that ccScript doesn't have
+    // FIXME: refactor this, implement std::move constructor for ccScript?
     void free_extra();
     int  add_global(int,const char*);
     int  add_string(const char*);
@@ -60,8 +59,8 @@ struct ccCompiledScript: public ccScript {
     void push_reg(int regg);
     void pop_reg(int regg);
 
-    ccCompiledScript();
-    virtual ~ccCompiledScript();
+    ccCompiledScript() = default;
+    virtual ~ccCompiledScript() = default;
 };
 
 #endif // __CC_COMPILEDSCRIPT_H

--- a/Compiler/script/cc_compiledscript.h
+++ b/Compiler/script/cc_compiledscript.h
@@ -45,7 +45,12 @@ struct ccCompiledScript: public ccScript {
     void set_line_number(int nlum) { next_line=nlum; }
     void flush_line_numbers();
     int  remove_any_import(const char*, SymbolDef *oldSym);
-    const char* start_new_section(const char *name);
+    void start_new_section(const char *name);
+
+    // Returns current code size as int32 value;
+    // this is meant for use in writing bytecode instructions, for compliance
+    // with the old compiler logic, which works only with int32s.
+    inline int32_t codesize_i32() const { return static_cast<int32_t>(code.size()); }
 
     void write_cmd(int cmdd);
     void write_cmd1(int cmdd,int param);

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -85,16 +85,16 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
 
             if ((stype == SYM_FUNCTION) || (stype == SYM_GLOBALVAR)) {
                 // unused func/variable
-                cctemp->imports[sym.entries[t].soffs][0] = 0;
+                cctemp->imports[sym.entries[t].soffs] = std::string();
             }
             else if (sym.entries[t].flags & SFLG_PROPERTY) {
                 // unused property -- get rid of the getter and setter
                 int propGet = sym.entries[t].get_propget();
                 int propSet = sym.entries[t].get_propset();
                 if (propGet >= 0)
-                    cctemp->imports[propGet][0] = 0;
+                    cctemp->imports[propGet] = std::string();
                 if (propSet >= 0)
-                    cctemp->imports[propSet][0] = 0;
+                    cctemp->imports[propSet] = std::string();
             }
         }
 

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -45,7 +45,6 @@ void ccSetSoftwareVersion(const char *versionNumber) {
 
 ccScript* ccCompileText(const char *texo, const char *scriptName) {
     ccCompiledScript *cctemp = new ccCompiledScript();
-    cctemp->init();
 
     sym.reset();
 
@@ -72,7 +71,6 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
     }
 
     if (cc_has_error()) {
-        cctemp->shutdown();
         delete cctemp;
         return NULL;
     }
@@ -110,10 +108,9 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
 
     if (ccGetOption(SCOPT_EXPORTALL)) {
         // export all functions
-        for (size_t t=0;t<cctemp->numfunctions;t++) {
-            if (cctemp->add_new_export(cctemp->functions[t],EXPORT_FUNCTION,
+        for (size_t t=0; t < cctemp->functions.size(); ++t) {
+            if (cctemp->add_new_export(cctemp->functions[t].c_str(), EXPORT_FUNCTION,
                 cctemp->funccodeoffs[t], cctemp->funcnumparams[t]) == -1) {
-                    cctemp->shutdown();
                     return NULL;
             }
 

--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -30,7 +30,6 @@
 #define NEST_DOSINGLE   9 // Single Do statement
 #define NEST_FOR        10 // For statement
 #define NEST_SWITCH     11 // Case block for a switch statement
-#define MAX_FUNCTIONS 2000
 #define MAX_FUNCTION_PARAMETERS 15
 #define SYM_GLOBALVAR 1
 #define SYM_LOCALVAR  2

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -25,7 +25,6 @@ extern int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*sc
 ccCompiledScript *newScriptFixture() {
     // TODO: investigate proper google test fixtures.
     ccCompiledScript *scrip = new ccCompiledScript();
-    scrip->init();
     sym.reset();  // <-- global
     return scrip;
 }

--- a/Editor/AGS.Native/Scripting.h
+++ b/Editor/AGS.Native/Scripting.h
@@ -22,6 +22,16 @@ namespace AGS
 		{
 		private:
 			PScript* _compiledScript;
+
+            void WriteCStr(System::IO::BinaryWriter ^writer, const std::string &str)
+            {
+                for (auto c : str)
+                {
+                    writer->Write((System::Byte)c);
+                }
+                writer->Write((System::Byte)0);
+            }
+
 		public:
 			CompiledScript(PScript script) 
 			{
@@ -60,58 +70,49 @@ namespace AGS
                     writer->Write((System::Byte)scfilesig[i]);
                 }
                 const ccScript *cs = _compiledScript->get();
-                writer->Write(SCOM_VERSION);
-                writer->Write(cs->globaldatasize);
-                writer->Write(cs->codesize);
-                writer->Write(cs->stringssize);
-                for (int i = 0; i < cs->globaldatasize; ++i)
+                writer->Write((unsigned)SCOM_VERSION_CURRENT);
+                writer->Write((unsigned)cs->globaldata.size());
+                writer->Write((unsigned)cs->code.size());
+                writer->Write((unsigned)cs->strings.size());
+                for (size_t i = 0; i < cs->globaldata.size(); ++i)
                 {
                     writer->Write((System::Byte)cs->globaldata[i]);
                 }
-                for (int i = 0; i < cs->codesize; ++i)
+                for (size_t i = 0; i < cs->code.size(); ++i)
                 {
                     writer->Write((int)cs->code[i]);
                 }
-                for (int i = 0; i < cs->stringssize; ++i)
+                for (size_t i = 0; i < cs->strings.size(); ++i)
                 {
                     writer->Write((System::Byte)cs->strings[i]);
                 }
-                writer->Write(cs->numfixups);
-                for (int i = 0; i < cs->numfixups; ++i)
+                writer->Write((unsigned)cs->fixups.size());
+                for (size_t i = 0; i < cs->fixups.size(); ++i)
                 {
                     writer->Write((System::Byte)cs->fixuptypes[i]);
                 }
-                for (int i = 0; i < cs->numfixups; ++i)
+                for (size_t i = 0; i < cs->fixups.size(); ++i)
                 {
                     writer->Write(cs->fixups[i]);
                 }
-                writer->Write(cs->numimports);
-                for (int i = 0; i < cs->numimports; ++i)
+                writer->Write((unsigned)cs->imports.size());
+                for (size_t i = 0; i < cs->imports.size(); ++i)
                 {
-                    for (int j = 0, len = strlen(cs->imports[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->imports[i][j]);
-                    }
+                    WriteCStr(writer, cs->imports[i]);
                 }
-                writer->Write(cs->numexports);
-                for (int i = 0; i < cs->numexports; ++i)
+                writer->Write((unsigned)cs->exports.size());
+                for (size_t i = 0; i < cs->exports.size(); ++i)
                 {
-                    for (int j = 0, len = strlen(cs->exports[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->exports[i][j]);
-                    }
+                    WriteCStr(writer, cs->exports[i]);
                     writer->Write(cs->export_addr[i]);
                 }
-                writer->Write(cs->numSections);
-                for (int i = 0; i < cs->numSections; ++i)
+                writer->Write((unsigned)cs->sectionNames.size());
+                for (size_t i = 0; i < cs->sectionNames.size(); ++i)
                 {
-                    for (int j = 0, len = strlen(cs->sectionNames[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->sectionNames[i][j]);
-                    }
+                    WriteCStr(writer, cs->sectionNames[i]);
                     writer->Write(cs->sectionOffsets[i]);
                 }
-                writer->Write(ENDFILESIG);
+                writer->Write((unsigned)ENDFILESIG);
             }
         };
 	}

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -406,8 +406,8 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
     const size_t mangled_len = snprintf(mangledName, sizeof(mangledName), "%s$", funcname);
     int export_args = numargs;
 
-    for (int k = 0; k < instanceof->numexports; k++) {
-        const char *thisExportName = instanceof->exports[k];
+    for (size_t k = 0; k < instanceof->exports.size(); k++) {
+        const char *thisExportName = instanceof->exports[k].c_str();
         bool match = false;
 
         // check for a mangled name match
@@ -1672,11 +1672,11 @@ RuntimeScriptValue ccInstance::GetSymbolAddress(const char *symname) const
     snprintf(altName, sizeof(altName), "%s$", symname);
     RuntimeScriptValue rval_null;
     const size_t len_altName = strlen(altName);
-    for (int k = 0; k < instanceof->numexports; k++) {
-        if (strcmp(instanceof->exports[k], symname) == 0)
+    for (size_t k = 0; k < instanceof->exports.size(); k++) {
+        if (strcmp(instanceof->exports[k].c_str(), symname) == 0)
             return exports[k];
         // mangled function name
-        if (strncmp(instanceof->exports[k], altName, len_altName) == 0)
+        if (strncmp(instanceof->exports[k].c_str(), altName, len_altName) == 0)
             return exports[k];
     }
     return rval_null;
@@ -1798,15 +1798,15 @@ bool ccInstance::_Create(PScript scri, const ccInstance * joined)
         // create own memory space
         // NOTE: globalvars are created in CreateGlobalVars()
         globalvars.reset(new ScVarMap());
-        globaldatasize = scri->globaldatasize;
+        globaldatasize = scri->globaldata.size();
         globaldata = nullptr;
         if (globaldatasize > 0)
         {
             globaldata = static_cast<char *>(malloc(globaldatasize));
-            memcpy(globaldata, scri->globaldata, globaldatasize);
+            memcpy(globaldata, &scri->globaldata[0], globaldatasize);
         }
 
-        codesize = scri->codesize;
+        codesize = scri->code.size();
         code = nullptr;
         if (codesize > 0)
         {
@@ -1819,8 +1819,8 @@ bool ccInstance::_Create(PScript scri, const ccInstance * joined)
     }
 
     // just use the pointer to the strings since they don't change
-    strings = scri->strings;
-    stringssize = scri->stringssize;
+    strings = &scri->strings[0];
+    stringssize = scri->strings.size();
     // create a stack
     stackdatasize = CC_STACK_DATA_SIZE;
     // This is quite a random choice; there's no way to deduce number of stack
@@ -1863,10 +1863,10 @@ bool ccInstance::_Create(PScript scri, const ccInstance * joined)
         }
     }
 
-    exports = new RuntimeScriptValue[scri->numexports];
+    exports = new RuntimeScriptValue[scri->exports.size()];
 
     // find the real address of the exports
-    for (int i = 0; i < scri->numexports; i++) {
+    for (size_t i = 0; i < scri->exports.size(); i++) {
         const int32_t etype = (scri->export_addr[i] >> 24L) & 0x000ff;
         const int32_t eaddr = (scri->export_addr[i] & 0x00ffffff);
         if (etype == EXPORT_FUNCTION)
@@ -1903,9 +1903,9 @@ bool ccInstance::_Create(PScript scri, const ccInstance * joined)
 
     if ((scri->instances == 1) && (ccGetOption(SCOPT_AUTOIMPORT) != 0)) {
         // import all the exported stuff from this script
-        for (int i = 0; i < scri->numexports; i++) {
-            if (!ccAddExternalScriptSymbol(scri->exports[i], exports[i], this)) {
-                cc_error("Export table overflow at '%s'", scri->exports[i]);
+        for (size_t i = 0; i < scri->exports.size(); i++) {
+            if (!ccAddExternalScriptSymbol(scri->exports[i].c_str(), exports[i], this)) {
+                cc_error("Export table overflow at '%s'", scri->exports[i].c_str());
                 return false;
             }
         }
@@ -1966,7 +1966,7 @@ bool ccInstance::ResolveScriptImports(const ccScript *scri)
     // To allow real-time import use, the sequence of imports in 'imports[]'
     // and 'resolved_imports[]' should not be modified.
 
-    numimports = scri->numimports;
+    numimports = scri->imports.size();
     if (numimports == 0)
     {
         // [PGB] AFAICS there's nothing wrong with not having any imports, and
@@ -1978,18 +1978,18 @@ bool ccInstance::ResolveScriptImports(const ccScript *scri)
 
     resolved_imports = new uint32_t[numimports];
     size_t errors = 0, last_err_idx = 0;
-    for (int import_idx = 0; import_idx < scri->numimports; ++import_idx)
+    for (size_t import_idx = 0; import_idx < scri->imports.size(); ++import_idx)
     {
-        if (scri->imports[import_idx] == nullptr)
+        if (scri->imports[import_idx].empty())
         {
             resolved_imports[import_idx] = UINT32_MAX;
             continue;
         }
 
-        resolved_imports[import_idx] = simp.get_index_of(scri->imports[import_idx]);
+        resolved_imports[import_idx] = simp.get_index_of(String::Wrapper(scri->imports[import_idx].c_str()));
         if (resolved_imports[import_idx] == UINT32_MAX)
         {
-            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[import_idx], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
+            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[import_idx].c_str(), scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "<unknown>");
             errors++;
             last_err_idx = import_idx;
         }
@@ -1997,9 +1997,9 @@ bool ccInstance::ResolveScriptImports(const ccScript *scri)
 
     if (errors > 0)
         cc_error("in %s: %d unresolved imports (last: %s)",
-            scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>",
+            scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "<unknown>",
             errors,
-            scri->imports[last_err_idx]);
+            scri->imports[last_err_idx].c_str());
 
     return errors == 0;
 }
@@ -2013,7 +2013,7 @@ bool ccInstance::CreateGlobalVars(const ccScript *scri)
     ScriptVariable glvar;
 
     // Step One: deduce global variables from fixups
-    for (int i = 0; i < scri->numfixups; ++i)
+    for (size_t i = 0; i < scri->fixuptypes.size(); ++i)
     {
         switch (scri->fixuptypes[i])
         {
@@ -2048,7 +2048,7 @@ bool ccInstance::CreateGlobalVars(const ccScript *scri)
     }
 
     // Step Two: deduce global variables from exports
-    for (int i = 0; i < scri->numexports; ++i)
+    for (size_t i = 0; i < scri->exports.size(); ++i)
     {
         const int32_t etype = (scri->export_addr[i] >> 24L) & 0x000ff;
         const int32_t eaddr = (scri->export_addr[i] & 0x00ffffff);
@@ -2118,23 +2118,23 @@ static void cc_error_fixups(const ccScript *scri, const size_t pc, const char *f
     va_start(ap, fmt);
     const String displbuf = String::FromFormatV(fmt, ap);
     va_end(ap);
-    const char *scname = scri->numSections > 0 ? scri->sectionNames[0] : "?";
+    const char *scname = scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "?";
     if (pc == SIZE_MAX)
     {
         cc_error("in script %s: %s", scname, displbuf.GetCStr());
     }
     else
     {
-        const int line = DetermineScriptLine(scri->code, scri->codesize, pc);
+        const int line = DetermineScriptLine(&scri->code[0], scri->code.size(), pc);
         cc_error("in script %s around line %d: %s", scname, line, displbuf.GetCStr());
     }
 }
 
 bool ccInstance::CreateRuntimeCodeFixups(const ccScript *scri)
 {
-    code_fixups = new char[scri->codesize];
-    memset(code_fixups, 0, scri->codesize);
-    for (int i = 0; i < scri->numfixups; ++i)
+    code_fixups = new char[scri->code.size()];
+    memset(code_fixups, 0, scri->code.size());
+    for (int i = 0; i < scri->fixups.size(); ++i)
     {
         if (scri->fixuptypes[i] == FIXUP_DATADATA)
         {
@@ -2142,10 +2142,10 @@ bool ccInstance::CreateRuntimeCodeFixups(const ccScript *scri)
         }
 
         const int32_t fixup = scri->fixups[i];
-        if (fixup < 0 || fixup >= scri->codesize)
+        if (fixup < 0 || fixup >= scri->code.size())
         {
             cc_error_fixups(scri, SIZE_MAX, "bad fixup at %d (fixup type %d, bytecode pos %d, bytecode range is 0..%d)",
-                i,  scri->fixuptypes[i], fixup, scri->codesize);
+                i,  scri->fixuptypes[i], fixup, scri->code.size());
             return false;
         }
 
@@ -2179,7 +2179,7 @@ bool ccInstance::CreateRuntimeCodeFixups(const ccScript *scri)
 
 bool ccInstance::ResolveImportFixups(const ccScript *scri)
 {
-    for (int fixup_idx = 0; fixup_idx < scri->numfixups; ++fixup_idx)
+    for (size_t fixup_idx = 0; fixup_idx < scri->fixups.size(); ++fixup_idx)
     {
         if (scri->fixuptypes[fixup_idx] != FIXUP_IMPORT)
             continue;


### PR DESCRIPTION
A variant of #2411 for ags3 branch.

This replaces C arrays in ccScript class, and all the related reallocation code, with std containers: std::vectors and std::strings.

A care had to be taken when fixing parsers, as AGS script's bytecode is based on int32 values for historical reasons.
Because of that I had to introduce a helper function codesize_i32() which lets to clearly state the purpose of using "current code size" in assignment to int32 variables.

NOTE: I backported a change (1f38e662fe5aa30a6eda69fd375cc5a359cde23e) that reverted to only doing compiled script writing in C++ code (as opposed to C#), because it's very inconvenient to have two versions of this code. I suppose eventually we will be using standalone compiler(s) instead anyway.
