### PR TITLE
Support importing 4-bit bitmaps as 8-bit (for masks and sprites)

### DIFF
--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -99,6 +99,22 @@ Bitmap *CreateBitmapFromPixels(int width, int height, int dst_color_depth,
         return bitmap.release();
     }
 
+    // Copy 4-bit indexed image into 8-bit image
+    if (dst_color_depth == 8 && src_col_depth == 4)
+    {
+        uint8_t *data_ptr = bitmap->GetDataForWriting();
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width / 2; ++x)
+            {
+                uint8_t sp = pixels[y * src_pitch + x];
+                data_ptr[y * width + x * 2]     = ((sp >> 4) & 0xF);
+                data_ptr[y * width + x * 2 + 1] = (sp & 0xF);
+            }
+        }
+        return bitmap.release();
+    }
+
     return nullptr;
 }
 

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -86,6 +86,22 @@ Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth)
 	return bitmap;
 }
 
+Bitmap *CreateBitmapFromPixels(int width, int height, int dst_color_depth,
+    const uint8_t *pixels, const int src_col_depth, const int src_pitch)
+{
+    std::unique_ptr<Bitmap> bitmap(new Bitmap(width, height, dst_color_depth));
+    if (!bitmap)
+        return nullptr;
+
+    if (dst_color_depth == src_col_depth)
+    {
+        ReadPixelsFromMemory(bitmap.get(), pixels, src_pitch);
+        return bitmap.release();
+    }
+
+    return nullptr;
+}
+
 Bitmap *LoadFromFile(const char *filename)
 {
     std::unique_ptr<Stream> in (

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -75,6 +75,8 @@ namespace BitmapHelper
     // Creates Bitmap of wanted color depth from a raw pixel array of a (possibly different)
     // specified color depth.
     // NOTE: color_depth is in BITS per pixel (i.e. 8, 16, 24, 32...).
+    // WARNING: the only conversion supported currently is 4-bit => 8-bit;
+    //          add more common conversions later!
     Bitmap *CreateBitmapFromPixels(int width, int height, int dst_color_depth,
         const uint8_t *pixels, const int src_col_depth, const int src_pitch);
 

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -72,6 +72,12 @@ namespace BitmapHelper
     // pass color depth 0 to keep the original one.
     Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth = 0);
 
+    // Creates Bitmap of wanted color depth from a raw pixel array of a (possibly different)
+    // specified color depth.
+    // NOTE: color_depth is in BITS per pixel (i.e. 8, 16, 24, 32...).
+    Bitmap *CreateBitmapFromPixels(int width, int height, int dst_color_depth,
+        const uint8_t *pixels, const int src_col_depth, const int src_pitch);
+
     // Load a bitmap from file; supported formats currently are: BMP, PCX.
 	Bitmap *LoadFromFile(const char *filename);
     inline Bitmap *LoadFromFile(const String &filename) { return LoadFromFile(filename.GetCStr()); }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -479,7 +479,8 @@ namespace AGS.Editor
                     return;
                 }
 
-                if (bmp.PixelFormat != PixelFormat.Format8bppIndexed)
+                if (bmp.PixelFormat != PixelFormat.Format8bppIndexed &&
+                    bmp.PixelFormat != PixelFormat.Format4bppIndexed)
                 {
                     Factory.GUIController.ShowMessage("This is not a valid mask bitmap. Masks must be 256-colour (8-bit) images, using the first colours in the palette to draw the room areas.", MessageBoxIcon.Warning);
                     bmp.Dispose();

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2124,70 +2124,57 @@ void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<i
 
 Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth)
 {
-	int colDepth;
-	if (bmp->PixelFormat == PixelFormat::Format8bppIndexed)
-	{
-		colDepth = 8;
-	}
-	else if (bmp->PixelFormat == PixelFormat::Format16bppRgb555)
-	{
-		colDepth = 15;
-	}
-	else if (bmp->PixelFormat == PixelFormat::Format16bppRgb565)
-	{
-		colDepth = 16;
-	}
-	else if (bmp->PixelFormat == PixelFormat::Format24bppRgb)
-	{
-		colDepth = 24;
-	}
-	else if (bmp->PixelFormat == PixelFormat::Format32bppRgb)
-	{
-		colDepth = 32;
-	}
-	else if (bmp->PixelFormat == PixelFormat::Format32bppArgb)
-	{
-		colDepth = 32;
-	}
-  else if ((bmp->PixelFormat == PixelFormat::Format48bppRgb) ||
-           (bmp->PixelFormat == PixelFormat::Format64bppArgb) ||
-           (bmp->PixelFormat == PixelFormat::Format64bppPArgb))
-  {
-    throw gcnew AGSEditorException("The source image is 48-bit or 64-bit colour. AGS does not support images with a colour depth higher than 32-bit. Make sure that your paint program is set to produce 32-bit images (8-bit per channel), not 48-bit images (16-bit per channel).");
-  }
-	else
-	{
-		throw gcnew AGSEditorException(gcnew System::String("Unknown pixel format"));
-	}
+    int src_depth, dst_depth;
+    switch (bmp->PixelFormat)
+    {
+    case PixelFormat::Format8bppIndexed:
+        src_depth = dst_depth = 8;
+        break;
+    case PixelFormat::Format16bppRgb555:
+        src_depth = dst_depth = 15; // FIXME: convert to 16-bit instead?
+        break;
+    case PixelFormat::Format16bppRgb565:
+        src_depth = dst_depth = 16;
+        break;
+    case PixelFormat::Format24bppRgb:
+        src_depth = dst_depth = 24; // FIXME: convert to 32-bit instead?
+        break;
+    case PixelFormat::Format32bppRgb:
+    case PixelFormat::Format32bppArgb:
+        src_depth = dst_depth = 32;
+        break;
+    case PixelFormat::Format48bppRgb:
+    case PixelFormat::Format64bppArgb:
+    case PixelFormat::Format64bppPArgb:
+        throw gcnew AGSEditorException("The source image is 48-bit or 64-bit colour. AGS does not support images with a colour depth higher than 32-bit. Make sure that your paint program is set to produce 32-bit images (8-bit per channel), not 48-bit images (16-bit per channel).");
+    default:
+        throw gcnew AGSEditorException(System::String::Format("Unsupported pixel format: \"{0}\"", bmp->PixelFormat.ToString()));
+    }
 
-  if ((thisgame.color_depth == 1) && (colDepth > 8))
-  {
-    throw gcnew AGSEditorException("You cannot import a hi-colour or true-colour image into a 256-colour game.");
-  }
+    if ((thisgame.color_depth == 1) && (src_depth > 8))
+    {
+        throw gcnew AGSEditorException("You cannot import a hi-colour or true-colour image into a 256-colour game.");
+    }
 
-  if (originalColDepth != NULL)
-    *originalColDepth = colDepth;
+    if (originalColDepth)
+        *originalColDepth = src_depth;
 
-  bool needToFixColourDepth = false;
-  if ((colDepth != thisgame.color_depth * 8) && (fixColourDepth))
-  {
-    needToFixColourDepth = true;
-  }
-
-	Common::Bitmap *tempsprite = Common::BitmapHelper::CreateBitmap(bmp->Width, bmp->Height, colDepth);
-    if (!tempsprite)
-        return nullptr; // out of mem?
+    // Test if destination bitmap will be not suitable for the game's color depth
+    const bool needToFixColourDepth = (dst_depth != thisgame.color_depth * 8) && (fixColourDepth);
 
 	System::Drawing::Rectangle rect(0, 0, bmp->Width, bmp->Height);
-	BitmapData ^bmpData = bmp->LockBits(rect, ImageLockMode::ReadWrite, bmp->PixelFormat);
-	unsigned char *address = (unsigned char*)bmpData->Scan0.ToPointer();
-	for (int y = 0; y < tempsprite->GetHeight(); y++) {
-	  memcpy(&tempsprite->GetScanLineForWriting(y)[0], address, bmp->Width * ((colDepth + 1) / 8));
-	  address += bmpData->Stride;
-	}
+	BitmapData ^bmpData = bmp->LockBits(rect, ImageLockMode::ReadOnly, bmp->PixelFormat);
+	const uint8_t *address = static_cast<const uint8_t*>(bmpData->Scan0.ToPointer());
+    AGSBitmap *tempsprite = BitmapHelper::CreateBitmapFromPixels(bmp->Width, bmp->Height, dst_depth,
+        address, src_depth, bmpData->Stride);
 	bmp->UnlockBits(bmpData);
 
-	if (colDepth == 8)
+    if (!tempsprite)
+    {
+        throw gcnew AGSEditorException("Failed to create bitmap of compatible color depth. Could be unsupported image format.");
+    }
+
+	if (src_depth == 8)
 	{
 		cli::array<System::Drawing::Color> ^bmpPalette = bmp->Palette->Entries;
     
@@ -2251,7 +2238,7 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
             return nullptr; // out of mem?
         }
 
-		if (colDepth == 8)
+		if (dst_depth == 8)
 		{
 			select_palette(imgpal);
 		}
@@ -2266,7 +2253,7 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
 			set_color_conversion(oldColorConv & ~COLORCONV_KEEP_TRANS);
 		}
 
-    if (colDepth == 8 && thisgame.color_depth > 1)
+    if (dst_depth == 8 && thisgame.color_depth > 1)
     {
       // manually compose to use the full palette instead of allegro 0-63 restricted one
       const int maskcolor = spriteAtRightDepth->GetMaskColor();
@@ -2295,7 +2282,7 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
     }
 		set_color_conversion(oldColorConv);
 
-		if (colDepth == 8) 
+		if (dst_depth == 8) 
 		{
 			unselect_palette();
 		}
@@ -2303,7 +2290,7 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
 		tempsprite = spriteAtRightDepth;
 	}
 
-	if (colDepth > 8) 
+	if (dst_depth > 8) 
 	{
 		fix_block(tempsprite);
 	}

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2127,6 +2127,9 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
     int src_depth, dst_depth;
     switch (bmp->PixelFormat)
     {
+    case PixelFormat::Format4bppIndexed:
+        src_depth = 4; dst_depth = 8; // convert 4-bit to 8-bit
+        break;
     case PixelFormat::Format8bppIndexed:
         src_depth = dst_depth = 8;
         break;


### PR DESCRIPTION
Fixes #2416

Implemented a conversion from imported 4-bit bitmaps into 8-bit ones supported by the Editor & Engine.

There were 2 potential approaches here, one is to convert on C# side, another in the native C++ side.
I chose to do this in native, and have a helper function in Common lib, to make this potentially usable in the engine. For example, this may be used when loading an image from file.