### PR TITLE
Improve Room Editor's navigation bar's scrolling

### DIFF
--- a/Editor/AGS.Controls/AGS.Controls.csproj
+++ b/Editor/AGS.Controls/AGS.Controls.csproj
@@ -144,6 +144,9 @@
     <Compile Include="AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Controls\ToolStripDropDownMenuEx.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="ScintillaHelper.cs" />
     <Compile Include="ScintillaNET\Annotation.cs" />
     <Compile Include="ScintillaNET\AutoCSelectionEventArgs.cs" />

--- a/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
+++ b/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
@@ -1,15 +1,8 @@
-#region Using Statements
-
-#region .NET Namespace
-
 using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
-
-#endregion
-
-#endregion
+using AGS.Controls;
 
 namespace AddressBarExt.Controls
 {
@@ -102,7 +95,7 @@ namespace AddressBarExt.Controls
         /// <summary>
         /// Drop down menu that contains the overflow menu
         /// </summary>
-        ToolStripDropDownMenu tsddOverflow = null;
+        ToolStripDropDownMenuEx tsddOverflow = null;
 
         #endregion
 
@@ -292,35 +285,16 @@ namespace AddressBarExt.Controls
         }
 
         /// <summary>
-        /// Method handler using the middle mouse wheel to scroll the drop down menus
-        /// </summary>
-        /// <param name="sender">Sender of this event</param>
-        /// <param name="e">Event arguments</param>
-        private void ScrollDropDownMenu(Object sender, MouseEventArgs e)
-        {
-            //if we have the right type
-            if (sender.GetType() == typeof(ToolStripDropDownMenu))
-            {
-                //This doesn't work :(
-
-                Point prev = ((ToolStripDropDownMenu)sender).AutoScrollOffset;
-                prev.Y += (e.Delta);
-                ((ToolStripDropDownMenu)sender).AutoScrollOffset = prev;
-
-            }
-        }
-
-        /// <summary>
-        /// Method that puts focus onto a given ToolStripDropDownMenu
+        /// Method that puts focus onto a given ToolStripDropDownMenuEx
         /// </summary>
         /// <param name="sender">Sender of this event</param>
         /// <param name="e">Event Arguments</param>
         private void GiveToolStripDropDownMenuFocus(Object sender, EventArgs e)
         {
-            if (sender.GetType() == typeof(ToolStripDropDownMenu))
+            if (sender.GetType() == typeof(ToolStripDropDownMenuEx))
             {
                 //focus on the item
-                ((ToolStripDropDownMenu)sender).Focus();
+                ((ToolStripDropDownMenuEx)sender).Focus();
             }
         }
 
@@ -338,7 +312,7 @@ namespace AddressBarExt.Controls
             //variables needed for our toolstrip
             ToolStripButton tsButton = null;
             ToolStripDropDownButton tsddButton = null;
-            ToolStripDropDownMenu tsDropDown = null;
+            ToolStripDropDownMenuEx tsDropDown = null;
 
             //update the node
             node.UpdateNode();
@@ -388,7 +362,7 @@ namespace AddressBarExt.Controls
                         IAddressNode curNode = null;
 
                         //create the drop down menu
-                        tsDropDown = new ToolStripDropDownMenu();
+                        tsDropDown = new ToolStripDropDownMenuEx();
                         tsDropDown.BackColor = DropDownBackColor;
                         tsDropDown.ForeColor = DropDownForeColor;
 
@@ -436,17 +410,14 @@ namespace AddressBarExt.Controls
                         //assign the parent
                         tsDropDown.Tag = tsddButton;
 
-                        //add the method handler for the mouse wheel scrolling
-                        tsDropDown.MouseWheel += new MouseEventHandler(ScrollDropDownMenu);
-
                         //handle the mouse entering/leaving the control
                         tsDropDown.MouseEnter += new EventHandler(GiveToolStripDropDownMenuFocus);
                     }
                     else
                     {
-                        if(node.Tag.GetType() == typeof(ToolStripDropDownMenu))
+                        if(node.Tag.GetType() == typeof(ToolStripDropDownMenuEx))
                         {
-                            tsDropDown = (ToolStripDropDownMenu)node.Tag;
+                            tsDropDown = (ToolStripDropDownMenuEx)node.Tag;
 
                             foreach (ToolStripItem tsmi in tsDropDown.Items)
                             {
@@ -567,7 +538,7 @@ namespace AddressBarExt.Controls
                 //ensure we have an overflow
                 if (this.tsddOverflow == null)
                 {
-                    tsddOverflow = new ToolStripDropDownMenu();
+                    tsddOverflow = new ToolStripDropDownMenuEx();
                     tsddOverflow.MaximumSize = new Size(1000, 400);
                 }
                 else

--- a/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
+++ b/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
@@ -120,6 +120,8 @@ namespace AddressBarExt.Controls
 
         public Color DropDownForeColor { get; set; }
 
+        public int MinDisplayedDropDownItems { get; set; }
+
         /// <summary>
         /// Gets/Sets the currently selected node. Validates upon set and updates the bar
         /// </summary>
@@ -369,6 +371,7 @@ namespace AddressBarExt.Controls
                         //Some variables to let the drawing happen smoothly
                         tsDropDown.LayoutStyle = ToolStripLayoutStyle.VerticalStackWithOverflow;
                         tsDropDown.MaximumSize = new Size(1000, 400);
+                        tsDropDown.MinDisplayedItems = MinDisplayedDropDownItems;
                         tsDropDown.ShowImageMargin = false;
                         tsDropDown.ShowCheckMargin = false;                        
                                                 

--- a/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
+++ b/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
@@ -26,6 +26,10 @@ namespace AGS.Controls
         /// as learnt from the WinForms source code. Used here as a reference.
         /// </summary>
         private const int DefaultScrollButtonHeight = 9;
+        /// <summary>
+        /// Default vertical gap between items on a DropDownMenu.
+        /// </summary>
+        private const int DefaultItemSpacing = 3;
 
         private delegate ToolStripControlHost GetScrollButtonDelegate(ToolStripDropDownMenu m);
         /// <summary>
@@ -66,9 +70,19 @@ namespace AGS.Controls
             get; set;
         }
 
+        /// <summary>
+        /// Gets/sets number of items that must be visible at all times.
+        /// May override the MaximalSize values upon showing this DropDownMenu.
+        /// </summary>
+        public int MinDisplayedItems
+        {
+            get; set;
+        }
+
         public ToolStripDropDownMenuEx()
         {
             ScrollButtonHeight = 24;
+            MinDisplayedItems = 0;
         }
 
         /// <summary>
@@ -79,6 +93,20 @@ namespace AGS.Controls
         {
             UpScrollButton(this).Control.MinimumSize = new Size(0, ScrollButtonHeight);
             DownScrollButton(this).Control.MinimumSize = new Size(0, ScrollButtonHeight);
+
+            if (MinDisplayedItems > 0)
+            {
+                int maxItemHeight = 0;
+                foreach (ToolStripItem item in Items)
+                {
+                    maxItemHeight = Math.Max(maxItemHeight, item.Height);
+                }
+                int requiredHeight = MinDisplayedItems * maxItemHeight + DefaultItemSpacing * (maxItemHeight - 1)
+                    + ScrollButtonHeight * 2;
+
+                if (MaximumSize.Height < requiredHeight)
+                    MaximumSize = new Size(MaximumSize.Width, requiredHeight);
+            }
 
             base.SetDisplayedItems();
 

--- a/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
+++ b/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
@@ -21,6 +21,7 @@ namespace AGS.Controls
     /// </summary>
     public class ToolStripDropDownMenuEx : ToolStripDropDownMenu
     {
+        private const int WS_EX_COMPOSITED = 0x02000000;
         /// <summary>
         /// DefaultScrollButtonHeight is the default scrolling button's height,
         /// as learnt from the WinForms source code. Used here as a reference.
@@ -83,6 +84,19 @@ namespace AGS.Controls
         {
             ScrollButtonHeight = 24;
             MinDisplayedItems = 0;
+        }
+
+        /// <summary>
+        /// Gets parameters of a new window.
+        /// </summary>
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                CreateParams cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_COMPOSITED; // for double buffering
+                return cp;
+            }
         }
 
         /// <summary>

--- a/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
+++ b/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AGS.Controls
+{
+    /// <summary>
+    /// ToolStripDropDownMenuEx is a customized variant of ToolStripDropDownMenu.
+    /// Note that some behavior here is achieved using "hacks", such as retrieving
+    /// private base class methods via reflection.
+    /// 
+    /// References:
+    /// 1. ToolStrip (and friends) source code:
+    /// https://referencesource.microsoft.com/#system.windows.forms/winforms/Managed/System/WinForms/ToolStripDropDownMenu.cs
+    /// 2. Ideas on coding ToolStrip scroll with a mousewheel:
+    /// https://stackoverflow.com/questions/13139074/mouse-wheel-scrolling-toolstrip-menu-items
+    /// </summary>
+    public class ToolStripDropDownMenuEx : ToolStripDropDownMenu
+    {
+        /// <summary>
+        /// DefaultScrollButtonHeight is the default scrolling button's height,
+        /// as learnt from the WinForms source code.
+        /// </summary>
+        private const int DefaultScrollButtonHeight = 9;
+
+        /// <summary>
+        /// ScrollInternal is a retrieved private method of a ToolStrip
+        /// that controls scrolling of items within the client area.
+        /// </summary>
+        private static Action<ToolStrip, int> ScrollInternal
+            = (Action<ToolStrip, int>)Delegate.CreateDelegate(typeof(Action<ToolStrip, int>),
+                typeof(ToolStrip).GetMethod("ScrollInternal",
+                  System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance));
+
+
+        public ToolStripDropDownMenuEx()
+        {
+        }
+
+        /// <summary>
+        /// Performs item scrolling by mouse wheel.
+        /// Raises the System.Windows.Forms.Control.MouseWheel event.
+        /// </summary>
+        /// <param name="e"></param>
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            // Apply "scroll speed" and negate
+            DoItemScroll(-(e.Delta / 4));
+            base.OnMouseWheel(e); // base class will fire MouseWheel event
+        }
+
+        /// <summary>
+        /// Perform item scroll by the given delta pixels.
+        /// </summary>
+        /// <param name="delta">pixels to scroll by, negative means scroll up, positive means scroll down.</param>
+        private void DoItemScroll(int delta)
+        {
+            // ToolStrip scrolling code idea by Bryce Wagner
+            // https://stackoverflow.com/questions/13139074/mouse-wheel-scrolling-toolstrip-menu-items
+
+            if (Items.Count == 0)
+                return; // no items
+
+            var firstItem = Items[0];
+            var lastItem = Items[Items.Count - 1];
+            var topPosition = DefaultScrollButtonHeight;
+            var bottomPosition = Height - DefaultScrollButtonHeight;
+
+            // Note that in the vertical scrolling strip the item positions
+            // are surpassing top and bottom parent control borders.
+            // If they are all kept within control's borders, this means
+            // that all items are visible, no need to scroll.
+            if (lastItem.Bounds.Bottom < Height && firstItem.Bounds.Top > 0)
+                return;
+
+            // Clamp to top and bottom positions.
+            // Scroll up until topmost item *moving down* is matching top parent position
+            if (delta < 0 && firstItem.Bounds.Top - delta > topPosition)
+            {
+                delta = firstItem.Bounds.Top - topPosition;
+            }
+            // Scroll down until bottom item *moving up* is matching bottom parent position
+            else if (delta > 0 && lastItem.Bounds.Bottom - delta < bottomPosition)
+            {
+                delta = lastItem.Bounds.Bottom - bottomPosition;
+            }
+
+            if (delta != 0)
+            {
+                ScrollInternal(this, delta);
+            }
+        }
+    }
+}

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -110,6 +110,10 @@ namespace AGS.Editor
             }
             
             RefreshLayersTree();
+
+            // Customize AddressBar to display at minimum 16 items in dropdown menus;
+            // 16 is currently the number of walkable areas, walk-behinds and regions
+            _editAddressBar.MinDisplayedDropDownItems = 16;
             _editAddressBar.SelectionChange += editAddressBar_SelectionChange;
             _startNode = _editAddressBar.CurrentNode.UniqueID;
 


### PR DESCRIPTION
Fix #2415

Wrote a ToolStripDropDownMenuEx class which extends ToolStripDropDownMenu and amends or overrides its behavior.
Unfortunately had to use various hacks, including getting internal base methods using reflection.

WHAT IS DONE:
* Scroll dropdown menu with mouse wheel.
* Allow to change arrow buttons height to a bigger value.
* Set dropdown height is at least as big to accommodate 16 items at once, that is current max number of walkable areas, etc.

~* Don't close the open dropdown menu when hovering over other items in the Address Bar.~
EDIT: this fix is temporarily removed, because it turned to be not reliable and causing new problems.
