### PR TITLE
AGS 4: Add GUI.ScaleX, ScaleY and SetScale(x,y)

### DIFF
--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -59,6 +59,7 @@ class GraphicSpace
 {
 public:
     GraphicSpace() {}
+    // TODO: constructor that accepts all floats! - remove loss of precision in redundant conversions
     GraphicSpace(int x, int y, int src_w, int src_h, int dst_w, int dst_h, float rot)
     {
         const float sx = src_w != 0.f ? (float)dst_w / src_w : 1.f;

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -64,9 +64,12 @@ public:
     {
         const float sx = src_w != 0.f ? (float)dst_w / src_w : 1.f;
         const float sy = src_h != 0.f ? (float)dst_h / src_h : 1.f;
-        assert((sx != 0.f) && (sy != 0.f));
+        const float sx_inv = std::fabs(sx) < std::numeric_limits<float>::epsilon()
+            ? 0.f : 1.f / sx;
+        const float sy_inv = std::fabs(sy) < std::numeric_limits<float>::epsilon()
+            ? 0.f : 1.f / sy;
         // World->local transform
-        W2LTransform = glmex::make_inv_transform2d((float)-x, (float)-y, 1.f / sx, 1.f / sy,
+        W2LTransform = glmex::make_inv_transform2d((float)-x, (float)-y, sx_inv, sy_inv,
             -Math::DegreesToRadians(rot), 0.5f * dst_w, 0.5f * dst_h);
         // Local->world transform + AABB
         L2WTransform = glmex::make_transform2d((float)x, (float)y, sx, sy,

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -514,12 +514,6 @@ Pointf GUIMain::GetScale() const
 
 void GUIMain::SetScale(float sx, float sy)
 {
-    assert(sx != 0.f && sy != 0.f);
-    if (std::fabs(sx) < std::numeric_limits<float>::epsilon())
-        sx = 1.f;
-    if (std::fabs(sy) < std::numeric_limits<float>::epsilon())
-        sy = 1.f;
-
     Scale = Pointf(sx, sy);
     MarkChanged();
     UpdateGraphicSpace();

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -76,6 +76,7 @@ void GUIMain::InitDefaults()
     MouseWasAt.Y  = -1;
 
     BlendMode     = kBlend_Normal;
+    Scale         = Pointf(1.f, 1.f);
     Rotation      = 0.f;
 
     OnClickHandler.Empty();
@@ -345,7 +346,7 @@ void GUIMain::DrawBlob(Bitmap *ds, int x, int y, color_t draw_color)
 
 void GUIMain::UpdateGraphicSpace()
 {
-    _gs = GraphicSpace(X, Y, Width, Height, Width, Height, Rotation);
+    _gs = GraphicSpace(X, Y, Width, Height, Width * Scale.X, Height * Scale.Y, Rotation);
 }
 
 void GUIMain::Poll(int mx, int my)
@@ -504,6 +505,24 @@ bool GUIMain::SetControlZOrder(int index, int zorder)
     ResortZOrder();
     NotifyControlPosition();
     return true;
+}
+
+Pointf GUIMain::GetScale() const
+{
+    return Scale;
+}
+
+void GUIMain::SetScale(float sx, float sy)
+{
+    assert(sx != 0.f && sy != 0.f);
+    if (std::fabs(sx) < std::numeric_limits<float>::epsilon())
+        sx = 1.f;
+    if (std::fabs(sy) < std::numeric_limits<float>::epsilon())
+        sy = 1.f;
+
+    Scale = Pointf(sx, sy);
+    MarkChanged();
+    UpdateGraphicSpace();
 }
 
 void GUIMain::SetRotation(float degrees)
@@ -674,8 +693,8 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version)
         // Reserved for transform options
         in->ReadInt32(); // sprite transform flags1
         in->ReadInt32(); // sprite transform flags2
-        in->ReadInt32(); // transform scale x
-        in->ReadInt32(); // transform scale y
+        Scale.X = in->ReadFloat32(); // transform scale x
+        Scale.Y = in->ReadFloat32(); // transform scale y
         in->ReadInt32(); // transform skew x
         in->ReadInt32(); // transform skew y
         Rotation = in->ReadFloat32(); // transform rotate
@@ -683,6 +702,11 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version)
         in->ReadInt32(); // sprite pivot y
         in->ReadInt32(); // sprite anchor x
         in->ReadInt32(); // sprite anchor y
+
+        if (Scale.X == 0.f)
+            Scale.X = 1.f;
+        if (Scale.Y == 0.f)
+            Scale.Y = 1.f;
     }
 
     UpdateGraphicSpace();
@@ -719,8 +743,8 @@ void GUIMain::WriteToSavegame(Common::Stream *out) const
     // Reserved for transform options
     out->WriteInt32(0); // sprite transform flags1
     out->WriteInt32(0); // sprite transform flags2
-    out->WriteInt32(0); // transform scale x
-    out->WriteInt32(0); // transform scale y
+    out->WriteFloat32(Scale.X); // transform scale x
+    out->WriteFloat32(Scale.Y); // transform scale y
     out->WriteInt32(0); // transform skew x
     out->WriteInt32(0); // transform skew y
     out->WriteFloat32(Rotation); // transform rotate

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -160,6 +160,10 @@ public:
     void    SetConceal(bool on);
     // Attempts to change control's zorder; returns if zorder changed
     bool    SetControlZOrder(int index, int zorder);
+    //
+    Pointf  GetScale() const;
+    //
+    void    SetScale(float sx, float sy);
     // Sets GUI rotation, in degrees
     void    SetRotation(float degrees);
     // Sets GUI size
@@ -209,6 +213,7 @@ public:
     int32_t PopupAtMouseY;  // popup when mousey < this
     int32_t Transparency;   // "incorrect" alpha (in legacy 255-range units)
     Common::BlendMode BlendMode; // render blend mode
+    Pointf  Scale;          // x,y scale
     float Rotation;         // rotation, in degrees
     int32_t ZOrder;
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1560,7 +1560,7 @@ builtin managed struct GUI {
   /// Gets/sets this GUI vertical scaling.
   import attribute float ScaleY;
   /// Sets this GUI horizontal and vertical scaling
-  import void SetScale(float x, float y = 0.0);
+  import void SetScale(float x, float y);
 
   import Point *GUIToScreenPoint(int guix, int guiy, bool clipToGUI = true);
   import Point *ScreenToGUIPoint(int screenx, int screeny, bool clipToGUI = true);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1561,6 +1561,9 @@ builtin managed struct GUI {
   import attribute float ScaleY;
   /// Sets this GUI horizontal and vertical scaling
   import void SetScale(float x, float y = 0.0);
+
+  import Point *GUIToScreenPoint(int guix, int guiy, bool clipToGUI = true);
+  import Point *ScreenToGUIPoint(int screenx, int screeny, bool clipToGUI = true);
 #endif
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1554,6 +1554,14 @@ builtin managed struct GUI {
   /// Gets/sets the GUI's image rotation in degrees.
   import attribute float Rotation;
 #endif
+#ifdef SCRIPT_API_v400
+  /// Gets/sets this GUI horizontal scaling.
+  import attribute float ScaleX;
+  /// Gets/sets this GUI vertical scaling.
+  import attribute float ScaleY;
+  /// Sets this GUI horizontal and vertical scaling
+  import void SetScale(float x, float y = 0.0);
+#endif
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2641,6 +2641,7 @@ void draw_gui_and_overlays()
             gui_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(gui.Transparency));
             gui_ddb->SetBlendMode(gui.BlendMode);
             gui_ddb->SetOrigin(0.f, 0.f);
+            gui_ddb->SetStretch(gui.Width * gui.Scale.X, gui.Height * gui.Scale.Y);
             gui_ddb->SetRotation(gui.Rotation);
             add_to_sprite_list(gui_ddb, gui.X, gui.Y,
                 gui.GetGraphicSpace().AABB(), gui.ZOrder, false, index);

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -31,8 +31,6 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
-extern int mousex, mousey;
-extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern CharacterInfo*playerchar;
 extern ScriptInvItem scrInv[MAX_INV];
 extern CCInventory ccDynamicInv;
@@ -65,16 +63,18 @@ void SetInvItemName(int invi, const char *newName) {
     GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
-int GetInvAt(int atx, int aty) {
-  int ongui = GetGUIAt(atx, aty);
+int GetInvAt(int scrx, int scry) {
+  int ongui = GetGUIAt(scrx, scry);
   if (ongui >= 0) {
-    int onobj = guis[ongui].FindControlAt(atx, aty);
-    GUIObject *guio = guis[ongui].GetControl(onobj);
+    GUIMain &gui = guis[ongui];
+    int onobj = gui.FindControlAt(scrx, scry);
+    GUIObject *guio = gui.GetControl(onobj);
     if (guio) {
-      mouse_ifacebut_xoffs = atx - guis[ongui].X - guio->X;
-      mouse_ifacebut_yoffs = aty - guis[ongui].Y - guio->Y;
+      Point guipt = gui.GetGraphicSpace().WorldToLocal(scrx, scry);
+      mouse_ifacebut_xoffs = guipt.X - guio->X;
+      mouse_ifacebut_yoffs = guipt.Y - guio->Y;
     }
-    if (guio && (guis[ongui].GetControlType(onobj) == kGUIInvWindow))
+    if (guio && (gui.GetControlType(onobj) == kGUIInvWindow))
       return offset_over_inv((GUIInvWindow*)guio);
   }
   return -1;

--- a/Engine/ac/global_inventoryitem.h
+++ b/Engine/ac/global_inventoryitem.h
@@ -20,7 +20,7 @@
 
 void set_inv_item_pic(int invi, int piccy);
 void SetInvItemName(int invi, const char *newName);
-int  GetInvAt (int xxx, int yyy);
+int  GetInvAt (int scrx, int scry);
 void GetInvName(int indx,char*buff);
 int  GetInvGraphic(int indx);
 void RunInventoryInteraction (int iit, int modd);

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -433,8 +433,6 @@ float GUI_GetScaleX(ScriptGUI *gui) {
 }
 
 void GUI_SetScaleX(ScriptGUI *gui, float scalex) {
-    if (scalex == 0.f)
-        scalex = 1.f;
     guis[gui->id].SetScale(scalex, guis[gui->id].GetScale().Y);
 }
 
@@ -443,16 +441,10 @@ float GUI_GetScaleY(ScriptGUI *gui) {
 }
 
 void GUI_SetScaleY(ScriptGUI *gui, float scaley) {
-    if (scaley == 0.f)
-        scaley = 1.f;
     guis[gui->id].SetScale(guis[gui->id].GetScale().X, scaley);
 }
 
 void GUI_SetScale(ScriptGUI *gui, float scalex, float scaley) {
-    if (scalex == 0.f)
-        scalex = 1.f;
-    if (scaley == 0.f)
-        scaley = scalex; // scaley is optional here
     guis[gui->id].SetScale(scalex, scaley);
 }
 

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -427,6 +427,34 @@ void GUI_SetRotation(ScriptGUI *gui, float rotation) {
     guis[gui->id].SetRotation(rotation);
 }
 
+float GUI_GetScaleX(ScriptGUI *gui) {
+    return guis[gui->id].GetScale().X;
+}
+
+void GUI_SetScaleX(ScriptGUI *gui, float scalex) {
+    if (scalex == 0.f)
+        scalex = 1.f;
+    guis[gui->id].SetScale(scalex, guis[gui->id].GetScale().Y);
+}
+
+float GUI_GetScaleY(ScriptGUI *gui) {
+    return guis[gui->id].GetScale().Y;
+}
+
+void GUI_SetScaleY(ScriptGUI *gui, float scaley) {
+    if (scaley == 0.f)
+        scaley = 1.f;
+    guis[gui->id].SetScale(guis[gui->id].GetScale().X, scaley);
+}
+
+void GUI_SetScale(ScriptGUI *gui, float scalex, float scaley) {
+    if (scalex == 0.f)
+        scalex = 1.f;
+    if (scaley == 0.f)
+        scaley = scalex; // scaley is optional here
+    guis[gui->id].SetScale(scalex, scaley);
+}
+
 //=============================================================================
 
 void remove_popup_interface(int ifacenum) {
@@ -1065,6 +1093,31 @@ RuntimeScriptValue Sc_GUI_SetRotation(void *self, const RuntimeScriptValue *para
     API_OBJCALL_VOID_PFLOAT(ScriptGUI, GUI_SetRotation);
 }
 
+RuntimeScriptValue Sc_GUI_GetScaleX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptGUI, GUI_GetScaleX);
+}
+
+RuntimeScriptValue Sc_GUI_SetScaleX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptGUI, GUI_SetScaleX);
+}
+
+RuntimeScriptValue Sc_GUI_GetScaleY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptGUI, GUI_GetScaleY);
+}
+
+RuntimeScriptValue Sc_GUI_SetScaleY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptGUI, GUI_SetScaleY);
+}
+
+RuntimeScriptValue Sc_GUI_SetScale(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT2(ScriptGUI, GUI_SetScale);
+}
+
 void RegisterGUIAPI()
 {
     ScFnRegister gui_api[] = {
@@ -1117,6 +1170,11 @@ void RegisterGUIAPI()
         { "GUI::set_BlendMode",           API_FN_PAIR(GUI_SetBlendMode) },
         { "GUI::get_Rotation",            API_FN_PAIR(GUI_GetRotation) },
         { "GUI::set_Rotation",            API_FN_PAIR(GUI_SetRotation) },
+        { "GUI::get_ScaleX",              API_FN_PAIR(GUI_GetScaleX) },
+        { "GUI::set_ScaleX",              API_FN_PAIR(GUI_SetScaleX) },
+        { "GUI::get_ScaleY",              API_FN_PAIR(GUI_GetScaleY) },
+        { "GUI::set_ScaleY",              API_FN_PAIR(GUI_SetScaleY) },
+        { "GUI::SetScale",                API_FN_PAIR(GUI_SetScale) },
     };
 
     ccAddExternalFunctions(gui_api);

--- a/Engine/ac/gui.h
+++ b/Engine/ac/gui.h
@@ -80,8 +80,13 @@ void    gui_on_mouse_hold(const int wasongui, const int wasbutdown);
 void    gui_on_mouse_up(const int wasongui, const int wasbutdown);
 void    gui_on_mouse_down(const int guin, const int mbut);
 
+// currently displayed pop-up GUI (-1 if none)
 extern int ifacepopped;
+// index of GUI the cursor was on
 extern int mouse_on_iface;
+// cursor position relative to a focused gui control
+extern int mouse_ifacebut_xoffs;
+extern int mouse_ifacebut_yoffs;
 extern std::vector<AGS::Common::GUIMain> guis;
 extern std::vector<AGS::Common::GUIButton> guibuts;
 extern std::vector<AGS::Common::GUIInvWindow> guiinv;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -44,7 +44,6 @@ using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern ScriptInvItem scrInv[MAX_INV];
-extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern SpriteCache spriteset;
 extern CharacterInfo*playerchar;
 extern AGSPlatformDriver *platform;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -86,7 +86,6 @@ extern int in_leaves_screen;
 extern int inside_script,in_graph_script;
 extern int no_blocking_functions;
 extern CharacterInfo*playerchar;
-extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern int cur_mode;
 extern RoomObject*objs;
 extern RoomStatus*croom;


### PR DESCRIPTION
Implements script API for GUI scaling. Set as draft for now, in case API receives any criticism.

Adds:
* GUI.ScaleX,
* GUI.ScaleY,
* GUI.SetScale(x,y),
* GUI.GUIToScreenPoint(int guix, int guiy, bool clipToGUI),
* ScreenToGUIPoint(int screenx, int screeny, bool clipToGUI)

All scale values are set in floats, and used as direct scaling factors, which means that
```
final_width = gui.Width * gui.ScaleX;
final_height = gui.Height * gui.ScaleY;
```

Scaled object's image shifts relative to object's "origin". In case of GUI that's **top-left corner**. If user wants to have scaling relative to GUI's center, they will have to adjust X,Y position as well.

Negative values are *allowed* and result in mirrored image. That's not "intentional", it just works this way... If this seems redundant, it's easy to force to strictly positive values.
Scale value `0` is allowed and means that the object is not drawn at all.

Note that visual results depend on number of factors, including game resolution, gui size, scaling.
"Render sprites at screen resolution" makes dramatic change in both upscale and downscale quality.

**ISSUES**

Scaling rotated GUI has unexpected results, where either origin or pivot point is being shifted around (scaled?), resulting in GUI visibly moving around while being scaled as well.
Either this is a problem with GUI's pivot not being the same location as origin, or a wrong order of transforms again...
A care has to be taken, make sure that any fixes to this won't break other types of objects that have different combinations of default origin/pivot.
**EDIT:** this seems to be a consequence of having separate origin and pivot point.
This may be proven by centering a gui using a script, for example:
```
int guix = gMyGUI.X;
int guiy = gMyGUI.Y;
float guisx = gMyGUI.ScaleX;
float guisy = gMyGUI.ScaleY;

// do some scaling and rotation

gMyGUI.X = guix + FloatToInt((IntToFloat(gMyGUI.Width) * guisx - IntToFloat(gMyGUI.Width) * gMyGUI.ScaleX) / 2.0, eRoundNearest);
gMyGUI.Y = guiy + FloatToInt((IntToFloat(gMyGUI.Height) * guisy - IntToFloat(gMyGUI.Height) * gMyGUI.ScaleY) / 2.0, eRoundNearest);
```