### PR TITLE
AGS 4: Watch script variables at runtime

### DIFF
--- a/Common/script/cc_common.h
+++ b/Common/script/cc_common.h
@@ -32,7 +32,8 @@
 #define SCOPT_UTF8          0x0100   // UTF-8 text mode
 #define SCOPT_RTTI          0x0200   // generate and export RTTI
 #define SCOPT_RTTIOPS       0x0400   // enable syntax & opcodes that require RTTI to work
-#define SCOPT_HIGHEST       SCOPT_RTTIOPS
+#define SCOPT_SCRIPT_TOC    0x0800   // generate and export ScriptTOC
+#define SCOPT_HIGHEST       SCOPT_SCRIPT_TOC
 
 extern void ccSetOption(int, int);
 extern int ccGetOption(int);

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -927,24 +927,9 @@ ScriptTOC ScriptTOCBuilder::Finalize(const RTTI *rtti)
     std::sort(_toc._functions.begin(), _toc._functions.end(),
         [](const ScriptTOC::Function &first, const ScriptTOC::Function &second) { return first.scope_begin < second.scope_begin; });
 
-    // Predicate used to sort scoped variables by scope and offset
-    struct ScopedVariableLess
-    {
-        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
-        { return (first.scope_begin < second.scope_begin) ||
-                 (first.scope_begin == second.scope_begin) && (first.offset < second.offset); }
-    };
-
-    // Predicate used to find whether a scoped variable lies inside particular parent scope
-    struct ScopedVariableLessScope
-    {
-        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
-        { return (first.scope_begin < second.scope_begin) && (first.scope_end <= second.scope_begin); }
-    };
-
     // Sort local entries by scope and offset
     auto &local_vars = _toc._locVariables;
-    std::sort(local_vars.begin(), local_vars.end(), ScopedVariableLess());
+    std::sort(local_vars.begin(), local_vars.end(), ScriptTOC::ScopedVariableLess());
 
     // Save complete function data, with params and local vars refs
     for (uint32_t i = 0; i < _toc._functions.size(); ++i)
@@ -963,7 +948,7 @@ ScriptTOC ScriptTOCBuilder::Finalize(const RTTI *rtti)
         }
         // Scan sorted local data for anything that matches this function's scope
         ScriptTOC::Variable test; test.scope_begin = fn.scope_begin; test.scope_end = fn.scope_end;
-        auto lv_range = std::equal_range(local_vars.begin(), local_vars.end(), test, ScopedVariableLessScope());
+        auto lv_range = std::equal_range(local_vars.begin(), local_vars.end(), test, ScriptTOC::ScopedVariableLessScope());
         if (lv_range.first != lv_range.second)
         {
             fn.local_data_index = lv_range.first - local_vars.begin(); // save first entry index

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -88,7 +88,7 @@ static uint32_t StrTableCopy(std::vector<char> &str_table, const char *string)
 //  uint32 | name                   | an offset in a string table
 //  uint32 | location id            | local location's ID
 //  uint32 | parent type (local id) | local type ID; 0? if no parent
-//  uint32 | type flags             |
+//  uint32 | type flags             | see RTTI::TypeFlags
 //  uint32 | type size              | in bytes
 //  uint32 | num fields             |
 //  uint32 | field table index      | an index of a first field
@@ -98,7 +98,7 @@ static uint32_t StrTableCopy(std::vector<char> &str_table, const char *string)
 //  uint32 | offset                 | relative offset, in bytes
 //  uint32 | name                   | an offset in a string table
 //  uint32 | type (local id)        | local type ID of this field
-//  uint32 | flags                  |
+//  uint32 | flags                  | see RTTI::FieldFlags
 //  uint32 | number of elements     | for arrays, 0 = single var
 //
 //*****************************************************************************
@@ -113,8 +113,8 @@ RTTI RTTISerializer::Read(Stream *in)
     const size_t head_sz = (uint32_t)in->ReadInt32();
     const size_t full_sz = (uint32_t)in->ReadInt32();
     const size_t loc_sz = (uint32_t)in->ReadInt32();
-    const size_t loc_table_off = (uint32_t)in->ReadInt32();
-    const size_t loc_table_len = (uint32_t)in->ReadInt32();
+    const uint32_t loc_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t loc_table_len = (uint32_t)in->ReadInt32();
     const size_t typei_sz = (uint32_t)in->ReadInt32();
     const uint32_t typei_table_off = (uint32_t)in->ReadInt32();
     const uint32_t typei_table_len = (uint32_t)in->ReadInt32();
@@ -252,6 +252,22 @@ void RTTISerializer::Write(const RTTI &rtti, Stream *out)
     out->Seek(end_soff, kSeekBegin);
 }
 
+const RTTI::Location *RTTI::FindLocationByLocalID(uint32_t loc_id) const
+{
+    if (loc_id >= _locs.size())
+        return nullptr;
+    return &_locs[loc_id];
+}
+
+const RTTI::Type *RTTI::FindTypeByLocalID(uint32_t type_id) const
+{
+    // TODO: this may be optimized if "typeid_to_type" map is kept after CreateQuickRefs?
+    // TODO: optimize this out for joint collection, as it has typeid = table index
+    auto it = std::find_if(_types.begin(), _types.end(),
+        [type_id](const Type& type) { return type.this_id == type_id; });
+    return it == _types.end() ? nullptr : &*it;
+}
+
 void RTTI::CreateQuickRefs()
 {
     // TODO: keep this map in the RTTI struct, or extended one?
@@ -332,7 +348,7 @@ RTTI RTTIBuilder::Finalize()
         memcpy(&_rtti._strings.front() + s.second, s.first.c_str(), s.first.size() + 1);
     }
 
-    // Save complete field data;
+    // Save complete field data
     for (auto &ti : _rtti._types)
     {
         auto fi_range = _fieldIdx.equal_range(ti.this_id);
@@ -494,6 +510,487 @@ void JointRTTI::Join(const RTTI &rtti,
     CreateQuickRefs();
 }
 
+//*****************************************************************************
+// ScriptTOC serialization
+//
+// TOC header:
+// ----------------
+//  uint32 | format                 | for expanding the format
+//  uint32 | header size            | size in bytes (counting from "format")
+//  uint32 | full data size         | size in bytes (counting from "format")
+//  uint32 | global vars entry size | fixed size of a global var info in bytes
+//  uint32 | global vars table off  | a relative pos of a global vars table
+//  uint32 | num global vars        | number of global vars in table
+//  uint32 | functions entry size   | fixed size of a function info in bytes
+//  uint32 | functions table off    | a relative pos of a functions table
+//  uint32 | num functions          | number of functions in table
+//  uint32 | func param entry size  | fixed size of a func param info in bytes
+//  uint32 | param table offset     | a relative pos of a func param table
+//  uint32 | num param fields       | number of func params in table
+//  uint32 | local vars entry size  | fixed size of a local var info in bytes
+//  uint32 | local vars table off   | a relative pos of a local vars table
+//  uint32 | num local vars         | number of local vars in table
+//  uint32 | string table offset    | a relative pos of a strings table
+//  uint32 | string table size      | size of a string table, in bytes
+//
+// Variable Info:
+// ----------------
+//   int32 | offset                 | offset in script data, in bytes
+//  uint32 | name                   | an offset in a string table
+//  uint32 | location (local id)    | local location's ID (ref to RTTI)
+//  uint32 | scope begin            | valid var's scope start, in bytecode pos
+//  uint32 | scope end              | valid var's scope end, in bytecode pos
+//  uint32 | variable flags         | see VariableFlags
+//  uint32 | type (local id)        | local type ID of this var (ref to RTTI)
+//  uint32 | field flags            | see RTTI::FieldFlags
+//  uint32 | number of elements     | for arrays, 0 = single var
+//
+// Function Info:
+// ----------------
+//  uint32 | name                   | an offset in a string table
+//  uint32 | location (local id)    | local location's ID (ref to RTTI)
+//  uint32 | scope begin            | function's scope start, in bytecode pos
+//  uint32 | scope end              | function's scope end, in bytecode pos
+//  uint32 | type (local id)        | local type ID of this func (ref to RTTI)
+//  uint32 | function flags         | see FunctionFlags
+//  uint32 | ret value type         | local type ID of return value
+//  uint32 | ret value flags        | see RTTI::FieldFlags
+//  uint32 | ret value elem count   | (reserved, unusable atm)
+//  uint32 | num params             | number of function parameters
+//  uint32 | param table index      | an index of a first parameter
+//  uint32 | num local data entries | number of related local data entries
+//  uint32 | param table index      | an index of a first local data entries
+//
+// Func Param Info (corresponds to RTTI's Type Field Info):
+// ----------------
+//  uint32 | offset                 | relative offset, in bytes
+//  uint32 | name                   | an offset in a string table
+//  uint32 | type (local id)        | local type ID of this param
+//  uint32 | flags                  | see RTTI::FieldFlags
+//  uint32 | number of elements     | (reserved, unusable atm)
+//
+//*****************************************************************************
+
+ScriptTOC ScriptTOCSerializer::Read(Stream *in, const RTTI *rtti)
+{
+    ScriptTOC toc;
+
+    // TOC Header
+    const soff_t toc_soff = in->GetPosition();
+    const uint32_t format = in->ReadInt32();
+    const size_t head_sz = (uint32_t)in->ReadInt32();
+    const size_t full_sz = (uint32_t)in->ReadInt32();
+    const uint32_t glvar_sz = (uint32_t)in->ReadInt32();
+    const uint32_t glvar_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t glvar_table_len = (uint32_t)in->ReadInt32();
+    const size_t func_sz = (uint32_t)in->ReadInt32();
+    const uint32_t func_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t func_table_len = (uint32_t)in->ReadInt32();
+    const size_t func_param_sz = (uint32_t)in->ReadInt32();
+    const uint32_t func_param_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t func_param_table_len = (uint32_t)in->ReadInt32();
+    const size_t locvar_sz = (uint32_t)in->ReadInt32();
+    const uint32_t locvar_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t locvar_table_len = (uint32_t)in->ReadInt32();
+    const uint32_t str_table_off = (uint32_t)in->ReadInt32();
+    const size_t str_table_sz = (uint32_t)in->ReadInt32();
+
+    const soff_t glvar_soff = toc_soff + glvar_table_off;
+    const soff_t func_soff = toc_soff + func_table_off;
+    const soff_t func_param_soff = toc_soff + func_param_table_off;;
+    const soff_t locvar_soff = toc_soff + locvar_table_off;
+    const soff_t str_soff = toc_soff + str_table_off;
+    const soff_t end_soff = toc_soff + full_sz;
+
+    // Global variables
+    in->Seek(glvar_soff, kSeekBegin);
+    for (size_t i = 0; i < glvar_table_len; ++i)
+    {
+        ScriptTOC::Variable var;
+        var.offset = in->ReadInt32();
+        var.name_stri = (uint32_t)in->ReadInt32();
+        var.loc_id = (uint32_t)in->ReadInt32();
+        var.scope_begin = (uint32_t)in->ReadInt32();
+        var.scope_end = (uint32_t)in->ReadInt32();
+        var.v_flags = (uint32_t)in->ReadInt32();
+        var.f_typeid = (uint32_t)in->ReadInt32();
+        var.f_flags = (uint32_t)in->ReadInt32();
+        var.num_elems = (uint32_t)in->ReadInt32();
+        toc._glVariables.push_back(var);
+    }
+
+    // Functions
+    in->Seek(func_soff, kSeekBegin);
+    for (size_t i = 0; i < func_table_len; ++i)
+    {
+        ScriptTOC::Function func;
+        func.name_stri = (uint32_t)in->ReadInt32();
+        func.loc_id = (uint32_t)in->ReadInt32();
+        func.scope_begin = (uint32_t)in->ReadInt32();
+        func.scope_end = (uint32_t)in->ReadInt32();
+        func.f_typeid = (uint32_t)in->ReadInt32();
+        func.flags = (uint32_t)in->ReadInt32();
+        func.rv_typeid = (uint32_t)in->ReadInt32();
+        func.rv_flags = (uint32_t)in->ReadInt32();
+        func.rv_num_elems = (uint32_t)in->ReadInt32();
+        func.param_num = (uint32_t)in->ReadInt32();
+        func.param_index = (uint32_t)in->ReadInt32();
+        func.local_data_num = (uint32_t)in->ReadInt32();
+        func.local_data_index = (uint32_t)in->ReadInt32();
+        toc._functions.push_back(func);
+    }
+
+    // Function parameters
+    in->Seek(func_param_soff, kSeekBegin);
+    for (size_t i = 0; i < func_param_table_len; ++i)
+    {
+        ScriptTOC::FunctionParam fp;
+        fp.offset = (uint32_t)in->ReadInt32();
+        fp.name_stri = (uint32_t)in->ReadInt32();
+        fp.f_typeid = (uint32_t)in->ReadInt32();
+        fp.flags = (uint32_t)in->ReadInt32();
+        fp.num_elems = (uint32_t)in->ReadInt32();
+        toc._fparams.push_back(fp);
+    }
+
+    // Local variables
+    in->Seek(locvar_soff, kSeekBegin);
+    for (size_t i = 0; i < locvar_table_len; ++i)
+    {
+        ScriptTOC::Variable var;
+        var.offset = in->ReadInt32();
+        var.name_stri = (uint32_t)in->ReadInt32();
+        var.loc_id = (uint32_t)in->ReadInt32();
+        var.scope_begin = (uint32_t)in->ReadInt32();
+        var.scope_end = (uint32_t)in->ReadInt32();
+        var.v_flags = (uint32_t)in->ReadInt32();
+        var.f_typeid = (uint32_t)in->ReadInt32();
+        var.f_flags = (uint32_t)in->ReadInt32();
+        var.num_elems = (uint32_t)in->ReadInt32();
+        toc._locVariables.push_back(var);
+    }
+
+    // String Table
+    in->Seek(str_soff, kSeekBegin);
+    if (str_table_sz > 0)
+    {
+        toc._strings.resize(str_table_sz);
+        in->Read(&toc._strings.front(), str_table_sz);
+    }
+
+    // Finish
+    in->Seek(end_soff, kSeekBegin);
+
+    toc.CreateQuickRefs(rtti);
+    return std::move(toc);
+}
+
+void ScriptTOCSerializer::Write(const ScriptTOC &toc, Stream *out)
+{
+    // TOC Header placeholder
+    const soff_t toc_soff = out->GetPosition();
+    out->WriteByteCount(0, 17 * sizeof(uint32_t));
+
+    // Global variables
+    uint32_t glvar_count = 0u;
+    const soff_t glvar_soff = out->GetPosition();
+    for (const auto &var : toc._glVariables)
+    {
+        out->WriteInt32(var.offset);
+        out->WriteInt32(var.name_stri);
+        out->WriteInt32(var.loc_id);
+        out->WriteInt32(var.scope_begin);
+        out->WriteInt32(var.scope_end);
+        out->WriteInt32(var.v_flags);
+        out->WriteInt32(var.f_typeid);
+        out->WriteInt32(var.f_flags);
+        out->WriteInt32(var.num_elems);
+        glvar_count++;
+    }
+
+    // Functions
+    const soff_t func_soff = out->GetPosition();
+    for (const auto &func : toc._functions)
+    {
+        out->WriteInt32(func.name_stri);
+        out->WriteInt32(func.loc_id);
+        out->WriteInt32(func.scope_begin);
+        out->WriteInt32(func.scope_end);
+        out->WriteInt32(func.f_typeid);
+        out->WriteInt32(func.flags);
+        out->WriteInt32(func.rv_typeid);
+        out->WriteInt32(func.rv_flags);
+        out->WriteInt32(func.rv_num_elems);
+        out->WriteInt32(func.param_num);
+        out->WriteInt32(func.param_index);
+        out->WriteInt32(func.local_data_num);
+        out->WriteInt32(func.local_data_index);
+    }
+
+    // Function parameters
+    const soff_t func_params_soff = out->GetPosition();
+    for (const auto &fp : toc._fparams)
+    {
+        out->WriteInt32(fp.offset);
+        out->WriteInt32(fp.name_stri);
+        out->WriteInt32(fp.f_typeid);
+        out->WriteInt32(fp.flags);
+        out->WriteInt32(fp.num_elems);
+    }
+
+    // Local variables
+    const soff_t locvar_soff = out->GetPosition();
+    uint32_t locvar_count = 0u;
+    for (const auto &var : toc._locVariables)
+    {
+        out->WriteInt32(var.offset);
+        out->WriteInt32(var.name_stri);
+        out->WriteInt32(var.loc_id);
+        out->WriteInt32(var.scope_begin);
+        out->WriteInt32(var.scope_end);
+        out->WriteInt32(var.v_flags);
+        out->WriteInt32(var.f_typeid);
+        out->WriteInt32(var.f_flags);
+        out->WriteInt32(var.num_elems);
+        locvar_count++;
+    }
+
+    // String Table
+    const soff_t str_soff = out->GetPosition();
+    if (toc._strings.size() > 0)
+    {
+        out->Write(&toc._strings.front(), toc._strings.size());
+    }
+
+    // Finalize, write actual TOC header
+    const soff_t end_soff = out->GetPosition();
+    out->Seek(toc_soff, kSeekBegin);
+    out->WriteInt32(0); // format
+    out->WriteInt32((uint32_t)(glvar_soff - toc_soff)); // header size
+    out->WriteInt32((uint32_t)(end_soff - toc_soff)); // full size
+    out->WriteInt32(ScriptTOC::Variable::FileSize); // global var size
+    out->WriteInt32((uint32_t)(glvar_soff - toc_soff)); // global var table offset
+    out->WriteInt32(glvar_count); // number of global variables
+    out->WriteInt32(ScriptTOC::Function::FileSize); // function size
+    out->WriteInt32((uint32_t)(func_soff - toc_soff)); // function table offset
+    out->WriteInt32(toc._functions.size()); // number of functions
+    out->WriteInt32(ScriptTOC::FunctionParam::FileSize); // function param size
+    out->WriteInt32((uint32_t)(func_params_soff - toc_soff)); // function param table offset
+    out->WriteInt32(toc._fparams.size()); // number of function params
+    out->WriteInt32(ScriptTOC::Variable::FileSize); // local var size
+    out->WriteInt32((uint32_t)(locvar_soff - toc_soff)); // local var table offset
+    out->WriteInt32(locvar_count); // number of local variables
+    out->WriteInt32((uint32_t)(str_soff - toc_soff)); // strings table offset
+    out->WriteInt32(toc._strings.size()); // string table size
+    out->Seek(end_soff, kSeekBegin);
+}
+
+void ScriptTOC::CreateQuickRefs(const RTTI *rtti)
+{
+    for (auto &var : _glVariables)
+    {
+        var.name = &_strings[var.name_stri];
+    }
+
+    for (auto &var : _locVariables)
+    {
+        var.name = &_strings[var.name_stri];
+    }
+
+    for (auto &fn : _functions)
+    {
+        fn.name = &_strings[fn.name_stri];
+        if (fn.param_num > 0u)
+        {
+            fn.first_param = &_fparams[fn.param_index];
+            for (uint32_t index = 0; index < fn.param_num; ++index)
+            {
+                auto &fp = _fparams[fn.param_index + index];
+                fp.name = &_strings[fp.name_stri];
+                fp.owner = &fn;
+                fp.prev_field = (index > 0) ? &_fparams[fn.param_index + index - 1] : nullptr;
+                fp.next_field = (index + 1 < fn.param_num) ? &_fparams[fn.param_index + index + 1] : nullptr;
+            }
+        }
+        if (fn.local_data_num > 0u)
+        {
+            fn.local_data = &_locVariables[fn.local_data_index];
+            for (uint32_t index = 0; index < fn.local_data_num; ++index)
+            {
+                auto &var = _locVariables[fn.local_data_index + index];
+                var.function = &fn;
+                var.prev_local = (index > 0) ? &_locVariables[fn.local_data_index + index - 1] : nullptr;
+                var.next_local = (index + 1 < fn.local_data_num) ? &_locVariables[fn.local_data_index + index + 1] : nullptr;
+            }
+        }
+    }
+
+    _rtti = rtti;
+    if (rtti)
+    {
+        for (auto &var : _glVariables)
+        {
+            var.location = rtti->FindLocationByLocalID(var.loc_id);
+            var.type = rtti->FindTypeByLocalID(var.f_typeid);
+        }
+        for (auto &var : _locVariables)
+        {
+            var.location = rtti->FindLocationByLocalID(var.loc_id);
+            var.type = rtti->FindTypeByLocalID(var.f_typeid);
+        }
+        for (auto &fn : _functions)
+        {
+            fn.location = rtti->FindLocationByLocalID(fn.loc_id);
+            fn.return_type = rtti->FindTypeByLocalID(fn.rv_typeid);
+        }
+        for (auto &fp : _fparams)
+        {
+            fp.type = rtti->FindTypeByLocalID(fp.f_typeid);
+        }
+    }
+}
+
+void ScriptTOCBuilder::AddGlobalVar(const std::string &name, uint32_t loc_id,
+    uint32_t offset, uint32_t v_flags, uint32_t f_type_id, uint32_t f_flags,
+    uint32_t num_elems)
+{
+    ScriptTOC::Variable var;
+    var.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    var.loc_id = loc_id;
+    var.offset = offset;
+    var.v_flags = v_flags
+        & ~(ScriptTOC::kVariable_Local | ScriptTOC::kVariable_Parameter);
+    var.f_typeid = f_type_id;
+    var.f_flags = f_flags;
+    var.num_elems = num_elems;
+    _toc._glVariables.push_back(var);
+}
+
+void ScriptTOCBuilder::AddLocalVar(const std::string &name, uint32_t loc_id,
+    uint32_t offset, uint32_t scope_begin, uint32_t scope_end, uint32_t v_flags,
+    uint32_t f_type_id, uint32_t f_flags, uint32_t num_elems)
+{
+    ScriptTOC::Variable var;
+    var.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    var.loc_id = loc_id;
+    var.offset = offset;
+    var.scope_begin = scope_begin;
+    var.scope_end = scope_end;
+    var.v_flags = v_flags | (ScriptTOC::kVariable_Local);
+    var.f_typeid = f_type_id;
+    var.f_flags = f_flags;
+    var.num_elems = num_elems;
+    _toc._locVariables.push_back(var);
+}
+
+uint32_t ScriptTOCBuilder::AddFunction(const std::string &name, uint32_t loc_id,
+    uint32_t scope_begin, uint32_t scope_end, uint32_t flags,
+    uint32_t rv_typeid, uint32_t rv_flags)
+{
+    ScriptTOC::Function func;
+    func.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    func.loc_id = loc_id;
+    func.scope_begin = scope_begin;
+    func.scope_end = scope_end;
+    func.flags = flags;
+    func.rv_typeid = rv_typeid;
+    func.rv_flags = rv_flags;
+    _toc._functions.push_back(func);
+    return static_cast<uint32_t>(_toc._functions.size() - 1);
+}
+
+void ScriptTOCBuilder::AddFunctionParam(uint32_t func_id, const std::string &name, uint32_t offset,
+    uint32_t f_typeid, uint32_t flags)
+{
+    ScriptTOC::FunctionParam fi;
+    fi.offset = offset;
+    fi.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    fi.f_typeid = f_typeid;
+    fi.flags = flags;
+    _paramIdx.insert(std::make_pair(func_id, fi)); // match field to owner type
+}
+
+ScriptTOC ScriptTOCBuilder::Finalize(const RTTI *rtti)
+{
+    // Save complete string data
+    _toc._strings.resize(_strpackedLen);
+    for (const auto &s : _strtable)
+    { // write strings at the precalculated offsets
+        memcpy(&_toc._strings.front() + s.second, s.first.c_str(), s.first.size() + 1);
+    }
+
+    // Sort global vars by offset
+    std::sort(_toc._glVariables.begin(), _toc._glVariables.end(),
+        [](const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) { return first.offset < second.offset; });
+
+    // Sort functions by scope
+    std::sort(_toc._functions.begin(), _toc._functions.end(),
+        [](const ScriptTOC::Function &first, const ScriptTOC::Function &second) { return first.scope_begin < second.scope_begin; });
+
+    // Predicate used to sort scoped variables by scope and offset
+    struct ScopedVariableLess
+    {
+        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
+        { return (first.scope_begin < second.scope_begin) ||
+                 (first.scope_begin == second.scope_begin) && (first.offset < second.offset); }
+    };
+
+    // Predicate used to find whether a scoped variable lies inside particular parent scope
+    struct ScopedVariableLessScope
+    {
+        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
+        { return (first.scope_begin < second.scope_begin) && (first.scope_end <= second.scope_begin); }
+    };
+
+    // Sort local entries by scope and offset
+    auto &local_vars = _toc._locVariables;
+    std::sort(local_vars.begin(), local_vars.end(), ScopedVariableLess());
+
+    // Save complete function data, with params and local vars refs
+    for (uint32_t i = 0; i < _toc._functions.size(); ++i)
+    {
+        auto &fn = _toc._functions[i];
+        // Find prepared parameters for this function
+        auto fi_range = _paramIdx.equal_range(i);
+        if (fi_range.first != _paramIdx.end())
+        {
+            fn.param_index = _toc._fparams.size(); // save first param index
+            fn.param_num = std::distance(fi_range.first, fi_range.second);
+            for (auto fi_it = fi_range.first; fi_it != fi_range.second; ++fi_it)
+            {
+                _toc._fparams.push_back(fi_it->second);
+            }
+        }
+        // Scan sorted local data for anything that matches this function's scope
+        ScriptTOC::Variable test; test.scope_begin = fn.scope_begin; test.scope_end = fn.scope_end;
+        auto lv_range = std::equal_range(local_vars.begin(), local_vars.end(), test, ScopedVariableLessScope());
+        if (lv_range.first != lv_range.second)
+        {
+            fn.local_data_index = lv_range.first - local_vars.begin(); // save first entry index
+            fn.local_data_num = lv_range.second - lv_range.first; // local data number
+            // Fixup local entries (CHECKME: perhaps do this upon loading instead? or both?)
+            for (auto it = lv_range.first; it != lv_range.second; ++it)
+            {
+                auto &var = *it;
+                var.loc_id = fn.loc_id;
+                var.scope_begin = std::min(fn.scope_end, std::max(fn.scope_begin, var.scope_begin));
+                var.scope_end = std::min(fn.scope_end, std::max(fn.scope_begin, var.scope_end));
+            }
+        }
+    }
+
+    _toc.CreateQuickRefs(rtti);
+
+    ScriptTOC toc = std::move(_toc);
+    _toc = ScriptTOC(); // reset, in case user will want to create a new collection
+    return toc;
+}
+
+//*****************************************************************************
+//
+// Additional helpers.
+//
+//*****************************************************************************
 
 String PrintRTTI(const RTTI &rtti)
 {

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -1040,17 +1040,33 @@ String PrintScriptTOC(const ScriptTOC &toc, const char *scriptname)
     String fullstr;
     fullstr.AppendFmt("%s\nScript '%s' Table of Contents\n%s\n", dbhr, scriptname, dbhr);
 
-    fullstr.AppendFmt("Global variables (%d):\n%s\n", glvars.size(), hr);
+    // Exclude imported variables from this list
+    uint32_t own_glvars = 0u;
+    for (const auto &var : glvars)
+        if ((var.v_flags & ScriptTOC::kVariable_Import) == 0)
+            own_glvars++;
+
+    fullstr.AppendFmt("Global variables (%d):\n%s\n", own_glvars, hr);
     for (const auto &var : glvars)
     {
+        if ((var.v_flags & ScriptTOC::kVariable_Import) != 0)
+            continue;
         fullstr.AppendFmt("%-8u: ", var.offset);
         FmtField(fullstr, var.type, var.f_flags, var.name);
         fullstr.AppendChar('\n');
     }
 
-    fullstr.AppendFmt("%s\nFunctions (%d):\n%s\n", dbhr, funcs.size(), hr);
+    // Exclude imported functions from this list
+    uint32_t own_funcs = 0u;
+    for (const auto &fn : funcs)
+        if ((fn.flags & ScriptTOC::kFunction_Import) == 0)
+            own_funcs++;
+
+    fullstr.AppendFmt("%s\nFunctions (%d):\n%s\n", dbhr, own_funcs, hr);
     for (const auto &fn : funcs)
     {
+        if ((fn.flags & ScriptTOC::kFunction_Import) != 0)
+            continue;
         FmtField(fullstr, fn.return_type, fn.rv_flags, nullptr);
         fullstr.AppendFmt("%s ( ", fn.name);
         for (const auto *p = fn.first_param; p; p = p->next_field)

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -397,6 +397,8 @@ public:
         const RTTI::Type *return_type = nullptr;
         const FunctionParam *first_param = nullptr;
         const Variable *local_data = nullptr;
+
+        inline uint32_t GetLocalDataIndex() const { return local_data_index; }
     private:
         // Internal references
         uint32_t name_stri = 0u; // variable's name (string table offset)
@@ -445,6 +447,23 @@ public:
     const std::vector<Variable> &GetLocalVariables() const { return _locVariables; }
     // Returns list of functions
     const std::vector<Function> &GetFunctions() const { return _functions; }
+
+    //
+    // Various helpers
+    //
+    // Predicate used to sort scoped variables by scope and offset
+    struct ScopedVariableLess
+    {
+        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
+        { return (first.scope_begin < second.scope_begin) ||
+                 (first.scope_begin == second.scope_begin) && (first.offset < second.offset); }
+    };
+    // Predicate used to find whether a scoped variable lies inside particular parent scope
+    struct ScopedVariableLessScope
+    {
+        bool operator() (const ScriptTOC::Variable &first, const ScriptTOC::Variable &second) const
+        { return (first.scope_begin < second.scope_begin) && (first.scope_end <= second.scope_begin); }
+    };
 
 private:
     // Generates quick reference fields, binding table entries between each other;

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -515,6 +515,8 @@ private:
 // TODO: provide TextWriter instead of returning a String,
 // but need to implement a TextWriter that writes into the engine's log
 AGS::Common::String PrintRTTI(const RTTI &rtti);
+// Prints Script TOC into the string
+AGS::Common::String PrintScriptTOC(const ScriptTOC &toc, const char *scriptname);
 
 } // namespace AGS
 

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -14,6 +14,35 @@
 //
 // Script reflection helpers. Intended to analyze script memory.
 //
+//-----------------------------------------------------------------------------
+//
+// NOTES on possible refactor:
+//
+// 1) Consider "de-optimizing" RTTI class and make it more user-friendly.
+// A bit of explanation:
+//    RTTI is serialized packed in a database-style format, where each entry
+//    has fixed size in memory (on disk, and in RAM, if unseralized as-is).
+//    Anything of dynamic size, such as strings, is gathered as large array
+//    and appended as an extension, while table entries store reference
+//    indexes to such array.
+//    This is good for a file storage; this format is very easy to parse,
+//    expand, and supports both forward and backward compatibility.
+//    But it looks "off" when represented as a struct.
+//    If desired, RTTI class and internal structs may be refactored into
+//    something more convenient for a common usage in program code.
+//    If that's done, then RTTIBuilder class should be likely merged with
+//    RTTISerializer, as data has still be packed prior writing it to a file,
+//    and unpacked when reading from a file.
+//    This may also let to get rid of uses of "friend" classes here.
+// Same refers to ScriptTOC class.
+//
+// 2) Generic "table building" and serialization.
+//    The code that constructs and (un)serializes RTTI may be factored into a
+//    generic (un)packing and serialization algorithm for any similar format:
+//    a series of tables of fixed-sized entries, that have anything of dynamic
+//    size in a separate table or list, and where entries reference each other
+//    by a integer indexes.
+//
 //=============================================================================
 #ifndef __CC_REFLECT_H
 #define __CC_REFLECT_H
@@ -42,6 +71,11 @@ class JointRTTI;
 // sequential (may have gaps). For a globally unique identifier -
 // use a "fully qualified name" instead: in a format of "locname::typename",
 // where "locname" is a name of location and "typename" is a name of type.
+//
+// TODO: support Function Types: that is a type of function pointer;
+// such types might be required for function pointer variables (or delegates).
+// Function Type should correspond to a particular function prototype.
+// In this case Fields could represent return value and parameters.
 class RTTI
 {
     friend RTTIBuilder;
@@ -85,8 +119,8 @@ public:
     struct Location
     {
         friend RTTI; friend RTTIBuilder; friend RTTISerializer; friend JointRTTI;
-    public:
         const static size_t FileSize = 3 * sizeof(uint32_t);
+    public:
         uint32_t id = 0u; // location's id
         uint32_t flags = 0u; // location flags
         // Quick-access links
@@ -100,8 +134,8 @@ public:
     struct Type
     {
         friend RTTI; friend RTTIBuilder; friend RTTISerializer; friend JointRTTI;
-    public:
         const static size_t FileSize = 8 * sizeof(uint32_t);
+    public:
         uint32_t this_id = 0u; // this type's id (local to current RTTI struct)
         uint32_t loc_id = 0u; // type location's id (script or header)
         uint32_t parent_id = 0u; // parent type's id
@@ -126,8 +160,8 @@ public:
     struct Field
     {
         friend RTTI; friend RTTIBuilder; friend RTTISerializer; friend JointRTTI;
-    public:
         const static size_t FileSize = 5 * sizeof(uint32_t);
+    public:
         uint32_t offset = 0u; // relative offset of this field, in bytes
         uint32_t f_typeid = 0u; // field's type id
         uint32_t flags = 0u; // field flags
@@ -161,6 +195,10 @@ public:
     // in collection is not defined, and an index in the list is not
     // guaranteed to match typeid at all.
     const std::vector<Type> &GetTypes() const { return _types; }
+    // Finds a location by its local id
+    const Location *FindLocationByLocalID(uint32_t loc_id) const;
+    // Finds a type by its local id
+    const Type *FindTypeByLocalID(uint32_t type_id) const;
 
 private:
     // Generates quick reference fields, binding table entries between each other
@@ -245,6 +283,232 @@ private:
         std::unordered_map<uint32_t, uint32_t> &type_l2g);
 };
 
+
+class ScriptTOCBuilder;
+class ScriptTOCSerializer;
+
+// Table of Contents for the script:
+// contains tables of functions and variables, both global and local ones.
+// Has strictly debugging and diagnostic purposes. Runtime script execution
+// must not depend on this table.
+//
+// Function infos define function's scope in bytecode positions,
+// return value and a list of parameters.
+// Local variables are defined in their respective lifetime Scope, a range
+// of script's bytecode positions in which this variable is valid.
+// Local variables table also includes function's named parameters. This
+// creates certain duplication of data, but makes it easier to cherry pick
+// data when parsing a file, or scan local script data at runtime.
+//
+// IMPORTANT: ScriptDataTOC depends on RTTI, but may be still used without one
+// to a certain extent (types and location ids won't be resolved).
+class ScriptTOC
+{
+    friend ScriptTOCBuilder; friend ScriptTOCSerializer;
+public:
+    enum VariableFlags
+    {
+        // Local variable, allocated on stack;
+        // variable's offset is saved as a positive number,
+        // where first non-parameter variable is at 0
+        kVariable_Local      = 0x0001,
+        // Is a function's parameter, allocated on stack;
+        // variable's offset is saved as a negative number
+        kVariable_Parameter  = 0x0002
+    };
+
+    enum FunctionFlags
+    {
+        // A variadic function; its param_num tells number of fixed params
+        kFunction_Variadic  = 0x0001
+    };
+
+    struct Function;
+
+    // Variable's info,
+    // serves for both global and local vars (including function parameters).
+    // Any variable may be uniquely identified by:
+    //     script + type of mem + scope + offset
+    // For global variables "script + offset" is enough.
+    // Note that "location id" tells where in script this variable was defined,
+    // but not where it is allocated. This has strictly diagnostic purposes.
+    // For local variables' offset contains relative address of
+    // this variable in function data on stack, where 0 is right after the last
+    // function parameter (local variables have offset >= 0, while the function
+    // parameters have offset < 0).
+    // The variable's scope is in bytecode pos; this makes it possible to
+    // know precisely whether variable is allocated at the given position
+    // of execution. (Scope is ignored for global variables.)
+    struct Variable
+    {
+        friend ScriptTOC; friend ScriptTOCBuilder; friend ScriptTOCSerializer;
+        const static size_t FileSize = 9 * sizeof(uint32_t);
+    public:
+        int32_t  offset = 0;  // offset of this variable, in bytes;
+            // this is either global or function data offset;
+            // function parameters have negative offset values
+        uint32_t loc_id = 0u; // variable's location's id (where defined)
+        uint32_t scope_begin = 0u; // lifetime scope start (in bytecode pos)
+        uint32_t scope_end = 0u; // lifetime scope end (in bytecode pos)
+        uint32_t v_flags = 0u; // variable's flags
+        uint32_t f_typeid = 0u; // field's type id
+        uint32_t f_flags = 0u; // field flags
+        uint32_t num_elems = 0u; // number of elements (for array)
+        // Quick-access links
+        const char *name = nullptr;
+        const RTTI::Location *location = nullptr;
+        const RTTI::Type *type = nullptr;
+        // Quick links for local variables only
+        const Function *function = nullptr; // for local vars
+        const Variable *prev_local = nullptr;
+        const Variable *next_local = nullptr;
+    private:
+        // Internal references
+        uint32_t name_stri = 0u; // variable's name (string table offset)
+    };
+
+    struct FunctionParam;
+
+    // Function's info
+    // Any function may be uniquely identified by:
+    //     script + scope begin
+    // TODO: might we require an explicit "local function id"? check the function pointers idea.
+    // Note that "location id" tells where in script this function was defined,
+    // but not which script's bytecode it is in. This has strictly diagnostic
+    // purposes.
+    struct Function
+    {
+        friend ScriptTOC; friend ScriptTOCBuilder; friend ScriptTOCSerializer;
+        const static size_t FileSize = 13 * sizeof(uint32_t);
+    public:
+        uint32_t loc_id = 0u; // variable's location's id (where defined)
+        uint32_t scope_begin = 0u; // execution scope start (in bytecode pos)
+        uint32_t scope_end = 0u; // execution scope end (in bytecode pos)
+        uint32_t f_typeid = 0u; // function's type id (type of prototype, reserved)
+        uint32_t flags = 0u; // function's flags
+        uint32_t rv_typeid = 0u; // return value's type id
+        uint32_t rv_flags = 0u; // return value's field flags
+        uint32_t rv_num_elems = 0u; // return value number of elements (reserved)
+        uint32_t param_num = 0u; // number of params, if any
+        uint32_t local_data_num = 0u; // number of related entries in the local vars table
+        // Quick-access links
+        const char *name = nullptr;
+        const RTTI::Location *location = nullptr;
+        const RTTI::Type *return_type = nullptr;
+        const FunctionParam *first_param = nullptr;
+        const Variable *local_data = nullptr;
+    private:
+        // Internal references
+        uint32_t name_stri = 0u; // variable's name (string table offset)
+        uint32_t param_index = 0u; // first param index in the params table
+        uint32_t local_data_index = 0u; // first index in the local variables table
+    };
+
+    // Function param's info
+    // FIXME: practically copies RTTI::Field, the only difference
+    // are "quick-access links". Refactor this, pick out base struct, etc...
+    struct FunctionParam
+    {
+        friend ScriptTOC; friend ScriptTOCBuilder; friend ScriptTOCSerializer;
+        const static size_t FileSize = 5 * sizeof(uint32_t);
+    public:
+        uint32_t offset = 0u; // relative offset of this field, in bytes
+        uint32_t f_typeid = 0u; // field's type id
+        uint32_t flags = 0u; // field flags
+        uint32_t num_elems = 0u; // number of elements (for array)
+        // Quick-access links
+        const char *name = nullptr;
+        const RTTI::Type *type = nullptr;
+        const Function *owner = nullptr;
+        const FunctionParam *prev_field = nullptr;
+        const FunctionParam *next_field = nullptr;
+    private:
+        // Internal references
+        uint32_t name_stri = 0u; // field's name (string table offset)
+    };
+
+    ScriptTOC()
+    {
+        _strings.push_back(0); // guarantee zero-len string at index 0
+    }
+
+    ScriptTOC(const ScriptTOC &rtti) = default;
+    ScriptTOC(ScriptTOC &&rtti) = default;
+
+    ScriptTOC &operator = (const ScriptTOC &rtti) = default;
+    ScriptTOC &operator = (ScriptTOC &&rtti) = default;
+
+    bool IsEmpty() const { return _glVariables.empty() && _functions.empty(); }
+    // Returns list of global variables
+    const std::vector<Variable> &GetGlobalVariables() const { return _glVariables; }
+    // Returns list of local variables
+    const std::vector<Variable> &GetLocalVariables() const { return _locVariables; }
+    // Returns list of functions
+    const std::vector<Function> &GetFunctions() const { return _functions; }
+
+private:
+    // Generates quick reference fields, binding table entries between each other;
+    // optionally lets link to RTTI types and locations
+    void CreateQuickRefs(const RTTI *rtti);
+
+    // An optional reference to RTTI
+    const RTTI *_rtti = nullptr;
+    // Global variables' descriptions
+    std::vector<Variable> _glVariables;
+    // Local variables' descriptions (includes all allocated loc data, fn params too)
+    std::vector<Variable> _locVariables;
+    // Function descriptions
+    std::vector<Function> _functions;
+    // Function params' descriptions
+    std::vector<FunctionParam> _fparams;
+    // All TOC strings packed, separated by null-terminators
+    std::vector<char> _strings;
+};
+
+// A helper class that implements ScriptTOC serialization in the dedicated format.
+class ScriptTOCSerializer
+{
+public:
+    // Reads the RTTI collection from the stream
+    static ScriptTOC Read(AGS::Common::Stream *in, const RTTI *rtti);
+    // Writes the RTTI collection to the stream
+    static void Write(const ScriptTOC &toc, AGS::Common::Stream *out);
+};
+
+// A helper class that lets you generate ScriptDataTOC collection.
+// Use Add* methods to construct list of types and their members,
+// then call Finalize which returns a constructed ScriptDataTOC object.
+class ScriptTOCBuilder
+{
+public:
+    ScriptTOCBuilder() = default;
+    // Add a global variable entry
+    void AddGlobalVar(const std::string &name, uint32_t loc_id,
+        uint32_t offset, uint32_t v_flags, uint32_t f_type_id, uint32_t f_flags,
+        uint32_t num_elems);
+    // Adds a function entry; returns assigned function's index
+    uint32_t AddFunction(const std::string &name, uint32_t loc_id,
+        uint32_t scope_begin, uint32_t scope_end, uint32_t flags,
+        uint32_t rv_typeid, uint32_t rv_flags);
+    // Add a function's parameter
+    void AddFunctionParam(uint32_t func_id, const std::string &name, uint32_t offset,
+        uint32_t f_typeid, uint32_t flags);
+    // Add a local variable entry, defined by lifetime scope (inside a function)
+    void AddLocalVar(const std::string &name, uint32_t loc_id,
+        uint32_t offset, uint32_t scope_begin, uint32_t scope_end, uint32_t v_flags,
+        uint32_t f_type_id, uint32_t f_flags, uint32_t num_elems);
+    // Finalizes the ScriptTOC, generates remaining data based on collected one;
+    // optionally lets link to RTTI types and locations
+    ScriptTOC Finalize(const RTTI *rtti);
+
+private:
+    // ScriptTOC that is being built
+    ScriptTOC _toc;
+    // Helper fields
+    std::multimap<uint32_t, ScriptTOC::FunctionParam> _paramIdx; // function id to param list
+    std::map<std::string, uint32_t> _strtable; // string to offset
+    uint32_t _strpackedLen = 0u; // packed string table size
+};
 
 
 // Prints RTTI types and their fields into the string.

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -308,19 +308,28 @@ class ScriptTOC
 public:
     enum VariableFlags
     {
+        // Variable is imported from elsewhere (only global variable);
+        // location id tells location of import declaration (not variable),
+        // offset value is unknown until runtime and must be ignored
+        kVariable_Import     = 0x0001,
         // Local variable, allocated on stack;
+        // scope has meaning only for local variables;
         // variable's offset is saved as a positive number,
         // where first non-parameter variable is at 0
-        kVariable_Local      = 0x0001,
+        kVariable_Local      = 0x0002,
         // Is a function's parameter, allocated on stack;
         // variable's offset is saved as a negative number
-        kVariable_Parameter  = 0x0002
+        kVariable_Parameter  = 0x0004
     };
 
     enum FunctionFlags
     {
+        // Function is imported from elsewhere;
+        // location id tells location of import declaration (not function),
+        // scope is unknown until runtime and must be ignored
+        kFunction_Import    = 0x0001,
         // A variadic function; its param_num tells number of fixed params
-        kFunction_Variadic  = 0x0001
+        kFunction_Variadic  = 0x0002
     };
 
     struct Function;

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -34,6 +34,9 @@
 //    RTTISerializer, as data has still be packed prior writing it to a file,
 //    and unpacked when reading from a file.
 //    This may also let to get rid of uses of "friend" classes here.
+// EDIT: at the very least, Type, Field etc structs may be split into a
+//    fully public struct with basic fields, and extended structs with extras,
+//    such as "quick reference links".
 // Same refers to ScriptTOC class.
 //
 // 2) Generic "table building" and serialization.
@@ -42,6 +45,14 @@
 //    a series of tables of fixed-sized entries, that have anything of dynamic
 //    size in a separate table or list, and where entries reference each other
 //    by a integer indexes.
+//
+//-----------------------------------------------------------------------------
+//
+// TODOs and FIXMEs:
+//
+// * Because of a design oversight, multi-dimensional arrays are not described
+//   correctly, there's no way to know number of dimensions, and therefore
+//   get an actual type of an element of a jagged array (dyn array of arrs).
 //
 //=============================================================================
 #ifndef __CC_REFLECT_H

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -46,6 +46,11 @@ protected:
             _script.rtti.reset(new RTTI(std::move(RTTISerializer::Read(in))));
             return HError::None();
         }
+        else if (ext_id.CompareNoCase("sctoc") == 0)
+        {
+            _script.sctoc.reset(new ScriptTOC(std::move(ScriptTOCSerializer::Read(in, _script.rtti.get() /* may be null */))));
+            return HError::None();
+        }
         return new Error(String::FromFormat("Unknown script extension: %s (%d)", ext_id.GetCStr(), block_id));
     }
 
@@ -127,6 +132,12 @@ void ccScript::Write(Stream *out)
     if (rtti && !rtti->IsEmpty())
     {
         WriteExtBlock("rtti", [rtti](Stream *out){ RTTISerializer::Write(*rtti, out); },
+                      kDataExt_NumID8 | kDataExt_File64, out);
+    }
+    const auto *sctoc = ccScript::sctoc.get();
+    if (sctoc && !sctoc->IsEmpty())
+    {
+        WriteExtBlock("sctoc", [sctoc](Stream *out){ ScriptTOCSerializer::Write(*sctoc, out); },
                       kDataExt_NumID8 | kDataExt_File64, out);
     }
     // Write ending

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -43,8 +43,9 @@ public:
     // of the code came from header files, and which from the main file
     std::vector<std::string> sectionNames;
     std::vector<int32_t> sectionOffsets;
-    // Extended information
+    // Extended information (optional)
     std::unique_ptr<RTTI> rtti;
+    std::unique_ptr<ScriptTOC> sctoc;
 
     int instances = 0; // reference count for this script object
 

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -531,8 +531,9 @@ bool inflate_decompress(uint8_t* data, size_t data_sz, int /*image_bpp*/, Stream
 // https://stackoverflow.com/questions/180947/base64-decode-snippet-in-c
 static const char *Base64Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-String base64_encode(const uint8_t *bytes, size_t input_size)
+String base64_encode(const void *addr, size_t input_size)
 {
+    const uint8_t *bytes = static_cast<const uint8_t*>(addr);
     String out;
     int val = 0, valb = -6;
     for (size_t i = 0; i < input_size; ++i)

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -14,9 +14,10 @@
 #ifndef __AC_COMPRESS_H
 #define __AC_COMPRESS_H
 
-#include "core/types.h"
 #include <memory>
 #include <vector>
+#include "core/types.h"
+#include "util/string.h"
 
 struct RGB;
 
@@ -40,6 +41,11 @@ bool lzw_decompress(uint8_t *data, size_t data_sz, int image_bpp, Common::Stream
 void save_lzw(Common::Stream *out, const Common::Bitmap *bmpp, const RGB (*pal)[256] = nullptr);
 // Loads bitmap decompressing
 std::unique_ptr<Common::Bitmap> load_lzw(Common::Stream *in, int dst_bpp, RGB (*pal)[256] = nullptr);
+
+// Base64 encoding
+Common::String base64_encode(const uint8_t *bytes, size_t input_size);
+Common::String base64_encode(const Common::String &input);
+void base64_decode(const Common::String &input, std::vector<uint8_t> &out);
 
 // Deflate compression
 bool deflate_compress(const uint8_t* data, size_t data_sz, int image_bpp, Common::Stream* out);

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -43,7 +43,7 @@ void save_lzw(Common::Stream *out, const Common::Bitmap *bmpp, const RGB (*pal)[
 std::unique_ptr<Common::Bitmap> load_lzw(Common::Stream *in, int dst_bpp, RGB (*pal)[256] = nullptr);
 
 // Base64 encoding
-Common::String base64_encode(const uint8_t *bytes, size_t input_size);
+Common::String base64_encode(const void *addr, size_t input_size);
 Common::String base64_encode(const Common::String &input);
 void base64_decode(const Common::String &input, std::vector<uint8_t> &out);
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -214,12 +214,13 @@ int String::CompareRightNoCase(const char *cstr, size_t count) const
     return ags_strnicmp(_cstr + _len - off, cstr, count);
 }
 
-size_t String::FindChar(char c, size_t from) const
+size_t String::FindChar(char c, size_t from, size_t to) const
 {
-    if (c && from < _len)
+    if (c && from < _len && from < to)
     {
-        const char * found_cstr = strchr(_cstr + from, c);
-        return found_cstr ? found_cstr - _cstr : NoIndex;
+        const char *end_cstr = _cstr + std::min(_len, to);
+        const char *found_cstr = std::find(static_cast<const char*>(_cstr) + from, end_cstr, c);
+        return found_cstr != end_cstr ? found_cstr - _cstr : NoIndex;
     }
     return NoIndex;
 }

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -168,7 +168,7 @@ public:
 
     // These functions search for character or substring inside this string
     // and return the index of the (first) character, or NoIndex if nothing found.
-    size_t  FindChar(char c, size_t from = 0) const;
+    size_t  FindChar(char c, size_t from = 0, size_t to = NoIndex) const;
     size_t  FindCharReverse(char c, size_t from = NoIndex) const;
     size_t  FindString(const String &str, size_t from = 0) const
                 { return FindString(str._cstr, from); }
@@ -374,7 +374,7 @@ public:
     String &operator=(const char *cstr);
     inline const char &operator[](size_t index) const
     {
-        assert(index < _len);
+        assert(index <= _len); // allow to access null terminator
         return _cstr[index];
     }
     inline bool operator ==(const String &str) const

--- a/Compiler/script/cc_symboldef.h
+++ b/Compiler/script/cc_symboldef.h
@@ -31,6 +31,7 @@ struct FuncParamInfo
     uint32_t Type = 0u;
     int32_t DefaultValue = 0;
     bool HasDefaultValue = false;
+    std::string Name;
 };
 
 struct SymbolDef {

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -43,6 +43,10 @@ int SymbolTableEntry::is_loadable_variable() const {
     return (stype == SYM_GLOBALVAR) || (stype == SYM_LOCALVAR) || (stype == SYM_CONSTANT);
 }
 
+bool SymbolTableEntry::is_variadic_function() const {
+    return (stype == SYM_FUNCTION) && (sscope > 100);
+}
+
 void SymbolTableEntry::set_propfuncs(int propget, int propset) {
     // TODO check ranges and throw exception
     soffs = (propget << 16) | (propset & 0xffff);

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -27,7 +27,7 @@ symbolTable::symbolTable() {
     stringStructSym = 0;
 }
 
-int SymbolTableEntry::get_num_args() {
+int SymbolTableEntry::get_num_args() const {
 	// TODO: assert is func?
     return sscope % 100;
 }
@@ -39,7 +39,7 @@ int symbolTable::get_type(int ii) {
     return entries[ii].stype;
 }
 
-int SymbolTableEntry::is_loadable_variable() {
+int SymbolTableEntry::is_loadable_variable() const {
     return (stype == SYM_GLOBALVAR) || (stype == SYM_LOCALVAR) || (stype == SYM_CONSTANT);
 }
 
@@ -47,14 +47,14 @@ void SymbolTableEntry::set_propfuncs(int propget, int propset) {
     // TODO check ranges and throw exception
     soffs = (propget << 16) | (propset & 0xffff);
 }
-int SymbolTableEntry::get_propget() {
+int SymbolTableEntry::get_propget() const {
     int toret = (soffs >> 16) & 0x00ffff;
 	if (toret == 0xffff) {
         return -1;
 	}
     return toret;
 }
-int SymbolTableEntry::get_propset() {
+int SymbolTableEntry::get_propset() const {
     int toret = soffs & 0xffff;
 	if (toret == 0xffff) {
         return -1;
@@ -70,6 +70,7 @@ void symbolTable::reset() {
 
 	entries.clear();
     sections.clear();
+    localEntries.clear();
 
     stringStructSym = 0;
     symbolTree.clear();
@@ -157,7 +158,7 @@ void symbolTable::reset() {
     add_ex("noloopcheck", SYM_LOOPCHECKOFF, 0);
     add_ex("builtin", SYM_BUILTIN, 0);
 }
-int SymbolTableEntry::operatorToVCPUCmd() {
+int SymbolTableEntry::operatorToVCPUCmd() const {
     //return ssize + 8;
     return vartype;
 }

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -45,6 +45,7 @@ struct SymbolTableEntry
 	int get_num_args() const;
 
 	int is_loadable_variable() const;
+    bool is_variadic_function() const;
 
     // Set indexes of get/set property handlers; 0xffff for no entry
 	void set_propfuncs(int propget, int propset);

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -25,32 +25,35 @@
 // So there's another symbol definition in cc_symboldef.h
 struct SymbolTableEntry
 {
-	std::string sname;
-        int section; // section index this symbol was declared in
-	int16_t stype;
-	int32_t flags;
-	int16_t vartype;
-	int soffs;
-	int32_t ssize; // or return type size for function
-	int16_t sscope; // or num arguments for function
-	int32_t arrsize;
-	int16_t extends; // inherits another class (classes) / owning class (member vars)
+    std::string sname;
+    int section = 0; // section index this symbol was declared in
+    int16_t stype = 0;
+    int32_t flags = 0;
+    int16_t vartype = 0;
+    int soffs = 0;
+    int32_t ssize = 0; // or return type size for function
+    int16_t sscope = 0; // or num arguments for function
+    // symbol's life scope, in bytecode pos
+    int32_t scope_section_begin = 0;
+    int32_t scope_section_end = 0;
+    int32_t arrsize = 0;
+    int16_t extends = 0; // inherits another class (classes) / owning class (member vars)
     // functions only, save types of return value and all parameters
     // return value is at index 0, actual args begin with 1
     std::vector<FuncParamInfo> funcparams;
 
-	int get_num_args();
+	int get_num_args() const;
 
-	int is_loadable_variable();
+	int is_loadable_variable() const;
 
     // Set indexes of get/set property handlers; 0xffff for no entry
 	void set_propfuncs(int propget, int propset);
     // Returns an index of get property handler; -1 means no entry
-	int get_propget();
+	int get_propget() const;
     // Returns an index of set property handler; -1 means no entry
-	int get_propset();
+	int get_propset() const;
 
-	int operatorToVCPUCmd();
+	int operatorToVCPUCmd() const;
 };
 
 struct symbolTable {
@@ -66,6 +69,8 @@ struct symbolTable {
 	std::vector<SymbolTableEntry> entries;
     // section names filled by tokenizer, required for RTTI
     std::vector<std::string> sections;
+    // saved local symbols, for generating script data TOC (optional)
+    std::vector<SymbolTableEntry> localEntries;
 
     symbolTable();
     void reset();    // clears table

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -143,6 +143,8 @@ static void ccCompileDataTOC(ScriptTOCBuilder &tocb,
         if (ste.stype == SYM_FUNCTION)
         {
             uint32_t func_flags = 0u;
+            if (entries[t].is_variadic_function())
+                func_flags |= ScriptTOC::kFunction_Variadic;
             // NOTE: old compiler saves function's return value and parameter flags
             // as STYPE_* constants, not SFLG_*
             uint32_t rval_type = entries[t].funcparams[0].Type & STYPE_MASK;
@@ -155,14 +157,15 @@ static void ccCompileDataTOC(ScriptTOCBuilder &tocb,
                     func_flags, rval_type, rval_flags);
 
             // Add function parameters
-            for (int i = 1; i < ste.get_num_args(); ++i)
+            for (int i = 1; i < ste.get_num_args() + 1; ++i)
             {
                 uint32_t param_type = entries[t].funcparams[i].Type & STYPE_MASK;
                 int stype_flags = entries[t].funcparams[i].Type & ~STYPE_MASK;
+                const std::string &name = entries[t].funcparams[i].Name;
                 uint32_t param_flags = 0u;
                 if ((stype_flags & STYPE_DYNARRAY) || (stype_flags & STYPE_POINTER))
                     param_flags |= RTTI::kField_ManagedPtr;
-                tocb.AddFunctionParam(func_id, "" /* TODO: param name */, 0u /* TODO: param offset */,
+                tocb.AddFunctionParam(func_id, name, 0u /* TODO: param offset? */,
                     param_type, param_flags);
             }
         }

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -974,6 +974,7 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
       sym.entries[funcsym].funcparams[numparams % 100].Type = cursym;
       sym.entries[funcsym].funcparams[numparams % 100].DefaultValue = 0;
       sym.entries[funcsym].funcparams[numparams % 100].HasDefaultValue = false;
+      sym.entries[funcsym].funcparams[numparams % 100].Name = {};
 
       if (next_is_const)
         sym.entries[funcsym].funcparams[numparams % 100].Type |= STYPE_CONST;
@@ -1054,6 +1055,10 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
         // stack has the first parameter. The +1 is because the
         // call will push the return address onto the stack as well
         sym.entries[cursym].soffs = scrip->cur_sp - (numparams+1)*4;
+
+        // Also save function parameter name
+        sym.entries[funcsym].funcparams[numparams % 100].Name = sym.get_name(cursym);
+
         createdLocalVar = true;
         numparams++;
       }

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -431,6 +431,7 @@ int remove_locals(int from_level, int just_count, ccCompiledScript *scrip) {
 
     for (cc=0; (size_t)cc<sym.entries.size();cc++) {
         if ((sym.entries[cc].sscope > from_level) && (sym.entries[cc].stype == SYM_LOCALVAR)) {
+
             // caller will sort out stack, so ignore parameters
             if ((sym.entries[cc].flags & SFLG_PARAMETER)==0) {
                 if (sym.entries[cc].flags & SFLG_DYNAMICARRAY)
@@ -458,6 +459,12 @@ int remove_locals(int from_level, int just_count, ccCompiledScript *scrip) {
             }
 
             if (just_count == 0) {
+                // Save a symbol copy in case we'll have to generate script data TOC
+                sym.entries[cc].scope_section_end = scrip->codesize_i32()
+                    + 1 // FIXME: dirty hack to mark past to (SCMD_SUB, SREG_SP, N) or SCMD_RET
+                        // rewrite this later!
+                    ;
+                sym.localEntries.push_back(sym.entries[cc]);
                 sym.entries[cc].stype = 0;
                 sym.entries[cc].sscope = 0;
                 sym.entries[cc].flags = 0;
@@ -926,6 +933,8 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
     return -1;
   }
   sym.entries[funcsym].soffs = in_func;  // save code offset of function
+  sym.entries[funcsym].scope_section_begin = scrip->codesize_i32();
+  sym.entries[funcsym].scope_section_end = scrip->codesize_i32();
 
   if (!next_is_import)
     scrip->cur_sp += 4;  // the return address will be pushed
@@ -1034,6 +1043,8 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
         sym.entries[cursym].vartype = vartypesym;
         sym.entries[cursym].ssize = 4; // param is 4 bytes
         sym.entries[cursym].sscope = nested_level + 1;
+        sym.entries[cursym].scope_section_begin = scrip->codesize_i32();
+        sym.entries[cursym].scope_section_end = scrip->codesize_i32();
         sym.entries[cursym].flags |= SFLG_PARAMETER;
         if (isPointerParam)
           sym.entries[cursym].flags |= SFLG_POINTER;
@@ -1109,6 +1120,8 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
       cc_error("';' expected (cannot define body of imported function)");
       return -1;
     }
+
+    assert(scrip->cur_sp == 0); // import declaration, no body, no local data
     in_func=-1;
   }
   else if (sym.get_type(targ.peeknext()) == SYM_OPENBRACE) {
@@ -3323,6 +3336,8 @@ int parse_variable_declaration(int32_t cursym,int *next_type,int isglobal,
   else {
     // local variable
     sym.entries[cursym].soffs = scrip->cur_sp;
+    sym.entries[cursym].scope_section_begin = scrip->codesize_i32();
+    sym.entries[cursym].scope_section_end = scrip->codesize_i32();
     scrip->write_cmd2(SCMD_REGTOREG,SREG_SP,SREG_MAR);
     if (need_fixup == 2) {
       // expression worked out into ax
@@ -3478,6 +3493,8 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                         sym.entries[thisSym].vartype = isMemberFunction;
                         sym.entries[thisSym].ssize = varsize; // pointer to struct
                         sym.entries[thisSym].sscope = nested_level;
+                        sym.entries[cursym].scope_section_begin = scrip->codesize_i32();
+                        sym.entries[cursym].scope_section_end = scrip->codesize_i32();
                         sym.entries[thisSym].flags = SFLG_READONLY | SFLG_ACCESSED | SFLG_POINTER | SFLG_THISPTR;
                         // declare as local variable
                         sym.entries[thisSym].soffs = scrip->cur_sp;
@@ -3528,6 +3545,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                 scrip->write_cmd2(SCMD_SUB,SREG_SP,totalsub);
             }
             if (nested_level == 0) {
+                sym.entries[inFuncSym].scope_section_end = scrip->codesize_i32();
                 in_func = -1;
                 inFuncSym = -1;
                 isMemberFunction = 0;

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -46,6 +46,7 @@ AGS::SymbolTableEntry &AGS::SymbolTableEntry::operator=(const SymbolTableEntry &
     this->Name = orig.Name;
     this->Declared = orig.Declared;
     this->Scope = orig.Scope;
+    this->LifeScope = orig.LifeScope;
     this->Accessed = orig.Accessed;
 
     // Deep copy semantics.
@@ -107,6 +108,7 @@ void AGS::SymbolTableEntry::Clear()
     // Leave the name so that symbols in the main phase equate to symbols in the pre phase.
     Declared = SymbolTableConstant::kNoSrcLocation;
     Scope = 0u;
+    LifeScope = {};
     // Don't clear Accessed so when a function is first used and then declared, this doesn't clobber the use.
 
     delete AttributeD;
@@ -130,28 +132,15 @@ void AGS::SymbolTableEntry::Clear()
 }
 
 AGS::SymbolTableEntry::SymbolTableEntry(SymbolTableEntry const &orig)
-    : Name(orig.Name)
-    , Declared(orig.Declared)
-    , Scope(orig.Scope)
-    , Accessed(orig.Accessed)
 {
-    // Deep copy semantics.
-    this->AttributeD = (orig.AttributeD) ? new SymbolTableEntry::AttributeDesc{ *(orig.AttributeD) } : nullptr;
-    this->ComponentD = (orig.ComponentD) ? new SymbolTableEntry::ComponentDesc{ *(orig.ComponentD) } : nullptr;
-    this->ConstantD = (orig.ConstantD) ? new SymbolTableEntry::ConstantDesc{ *(orig.ConstantD) } : nullptr;
-    this->DelimeterD = (orig.DelimeterD) ? new SymbolTableEntry::DelimeterDesc{ *(orig.DelimeterD) } : nullptr;
-    this->FunctionD = (orig.FunctionD) ? new SymbolTableEntry::FunctionDesc{ *(orig.FunctionD) } : nullptr;
-    this->LiteralD = (orig.LiteralD) ? new SymbolTableEntry::LiteralDesc{ *(orig.LiteralD) } : nullptr;
-    this->OperatorD = (orig.OperatorD) ? new SymbolTableEntry::OperatorDesc{ *(orig.OperatorD) } : nullptr;
-    this->VariableD = (orig.VariableD) ? new SymbolTableEntry::VariableDesc{ *(orig.VariableD) } : nullptr;
-    this->VartypeD = (orig.VartypeD) ? new SymbolTableEntry::VartypeDesc{ *(orig.VartypeD) } : nullptr;
+    *this = orig;
 }
 
 AGS::SymbolTable::SymbolTable()
     : _stringStructSym (kKW_NoSymbol)
     , _stringStructPtrSym(kKW_NoSymbol)
 {
-   _findCache.clear();
+    _findCache.clear();
     _vartypesCache.clear();
 
     entries.clear();

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -245,7 +245,9 @@ struct SymbolTableEntry : public SymbolTableConstant
 {
     std::string Name = "";
     size_t Declared = kNoSrcLocation;    // where this was declared, pertains to _src
-    size_t Scope = 0u;   
+    size_t Scope = 0u;
+    // Symbol lifetime scope, for functions and local defs, in bytecode pos
+    std::pair<CodeLoc, CodeLoc> LifeScope = {};
     bool Accessed = false;  // will be set to 'true' on first access
 
     // For attributes
@@ -398,6 +400,9 @@ private:
 public:
     std::vector<SymbolTableEntry> entries;
     inline SymbolTableEntry &operator[](Symbol sym) { return entries.at(sym); };
+
+    // Recorded list of all the local symbols: variables and function parameters
+    std::vector<SymbolTableEntry> localEntries;
 
     SymbolTable();
 

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -81,7 +81,8 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt, const Sectio
             if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
                 (field_type.VartypeD->Type == VTT::kDynarray))
                 flags |= RTTI::kField_ManagedPtr;
-            if (field_type.VartypeD->Type == VTT::kArray)
+            if ((field_type.VartypeD->Type == VTT::kArray) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
                 flags |= RTTI::kField_Array;
             uint32_t num_elems = 0u;
             for (const auto sz : field_type.VartypeD->Dims)
@@ -93,6 +94,115 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt, const Sectio
 
     return std::unique_ptr<RTTI>(
         new RTTI(std::move(rtb.Finalize())));
+}
+
+static void ccCompileDataTOC(ScriptTOCBuilder &tocb,
+    const SymbolTable &symt, const std::vector<SymbolTableEntry> &entries, const SectionList &seclist,
+    const RTTI *rtti)
+{
+    for (size_t t = 0; t < entries.size(); t++)
+    {
+        const SymbolTableEntry &ste = entries[t];
+
+        // Add global variables, local variables and function parameters
+        if (ste.VariableD && !ste.ComponentD && !ste.VariableD->TypeQualifiers[TQ::kImport])
+        {
+            ScriptTOC::Variable var;
+            const auto &field_type = symt.entries[ste.VariableD->Vartype];
+            if (!field_type.VartypeD)
+                continue; // probably a special "variable" like "this"
+
+            uint32_t f_typeid = symt.GetFirstBaseVartype(ste.VariableD->Vartype);
+            uint32_t f_flags = 0u;
+            if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
+                f_flags |= RTTI::kField_ManagedPtr;
+            if ((field_type.VartypeD->Type == VTT::kArray) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
+                f_flags |= RTTI::kField_Array;
+
+            uint32_t num_elems = 0u;
+            for (const auto sz : field_type.VartypeD->Dims)
+                num_elems += sz; // CHECKME if correct
+
+            uint32_t section_id = 0u;
+            if (ste.Declared < INT_MAX)
+                section_id = seclist.GetSectionIdAt(ste.Declared);
+
+            // Global variable
+            if (ste.Scope == 0u)
+            {
+                tocb.AddGlobalVar(ste.Name, section_id, ste.VariableD->Offset,
+                    0u /* v_flags */, f_typeid, f_flags, num_elems);
+            }
+            // Scoped variable: local or parameter
+            else
+            {
+                uint32_t v_flags = ScriptTOC::kVariable_Local;
+                if (ste.Scope == SymbolTableConstant::kParameterScope)
+                    v_flags |= ScriptTOC::kVariable_Parameter;
+                tocb.AddLocalVar(ste.Name, section_id, ste.VariableD->Offset,
+                    ste.LifeScope.first, ste.LifeScope.second,
+                    v_flags, f_typeid, f_flags, num_elems);
+            }
+        }
+
+        // Add functions (not import declarations)
+        if (ste.FunctionD && !ste.FunctionD->TypeQualifiers[TQ::kImport])
+        {
+            uint32_t func_flags = 0u;
+            if (ste.FunctionD->IsVariadic)
+                func_flags |= ScriptTOC::kFunction_Variadic;
+
+            const auto &ret_param = ste.FunctionD->Parameters[0];
+            const auto &field_type = symt.entries[ret_param.Vartype];
+            uint32_t rval_type = symt.GetFirstBaseVartype(ret_param.Vartype);
+            uint32_t rval_flags = 0u;
+            if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
+                rval_flags |= RTTI::kField_ManagedPtr;
+            if ((field_type.VartypeD->Type == VTT::kArray) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
+                rval_flags |= RTTI::kField_Array;
+
+            uint32_t section_id = 0u;
+            if (ste.Declared < INT_MAX)
+                section_id = seclist.GetSectionIdAt(ste.Declared);
+
+            const uint32_t func_id =
+                tocb.AddFunction(ste.Name, section_id, ste.LifeScope.first, ste.LifeScope.second,
+                    func_flags, rval_type, rval_flags);
+
+            // Add function parameters
+            for (size_t i = 1; i < ste.FunctionD->Parameters.size(); ++i)
+            {
+                const auto &param = ste.FunctionD->Parameters[i];
+                const auto &field_type = symt.entries[param.Vartype];
+                uint32_t param_type = symt.GetFirstBaseVartype(param.Vartype);
+                uint32_t param_flags = 0u;
+                if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
+                    (field_type.VartypeD->Type == VTT::kDynarray))
+                    param_flags |= RTTI::kField_ManagedPtr;
+                if ((field_type.VartypeD->Type == VTT::kArray) ||
+                    (field_type.VartypeD->Type == VTT::kDynarray))
+                    param_flags |= RTTI::kField_Array;
+                std::string param_name = symt.entries[param.Name].Name;
+                tocb.AddFunctionParam(func_id, param_name, 0u /* TODO: param offset? */,
+                    param_type, param_flags);
+            }
+        }
+    }
+}
+
+static std::unique_ptr<ScriptTOC> ccCompileDataTOC(const SymbolTable &symt, const SectionList &seclist, const RTTI *rtti)
+{
+    ScriptTOCBuilder tocb;
+
+    ccCompileDataTOC(tocb, symt, symt.entries, seclist, rtti);
+    ccCompileDataTOC(tocb, symt, symt.localEntries, seclist, rtti);
+
+    return std::unique_ptr<ScriptTOC>(
+        new ScriptTOC(std::move(tocb.Finalize(rtti))));
 }
 
 
@@ -140,6 +250,11 @@ ccScript *ccCompileText2(std::string const &script, std::string const &scriptNam
     if (FlagIsSet(options, SCOPT_RTTI))
     {
         compiled_script->rtti = ccCompileRTTI(symt, seclist);
+    }
+
+    if (FlagIsSet(options, SCOPT_SCRIPT_TOC))
+    {
+        compiled_script->sctoc = ccCompileDataTOC(symt, seclist, compiled_script->rtti.get());
     }
 
     ccCurScriptName = nullptr;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -372,6 +372,7 @@ namespace AGS.Editor
             Factory.GUIController.HideOutputPanel();
             Factory.GUIController.ShowCallStack(callStack);
             Factory.GUIController.ZoomToFile(callStack.Lines[0].ScriptName, callStack.Lines[0].LineNumber, true, callStack.ErrorMessage);
+            Factory.GUIController.NotifyWatchVariables();
         }
 
         public void RegenerateScriptHeader(Room currentRoom)

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -930,11 +930,15 @@ namespace AGS.Editor
             compileTasks.Add(new CompileTask(dialogScripts, headers));
             _game.ScriptsToCompile.Add(new ScriptAndHeader(null, dialogScripts));
 
+            // The extended compiler doesn't use static memory, 
+            // so several instances can run in parallel.
+            bool compileParallel = _game.Settings.ExtendedCompiler
+                //&& false // uncomment if debugging script compiler; TODO: add Editor preference?
+                ;
+
             // Compile the scripts
-            if (_game.Settings.ExtendedCompiler)
+            if (compileParallel)
             {
-                // The extended compiler doesn't use static memory, 
-                // so several instances can run in parallel.
                 Parallel.ForEach(compileTasks, (ct, state) =>
                 {
                     CompileMessages messages = new CompileMessages();

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -213,6 +213,12 @@
     <Compile Include="GUI\LogPanel.Designer.cs">
       <DependentUpon>LogPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\WatchVariablesPanel.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\WatchVariablesPanel.Designer.cs">
+      <DependentUpon>WatchVariablesPanel.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\NumberEntryWithInfoDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -442,6 +448,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\LogPanel.resx">
       <DependentUpon>LogPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\WatchVariablesPanel.resx">
+      <DependentUpon>WatchVariablesPanel.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\NumberEntryWithInfoDialog.resx">
       <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -178,6 +178,8 @@ namespace AGS.Editor.Components
                 {
                     _testGameInProgress = true;
                     _guiController.InteractiveTasks.TestGame(withDebugger);
+                    // Depending on which panels are enabled, one of them may end up being shown on top
+                    _guiController.ShowWatchVariablesPanel(true);
                     _guiController.ShowLogPanel(true);
                 }
             }

--- a/Editor/AGS.Editor/Debugger/DebugController.cs
+++ b/Editor/AGS.Editor/Debugger/DebugController.cs
@@ -16,11 +16,13 @@ namespace AGS.Editor
         {
             public string Type;
             public string Value;
+            public string TypeHint;
 
-            public VariableInfo(string type, string value)
+            public VariableInfo(string type, string value, string hint)
             {
                 Type = type;
                 Value = value;
+                TypeHint = hint;
             }
         }
 
@@ -114,9 +116,13 @@ namespace AGS.Editor
                     string reqID = doc.DocumentElement.SelectSingleNode("ReqID").InnerText;
                     var typeNode = doc.DocumentElement.SelectSingleNode("Type");
                     var valueNode = doc.DocumentElement.SelectSingleNode("Value");
-                    if (typeNode != null && valueNode != null)
+                    var hintNode = doc.DocumentElement.SelectSingleNode("Hint");
+                    if (valueNode != null)
                     {
-                        ReceiveVariable.Invoke(uint.Parse(reqID), new VariableInfo(typeNode.InnerText, valueNode.InnerText));
+                        ReceiveVariable.Invoke(uint.Parse(reqID), new VariableInfo(
+                            typeNode != null ? typeNode.InnerText : "",
+                            valueNode.InnerText,
+                            hintNode != null ? hintNode.InnerText : ""));
                     }
                     else
                     {

--- a/Editor/AGS.Editor/Debugger/DebugController.cs
+++ b/Editor/AGS.Editor/Debugger/DebugController.cs
@@ -17,12 +17,14 @@ namespace AGS.Editor
             public string Type;
             public string Value;
             public string TypeHint;
+            public string ErrorText;
 
-            public VariableInfo(string type, string value, string hint)
+            public VariableInfo(string type, string value, string hint, string errorText)
             {
                 Type = type;
                 Value = value;
                 TypeHint = hint;
+                ErrorText = errorText;
             }
         }
 
@@ -117,16 +119,21 @@ namespace AGS.Editor
                     var typeNode = doc.DocumentElement.SelectSingleNode("Type");
                     var valueNode = doc.DocumentElement.SelectSingleNode("Value");
                     var hintNode = doc.DocumentElement.SelectSingleNode("Hint");
+                    var errorNode = doc.DocumentElement.SelectSingleNode("Error");
                     if (valueNode != null)
                     {
                         ReceiveVariable.Invoke(uint.Parse(reqID), new VariableInfo(
                             typeNode != null ? typeNode.InnerText : "",
                             valueNode.InnerText,
-                            hintNode != null ? hintNode.InnerText : ""));
+                            hintNode != null ? hintNode.InnerText : "",
+                            errorNode != null ? errorNode.InnerText : null));
                     }
                     else
                     {
-                        ReceiveVariable.Invoke(uint.Parse(reqID), new VariableInfo());
+                        ReceiveVariable.Invoke(uint.Parse(reqID), new VariableInfo(
+                            null, null, null,
+                            errorNode != null ? errorNode.InnerText : null
+                            ));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Debugger/DebugController.cs
+++ b/Editor/AGS.Editor/Debugger/DebugController.cs
@@ -51,6 +51,14 @@ namespace AGS.Editor
 		}
 
         /// <summary>
+        /// Tells whether Debugger is in a active working state.
+        /// </summary>
+        public bool IsActive
+        {
+            get { return _debugState != DebugState.NotRunning; }
+        }
+
+        /// <summary>
         /// Allows more than one instance of the AGS Editor to run simulatenously
         /// </summary>
         public string InstanceIdentifier
@@ -197,8 +205,7 @@ namespace AGS.Editor
 
         public void AddedBreakpoint(Script script, int lineNumber)
         {
-            if ((_debugState == DebugState.Paused) ||
-                (_debugState == DebugState.Running))
+            if (IsActive)
             {
                 SetBreakpoint(script, lineNumber);
             }
@@ -206,8 +213,7 @@ namespace AGS.Editor
 
         public void RemovedBreakpoint(Script script, int lineNumber)
         {
-            if ((_debugState == DebugState.Paused) ||
-                (_debugState == DebugState.Running))
+            if (IsActive)
             {
                 UnsetBreakpoint(script, lineNumber);
             }
@@ -227,7 +233,7 @@ namespace AGS.Editor
 
         public bool QueryVariable(string varId, out uint requestKey)
         {
-            if ((_debugState != DebugState.Paused) && (_debugState != DebugState.Running))
+            if (!IsActive)
             {
                 requestKey = 0;
                 return false;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -49,6 +49,7 @@ namespace AGS.Editor
         private delegate void ZoomToFileDelegate(string fileName, ZoomToFileZoomType zoomType, int lineNumber, bool isDebugExecutionPoint, bool selectWholeLine, string errorMessage, bool activateEditor);
         private delegate void ShowCallStackDelegate(DebugCallStack callStack);
         private delegate void ShowFindSymbolResultsDelegate(List<ScriptTokenReference> results);
+        private delegate void NotifyWatchVariablesDelegate();
 
         private frmMain _mainForm;
         private LogPanel _pnlEngineLog;
@@ -467,6 +468,17 @@ namespace AGS.Editor
         public void PrintEngineLog(string message, LogGroup group, LogLevel level)
         {
             _pnlEngineLog?.WriteLogMessage(message, group, level);
+        }
+
+        public void NotifyWatchVariables()
+        {
+            if (_mainForm.pnlWatchVariables.InvokeRequired)
+            {
+                _mainForm.pnlWatchVariables.Invoke(new NotifyWatchVariablesDelegate(NotifyWatchVariables));
+                return;
+            }
+
+            _mainForm.pnlWatchVariables.UpdateAllWatches();
         }
 
         public ContentDocument ActivePane

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -448,6 +448,13 @@ namespace AGS.Editor
             _mainForm.pnlFindResults.Hide();
         }
 
+        public void ShowWatchVariablesPanel(bool ifEnabled)
+        {
+            if (ifEnabled && _mainForm.pnlWatchVariables.IsHidden)
+                return;
+            _mainForm.pnlWatchVariables.Show();
+        }
+
         public void SetLogPanel(LogPanel pnlEngineLog)
         {
             _pnlEngineLog = pnlEngineLog;

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.Designer.cs
@@ -57,6 +57,7 @@
             this.listView1.TabIndex = 0;
             this.listView1.UseCompatibleStateImageBehavior = false;
             this.listView1.View = System.Windows.Forms.View.Details;
+            this.listView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listView1_KeyDown);
             this.listView1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseUp);
             // 
             // symbolHeader

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.Designer.cs
@@ -1,0 +1,134 @@
+﻿namespace AGS.Editor
+{
+    partial class WatchVariablesPanel
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.listView1 = new System.Windows.Forms.ListView();
+            this.symbolHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.typeHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.valueHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.addToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.removeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.contextMenuStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // listView1
+            // 
+            this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.symbolHeader,
+            this.typeHeader,
+            this.valueHeader});
+            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listView1.FullRowSelect = true;
+            this.listView1.GridLines = true;
+            this.listView1.LabelEdit = true;
+            this.listView1.LabelWrap = false;
+            this.listView1.Location = new System.Drawing.Point(0, 0);
+            this.listView1.Name = "listView1";
+            this.listView1.Size = new System.Drawing.Size(579, 137);
+            this.listView1.TabIndex = 0;
+            this.listView1.UseCompatibleStateImageBehavior = false;
+            this.listView1.View = System.Windows.Forms.View.Details;
+            this.listView1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseUp);
+            // 
+            // symbolHeader
+            // 
+            this.symbolHeader.Text = "Variable";
+            this.symbolHeader.Width = 120;
+            // 
+            // typeHeader
+            // 
+            this.typeHeader.Text = "Type";
+            this.typeHeader.Width = 40;
+            // 
+            // valueHeader
+            // 
+            this.valueHeader.Text = "Value";
+            this.valueHeader.Width = 400;
+            // 
+            // addToolStripMenuItem
+            // 
+            this.addToolStripMenuItem.Name = "addToolStripMenuItem";
+            this.addToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.addToolStripMenuItem.Text = "Add";
+            this.addToolStripMenuItem.Click += new System.EventHandler(this.addToolStripMenuItem_Click);
+            // 
+            // removeToolStripMenuItem
+            // 
+            this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.removeToolStripMenuItem.Text = "Remove";
+            this.removeToolStripMenuItem.Click += new System.EventHandler(this.removeToolStripMenuItem_Click);
+            // 
+            // clearToolStripMenuItem
+            // 
+            this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
+            this.clearToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.clearToolStripMenuItem.Text = "Clear";
+            this.clearToolStripMenuItem.Click += new System.EventHandler(this.clearToolStripMenuItem_Click);
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.addToolStripMenuItem,
+            this.removeToolStripMenuItem,
+            this.clearToolStripMenuItem});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(114, 70);
+            // 
+            // WatchVariablesPanel
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(579, 137);
+            this.Controls.Add(this.listView1);
+            this.Name = "WatchVariablesPanel";
+            this.Text = "WatchVariablesPanel";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.WatchVariablesPanel_FormClosed);
+            this.Shown += new System.EventHandler(this.WatchVariablesPanel_Shown);
+            this.VisibleChanged += new System.EventHandler(this.WatchVariablesPanel_VisibleChanged);
+            this.contextMenuStrip1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ListView listView1;
+        private System.Windows.Forms.ColumnHeader symbolHeader;
+        private System.Windows.Forms.ColumnHeader valueHeader;
+        private System.Windows.Forms.ToolStripMenuItem addToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.ColumnHeader typeHeader;
+    }
+}

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
@@ -75,12 +75,51 @@ namespace AGS.Editor
             string varName;
             if (_varRequests.TryGetValue(requestID, out varName))
             {
+                string typeName = info.Type ?? "";
+                string value = "";
+
+                if (string.IsNullOrEmpty(info.TypeHint) || info.Value == null)
+                {
+                    value = "unknown data";
+                }
+                else if (info.TypeHint == "s")
+                {
+                    value = string.Format("\"{0}\"", info.Value);
+                }
+                else
+                {
+                    // This is a byte array, so decode from base64
+                    byte[] bytes = null;
+                    try
+                    {
+                        bytes = System.Convert.FromBase64String(info.Value);
+                        if (bytes == null || bytes.Length == 0)
+                            value = "unknown data";
+                        else if (info.TypeHint == "i1")
+                            value = string.Format("{0} ('{1}')", bytes[0], (char)bytes[0]);
+                        else if (info.TypeHint == "i2")
+                            value = string.Format("{0}", BitConverter.ToInt16(bytes, 0));
+                        else if (info.TypeHint == "i4")
+                            value = string.Format("{0}", BitConverter.ToInt32(bytes, 0));
+                        else if (info.TypeHint == "f4")
+                            value = string.Format("{0}", BitConverter.ToSingle(bytes, 0));
+                        else if (info.TypeHint == "h")
+                            value = string.Format("{0} (memory handle)", BitConverter.ToInt32(bytes, 0));
+                        else
+                            value = "unknown data";
+                    }
+                    catch (Exception)
+                    {
+                        value = "error";
+                    }
+                }
+
                 for (var item = listView1.FindItemWithText(varName, false, 0, false);
                     item != null;
                     item = item.Index < listView1.Items.Count - 1 ? listView1.FindItemWithText(varName, false, item.Index + 1, false) : null)
                 {
-                    item.SubItems[1].Text = info.Type ?? "";
-                    item.SubItems[2].Text = info.Value ?? "";
+                    item.SubItems[1].Text = typeName;
+                    item.SubItems[2].Text = value;
                 }
                 _varRequests.Remove(requestID);
             }

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
@@ -120,7 +120,7 @@ namespace AGS.Editor
 
                 if (string.IsNullOrEmpty(info.TypeHint) || info.Value == null)
                 {
-                    value = "unknown data";
+                    value = info.ErrorText ?? "unknown data";
                 }
                 else if (info.TypeHint == "s")
                 {

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using WeifenLuo.WinFormsUI.Docking;
+
+namespace AGS.Editor
+{
+    public partial class WatchVariablesPanel : DockContent
+    {
+        private Dictionary<uint, string> _varRequests = new Dictionary<uint, string>();
+
+        // TODO: there should be a working thread for updating items instead,
+        // with a list of items to update that may be added and removed async.
+        private Timer _updateItemTimer = new Timer();
+        private ListViewItem _itemToUpdate;
+
+        public WatchVariablesPanel()
+        {
+            InitializeComponent();
+
+            listView1.AfterLabelEdit += ListView1_AfterLabelEdit;
+            _updateItemTimer.Interval = 100;
+            _updateItemTimer.Tick += _updateItemTimer_Tick;
+        }
+
+        private void _updateItemTimer_Tick(object sender, EventArgs e)
+        {
+            _updateItemTimer.Enabled = false;
+            if (_itemToUpdate != null)
+            {
+                UpdateSingleWatch(_itemToUpdate);
+            }
+        }
+
+        private void ListView1_AfterLabelEdit(object sender, LabelEditEventArgs e)
+        {
+            _itemToUpdate = listView1.Items[e.Item];
+            _updateItemTimer.Start();
+        }
+
+        private void WatchVariablesPanel_Shown(object sender, EventArgs e)
+        {
+            AGSEditor.Instance.Debugger.ReceiveVariable += Debugger_ReceiveVariable;
+        }
+
+        private void WatchVariablesPanel_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            AGSEditor.Instance.Debugger.ReceiveVariable -= Debugger_ReceiveVariable;
+        }
+
+        private void WatchVariablesPanel_VisibleChanged(object sender, EventArgs e)
+        {
+            if (Visible)
+                AGSEditor.Instance.Debugger.ReceiveVariable += Debugger_ReceiveVariable;
+            else
+                AGSEditor.Instance.Debugger.ReceiveVariable -= Debugger_ReceiveVariable;
+        }
+
+        private void Debugger_ReceiveVariable(uint requestID, DebugController.VariableInfo info)
+        {
+            if (this.InvokeRequired)
+            {
+                this.Invoke(new DebugController.ReceiveVariableHandler(Debugger_ReceiveVariable), requestID, info);
+                return;
+            }
+
+            // FIXME: protect _varRequests by a mutex
+
+            string varName;
+            if (_varRequests.TryGetValue(requestID, out varName))
+            {
+                for (var item = listView1.FindItemWithText(varName, false, 0, false);
+                    item != null;
+                    item = item.Index < listView1.Items.Count - 1 ? listView1.FindItemWithText(varName, false, item.Index + 1, false) : null)
+                {
+                    item.SubItems[1].Text = info.Type ?? "";
+                    item.SubItems[2].Text = info.Value ?? "";
+                }
+                _varRequests.Remove(requestID);
+            }
+        }
+
+        private void UpdateSingleWatch(ListViewItem item)
+        {
+            if (!AGSEditor.Instance.Debugger.CanUseDebugger)
+                return;
+
+            string varName = item.Text;
+            if (string.IsNullOrEmpty(varName))
+                return;
+
+            // FIXME: it's currently potentially possible that reply comes faster than reqID gets into the _varRequests?!
+            //        maybe block replies until registering of requests is complete?
+            uint reqKey;
+            if (AGSEditor.Instance.Debugger.QueryVariable(varName, out reqKey))
+                _varRequests.Add(reqKey, varName);
+        }
+
+        public void UpdateAllWatches()
+        {
+            _varRequests.Clear();
+            foreach (ListViewItem item in listView1.Items)
+            {
+                UpdateSingleWatch(item);
+            }
+        }
+
+        private void listView1_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                contextMenuStrip1.Show(listView1, e.Location);
+            }
+        }
+
+        private void addToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = new ListViewItem();
+            item.Text = "VARIABLE NAME";
+            item.SubItems.Add(new ListViewItem.ListViewSubItem());
+            item.SubItems.Add(new ListViewItem.ListViewSubItem());
+            item = listView1.Items.Add(item);
+            item.BeginEdit();
+        }
+
+        private void removeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            foreach (var item in listView1.SelectedItems)
+                listView1.Items.Remove(item as ListViewItem);
+        }
+
+        private void clearToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            listView1.Items.Clear();
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/WatchVariablesPanel.resx
+++ b/Editor/AGS.Editor/GUI/WatchVariablesPanel.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Editor/AGS.Editor/GUI/frmMain.Designer.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.Designer.cs
@@ -229,7 +229,7 @@ namespace AGS.Editor
             this.pnlWatchVariables.HideOnClose = true;
             this.pnlWatchVariables.Location = new System.Drawing.Point(0, 0);
             this.pnlWatchVariables.Name = "pnlWatchVariables";
-            this.pnlWatchVariables.Text = "Watch variables";
+            this.pnlWatchVariables.Text = "Watch Variables";
             this.pnlWatchVariables.Pane = null;
             this.pnlWatchVariables.PanelPane = null;
             this.pnlWatchVariables.ShowHint = WeifenLuo.WinFormsUI.Docking.DockState.DockBottom;

--- a/Editor/AGS.Editor/GUI/frmMain.Designer.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.Designer.cs
@@ -62,6 +62,7 @@ namespace AGS.Editor
             this.pnlCallStack = new AGS.Editor.CallStackPanel();
             this.pnlFindResults = new AGS.Editor.FindResultsPanel();
             this.pnlOutput = new AGS.Editor.OutputPanel();
+            this.pnlWatchVariables = new AGS.Editor.WatchVariablesPanel();
             this.projectPanel = new AGS.Editor.ProjectPanel();
             this.propertiesPanel = new AGS.Editor.PropertiesPanel();
             this.mainMenu = new MenuStripExtended();
@@ -216,6 +217,25 @@ namespace AGS.Editor
             this.pnlOutput.Visible = true;
             this.pnlOutput.VisibleState = WeifenLuo.WinFormsUI.Docking.DockState.DockBottom;
             // 
+            // pnlWatchVariables
+            // 
+            this.pnlWatchVariables.ClientSize = new System.Drawing.Size(489, 65);
+            this.pnlWatchVariables.DockPanel = this.mainContainer;
+            this.pnlWatchVariables.DockState = WeifenLuo.WinFormsUI.Docking.DockState.Unknown;
+            this.pnlWatchVariables.FloatPane = null;
+            this.pnlWatchVariables.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.pnlWatchVariables.IsFloat = false;
+            this.pnlWatchVariables.IsHidden = true;
+            this.pnlWatchVariables.HideOnClose = true;
+            this.pnlWatchVariables.Location = new System.Drawing.Point(0, 0);
+            this.pnlWatchVariables.Name = "pnlWatchVariables";
+            this.pnlWatchVariables.Text = "Watch variables";
+            this.pnlWatchVariables.Pane = null;
+            this.pnlWatchVariables.PanelPane = null;
+            this.pnlWatchVariables.ShowHint = WeifenLuo.WinFormsUI.Docking.DockState.DockBottom;
+            this.pnlWatchVariables.Visible = false;
+            this.pnlWatchVariables.VisibleState = WeifenLuo.WinFormsUI.Docking.DockState.DockBottom;
+            // 
             // projectPanel
             // 
             this.projectPanel.DockPanel = this.mainContainer;
@@ -323,6 +343,7 @@ namespace AGS.Editor
         internal System.Windows.Forms.ToolStripStatusLabel statusLabel;
         internal CallStackPanel pnlCallStack;
         internal FindResultsPanel pnlFindResults;
+        internal WatchVariablesPanel pnlWatchVariables;
     }
 }
 

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -57,7 +57,8 @@ namespace AGS.Editor
                 propertiesPanel,
                 pnlOutput,
                 pnlFindResults,
-                pnlCallStack
+                pnlCallStack,
+                pnlWatchVariables
             };
         }
 

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -75,6 +75,7 @@ namespace AGS
                 SCOPT_UTF8 * (game->UnicodeMode) |
                 SCOPT_RTTI |
                 SCOPT_RTTIOPS |
+                SCOPT_SCRIPT_TOC * (game->Settings->DebugMode) |
                 false;
 
         if (game->Settings->ExtendedCompiler)

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -267,6 +267,8 @@ target_sources(engine
     debug/filebasedagsdebugger.h
     debug/logfile.cpp
     debug/logfile.h
+    debug/memory_inspect.cpp
+    debug/memory_inspect.h
     device/mousew32.cpp
     device/mousew32.h
     font/fonts_engine.cpp

--- a/Engine/ac/dynobj/cc_agsdynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.cpp
@@ -44,29 +44,34 @@ void *CCBasicObject::GetFieldPtr(void *address, intptr_t offset)
     return static_cast<uint8_t*>(address) + offset;
 }
 
-void CCBasicObject::Read(void *address, intptr_t offset, uint8_t *dest, size_t size)
+const void *CCBasicObject::GetFieldPtr(const void *address, intptr_t offset)
 {
-    memcpy(dest, static_cast<uint8_t*>(address) + offset, size);
+    return static_cast<const uint8_t*>(address) + offset;
 }
 
-uint8_t CCBasicObject::ReadInt8(void *address, intptr_t offset)
+void CCBasicObject::Read(const void *address, intptr_t offset, uint8_t *dest, size_t size)
 {
-    return *(uint8_t*)(static_cast<uint8_t*>(address) + offset);
+    memcpy(dest, static_cast<const uint8_t*>(address) + offset, size);
 }
 
-int16_t CCBasicObject::ReadInt16(void *address, intptr_t offset)
+uint8_t CCBasicObject::ReadInt8(const void *address, intptr_t offset)
 {
-    return *(int16_t*)(static_cast<uint8_t*>(address) + offset);
+    return *(const uint8_t*)(static_cast<const uint8_t*>(address) + offset);
 }
 
-int32_t CCBasicObject::ReadInt32(void *address, intptr_t offset)
+int16_t CCBasicObject::ReadInt16(const void *address, intptr_t offset)
 {
-    return *(int32_t*)(static_cast<uint8_t*>(address) + offset);
+    return *(const int16_t*)(static_cast<const uint8_t*>(address) + offset);
 }
 
-float CCBasicObject::ReadFloat(void *address, intptr_t offset)
+int32_t CCBasicObject::ReadInt32(const void *address, intptr_t offset)
 {
-    return *(float*)(static_cast<uint8_t*>(address) + offset);
+    return *(const int32_t*)(static_cast<const uint8_t*>(address) + offset);
+}
+
+float CCBasicObject::ReadFloat(const void *address, intptr_t offset)
+{
+    return *(const float*)(static_cast<const uint8_t*>(address) + offset);
 }
 
 void CCBasicObject::Write(void *address, intptr_t offset, const uint8_t *src, size_t size)

--- a/Engine/ac/dynobj/cc_agsdynamicobject.h
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.h
@@ -62,11 +62,12 @@ public:
     // Legacy support for reading and writing object fields by their relative offset
     //
     void *GetFieldPtr(void* address, intptr_t offset) override;
-    void Read(void *address, intptr_t offset, uint8_t *dest, size_t size) override;
-    uint8_t ReadInt8(void *address, intptr_t offset) override;
-    int16_t ReadInt16(void *address, intptr_t offset) override;
-    int32_t ReadInt32(void *address, intptr_t offset) override;
-    float ReadFloat(void *address, intptr_t offset) override;
+    const void *GetFieldPtr(const void* address, intptr_t offset) override;
+    void Read(const void *address, intptr_t offset, uint8_t *dest, size_t size) override;
+    uint8_t ReadInt8(const void *address, intptr_t offset) override;
+    int16_t ReadInt16(const void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
+    float ReadFloat(const void *address, intptr_t offset) override;
     void Write(void *address, intptr_t offset, const uint8_t *src, size_t size) override;
     void WriteInt8(void *address, intptr_t offset, uint8_t val) override;
     void WriteInt16(void *address, intptr_t offset, int16_t val) override;

--- a/Engine/ac/dynobj/cc_character.cpp
+++ b/Engine/ac/dynobj/cc_character.cpp
@@ -47,10 +47,10 @@ void CCCharacter::Unserialize(int index, Stream *in, size_t /*data_sz*/)
     ccRegisterUnserializedPersistentObject(index, &game.chars[num], this);
 }
 
-uint8_t CCCharacter::ReadInt8(void *address, intptr_t offset)
+uint8_t CCCharacter::ReadInt8(const void *address, intptr_t offset)
 {
     // The only supported variable remaining in 3.4.*
-    const CharacterInfo *ci = static_cast<CharacterInfo*>(address);
+    const CharacterInfo *ci = static_cast<const CharacterInfo*>(address);
     const int on_offset = 28 * sizeof(int32_t) /* first var group */
         + 301 * sizeof(int16_t) /* inventory */ + sizeof(int16_t) * 2 /* two shorts */ + 40 /* name */ + 20 /* scrname */;
     if (offset == on_offset)
@@ -71,7 +71,7 @@ void CCCharacter::WriteInt8(void *address, intptr_t offset, uint8_t val)
         cc_error("ScriptCharacter: unsupported 'char' variable offset %d", offset);
 }
 
-int16_t CCCharacter::ReadInt16(void *address, intptr_t offset)
+int16_t CCCharacter::ReadInt16(const void *address, intptr_t offset)
 {
     cc_error("ScriptCharacter: unsupported 'short' variable offset %d", offset);
     return 0;
@@ -82,7 +82,7 @@ void CCCharacter::WriteInt16(void *address, intptr_t offset, int16_t val)
     cc_error("ScriptCharacter: unsupported 'short' variable offset %d", offset);
 }
 
-int32_t CCCharacter::ReadInt32(void *address, intptr_t offset)
+int32_t CCCharacter::ReadInt32(const void *address, intptr_t offset)
 {
     cc_error("ScriptCharacter: unsupported 'int' variable offset %d", offset);
     return 0;

--- a/Engine/ac/dynobj/cc_character.h
+++ b/Engine/ac/dynobj/cc_character.h
@@ -28,9 +28,9 @@ public:
     const char *GetType() override;
     void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
 
-    uint8_t ReadInt8(void *address, intptr_t offset) override;
-    int16_t ReadInt16(void *address, intptr_t offset) override;
-    int32_t ReadInt32(void *address, intptr_t offset) override;
+    uint8_t ReadInt8(const void *address, intptr_t offset) override;
+    int16_t ReadInt16(const void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
     void WriteInt8(void *address, intptr_t offset, uint8_t val) override;
     void WriteInt16(void *address, intptr_t offset, int16_t val) override;
     void WriteInt32(void *address, intptr_t offset, int32_t val) override;

--- a/Engine/ac/dynobj/cc_scriptobject.h
+++ b/Engine/ac/dynobj/cc_scriptobject.h
@@ -100,11 +100,12 @@ struct IScriptObject
     // The worst thing here is that with the current byte-code structure we can never tell whether
     // offset 0 means getting pointer to whole object or a pointer to its first field.
     virtual void   *GetFieldPtr(void *address, intptr_t offset)               = 0;
-    virtual void    Read(void *address, intptr_t offset, uint8_t *dest, size_t size) = 0;
-    virtual uint8_t ReadInt8(void *address, intptr_t offset)                  = 0;
-    virtual int16_t ReadInt16(void *address, intptr_t offset)                 = 0;
-    virtual int32_t ReadInt32(void *address, intptr_t offset)                 = 0;
-    virtual float   ReadFloat(void *address, intptr_t offset)                 = 0;
+    virtual const void *GetFieldPtr(const void *address, intptr_t offset)     = 0;
+    virtual void    Read(const void *address, intptr_t offset, uint8_t *dest, size_t size) = 0;
+    virtual uint8_t ReadInt8(const void *address, intptr_t offset)            = 0;
+    virtual int16_t ReadInt16(const void *address, intptr_t offset)           = 0;
+    virtual int32_t ReadInt32(const void *address, intptr_t offset)           = 0;
+    virtual float   ReadFloat(const void *address, intptr_t offset)           = 0;
     virtual void    Write(void *address, intptr_t offset, const uint8_t *src, size_t size) = 0;
     virtual void    WriteInt8(void *address, intptr_t offset, uint8_t val)    = 0;
     virtual void    WriteInt16(void *address, intptr_t offset, int16_t val)   = 0;

--- a/Engine/ac/dynobj/cc_staticarray.cpp
+++ b/Engine/ac/dynobj/cc_staticarray.cpp
@@ -27,33 +27,38 @@ void* CCStaticObjectArray::GetFieldPtr(void *address, intptr_t offset)
     return GetElementPtr(address, offset);
 }
 
-void CCStaticObjectArray::Read(void *address, intptr_t offset, uint8_t *dest, size_t size)
+const void* CCStaticObjectArray::GetFieldPtr(const void *address, intptr_t offset)
 {
-    void *el_ptr = GetElementPtr(address, offset);
+    return GetElementPtr(address, offset);
+}
+
+void CCStaticObjectArray::Read(const void *address, intptr_t offset, uint8_t *dest, size_t size)
+{
+    const void *el_ptr = GetElementPtr(address, offset);
     return _mgr->Read(el_ptr, offset % _elemScriptSize, dest, size);
 }
 
-uint8_t CCStaticObjectArray::ReadInt8(void *address, intptr_t offset)
+uint8_t CCStaticObjectArray::ReadInt8(const void *address, intptr_t offset)
 {
-    void *el_ptr = GetElementPtr(address, offset);
+    const void *el_ptr = GetElementPtr(address, offset);
     return _mgr->ReadInt8(el_ptr, offset % _elemScriptSize);
 }
 
-int16_t CCStaticObjectArray::ReadInt16(void *address, intptr_t offset)
+int16_t CCStaticObjectArray::ReadInt16(const void *address, intptr_t offset)
 {
-    void *el_ptr = GetElementPtr(address, offset);
+    const void *el_ptr = GetElementPtr(address, offset);
     return _mgr->ReadInt16(el_ptr, offset % _elemScriptSize);
 }
 
-int32_t CCStaticObjectArray::ReadInt32(void *address, intptr_t offset)
+int32_t CCStaticObjectArray::ReadInt32(const void *address, intptr_t offset)
 {
-    void *el_ptr = GetElementPtr(address, offset);
+    const void *el_ptr = GetElementPtr(address, offset);
     return _mgr->ReadInt32(el_ptr, offset % _elemScriptSize);
 }
 
-float CCStaticObjectArray::ReadFloat(void *address, intptr_t offset)
+float CCStaticObjectArray::ReadFloat(const void *address, intptr_t offset)
 {
-    void *el_ptr = GetElementPtr(address, offset);
+    const void *el_ptr = GetElementPtr(address, offset);
     return _mgr->ReadFloat(el_ptr, offset % _elemScriptSize);
 }
 

--- a/Engine/ac/dynobj/cc_staticarray.h
+++ b/Engine/ac/dynobj/cc_staticarray.h
@@ -83,12 +83,18 @@ public:
         return static_cast<uint8_t*>(address) + (legacy_offset / _elemScriptSize) * _elemMemSize;
     }
 
+    inline const void *GetElementPtr(const void *address, intptr_t legacy_offset)
+    {
+        return static_cast<const uint8_t*>(address) + (legacy_offset / _elemScriptSize) * _elemMemSize;
+    }
+
     void   *GetFieldPtr(void *address, intptr_t offset) override;
-    void    Read(void *address, intptr_t offset, uint8_t *dest, size_t size) override;
-    uint8_t ReadInt8(void *address, intptr_t offset) override;
-    int16_t ReadInt16(void *address, intptr_t offset) override;
-    int32_t ReadInt32(void *address, intptr_t offset) override;
-    float   ReadFloat(void *address, intptr_t offset) override;
+    const void *GetFieldPtr(const void *address, intptr_t offset) override;
+    void    Read(const void *address, intptr_t offset, uint8_t *dest, size_t size) override;
+    uint8_t ReadInt8(const void *address, intptr_t offset) override;
+    int16_t ReadInt16(const void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
+    float   ReadFloat(const void *address, intptr_t offset) override;
     void    Write(void *address, intptr_t offset, const uint8_t *src, size_t size) override;
     void    WriteInt8(void *address, intptr_t offset, uint8_t val) override;
     void    WriteInt16(void *address, intptr_t offset, int16_t val) override;

--- a/Engine/ac/dynobj/scriptgame.cpp
+++ b/Engine/ac/dynobj/scriptgame.cpp
@@ -25,7 +25,7 @@ extern GameSetupStruct game;
 CCScriptGame GameStaticManager;
 
 
-int32_t CCScriptGame::ReadInt32(void *address, intptr_t offset)
+int32_t CCScriptGame::ReadInt32(const void *address, intptr_t offset)
 {
     const int index = offset / sizeof(int32_t);
     if (index >= 5 && index < 5 + GamePlayState::LEGACY_MAXGLOBALVARS)

--- a/Engine/ac/dynobj/scriptgame.h
+++ b/Engine/ac/dynobj/scriptgame.h
@@ -23,7 +23,7 @@
 struct CCScriptGame : public AGSCCStaticObject
 {
 public:
-    int32_t ReadInt32(void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
     void    WriteInt32(void *address, intptr_t offset, int32_t val) override;
 };
 

--- a/Engine/ac/dynobj/scriptmouse.cpp
+++ b/Engine/ac/dynobj/scriptmouse.cpp
@@ -15,7 +15,7 @@
 #include "debug/debug_log.h"
 #include "script/cc_common.h"
 
-int32_t ScriptMouse::ReadInt32(void *address, intptr_t offset)
+int32_t ScriptMouse::ReadInt32(const void *address, intptr_t offset)
 {
     switch (offset)
     {

--- a/Engine/ac/dynobj/scriptmouse.h
+++ b/Engine/ac/dynobj/scriptmouse.h
@@ -26,7 +26,7 @@ public:
     int x;
     int y;
 
-    int32_t ReadInt32(void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
     void    WriteInt32(void *address, intptr_t offset, int32_t val) override;
 };
 

--- a/Engine/ac/dynobj/scriptsystem.cpp
+++ b/Engine/ac/dynobj/scriptsystem.cpp
@@ -15,7 +15,7 @@
 #include "debug/debug_log.h"
 #include "script/cc_common.h"
 
-int32_t ScriptSystem::ReadInt32(void *address, intptr_t offset)
+int32_t ScriptSystem::ReadInt32(const void *address, intptr_t offset)
 {
     const int index = offset / sizeof(int32_t);
     switch (index)

--- a/Engine/ac/dynobj/scriptsystem.h
+++ b/Engine/ac/dynobj/scriptsystem.h
@@ -32,7 +32,7 @@ struct ScriptSystem : public AGSCCStaticObject
     int viewport_width = 0; // game viewport width (normal or letterboxed)
     int viewport_height = 0; // game viewport height (normal or letterboxed)
     
-    int32_t ReadInt32(void *address, intptr_t offset) override;
+    int32_t ReadInt32(const void *address, intptr_t offset) override;
     void    WriteInt32(void *address, intptr_t offset, int32_t val) override;
 };
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -92,7 +92,7 @@ extern unsigned int loopcounter;
 extern IDriverDependantBitmap* roomBackgroundBmp;
 extern IGraphicsDriver *gfxDriver;
 extern RGB palette[256];
-extern bool logScriptRTTI;
+extern bool logScriptRTTI, logScriptTOC;
 
 extern CCHotspot ccDynamicHotspot;
 extern CCObject ccDynamicObject;
@@ -454,6 +454,11 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     if (logScriptRTTI && ccInstance::GetRTTI())
     {
         Debug::Printf(PrintRTTI(ccInstance::GetRTTI()->AsConstRTTI()));
+    }
+    // Optionally dump room script's TOC into the log
+    if (logScriptTOC && thisroom.CompiledScript && thisroom.CompiledScript->sctoc)
+    {
+        Debug::Printf(PrintScriptTOC(*thisroom.CompiledScript->sctoc, thisroom.CompiledScript->sectionNames[0].c_str()));
     }
 
     set_our_eip(201);

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -89,7 +89,7 @@ FPSDisplayMode display_fps = kFPS_Hide;
 void send_message_to_debugger(IAGSEditorDebugger *ide_debugger,
     const std::vector<std::pair<String, String>>& tag_values, const String& command)
 {
-    String messageToSend = String::FromFormat(R"(<?xml version="1.0" encoding="Windows-1252"?><Debugger Command="%s">)", command.GetCStr());
+    String messageToSend = String::FromFormat(R"(<?xml version="1.0" encoding="UTF-8"?><Debugger Command="%s">)", command.GetCStr());
 #if AGS_PLATFORM_OS_WINDOWS
     messageToSend.Append(String::FromFormat("  <EngineWindow>%" PRIdPTR "</EngineWindow> ", sys_win_get_window()));
 #endif
@@ -592,14 +592,15 @@ int check_for_messages_from_debugger()
 
             String req_id(req_id_str + 1, var_ref_str - req_id_str - 1);
             String var_ref(var_ref_str + 1, end_str - var_ref_str - 1);
-            String mem_type, mem_value;
-            bool success = MemoryInspect::QueryScriptVariableInContext(var_ref, mem_type, mem_value);
+            MemoryInspect::VariableInfo var_info;
+            bool success = MemoryInspect::QueryScriptVariableInContext(var_ref, var_info);
             std::vector<std::pair<String, String>> values;
             values.push_back(std::make_pair("ReqID", req_id));
             if (success)
             {
-                values.push_back(std::make_pair("Type", mem_type));
-                values.push_back(std::make_pair("Value", mem_value));
+                values.push_back(std::make_pair("Type", var_info.TypeName));
+                values.push_back(std::make_pair("Hint", var_info.TypeHint));
+                values.push_back(std::make_pair("Value", var_info.Value));
             }
             send_message_to_debugger(editor_debugger, values, "RECVVAR");
         }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -593,14 +593,18 @@ int check_for_messages_from_debugger()
             String req_id(req_id_str + 1, var_ref_str - req_id_str - 1);
             String var_ref(var_ref_str + 1, end_str - var_ref_str - 1);
             MemoryInspect::VariableInfo var_info;
-            bool success = MemoryInspect::QueryScriptVariableInContext(var_ref, var_info);
+            HError err = MemoryInspect::QueryScriptVariableInContext(var_ref, var_info);
             std::vector<std::pair<String, String>> values;
             values.push_back(std::make_pair("ReqID", req_id));
-            if (success)
+            if (err)
             {
                 values.push_back(std::make_pair("Type", var_info.TypeName));
                 values.push_back(std::make_pair("Hint", var_info.TypeHint));
                 values.push_back(std::make_pair("Value", var_info.Value));
+            }
+            else
+            {
+                values.push_back(std::make_pair("Error", err->FullMessage()));
             }
             send_message_to_debugger(editor_debugger, values, "RECVVAR");
         }

--- a/Engine/debug/memory_inspect.cpp
+++ b/Engine/debug/memory_inspect.cpp
@@ -24,6 +24,7 @@
 #include "debug/memory_inspect.h"
 #include <algorithm>
 #include "ac/dynobj/dynobj_manager.h"
+#include "script/cc_common.h"
 #include "script/cc_instance.h"
 #include "script/systemimports.h"
 #include "util/compress.h"
@@ -680,6 +681,7 @@ HError QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_inf
         var_info = VariableInfo(mem_value.Value, type_name, mem_value.TypeHint);
         return HError::None();
     }
+    cc_clear_error(); // reset script error in case resolving memory went wrong
     return new Error("Failed to resolve script memory");
 }
 

--- a/Engine/debug/memory_inspect.cpp
+++ b/Engine/debug/memory_inspect.cpp
@@ -1,0 +1,494 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "debug/memory_inspect.h"
+#include <algorithm>
+#include "ac/dynobj/dynobj_manager.h"
+#include "script/cc_instance.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace Engine
+{
+namespace MemoryInspect
+{
+
+// Resolves script memory using a memory pointer, and a instruction list ("mem_ref").
+// Fills in memory value formatted according to its type.
+// Returns whether was successful.
+// NOTE: this function is run recursively, until reaching end of instruction list.
+//
+// Instruction format:
+//   offset[,type[:offset,type[:...]]
+//
+//   offset is in bytes
+//   type can be:
+//     - c    - char (1 byte integer)
+//     - iN   - integer of given size in bytes, e.g. i1, i2, i4
+//     - fN   - float of given size in bytes, e.g. f4
+//     - dN   - plain data (struct, plain array), optionally of given size in bytes
+//     - s    - plain string (null-terminated sequences of chars)
+//     - p    - pointer, reserved
+//     - h    - handle (managed), an int32 that may be resolved to a pointer
+//   each entry in this instruction list is resolved to a new memory ptr,
+//   according to its type, and the following entry is read relative to that
+//   new memory ptr.
+//   "mem_sz" argument, as well as data sizes met in the instruction list are
+//   used to prevent reading past valid memory range.
+//
+// TODO: value formatting option?
+static bool ResolveMemory(const uint8_t *mem_ptr, size_t mem_sz,
+    const String &mem_ref, const size_t parse_at, String &value)
+{
+    assert(mem_ptr);
+    assert(!mem_ref.IsEmpty());
+    if (!mem_ptr || mem_ref.IsEmpty())
+        return false;
+
+    int offset = atoi(&mem_ref[parse_at]);
+    const size_t type_at = mem_ref.FindChar(',', parse_at);
+    const size_t next_off_at = mem_ref.FindChar(':', parse_at);
+    char type = 0;
+    size_t size = 0u;
+    
+    if ((type_at != String::NoIndex) && (type_at < next_off_at))
+    {
+        type = mem_ref[type_at + 1];
+        if (type_at + 2 < mem_ref.GetLength())
+            size = atoi(&mem_ref[type_at + 2]);
+    }
+    else
+    {
+        // default to 'i4'
+        type = 'i';
+        size = 4u;
+    }
+
+    if (offset < 0 || ((mem_sz != 0) && (static_cast<uint32_t>(offset) >= mem_sz + size)))
+        return false; // attempt to read beyond valid range
+
+    mem_ptr = mem_ptr + offset;
+    if (next_off_at != String::NoIndex)
+    {
+        // Resolve sub-entry, if possible
+        switch (type)
+        {
+        case 'd': // plain data, keep same mem ptr
+            mem_sz -= offset;
+            break;
+        case 'p': // value of a address, reserved but not supported atm
+            return false;
+        case 'h': // managed handle, resolve to managed object addr
+        {
+            const int32_t *value_ptr = reinterpret_cast<const int32_t*>(mem_ptr);
+            const void *addr = ccGetObjectAddressFromHandle(*value_ptr);
+            if (!addr)
+                return false; // object not found
+            mem_ptr = reinterpret_cast<const uint8_t*>(addr);
+            mem_sz = 0u; // FIXME... how to get it? use dynamic manager? need to expand iface
+            break;
+        }
+        default: // invalid type for sub-entries, fail
+            return false;
+        }
+
+        return ResolveMemory(mem_ptr, mem_sz, mem_ref, next_off_at + 1, value);
+    }
+
+    // Resolve final entry
+    switch (type)
+    {
+    case 'c': // byte printed as a character
+    {
+        const int8_t *value_ptr = reinterpret_cast<const int8_t*>(mem_ptr);
+        value = String::FromFormat("%c", *value_ptr);
+        break;
+    }
+    case 'i': // integer printed as a number
+        switch (size)
+        {
+        case 1:
+        {
+            const int8_t *value_ptr = reinterpret_cast<const int8_t*>(mem_ptr);
+            value = String::FromFormat("%d", *value_ptr);
+            break;
+        }
+        case 2:
+        {
+            const int16_t *value_ptr = reinterpret_cast<const int16_t*>(mem_ptr);
+            value = String::FromFormat("%d", *value_ptr);
+            break;
+        }
+        case 4:
+        {
+            const int32_t *value_ptr = reinterpret_cast<const int32_t*>(mem_ptr);
+            value = String::FromFormat("%d", *value_ptr);
+            break;
+        }
+        default: // unknown type, fail
+            return false;
+        }
+        break;
+    case 'f': // float printed as a number
+        switch (size)
+        {
+        case 4:
+        {
+            const float *value_ptr = reinterpret_cast<const float*>(mem_ptr);
+            value = String::FromFormat("%f", *value_ptr);
+            break;
+        }
+        default: // unknown type, fail
+            return false;
+        }
+        break;
+    case 'd': // plain data... not supported yet
+        // TODO: convert requested size to base64?
+        break;
+    case 's': // string pointer, print as a string
+        value = reinterpret_cast<const char*>(mem_ptr);
+        break;
+    case 'p': // value of a address, reserved
+        break;
+    case 'h': // value of a managed handle (int32)
+    {
+        const int32_t *value_ptr = reinterpret_cast<const int32_t*>(mem_ptr);
+        value = String::FromFormat("%d", *value_ptr);
+        break;
+    }
+    default: // unknown type, fail
+        return false;
+    }
+    return true;
+}
+
+// Writes (appends) a memory read instruction into the provided string
+// TODO: split the array + element operation into two passes
+static void WriteMemReadInstruction(String &mem_ref, const RTTI::Type &type,
+    uint32_t f_flags, uint32_t f_offset, uint32_t arr_index)
+{
+    // Handle array field
+    if ((f_flags & RTTI::kField_Array) != 0)
+    {
+        // dynamic array or regular array
+        if ((f_flags & RTTI::kField_ManagedPtr) != 0)
+            mem_ref.AppendFmt("%u,h", f_offset);
+        else
+            mem_ref.AppendFmt("%u,d0", f_offset); // FIXME: pass full array size (in bytes)
+
+        if (arr_index == UINT32_MAX)
+            return; // return array itself... ?
+
+        // new offset is relative to array
+        mem_ref.AppendChar(':');
+        uint32_t arr_elem_size = (type.flags & RTTI::kType_Managed) ?
+            RTTI::PointerSize : type.size;
+        f_offset = arr_index * arr_elem_size;
+    }
+
+    // Using hardcoded type names here, is there another way?...
+    // TODO: perhaps generate a table of basic types, avoid testing name every time
+    char typec;
+    uint32_t typesz;
+    if (strcmp(type.name, "char") == 0)
+    {
+        typec = 'i'; typesz = 1;
+    }
+    else if (strcmp(type.name, "short") == 0)
+    {
+        typec = 'i'; typesz = 2;
+    }
+    else if (strcmp(type.name, "int") == 0)
+    {
+        typec = 'i'; typesz = 4;
+    }
+    else if (strcmp(type.name, "float") == 0)
+    {
+        typec = 'f'; typesz = 4;
+    }
+    else if (strcmp(type.name, "string") == 0)
+    {
+        typec = 's'; typesz = 200; // old-style string of fixed size
+    }
+    else if ((type.flags & RTTI::kType_Managed) != 0)
+    {
+        typec = 'h'; typesz = 4; // managed handle int32, must be resolved
+    }
+    else
+    {
+        typec = 'd'; typesz = type.size; // plain data or unknown type
+    }
+
+    mem_ref.AppendFmt("%u,%c%u", f_offset, typec, typesz);
+}
+
+static bool TryGetGlobalVariable(const String &field_ref, const ccInstance *inst,
+    const ScriptTOC::Variable *&found_var, const void *&found_mem_ptr, size_t &found_mem_sz, size_t &use_var_offset)
+{
+    const auto &toc = *inst->instanceof->sctoc;
+    if (toc.GetGlobalVariables().empty())
+        return false; // no global data
+
+    auto var_it = inst->GetGlobalVariableLookup().find(field_ref);
+    if (var_it == inst->GetGlobalVariableLookup().end())
+        return false; // cannot find a global variable
+
+    const auto &var = toc.GetGlobalVariables()[var_it->second];
+    // Fixup instance if it's an imported variable
+    // FIXME: following variants may be simplified by recording variable ptr in runtime TOC
+    if (/*(var.v_flags & ScriptTOC::kVariable_Import) != 0*/false)
+    {
+        // TODO
+        return false;
+    }
+    else
+    {
+        found_var = &var;
+        found_mem_ptr = inst->globaldata;
+        found_mem_sz = inst->globaldatasize;
+        use_var_offset = var.offset;
+        return true;
+    }
+}
+
+static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
+    const ScriptTOC::Variable *&found_var, const void *&found_mem_ptr, size_t &found_mem_sz, size_t &use_var_offset)
+{
+    const auto &toc = *inst->instanceof->sctoc;
+    if (toc.GetLocalVariables().empty())
+        return false; // no local data
+
+    // TODO: use runtime TOC where we can guarantee sorted function list (or fixup TOC on load)
+    ScriptTOC::Function test_func; test_func.scope_begin = inst->pc; test_func.scope_end = inst->pc + 1;
+    auto func_it = std::lower_bound(toc.GetFunctions().begin(), toc.GetFunctions().end(), test_func,
+        [](const ScriptTOC::Function &first, const ScriptTOC::Function &second)
+        { return (first.scope_begin < second.scope_begin) && (first.scope_end <= second.scope_begin); });
+
+    if (func_it == toc.GetFunctions().end())
+        return false; // no matching function found (unexpected...)
+    if (!func_it->local_data)
+        return false; // no local data in this function
+
+    const auto &func = *func_it;
+    // Find the latest variable which scope begins prior to the current script pos
+    const ScriptTOC::Variable *var = func.local_data;
+    for (const ScriptTOC::Variable *next_var = var;
+        next_var && next_var->scope_begin <= static_cast<uint32_t>(inst->pc);
+        var = next_var, next_var = next_var->next_local);
+
+    // FIXME: helper method returning stack? don't direct access!
+    // Note this stack ptr is set *after* the last allocated local data
+    const auto *stack_ptr = inst->registers[SREG_SP].RValue;
+    const ScriptTOC::Variable *last_var = nullptr;
+    // Scan local variable backwards before we find one that matches the name
+    for (; var; var = var->prev_local)
+    {
+        assert(var->v_flags & ScriptTOC::kVariable_Local);
+        // Skip if local variable's scope ends before current pos;
+        // note we don't break, as this may be a nested scope inside a function
+        if (var->scope_end <= static_cast<uint32_t>(inst->pc))
+            continue;
+
+        --stack_ptr;
+
+        // HACK: detect when we reach function parameter list,
+        // and skip 1 extra entry on stack, reserved for the return value;
+        // FIXME: can we use variable's offset parameter?
+        if ((var->v_flags & ScriptTOC::kVariable_Parameter) &&
+            (!last_var || (last_var->v_flags & ScriptTOC::kVariable_Parameter) == 0))
+        {
+            --stack_ptr;
+        }
+
+        if (strcmp(var->name, field_ref.GetCStr()) == 0)
+        {
+            found_var = var;
+            // FIXME: this is horrible...
+            if (stack_ptr->Type < kScValStackPtr)
+                found_mem_ptr = &stack_ptr->IValue;
+            else
+                found_mem_ptr = stack_ptr->GetDirectPtr();
+            found_mem_sz = stack_ptr->Size;
+            use_var_offset = 0u;
+            return true;
+        }
+
+        last_var = var;
+    }
+    return false;
+}
+
+// Try getting a registered variable from the current script's global memory,
+// or local memory (stack); or, if this is an imported variable, then lookup
+// the import table for its real address.
+// TODO: don't pass array_index, apply separately, outside of this func
+static bool ParseScriptVariable(const String &field_ref, const ccInstance *inst,
+    const RTTI &rtti, uint32_t array_index,
+    String &mem_ref, const uint8_t *&found_mem_ptr, size_t &found_mem_sz,
+    const RTTI::Type *&next_field_type)
+{
+    const ScriptTOC::Variable *var_ptr = nullptr;
+    const void *mem_ptr = nullptr;
+    size_t mem_sz = 0u;
+    // NOTE: we cannot use found variable's offset directly, because the some
+    // are not stored in script memory, and also the script VM's stack has a special storage.
+    size_t use_var_offset = 0u;
+
+    // First try local data
+    if (!TryGetLocalVariable(field_ref, inst, var_ptr, mem_ptr, mem_sz, use_var_offset))
+    {
+        // Then try script's global variable
+        if (!TryGetGlobalVariable(field_ref, inst, var_ptr, mem_ptr, mem_sz, use_var_offset))
+        {
+            // Finally, try imported symbol (? or do this in TryGetGlobalVariable?)
+            //
+            return false;
+        }
+    }
+
+    // Add found variable to the instruction list
+    const auto &var = *var_ptr;
+    // resolve local script's type to a global type index
+    // todo: this should be resolved after loading script, similar to RTTI!
+    const auto *l2gtypes = &inst->GetLocal2GlobalTypeMap();
+    auto type_it = l2gtypes->find(var.f_typeid);
+    if (type_it == l2gtypes->end())
+        return false; // cannot find global type
+    uint32_t g_typeid = type_it->second;
+    const RTTI::Type &field_type = rtti.GetTypes()[g_typeid];
+    WriteMemReadInstruction(mem_ref, field_type, var.f_flags, use_var_offset, array_index);
+    found_mem_ptr = static_cast<const uint8_t*>(mem_ptr);
+    found_mem_sz = mem_sz;
+    next_field_type = &field_type;
+    return true;
+}
+
+// Parses a field name of a given type, writes memory read instruction into "mem_ref",
+// assigns the found field's type into provided "field_type".
+// Returns success if field was found, failure otherwise.
+static bool ParseTypeField(const String &field_ref, const RTTI &rtti,
+    const RTTI::Type &type, uint32_t array_index,
+    String &mem_ref, const RTTI::Type *&next_field_type)
+{
+    // TODO: is it possible to speed this up, making a field lookup,
+    // or that would be too costly to do per type?
+    const RTTI::Field *found_field = nullptr;
+    for (const auto *field = type.first_field; field; field = field->next_field)
+    {
+        if (strcmp(field->name, field_ref.GetCStr()) == 0)
+        {
+            found_field = field;
+            break;
+        }
+    }
+
+    if (!found_field)
+        return false; // couldn't resolve next symbol
+
+    // "f_typeid" here is already resolved to global type id,
+    // because we're using joint global RTTI, not local script's one
+    const RTTI::Type &field_type = rtti.GetTypes()[found_field->f_typeid];
+    mem_ref.AppendChar(':');
+    WriteMemReadInstruction(mem_ref, field_type, found_field->flags,
+        found_field->offset, array_index);
+    next_field_type = &field_type;
+    return true;
+}
+
+// Parses the naming chain item by item, and build mem_ref string,
+// containing set of instructions used to access and resolve actual memory
+static bool VariableRefToMemoryRef(const String &var_ref, const ccInstance *inst,
+    const uint8_t *&found_mem_ptr, size_t &found_mem_sz, String &mem_ref, String &last_type_name)
+{
+    const String &items = var_ref;
+    String memory_ref;
+    const auto &rtti = ccInstance::GetRTTI()->AsConstRTTI();
+    const RTTI::Type *last_type = nullptr;
+    const RTTI::Type *next_type = nullptr;
+
+    String item;
+    size_t index = 0;
+    for (item = items.Section('.', index, index);
+        !item.IsEmpty();
+        ++index, item = items.Section('.', index, index))
+    {
+        // Separate symbol name from optional array index
+        // TODO: split the array + element operation into two passes
+        // FIXME: make this index parsing more reliable
+        uint32_t array_index = 0u;
+        size_t has_array_at = item.FindChar('[');
+        if (has_array_at != String::NoIndex)
+        {
+            array_index = atoi(&item[has_array_at + 1]);
+            item = item.Left(has_array_at);
+        }
+
+        if (next_type)
+        {
+            // Try getting a member of the last found type; save field's type into "next_type"
+            if (!ParseTypeField(item, rtti, *next_type, array_index, mem_ref, next_type))
+                return false;
+        }
+        else
+        {
+            // Try getting a variable in the current script
+            if (!ParseScriptVariable(item, inst, rtti, array_index, mem_ref,
+                found_mem_ptr, found_mem_sz, next_type))
+                return false;
+        }
+
+        last_type = next_type;
+    }
+
+    // FIXME: this is a hack, force resolve managed "String" type
+    // so that user receives a string value instead of a handle int32;
+    // need to think how to deal with this situation in a generic way.
+    if (((last_type->flags & RTTI::kType_Managed) != 0) &&
+        (strcmp(last_type->name, "String") == 0))
+    {
+        mem_ref.Append(":0,s");
+    }
+
+    last_type_name = last_type->name;
+    return true;
+}
+
+bool QueryScriptVariableInContext(const String &var_ref, String &type_str, String &value_str)
+{
+    if (var_ref.IsNullOrSpace())
+        return false; // no name
+
+    ccInstance *inst = ccInstance::GetCurrentInstance();
+    if (!inst)
+        return false; // not in running script
+    
+    const uint8_t *entry_mem_ptr = nullptr;
+    size_t entry_mem_sz = 0u;
+    String mem_ref;
+    String last_type_name;
+    if (!VariableRefToMemoryRef(var_ref, inst, entry_mem_ptr, entry_mem_sz, mem_ref, last_type_name))
+        return false; // failed to parse variable name chain
+    
+    if (ResolveMemory(entry_mem_ptr, entry_mem_sz, mem_ref, 0u, value_str))
+    {
+        type_str = last_type_name;
+        return true;
+    }
+    return false;
+}
+
+} // namespace MemoryInspect
+} // namespace Engine
+} // namespace AGS

--- a/Engine/debug/memory_inspect.h
+++ b/Engine/debug/memory_inspect.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_DEBUG__MEMORYINSPECT_H
 #define __AGS_EE_DEBUG__MEMORYINSPECT_H
 
+#include "util/error.h"
 #include "util/string.h"
 
 namespace AGS
@@ -25,6 +26,7 @@ namespace AGS
 namespace Engine
 {
 
+using AGS::Common::HError;
 using AGS::Common::String;
 
 namespace MemoryInspect
@@ -51,7 +53,7 @@ namespace MemoryInspect
     // - imports from other scripts, plugins or engine itself.
     // Requirements: ScriptTOC and RTTI.
     // TODO: value format option?
-    bool QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_info);
+    HError QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_info);
 }
 
 } // namespace Engine

--- a/Engine/debug/memory_inspect.h
+++ b/Engine/debug/memory_inspect.h
@@ -29,6 +29,17 @@ using AGS::Common::String;
 
 namespace MemoryInspect
 {
+    struct VariableInfo
+    {
+        String Value;
+        String TypeName;
+        String TypeHint;
+
+        VariableInfo() = default;
+        VariableInfo(const String &value, const String &type, const String &hint)
+            : Value(value), TypeName(type), TypeHint(hint) {}
+    };
+
     // Search a script variable by a *context-dependent* name chain ("foo.bar.baz"),
     // on success returns its type and value as a string, formatted according to its type.
     // Supports name chain of any complexity. Resolves structs, pointers and arrays using RTTI.
@@ -40,7 +51,7 @@ namespace MemoryInspect
     // - imports from other scripts, plugins or engine itself.
     // Requirements: ScriptTOC and RTTI.
     // TODO: value format option?
-    bool QueryScriptVariableInContext(const String &var_ref, String &type_str, String &value_str);
+    bool QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_info);
 }
 
 } // namespace Engine

--- a/Engine/debug/memory_inspect.h
+++ b/Engine/debug/memory_inspect.h
@@ -1,0 +1,50 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Methods for inspecting game and script memory.
+//
+//=============================================================================
+#ifndef __AGS_EE_DEBUG__MEMORYINSPECT_H
+#define __AGS_EE_DEBUG__MEMORYINSPECT_H
+
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+using AGS::Common::String;
+
+namespace MemoryInspect
+{
+    // Search a script variable by a *context-dependent* name chain ("foo.bar.baz"),
+    // on success returns its type and value as a string, formatted according to its type.
+    // Supports name chain of any complexity. Resolves structs, pointers and arrays using RTTI.
+    // Context is defined by the current position of script execution,
+    // which means - script module and a function. Starting variables are searched in an
+    // order reverse to the order of symbol overriding:
+    // - local variables of the current scope (of any nesting level),
+    // - global variables of the current script,
+    // - imports from other scripts, plugins or engine itself.
+    // Requirements: ScriptTOC and RTTI.
+    // TODO: value format option?
+    bool QueryScriptVariableInContext(const String &var_ref, String &type_str, String &value_str);
+}
+
+} // namespace Engine
+} // namespace AGS
+
+
+#endif // __AGS_EE_DEBUG__MEMORYINSPECT_H

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -68,6 +68,7 @@ bool justTellInfo = false;
 bool attachToParentConsole = false;
 bool hideMessageBoxes = false;
 bool logScriptRTTI = false;
+bool logScriptTOC = false;
 std::set<String> tellInfoKeys;
 String loadSaveGameOnStartup;
 
@@ -341,6 +342,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "--console-attach") == 0) attachToParentConsole = true;
         else if (ags_stricmp(arg, "--no-message-box") == 0) hideMessageBoxes = true;
         else if (ags_stricmp(arg, "--print-rtti") == 0) logScriptRTTI = true;
+        else if (ags_stricmp(arg, "--print-scripttoc") == 0) logScriptTOC = true;
         //
         // Special case: data file location
         //

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -212,6 +212,14 @@ public:
     // Also change CALLEXT op-codes to CALLAS when they pertain to a script instance 
     bool    ResolveImportFixups(const ccScript *scri);
 
+    // Returns a dictionary that maps local script's typeid to global typeid (in joint RTTI)
+    // Requires RTTI
+    const std::unordered_map<uint32_t, uint32_t> &
+        GetLocal2GlobalTypeMap() const { return _typeidLocal2Global; }
+    const std::unordered_map<Common::String, uint32_t> &
+        GetGlobalVariableLookup() const { return _globalVarLookup; }
+
+
 private:
     bool    _Create(PScript scri, const ccInstance * joined);
     // free the memory associated with the instance
@@ -254,6 +262,8 @@ private:
     std::unordered_map<uint32_t, uint32_t> _locidLocal2Global;
     // Map local script's type id to global (program-wide)
     std::unordered_map<uint32_t, uint32_t> _typeidLocal2Global;
+    // Global variables name-to-index lookup (in script's TOC)
+    std::unordered_map<Common::String, uint32_t> _globalVarLookup;
 
     // Minimal timeout: how much time may pass without any engine update
     // before we want to check on the situation and do system poll

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -38,16 +38,20 @@
 #include "script/cc_common.h"
 #include "debug/debugger.h"
 #include "debug/debug_log.h"
+#include "debug/out.h"
 #include "main/game_run.h"
 #include "script/script_runtime.h"
 #include "util/string_compat.h"
 #include "media/audio/audio_system.h"
+
+using namespace AGS::Common;
 
 extern GameSetupStruct game;
 extern int gameHasBeenRestored, displayed_room;
 extern unsigned int load_new_game;
 extern RoomObject*objs;
 extern CharacterInfo*playerchar;
+extern bool logScriptTOC;
 
 ExecutingScript scripts[MAX_SCRIPT_AT_ONCE];
 ExecutingScript *curscript = nullptr; // non-owning ptr
@@ -249,6 +253,17 @@ int create_global_script() {
         return kscript_create_error;
 
     ccSetOption(SCOPT_AUTOIMPORT, 0);
+
+    // Optionally dump script's TOC into the log
+    if (logScriptTOC)
+    {
+        for (const auto &inst : all_insts)
+        {
+            if (inst->instanceof->sctoc)
+                Debug::Printf(PrintScriptTOC(*inst->instanceof->sctoc, inst->instanceof->sectionNames[0].c_str()));
+        }
+    }
+
     return 0;
 }
 

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -572,6 +572,7 @@
     <ClCompile Include="..\..\Engine\debug\debug.cpp" />
     <ClCompile Include="..\..\Engine\debug\filebasedagsdebugger.cpp" />
     <ClCompile Include="..\..\Engine\debug\logfile.cpp" />
+    <ClCompile Include="..\..\Engine\debug\memory_inspect.cpp" />
     <ClCompile Include="..\..\Engine\device\mousew32.cpp" />
     <ClCompile Include="..\..\Engine\font\fonts_engine.cpp" />
     <ClCompile Include="..\..\Engine\game\game_init.cpp" />
@@ -820,6 +821,7 @@
     <ClInclude Include="..\..\Engine\debug\dummyagsdebugger.h" />
     <ClInclude Include="..\..\Engine\debug\filebasedagsdebugger.h" />
     <ClInclude Include="..\..\Engine\debug\logfile.h" />
+    <ClInclude Include="..\..\Engine\debug\memory_inspect.h" />
     <ClInclude Include="..\..\Engine\device\mousew32.h" />
     <ClInclude Include="..\..\Engine\game\game_init.h" />
     <ClInclude Include="..\..\Engine\game\savegame.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -780,6 +780,9 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptvideoplayer.cpp">
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\debug\memory_inspect.cpp">
+      <Filter>Source Files\debug</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1558,6 +1561,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptvideoplayer.h">
       <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\debug\memory_inspect.h">
+      <Filter>Header Files\debug</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This implements an mechanism for retrieving contents of a script memory via a debugger communication interface. Adds the "Watch variables" panel in the Editor, which lets user type in variable names, and receive current values.

The list of variables currently is worked with using **a context menu** that has Add/Remove/Clear commands. You may also edit variable's name by single clicking on a existing item in the list.

<details>
<summary>A tall screenshot under the spoiler: **CLICK HERE**</summary>

![ags4-memorywatch-draft4](https://github.com/adventuregamestudio/ags/assets/1833754/20b6007b-a1a3-4fb6-825a-683faa22334f)

</details>

### What works:

* Global variables, including ones imported from other scripts, *plugins or the engine itself*;
* Local variables, including function parameters. Their lifescope should be detected correctly.
* Resolves any chain of struct members and pointers access.
* Accessing array elements using `[n]` notation.
* Managed pointers are displayed as handle values; this is not entirely useful, but lets to see if they are null, and compare among themselves.
* Special hardcoded treatment for managed String types which resolves them to the internal char buffer.

### What does not work:

1. Attributes (aka properties). Attributes in AGS are secretly pairs of get/set functions. Reading an attribute's value means calling a getter function. There are two major issues with that currently:
    * First, such call may have side effects, including but not limited to creation of a managed object or returning a managed object with incrementing its ref count;
    * Second, if an attribute is user-defined, then this would require to run a script. But engine currently does not support running more scripts while in a "break" state. So, this is something left for the future consideration.
2. Displaying full contents of a struct's or managed struct's object (or array, fwiw) after typing its name. I suppose that is theoretically possible, but will not do this at the first stage. For now you'll have to type each struct's member separately.

### How this is achieved

1. While compiling the script, compiler (optionally) builds a "table of contents" of all script's variables, global and local, and own functions (aka ScriptTOC). This table of contents is saved as a (optional) compiled script's extension, similarly to the previously added RTTI table. For the moment I enabled this for Debug build mode only.
2. Implemented a new debugger command: "GETVAR", which requests value of a script variable from the running engine.  command has an argument containing variable's name, or chain of access of any complexity, e.g. `mystruct.member_field.internal_field` etc. In order to process this command and correctly resolve all memory addresses engine requires "table of contents" from the current script and RTTI. If these are not available, then it will fail. If they are present then engine builds a memory access instruction, and then processes this instruction as a separate operation. This is when it gets to the final memory address, reads a value of certain size, and then ~formats it into a string, depending on its type.~ encodes value's bytes into a base64 string, except when value is already a string, and sends back to debugger.
3. Implemented a new debugger command "RECVVAR" which is sent by the engine back to debugger, with the previous query result. "GETVAR" and "RECVVAR" have a arbitrary generated "request id" field, which lets to connect them together (in case of multiple or parallel commands).
4. On the Editor's side, added a "Watch variables" panel, which is basically a list with 3 columns: variable name, type and value. User adds entries (I added a simple context menu for now) and inputs variable names. Editor sends a "GETVAR" command, receives "RECVVAR" command, and displays a value in the corresponding item. Editor sends these commands in following cases:
    * When a breakpoint is hit - all entries are updated in a batch;
    * Per step during step-by-step execution
    * When a new item is added, and run script is currently in break.

Other notes...

6. Global variables need only their address in script's global memory, name and type.
7. Imported global variables are marked as such at TOC generation, and their actual address is resolved on the fly when retrieving variable value.
8. Local variables are the trickiest. For them the TOC records their lifetime scope, using bytecode positions: pos at which the variable is allocated, and pos at which it's removed from the stack. When the engine is resolving these it searches for the vars that are allocated prior to the current execution pos, and not yet removed. Additionally, this search is restricted by the current function's scope (also recorded in bytecode positions).

### Design issues

1. Script TOC does not have to be saved as a compiled script extension. Unlike RTTI, it's not used for any script operations, only for debugging. Therefore, as an alternative, it may be saved in a separate file.
2. I consider the way TOC lists imports a temporary solution. The reason why I need to add them at all is because we need to know import's type in order to resolve it properly. Existing list of imports in script data does not have anything but names, and there's no existing reliable way to define their types at runtime at linking stage (exports may come from plugins too, for example). So, for a moment the easiest way to record their types is at compilation stage, using their declarations.
But the problem is that they make a lot of duplicate entries in script TOCs. And also ScriptTOC is intended to serve an index of things found *inside* script, so presence of imported declarations there looks like a logical flaw. I suppose that their type info could be added to existing list of imports in the script data instead.
3. [**DONE**] Value formatting is currently done on the engine's side, but it may be better to leave this for debugger (editor). In such case engine should only return memory contents packed in certain format (base64).

### Backporting to AGS 3

If there's a wish to backport this watch feature to ags3, the RTTI generation must also be backported. Any RTTI-based features (in scripting) may be omitted, but RTTI table itself has to be present to be able to access nested fields and recognize types.

### Known problems and TODOs

1. **FIXED** ~Parsing array access is done inconveniently in "query variable" code, and should be rewritten.~
2. **PARTIALLY HANDLED** No buffer size check or array bounds check is currently done (although it's been planned), so it's possible to read past the valid data using a high enough array index.
3. **FIXED** ~Plain fields of builtin structs may be read incorrectly, their access has to be rewritten.~
4. **FIXED** ~TOCs compiled by an *old compiler* report regular array of managed pointers as a "managed pointer" itself, which results in unexpected values when typing only such array's name (without element index).~
5. **FIXED** ~With TOCs compiled by a *new compiler* there's a small mistake in local variable scope, which results in wrong local variable results at the first line inside a nested scope and the first line right after a nested scope.~
6. Multidimensional arrays may have issues (need testing); also I have suspicion that their types may not be correctly tagged in RTTI (must investigate). Also - mixed arrays, like static array of dynamic arrays which is recently supported by the new compiler.
7. Support "nested expression" (variable references) as an array index in `[]`; this means that multiple variables have to be resolved in a sequence (or recursively).
8. **FIXED** ~Null pointers return no value instead of "0".~
9. **DONE** ~String values should perhaps be reported in double quotes, in order to distinguish them from any special results, like "0" for a null string, or some service messages ("invalid variable" etc).~
10. **DONE** ~`Char` variables should perhaps have both numeric value and char value shown in a result string.~
11. **DONE** ~Return errors from the engine, instead of empty value string on failure.~
12. **FIXED** (presumably) ~There's a potential opportunity of missing an engine's reply in the editor; that's because listening is currently coded a bit incorrectly.~
13. **DONE** ~In the Editor, "Output" panel is always sent to front whenever a compilation is started. Possibly it should bring "Watch variables" in front as soon as a test run is launched.~
14. It would be convenient to save last watched variables in a workspace settings (see also #2384).
15. **PARTIAL** ~Minor GUI improvements may be wanted, but these may addressed separately afterwards.~