### PR TITLE
Backport importing indexed PNGs as room backgrounds and masks (AGS 4 -> AGS 3)

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
+    <Compile Include="Utils\BitmapExtensions.cs" />
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\MathExtra.cs" />

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -513,7 +513,7 @@ namespace AGS.Editor
             try
             {
                 Bitmap bmp = Factory.NativeProxy.ExportAreaMask(_room, this.MaskToDraw);
-                bmp.Save(fileName, ImageFormat.Bmp);
+                ImportExport.ExportBitmapToFile(fileName, bmp);
                 bmp.Dispose();
             }
             catch (Exception ex)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -1,3 +1,4 @@
+using AGS.Editor.Utils;
 using AGS.Types;
 using System;
 using System.Collections.Generic;
@@ -465,9 +466,10 @@ namespace AGS.Editor
 
         private void ImportMaskFromFile(string fileName)
         {
+            Bitmap bmp = null;
             try
             {
-                Bitmap bmp = new Bitmap(fileName);
+                bmp = BitmapExtensions.LoadNonLockedBitmap(fileName);
 
                 if (!(((bmp.Width == _room.Width) && (bmp.Height == _room.Height)) ||
                     ((bmp.Width == _room.Width / 2) && (bmp.Height == _room.Height / 2))))
@@ -498,6 +500,11 @@ namespace AGS.Editor
             catch (Exception ex)
             {
                 Factory.GUIController.ShowMessage("There was an error importing the area mask. The error was: " + ex.Message, MessageBoxIcon.Warning);
+            }
+            finally
+            {
+                if (bmp != null)
+                    bmp.Dispose();
             }
         }
 

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AGS.Editor.Utils
+{
+    //
+    // BitmapExtensions module is purposed for various manipulations with Bitmap
+    // and Image objects: their loading, saving, transformation, etc.
+    //
+
+    public static class BitmapTransparencyFixUp
+    {
+        // methods from https://stackoverflow.com/questions/4803935/free-file-locked-by-new-bitmapfilepath/48170549#48170549
+        // and from https://stackoverflow.com/questions/24074641/how-to-read-8-bit-png-image-as-8-bit-png-image-only
+
+        /// <summary>
+        /// Clones an image object to free it from any backing resources.
+        /// Code taken from http://stackoverflow.com/a/3661892/ with some extra fixes.
+        /// </summary>
+        /// <param name="sourceImage">The image to clone</param>
+        /// <returns>The cloned image</returns>
+        public static Bitmap CloneImage(Bitmap sourceImage)
+        {
+            Rectangle rect = new Rectangle(0, 0, sourceImage.Width, sourceImage.Height);
+            Bitmap targetImage = new Bitmap(rect.Width, rect.Height, sourceImage.PixelFormat);
+            targetImage.SetResolution(sourceImage.HorizontalResolution, sourceImage.VerticalResolution);
+            BitmapData sourceData = sourceImage.LockBits(rect, ImageLockMode.ReadOnly, sourceImage.PixelFormat);
+            BitmapData targetData = targetImage.LockBits(rect, ImageLockMode.WriteOnly, targetImage.PixelFormat);
+            Int32 actualDataWidth = ((Image.GetPixelFormatSize(sourceImage.PixelFormat) * rect.Width) + 7) / 8;
+            Int32 h = sourceImage.Height;
+            Int32 origStride = sourceData.Stride;
+            Boolean isFlipped = origStride < 0;
+            origStride = Math.Abs(origStride); // Fix for negative stride in BMP format.
+            Int32 targetStride = targetData.Stride;
+            Byte[] imageData = new Byte[actualDataWidth];
+            IntPtr sourcePos = sourceData.Scan0;
+            IntPtr destPos = targetData.Scan0;
+            // Copy line by line, skipping by stride but copying actual data width
+            for (Int32 y = 0; y < h; y++)
+            {
+                Marshal.Copy(sourcePos, imageData, 0, actualDataWidth);
+                Marshal.Copy(imageData, 0, destPos, actualDataWidth);
+                sourcePos = new IntPtr(sourcePos.ToInt64() + origStride);
+                destPos = new IntPtr(destPos.ToInt64() + targetStride);
+            }
+            targetImage.UnlockBits(targetData);
+            sourceImage.UnlockBits(sourceData);
+            // Fix for negative stride on BMP format.
+            if (isFlipped)
+                targetImage.RotateFlip(RotateFlipType.Rotate180FlipX);
+            // For indexed images, restore the palette. This is not linking to a referenced
+            // object in the original image; the getter of Palette creates a new object when called.
+            if ((sourceImage.PixelFormat & PixelFormat.Indexed) != 0)
+                targetImage.Palette = sourceImage.Palette;
+            // Restore DPI settings
+            targetImage.SetResolution(sourceImage.HorizontalResolution, sourceImage.VerticalResolution);
+            return targetImage;
+        }
+
+        private static Byte[] PNG_IDENTIFIER = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+
+        /// <summary>
+        /// Loads an image, checks if it is a PNG containing palette transparency, and if so, ensures it loads correctly.
+        /// The theory can be found at http://www.libpng.org/pub/png/book/chapter08.html
+        /// Always unlocked
+        /// </summary>
+        /// <param name="filename">Filename to load</param>
+        /// <returns>The loaded image</returns>
+        public static Bitmap LoadBitmap(String filename)
+        {
+            Byte[] data = File.ReadAllBytes(filename);
+            return LoadBitmap(data);
+        }
+
+        /// <summary>
+        /// Loads an image, checks if it is a PNG containing palette transparency, and if so, ensures it loads correctly.
+        /// The theory can be found at http://www.libpng.org/pub/png/book/chapter08.html
+        /// </summary>
+        /// <param name="data">File data to load</param>
+        /// <returns>The loaded image</returns>
+        public static Bitmap LoadBitmap(Byte[] data)
+        {
+            Byte[] transparencyData = null;
+            if (data.Length > PNG_IDENTIFIER.Length)
+            {
+                // Check if the image is a PNG.
+                Byte[] compareData = new Byte[PNG_IDENTIFIER.Length];
+                Array.Copy(data, compareData, PNG_IDENTIFIER.Length);
+                if (PNG_IDENTIFIER.SequenceEqual(compareData))
+                {
+                    // Check if it contains a palette.
+                    Int32 plteOffset = FindChunk(data, "PLTE");
+                    if (plteOffset != -1)
+                    {
+                        // Check if it contains a palette transparency chunk.
+                        Int32 trnsOffset = FindChunk(data, "tRNS");
+                        if (trnsOffset != -1)
+                        {
+                            // Get chunk
+                            Int32 trnsLength = GetChunkDataLength(data, trnsOffset);
+                            transparencyData = new Byte[trnsLength];
+                            Array.Copy(data, trnsOffset + 8, transparencyData, 0, trnsLength);
+                            // filter out the palette alpha chunk, make new data array
+                            Byte[] data2 = new Byte[data.Length - (trnsLength + 12)];
+                            Array.Copy(data, 0, data2, 0, trnsOffset);
+                            Int32 trnsEnd = trnsOffset + trnsLength + 12;
+                            Array.Copy(data, trnsEnd, data2, trnsOffset, data.Length - trnsEnd);
+                            data = data2;
+                        }
+                    }
+                }
+            }
+            Bitmap loadedImage;
+            using (MemoryStream ms = new MemoryStream(data))
+            using (Bitmap tmp = new Bitmap(ms))
+                loadedImage = CloneImage(tmp);
+            ColorPalette pal = loadedImage.Palette;
+            if (pal.Entries.Length == 0 || transparencyData == null)
+                return loadedImage;
+            for (Int32 i = 0; i < pal.Entries.Length; i++)
+            {
+                if (i >= transparencyData.Length)
+                    break;
+                Color col = pal.Entries[i];
+                pal.Entries[i] = Color.FromArgb(transparencyData[i], col.R, col.G, col.B);
+            }
+            loadedImage.Palette = pal;
+            return loadedImage;
+        }
+
+        /// <summary>
+        /// Finds the start of a png chunk. This assumes the image is already identified as PNG.
+        /// It does not go over the first 8 bytes, but starts at the start of the header chunk.
+        /// </summary>
+        /// <param name="data">The bytes of the png image</param>
+        /// <param name="chunkName">The name of the chunk to find.</param>
+        /// <returns>The index of the start of the png chunk, or -1 if the chunk was not found.</returns>
+        private static Int32 FindChunk(Byte[] data, String chunkName)
+        {
+            if (chunkName.Length != 4)
+                throw new ArgumentException("Chunk must be 4 characters!", "chunkName");
+            Byte[] chunkNamebytes = Encoding.ASCII.GetBytes(chunkName);
+            if (chunkNamebytes.Length != 4)
+                throw new ArgumentException("Chunk must be 4 characters!", "chunkName");
+            Int32 offset = PNG_IDENTIFIER.Length;
+            Int32 end = data.Length;
+            Byte[] testBytes = new Byte[4];
+            // continue until either the end is reached, or there is not enough space behind it for reading a new chunk
+            while (offset + 12 <= end)
+            {
+                Array.Copy(data, offset + 4, testBytes, 0, 4);
+                // Alternative for more visual debugging:
+                //String currentChunk = Encoding.ASCII.GetString(testBytes);
+                //if (chunkName.Equals(currentChunk))
+                //    return offset;
+                if (chunkNamebytes.SequenceEqual(testBytes))
+                    return offset;
+                Int32 chunkLength = GetChunkDataLength(data, offset);
+                // chunk size + chunk header + chunk checksum = 12 bytes.
+                offset += 12 + chunkLength;
+            }
+            return -1;
+        }
+
+        private static Int32 GetChunkDataLength(Byte[] data, Int32 offset)
+        {
+            if (offset + 4 > data.Length)
+                throw new IndexOutOfRangeException("Bad chunk size in png image.");
+            // Don't want to use BitConverter; then you have to check platform endianness and all that mess.
+            Int32 length = data[offset + 3] + (data[offset + 2] << 8) + (data[offset + 1] << 16) + (data[offset] << 24);
+            if (length < 0)
+                throw new IndexOutOfRangeException("Bad chunk size in png image.");
+            return length;
+        }
+    }
+
+    /// <summary>
+    /// BitmapExtensions is a collection of helpers for operations with bitmaps.
+    /// </summary>
+    public static class BitmapExtensions
+    {
+        /// <summary>
+        /// Gets an integer with the color depth of the image.
+        /// </summary>
+        /// <param name="bmp">The image to get the color depth from.</param>
+        /// <returns>An integer with the color depth.</returns>
+        public static int GetColorDepth(this Bitmap bmp) => Image.GetPixelFormatSize(bmp.PixelFormat);
+
+        /// <summary>
+        /// Check if <see cref="Bitmap"/> is indexed image.
+        /// </summary>
+        /// <param name="bmp">Check if this argument is indexed image.</param>
+        /// <returns>A bool indicating if this image is indexed.</returns>
+        public static bool IsIndexed(this Bitmap bmp) =>
+            bmp.PixelFormat == PixelFormat.Format1bppIndexed ||
+            bmp.PixelFormat == PixelFormat.Format4bppIndexed ||
+            bmp.PixelFormat == PixelFormat.Format8bppIndexed;
+
+        /// <summary>
+        /// Loads a <see cref="Bitmap"/> from file that doesn't lock the original file.
+        /// </summary>
+        public static Bitmap LoadNonLockedBitmap(string path)
+        {
+            return BitmapTransparencyFixUp.LoadBitmap(path);
+        }
+    }
+}

--- a/Editor/AGS.Types/Constants.cs
+++ b/Editor/AGS.Types/Constants.cs
@@ -10,7 +10,7 @@ namespace AGS.Types
 		public const string AUTOCOMPLETE_ACCEPT_KEYS = "([,.=+-";
         public const string IMAGE_FILE_FILTER = "All supported images (*.bmp; *.gif; *.jpg; *.png; *.tif; *.tiff)|*.bmp;*.gif;*.jpg;*.png;*.tif;*.tiff|Windows bitmap files (*.bmp)|*.bmp|Compuserve Graphics Interchange (*.gif)|*.gif|JPEG (*.jpg)|*.jpg|Portable Network Graphics (*.png)|*.png|Tagged Image File (*.tif; *.tiff)|*.tif;*.tiff";
         public const string FONT_FILE_FILTER = "All supported fonts (font.*; *.ttf; *.wfn)|font.*;*.ttf;*.wfn|TrueType font files (*.ttf)|*.ttf|SCI font files (FONT.*)|font.*|WFN font files (*.wfn)|*.wfn";
-        public const string MASK_IMAGE_FILE_FILTER = "Windows bitmap files (*.bmp)|*.bmp";
+        public const string MASK_IMAGE_FILE_FILTER = "All supported images (*.bmp; *.png)|*.bmp;*.png|Windows bitmap files (*.bmp)|*.bmp|Portable Network Graphics (*.png)|*.png";
         public const string GAME_TEMPLATE_FILE_FILTER = "AGS game template files (*.agt)|*.agt";
         public const string ROOM_TEMPLATE_FILE_FILTER = "AGS room template files (*.art)|*.art";
 	}


### PR DESCRIPTION
This ports minimal necessary code from AGS 4 to AGS 3, letting users to import indexed PNGs (of any palette size) as 8-bit room backgrounds and masks.

I am not certain why this was never added to ags3 branch, perhaps simply forgotten. I think this was addressed for ags4 in issues #1771 and #1772.

I copied only minimal necessary code from BitmapExtensions class, and it seems that, combined with the recent support for small palette image import, this allows to import any indexed PNGs as room bgs and masks.