### PR TITLE
Engine: hotfix certain platforms to not save "warnings.log" in current working dir

### DIFF
--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -161,9 +161,10 @@ void SDL_Log_Output(void* /*userdata*/, int category, SDL_LogPriority priority, 
 // Log configuration
 // ----------------------------------------------------------------------------
 
-PDebugOutput create_log_output(const String &name, const String &path = "", LogFile::OpenMode open_mode = LogFile::kLogFile_Overwrite)
+// Create a new log output by ID
+PDebugOutput create_log_output(const String &name, const String &dir = "", const String &filename = "",
+    LogFile::OpenMode open_mode = LogFile::kLogFile_Overwrite)
 {
-    // Else create new one, if we know this ID
     if (name.CompareNoCase(OutputSystemID) == 0)
     {
         return DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
@@ -171,13 +172,21 @@ PDebugOutput create_log_output(const String &name, const String &path = "", LogF
     else if (name.CompareNoCase(OutputFileID) == 0)
     {
         DebugLogFile.reset(new LogFile());
-        String logfile_path = path;
-        if (logfile_path.IsEmpty())
+        String logfile_dir = dir;
+        if (dir.IsEmpty())
         {
             FSLocation fs = platform->GetAppOutputDirectory();
             CreateFSDirs(fs);
-            logfile_path = Path::ConcatPaths(fs.FullDir, "ags.log");
+            logfile_dir = fs.FullDir;
         }
+        else if (Path::IsRelativePath(dir) && platform->IsLocalDirRestricted())
+        {
+            FSLocation fs = GetGameUserDataDir();
+            CreateFSDirs(fs);
+            logfile_dir = fs.FullDir;
+        }
+        String logfilename = filename.IsEmpty() ? "ags.log" : filename;
+        String logfile_path = Path::ConcatPaths(logfile_dir, logfilename);
         if (!DebugLogFile->OpenFile(logfile_path, open_mode))
             return nullptr;
         Debug::Printf(kDbgMsg_Info, "Logging to %s", logfile_path.GetCStr());
@@ -336,7 +345,7 @@ void apply_debug_config(const ConfigTree &cfg)
     // then open "warnings.log" for printing script warnings.
     if (game.options[OPT_DEBUGMODE] != 0 && !DebugLogFile)
     {
-        auto dbgout = create_log_output(OutputFileID, "warnings.log", LogFile::kLogFile_OverwriteAtFirstMessage);
+        auto dbgout = create_log_output(OutputFileID, "./", "warnings.log", LogFile::kLogFile_OverwriteAtFirstMessage);
         if (dbgout)
         {
             dbgout->SetGroupFilter(kDbgGroup_Game, kDbgMsg_Warn);

--- a/Engine/platform/base/agsplatform_xdg_unix.cpp
+++ b/Engine/platform/base/agsplatform_xdg_unix.cpp
@@ -84,6 +84,12 @@ FSLocation AGSPlatformXDGUnix::GetAppOutputDirectory()
     return UserDataDirectory;
 }
 
+bool AGSPlatformXDGUnix::IsLocalDirRestricted()
+{
+    // Let them to create temp files in the current working dir
+    return false;
+}
+
 uint64_t AGSPlatformXDGUnix::GetDiskFreeSpaceMB(const String &path) {
     // placeholder
     return 100;

--- a/Engine/platform/base/agsplatform_xdg_unix.h
+++ b/Engine/platform/base/agsplatform_xdg_unix.h
@@ -31,6 +31,7 @@ struct AGSPlatformXDGUnix : AGSPlatformDriver {
     FSLocation GetUserConfigDirectory() override;
     FSLocation GetUserGlobalConfigDirectory() override;
     FSLocation GetAppOutputDirectory() override;
+    bool IsLocalDirRestricted() override;
     uint64_t GetDiskFreeSpaceMB(const AGS::Common::String &path) override;
     const char* GetBackendFailUserHint() override;
 };

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -95,6 +95,10 @@ public:
     virtual FSLocation GetUserGlobalConfigDirectory()  { return FSLocation("."); }
     // Get default directory for program output (logs)
     virtual FSLocation GetAppOutputDirectory() { return FSLocation("."); }
+    // Tells whether it's not permitted to write to the local directory (cwd, or game dir),
+    // and only specified user/app directories should be used.
+    // FIXME: this is a part of a hotfix, review uses of this function later.
+    virtual bool IsLocalDirRestricted() { return true; }
     // Returns array of characters illegal to use in file names
     virtual const char *GetIllegalFileChars() { return "\\/"; }
     virtual const char *GetDiskWriteAccessTroubleshootingText();

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -62,6 +62,7 @@ struct AGSWin32 : AGSPlatformDriver {
   FSLocation GetUserConfigDirectory() override;
   FSLocation GetUserGlobalConfigDirectory() override;
   FSLocation GetAppOutputDirectory() override;
+  bool IsLocalDirRestricted() override;
   const char *GetIllegalFileChars() override;
   const char *GetGraphicsTroubleshootingText() override;
   uint64_t GetDiskFreeSpaceMB(const String &path) override;
@@ -238,6 +239,12 @@ FSLocation AGSWin32::GetAppOutputDirectory()
 {
   DetermineAppOutputDirectory();
   return win32OutputDirectory;
+}
+
+bool AGSWin32::IsLocalDirRestricted()
+{
+  // Let them to create temp files in the current working dir
+  return false;
 }
 
 const char *AGSWin32::GetIllegalFileChars()


### PR DESCRIPTION
Fix #2437

There are platforms where this behavior is not suitable even for a Debug game build, because writing to current working dir will modify the game bundle, causing reaction from the operating system or app store. Introduce a IsLocalDirRestricted() method to the platform driver class, use it when "warnings.log" is created to know whether we are allowed to write it into cwd, or should be using a safer user dir.

For the time being, do not impose this restriction on Windows and Linux.

NOTE: this is a temporary hotfix. For the proper solution we'd need to revise "warnings.log" feature and possibly use config settings instead.