### PR TITLE
Engine,Editor: add Touch Script API

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -366,6 +366,13 @@ managed struct Point {
 };
 #endif
 
+#ifdef SCRIPT_API_v400
+managed struct TouchPoint {
+	int ID, X, Y;
+	bool IsDown;
+};
+#endif
+
 #define CHARID int  // $AUTOCOMPLETEIGNORE$
 builtin struct ColorType {
   char r,g,b;
@@ -2752,8 +2759,12 @@ builtin managed struct VideoPlayer {
   /// The volume of this video's sound, from 0 to 100.
   import attribute int Volume;
 };
-#endif
 
+builtin struct Touch {
+  /// Returns array of touch points
+  import static TouchPoint*[] GetTouchPoints();      // $AUTOCOMPLETESTATICONLY$
+};
+#endif
 
 import ColorType palette[PALETTE_SIZE];
 import Mouse mouse;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -207,6 +207,8 @@ target_sources(engine
     ac/parser.cpp
     ac/parser.h
     ac/path_helper.h
+    ac/touch.cpp
+    ac/touch.h
     ac/properties.cpp
     ac/properties.h
     ac/region.cpp

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -126,3 +126,15 @@ ScriptUserObject *ScriptStructHelpers::CreatePoint(int x, int y)
     ref.Mgr->WriteInt32(ref.Obj, sizeof(int32_t), y);
     return static_cast<ScriptUserObject*>(ref.Obj);
 }
+
+// Allocates managed struct containing four ints: ID, X, Y and Up/Down state
+DynObjectRef ScriptStructHelpers::CreateTouchPointRef(int id, int x, int y, int down)
+{
+    // FIXME: type id! (is it possible to RTTI?)
+    DynObjectRef ref = ScriptUserObject::Create(RTTI::NoType, sizeof(int32_t) * 4);
+    ref.Mgr->WriteInt32(ref.Obj, 0, id);
+    ref.Mgr->WriteInt32(ref.Obj, sizeof(int32_t), x);
+    ref.Mgr->WriteInt32(ref.Obj, sizeof(int32_t)*2, y);
+    ref.Mgr->WriteInt32(ref.Obj, sizeof(int32_t)*3, down);
+    return ref;
+}

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -88,6 +88,7 @@ namespace ScriptStructHelpers
 {
     // Creates a managed Point object, represented as a pair of X and Y coordinates.
     ScriptUserObject *CreatePoint(int x, int y);
+    DynObjectRef CreateTouchPointRef(int id, int x, int y, int down);
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTUSERSTRUCT_H

--- a/Engine/ac/touch.cpp
+++ b/Engine/ac/touch.cpp
@@ -1,0 +1,106 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+
+#include <array>
+#include "ac/dynobj/scriptuserobject.h"
+#include "ac/dynobj/cc_dynamicarray.h"
+#include "device/mousew32.h"
+#include "touch.h"
+#include "ac/common.h"
+
+enum class touch_state {
+    up,
+    motion,
+    down
+};
+
+struct touch_point {
+    int x;
+    int y;
+    bool down;
+};
+
+struct tp {
+    static const int MAX_POINTERS = 10;
+    int point_count = 0;
+    std::array<touch_point, MAX_POINTERS> touch_points = {};
+} _tp;
+
+void on_touch_pointer(int pointer_id, Point position, touch_state state)
+{
+    _tp.point_count = std::max(pointer_id+1, _tp.point_count);
+    _tp.touch_points[pointer_id].x = position.X;
+    _tp.touch_points[pointer_id].y = position.Y;
+    _tp.touch_points[pointer_id].down = state != touch_state::up;
+}
+
+void on_touch_pointer_down(int pointer_id, Point position)
+{
+    on_touch_pointer(pointer_id, position, touch_state::down);
+}
+
+void on_touch_pointer_motion(int pointer_id, Point position)
+{
+    on_touch_pointer(pointer_id, position, touch_state::motion);
+}
+
+void on_touch_pointer_up(int pointer_id, Point position)
+{
+    on_touch_pointer(pointer_id, position, touch_state::up);
+}
+
+DynObjectRef create_touchpoint(int n)
+{
+    if (n < 0 || n >= tp::MAX_POINTERS)
+        quit("!Touch: invalid index for touchpoint");
+
+    touch_point p = _tp.touch_points[n];
+    return ScriptStructHelpers::CreateTouchPointRef(n, p.x, p.y, p.down);
+}
+
+void* Touch_GetTouchPoints()
+{
+    std::vector<DynObjectRef> objs{};
+
+    for(int i=0; i< _tp.point_count; i++){
+        objs.push_back(create_touchpoint(i));
+    }
+
+    DynObjectRef arr = DynamicArrayHelpers::CreateScriptArray(std::move(objs));
+    return arr.Obj;
+}
+
+//=============================================================================
+//
+// Script API Functions
+//
+//=============================================================================
+
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+
+// Point*[] ()
+RuntimeScriptValue Sc_Touch_GetTouchPoints(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(ScriptUserObject, globalDynamicArray, Touch_GetTouchPoints);
+}
+
+void RegisterTouchAPI()
+{
+    ScFnRegister touch_api[] = {
+            { "Touch::GetTouchPoints^0",               API_FN_PAIR(Touch_GetTouchPoints) },
+    };
+
+    ccAddExternalFunctions(touch_api);
+}

--- a/Engine/ac/touch.h
+++ b/Engine/ac/touch.h
@@ -1,0 +1,24 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_EE_AC_TOUCH_H
+#define __AGS_EE_AC_TOUCH_H
+
+#include "util/geometry.h"
+
+void on_touch_pointer_down(int pointer_id, Point position);
+void on_touch_pointer_motion(int pointer_id, Point position);
+void on_touch_pointer_up(int pointer_id, Point position);
+
+
+#endif //__AGS_EE_AC_TOUCH_H

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -45,6 +45,7 @@ extern void RegisterMouseAPI();
 extern void RegisterObjectAPI();
 extern void RegisterOverlayAPI();
 extern void RegisterParserAPI();
+extern void RegisterTouchAPI();
 extern void RegisterRegionAPI();
 extern void RegisterRoomAPI();
 extern void RegisterScreenAPI();
@@ -90,6 +91,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterObjectAPI();
     RegisterOverlayAPI();
     RegisterParserAPI();
+    RegisterTouchAPI();
     RegisterRegionAPI();
     RegisterRoomAPI();
     RegisterScreenAPI();

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -545,6 +545,7 @@
     <ClCompile Include="..\..\Engine\ac\object.cpp" />
     <ClCompile Include="..\..\Engine\ac\overlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\parser.cpp" />
+    <ClCompile Include="..\..\Engine\ac\touch.cpp" />
     <ClCompile Include="..\..\Engine\ac\properties.cpp" />
     <ClCompile Include="..\..\Engine\ac\route_finder_impl.cpp" />
     <ClCompile Include="..\..\Engine\ac\scriptcontainers.cpp" />
@@ -791,6 +792,7 @@
     <ClInclude Include="..\..\Engine\ac\overlay.h" />
     <ClInclude Include="..\..\Engine\ac\parser.h" />
     <ClInclude Include="..\..\Engine\ac\path_helper.h" />
+    <ClInclude Include="..\..\Engine\ac\touch.h" />
     <ClInclude Include="..\..\Engine\ac\properties.h" />
     <ClInclude Include="..\..\Engine\ac\route_finder_impl.h" />
     <ClInclude Include="..\..\Engine\ac\sys_events.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -324,6 +324,9 @@
     <ClCompile Include="..\..\Engine\ac\parser.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\touch.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Engine\ac\properties.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
@@ -945,6 +948,9 @@
       <Filter>Header Files\ac</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\path_helper.h">
+      <Filter>Header Files\ac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\touch.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\properties.h">


### PR DESCRIPTION
fix #1538

A minimal touch api that can be used to detect touching a screen.

```
void repeatedly_execute_always() 
{
  TouchPoint* points[];
  points = Touch.GetTouchPoints();
  
  String s = "";
  for(int i=0; i<points.Length; i++)
  {
    TouchPoint* p = points[i];
    if(p.IsDown) {
      s = s.Append(String.Format("P(%d) _DOWN_ (%d, %d)\n", p.ID, p.X, p.Y));      
    } else {
      s = s.Append(String.Format("P(%d) __UP__ (%d, %d)\n", p.ID, p.X, p.Y));
    }
  }
  
  lbl_dbg.Text = s;
}
```