### PR TITLE
Engine: fix string overflow in parser

### DIFF
--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -243,7 +243,11 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
                             thisword[text - textStart] = 0;
                             // forward past any multi-word alternatives
                             if (FindMatchingMultiWordWord(thisword, &text) >= 0)
+                            {
+                                if (text[0] == 0)
+                                    break;
                                 continueSearching = 1;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Under certain conditions sentence parsing function can read beyond the end of input string resulting in unpredictable behavior and/or crashes, this small fix prevents this.

The problematic scenario happens when a multi-word is the last alternative in the input and an earlier alternative has already been matched. For example: "one,two,three point five" where "three point five" is a multi-word and "two" has already been matched. The logic that is supposed to skip other alternatives will jump beyond the end of the input string.

The issue is FindMatchingMultiWordWord() sets text to point to the first character after matched multi-word which in this scenario is \0. The search continues and in the next iteration text is incremented to the first character after \0 which reads out-of-bounds memory. Most of the time this is benign (random invalid characters might go unnoticed) but if it accidentally reads ']' for example it will result in game crash due to malformed input (original issue we've observed).