### PR TITLE
Engine: fix check for word boundaries in the parser

### DIFF
--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -233,7 +233,7 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
                         const char *textStart = ++text; // begin with next char
 
                         // find where the next word ends
-                        while ((text[0] == ',') || (isalnum((unsigned char)text[0]) != 0))
+                        while ((text[0] == ',') || is_valid_word_char(text[0]))
                         {
                             // shift beginning of potential multi-word each time we see a comma
                             if(text[0] == ',')


### PR DESCRIPTION
Parser should exclusively use is_valid_word_char to check for word boundaries (affects dash and apostrophe containing words).