### PR TITLE
Editor: Fix properties for properties indicator in BusyDialog

### DIFF
--- a/Editor/AGS.Editor/GUI/BusyDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/BusyDialog.Designer.cs
@@ -38,13 +38,17 @@ namespace AGS.Editor
             // 
             // btnImage
             // 
+            this.btnImage.CausesValidation = false;
             this.btnImage.FlatAppearance.BorderSize = 0;
+            this.btnImage.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+            this.btnImage.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
             this.btnImage.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnImage.ForeColor = System.Drawing.Color.Transparent;
             this.btnImage.Location = new System.Drawing.Point(24, 37);
             this.btnImage.Name = "btnImage";
             this.btnImage.Size = new System.Drawing.Size(79, 57);
             this.btnImage.TabIndex = 0;
+            this.btnImage.TabStop = false;
             this.btnImage.UseVisualStyleBackColor = true;
             // 
             // lblMessage

--- a/Editor/AGS.Editor/GUI/BusyDialog.resx
+++ b/Editor/AGS.Editor/GUI/BusyDialog.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
Fixing something that bothered me for the longest time. When the game builds and the BusyDialog appears, the user can hover over the progress indicator, and the background will slightly change color. The reason behind this is that the indicator is a hacked button.

What I did to solve it was tor set the background for click/hover to transparent. Additionally, I removed a tab index and disabled validation since it's not needed.

Before - note that the screenshot does not include the mouse cursor, but it's placed over the progress indicator:
![image](https://github.com/adventuregamestudio/ags/assets/168664/73ad65f9-c17c-4d6d-801e-a50468516f5d)
