### PR TITLE
Editor,Engine: declare game object imports as pointers

### DIFF
--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -764,7 +764,7 @@ namespace AGS.Editor
                     {
                         if (control.Name.Length > 0)
                         {
-                            sb.AppendLine("import " + control.ScriptClassType + " " + control.Name + ";");
+                            sb.AppendLine("import readonly " + control.ScriptClassType + " *" + control.Name + ";");
                         }
                     }
                 }

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -691,7 +691,7 @@ namespace AGS.Editor
                 {
                     if (item.Name.Length > 0)
                     {
-                        sb.AppendLine("import InventoryItem " + item.Name + ";");
+                        sb.AppendLine("import readonly InventoryItem *" + item.Name + ";");
                     }
                 }
             }
@@ -712,7 +712,7 @@ namespace AGS.Editor
                 {
                     if (item.Name.Length > 0)
                     {
-                        sb.AppendLine("import Dialog " + item.Name + ";");
+                        sb.AppendLine("import readonly Dialog *" + item.Name + ";");
                     }
                 }
             }
@@ -752,7 +752,7 @@ namespace AGS.Editor
                         continue;
                     }
 
-                    sb.AppendLine("import GUI " + gui.Name + ";");
+                    sb.AppendLine("import readonly GUI *" + gui.Name + ";");
 
                     if (gui.Name.StartsWith("g"))
                     {
@@ -806,7 +806,7 @@ namespace AGS.Editor
                     }
                     if (character.ScriptName.Length > 0)
                     {
-                        sb.AppendLine("import Character " + character.ScriptName + ";");
+                        sb.AppendLine("import readonly Character *" + character.ScriptName + ";");
                     }
                 }
             }

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -667,7 +667,7 @@ namespace AGS.Editor
             {
                 if (obj.Name.Length > 0)
                 {
-                    sb.AppendLine("import Object " + obj.Name + ";");
+                    sb.AppendLine("import readonly Object *" + obj.Name + ";");
                 }
             }
 
@@ -675,7 +675,7 @@ namespace AGS.Editor
             {
                 if (hotspot.Name.Length > 0)
                 {
-                    sb.AppendLine("import Hotspot " + hotspot.Name + ";");
+                    sb.AppendLine("import readonly Hotspot *" + hotspot.Name + ";");
                 }
             }
         }

--- a/Engine/ac/dynobj/cc_character.cpp
+++ b/Engine/ac/dynobj/cc_character.cpp
@@ -21,6 +21,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticCharacterArray;
 
 extern GameSetupStruct game;
 
@@ -44,7 +45,7 @@ void CCCharacter::Serialize(const void *address, Stream *out)
 void CCCharacter::Unserialize(int index, Stream *in, size_t /*data_sz*/)
 {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &game.chars[num], this);
+    StaticCharacterArray[num] = ccRegisterUnserializedPersistentObject(index, &game.chars[num], this);
 }
 
 uint8_t CCCharacter::ReadInt8(const void *address, intptr_t offset)

--- a/Engine/ac/dynobj/cc_dialog.cpp
+++ b/Engine/ac/dynobj/cc_dialog.cpp
@@ -19,6 +19,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticDialogArray;
 
 // return the type name of the object
 const char *CCDialog::GetType() {
@@ -37,5 +38,5 @@ void CCDialog::Serialize(const void *address, Stream *out) {
 
 void CCDialog::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &scrDialog[num], this);
+    StaticDialogArray[num] = ccRegisterUnserializedPersistentObject(index, &scrDialog[num], this);
 }

--- a/Engine/ac/dynobj/cc_gui.cpp
+++ b/Engine/ac/dynobj/cc_gui.cpp
@@ -18,6 +18,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticGUIArray;
 
 extern std::vector<ScriptGUI> scrGui;
 
@@ -38,5 +39,5 @@ void CCGUI::Serialize(const void *address, Stream *out) {
 
 void CCGUI::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &scrGui[num], this);
+    StaticGUIArray[num] = ccRegisterUnserializedPersistentObject(index, &scrGui[num], this);
 }

--- a/Engine/ac/dynobj/cc_guiobject.cpp
+++ b/Engine/ac/dynobj/cc_guiobject.cpp
@@ -18,6 +18,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<std::vector<int>> StaticGUIControlsHandles;
 
 // return the type name of the object
 const char *CCGUIObject::GetType() {
@@ -38,5 +39,6 @@ void CCGUIObject::Serialize(const void *address, Stream *out) {
 void CCGUIObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int guinum = in->ReadInt32();
     int objnum = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, guis[guinum].GetControl(objnum), this);
+    int handle = ccRegisterUnserializedPersistentObject(index, guis[guinum].GetControl(objnum), this);
+    (StaticGUIControlsHandles[guinum])[objnum] = handle;
 }

--- a/Engine/ac/dynobj/cc_hotspot.cpp
+++ b/Engine/ac/dynobj/cc_hotspot.cpp
@@ -19,6 +19,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticHotspotArray;
 
 extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
 
@@ -39,5 +40,5 @@ void CCHotspot::Serialize(const void *address, Stream *out) {
 
 void CCHotspot::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &scrHotspot[num], this);
+    StaticHotspotArray[num] = ccRegisterUnserializedPersistentObject(index, &scrHotspot[num], this);
 }

--- a/Engine/ac/dynobj/cc_inventory.cpp
+++ b/Engine/ac/dynobj/cc_inventory.cpp
@@ -18,6 +18,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticInventoryArray;
 
 extern ScriptInvItem scrInv[MAX_INV];
 
@@ -38,5 +39,5 @@ void CCInventory::Serialize(const void *address, Stream *out) {
 
 void CCInventory::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &scrInv[num], this);
+    StaticInventoryArray[num] = ccRegisterUnserializedPersistentObject(index, &scrInv[num], this);
 }

--- a/Engine/ac/dynobj/cc_object.cpp
+++ b/Engine/ac/dynobj/cc_object.cpp
@@ -19,6 +19,7 @@
 #include "util/stream.h"
 
 using namespace AGS::Common;
+extern std::vector<int> StaticObjectArray;
 
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 
@@ -39,5 +40,5 @@ void CCObject::Serialize(const void *address, Stream *out) {
 
 void CCObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedPersistentObject(index, &scrObj[num], this);
+    StaticObjectArray[num] = ccRegisterUnserializedPersistentObject(index, &scrObj[num], this);
 }

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -658,10 +658,6 @@ void unexport_all_gui_controls()
         unexport_gui_controls(i);
     }
     StaticGUIControlsHandles.clear();
-
-    // FIX-ME: for some reason this method is called in DoBeforeRestore
-    // so we must reset arrays sizes below. Remove if removed from DoBeforeRestore
-    set_array_all_gui_controls_size();
 }
 
 void update_gui_disabled_status()

--- a/Engine/ac/gui.h
+++ b/Engine/ac/gui.h
@@ -67,8 +67,8 @@ void	update_gui_zorder();
 // Initializes all GUI and controls for runtime state;
 // this must be done after creating or loading GUIs.
 void    prepare_gui_runtime(bool startup);
-void	export_gui_controls(int ee);
-void	unexport_gui_controls(int ee);
+void	export_all_gui_controls();
+void    unexport_all_gui_controls();
 void	update_gui_disabled_status();
 int		adjust_x_for_guis(int xx, int yy, bool assume_blocking = false);
 int		adjust_y_for_guis(int yy, bool assume_blocking = false);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -105,6 +105,8 @@ extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern ScriptRegion scrRegion[MAX_ROOM_REGIONS];
 extern ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
 extern ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
+extern std::vector<int> StaticObjectArray;
+extern std::vector<int> StaticHotspotArray;
 
 std::unique_ptr<MaskRouteFinder> room_pathfinder;
 RGB_MAP rgb_table;  // for 256-col antialiasing
@@ -585,14 +587,14 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         // export the object's script object
         if (thisroom.Objects[cc].ScriptName.IsEmpty())
             continue;
-        ccAddExternalScriptObject(thisroom.Objects[cc].ScriptName, &scrObj[cc], &ccDynamicObject);
+        ccAddExternalScriptObject(thisroom.Objects[cc].ScriptName, &StaticObjectArray[cc], &GlobalStaticManager);
     }
 
     for (int cc = 0; cc < MAX_ROOM_HOTSPOTS; cc++) {
         if (thisroom.Hotspots[cc].ScriptName.IsEmpty())
             continue;
 
-        ccAddExternalScriptObject(thisroom.Hotspots[cc].ScriptName, &scrHotspot[cc], &ccDynamicHotspot);
+        ccAddExternalScriptObject(thisroom.Hotspots[cc].ScriptName, &StaticHotspotArray[cc], &GlobalStaticManager);
     }
 
     set_our_eip(210);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -172,7 +172,7 @@ void InitAndRegisterCharacters(GameSetupStruct &game, const LoadedGameEntities &
         StaticCharacterArray[i] = handle;
 
         // export the character's script object
-        ccAddExternalScriptObject(game.chars[i].scrname, &game.chars[i], &ccDynamicCharacter);
+        ccAddExternalScriptObject(game.chars[i].scrname, &StaticCharacterArray[i], &GlobalStaticManager);
     }
 
     // extra character properties (because the characters are split into 2 structs now)
@@ -200,7 +200,7 @@ void InitAndRegisterDialogs(const GameSetupStruct &game)
         StaticDialogArray[i] = handle;
 
         if (!game.dialogScriptNames[i].IsEmpty())
-            ccAddExternalScriptObject(game.dialogScriptNames[i], &scrDialog[i], &ccDynamicDialog);
+            ccAddExternalScriptObject(game.dialogScriptNames[i], &StaticDialogArray[i], &GlobalStaticManager);
     }
 }
 
@@ -239,7 +239,7 @@ HError InitAndRegisterGUI(const GameSetupStruct &game)
         StaticGUIArray[i] = handle;
 
         // export the gui script object
-        ccAddExternalScriptObject(guis[i].Name, &scrGui[i], &ccDynamicGUI);
+        ccAddExternalScriptObject(guis[i].Name, &StaticGUIArray[i], &GlobalStaticManager);
 
         // export all the GUI's controls
         export_gui_controls(i);
@@ -260,7 +260,7 @@ void InitAndRegisterInvItems(const GameSetupStruct &game)
         StaticInventoryArray[i] = handle;
 
         if (!game.invScriptNames[i].IsEmpty())
-            ccAddExternalScriptObject(game.invScriptNames[i], &scrInv[i], &ccDynamicInv);
+            ccAddExternalScriptObject(game.invScriptNames[i], &StaticInventoryArray[i], &GlobalStaticManager);
     }
 }
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -91,7 +91,6 @@ CCStaticArray StaticHandlesArray;
 std::vector<int> StaticCharacterArray;
 std::vector<int> StaticObjectArray;
 std::vector<int> StaticGUIArray;
-std::vector<int> StaticGUIControlsArray;
 std::vector<int> StaticHotspotArray;
 std::vector<int> StaticRegionArray;
 std::vector<int> StaticWalkareaArray;

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -91,6 +91,7 @@ CCStaticArray StaticHandlesArray;
 std::vector<int> StaticCharacterArray;
 std::vector<int> StaticObjectArray;
 std::vector<int> StaticGUIArray;
+std::vector<int> StaticGUIControlsArray;
 std::vector<int> StaticHotspotArray;
 std::vector<int> StaticRegionArray;
 std::vector<int> StaticWalkareaArray;
@@ -240,10 +241,10 @@ HError InitAndRegisterGUI(const GameSetupStruct &game)
 
         // export the gui script object
         ccAddExternalScriptObject(guis[i].Name, &StaticGUIArray[i], &GlobalStaticManager);
-
-        // export all the GUI's controls
-        export_gui_controls(i);
     }
+    // export all the GUI's controls
+    export_all_gui_controls();
+
     return HError::None();
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -350,10 +350,7 @@ void DoBeforeRestore(PreservedParams &pp)
     RemoveAllButtonAnimations();
     // unregister gui controls from API exports
     // FIXME: find out why are we doing this here??! why only to gui controls??!
-    for (int i = 0; i < game.numgui; ++i)
-    {
-        unexport_gui_controls(i);
-    }
+    unexport_all_gui_controls();
     // Clear the managed object pool
     ccUnregisterAllObjects();
 
@@ -442,8 +439,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
     export_missing_audiochans();
 
     // CHECKME: find out why are we doing this here? why only to gui controls?
-    for (int i = 0; i < game.numgui; ++i)
-        export_gui_controls(i);
+    export_all_gui_controls();
 
     AllocScriptModules();
     if (create_global_script())

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -348,9 +348,6 @@ void DoBeforeRestore(PreservedParams &pp)
     free_do_once_tokens();
 
     RemoveAllButtonAnimations();
-    // unregister gui controls from API exports
-    // FIXME: find out why are we doing this here??! why only to gui controls??!
-    unexport_all_gui_controls();
     // Clear the managed object pool
     ccUnregisterAllObjects();
 
@@ -437,9 +434,6 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
 
     // Re-export any missing audio channel script objects, e.g. if restoring old save
     export_missing_audiochans();
-
-    // CHECKME: find out why are we doing this here? why only to gui controls?
-    export_all_gui_controls();
 
     AllocScriptModules();
     if (create_global_script())


### PR DESCRIPTION
This change affects GUIs, Inventory Items, Dialogs and Characters

These elements are imported using their direct raw memory references instead of handles but they are used in script as pointers, this change modifies the header generation to actually use pointers and also registers to them their handles.

This change can be visible when using the Watch Variable feature as the handle will show up there. I am leaving this as draft because I am not sure yet of the consequences of  this change.