### PR TITLE
Editor: Add shortcut keys for context menu items and Go to Definition, Find All Usages, Go to Sprite, and dd items to Edit menu

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -32,7 +32,6 @@ namespace AGS.Editor
         private const string CONTEXT_MENU_CUT = "CtxCut";
         private const string CONTEXT_MENU_COPY = "CtxCopy";
         private const string CONTEXT_MENU_PASTE = "CtxPaste";
-        private const string CONTEXT_MENU_GO_TO_DEFINITION = "CtxDefinition";
 
         private const string THIS_STRUCT = "this";
         private const int INVALID_POSITION = -1;
@@ -2450,12 +2449,23 @@ namespace AGS.Editor
                 {
                     menu.Items.Add(new ToolStripSeparator());
                 }
-                menu.Items.Add(new ToolStripMenuItem("Cut", Factory.GUIController.ImageList.Images["CutIcon"], onClick, CONTEXT_MENU_CUT));
-                menu.Items[menu.Items.Count - 1].Enabled = this.CanCutAndCopy();
-                menu.Items.Add(new ToolStripMenuItem("Copy", Factory.GUIController.ImageList.Images["CopyIcon"], onClick, CONTEXT_MENU_COPY));
-                menu.Items[menu.Items.Count - 1].Enabled = this.CanCutAndCopy();
-                menu.Items.Add(new ToolStripMenuItem("Paste", Factory.GUIController.ImageList.Images["PasteIcon"], onClick, CONTEXT_MENU_PASTE));
-                menu.Items[menu.Items.Count - 1].Enabled = this.CanPaste();
+
+                ToolStripMenuItem menuItem;
+
+                menuItem = new ToolStripMenuItem("Cut", Factory.GUIController.ImageList.Images["CutIcon"], onClick, CONTEXT_MENU_CUT);
+                menuItem.ShortcutKeys = Keys.Control | Keys.X;
+                menuItem.Enabled = this.CanCutAndCopy();
+                menu.Items.Add(menuItem);
+
+                menuItem = new ToolStripMenuItem("Copy", Factory.GUIController.ImageList.Images["CopyIcon"], onClick, CONTEXT_MENU_COPY);
+                menuItem.ShortcutKeys = Keys.Control | Keys.C;
+                menuItem.Enabled = this.CanCutAndCopy();
+                menu.Items.Add(menuItem);
+
+                menuItem = new ToolStripMenuItem("Paste", Factory.GUIController.ImageList.Images["PasteIcon"], onClick, CONTEXT_MENU_PASTE);
+                menuItem.ShortcutKeys = Keys.Control | Keys.V;
+                menuItem.Enabled = this.CanPaste();
+                menu.Items.Add(menuItem);
 
                 menu.Show(this.scintillaControl1, e.X, e.Y);
             }

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -136,6 +136,7 @@ namespace AGS.Editor
 
         protected override void AddEditMenuCommands(MenuCommands commands)
         {
+            commands.Commands.Add(MenuCommand.Separator);
             commands.Commands.Add(new MenuCommand(TOGGLE_BREAKPOINT_COMMAND, "Toggle Breakpoint", Keys.F9, "ToggleBreakpointMenuIcon"));
             commands.Commands.Add(new MenuCommand(SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND, "Switch to Matching Script or Header", Keys.Control | Keys.M));
         }

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -136,15 +136,18 @@ namespace AGS.Editor
 
         protected override void AddEditMenuCommands(MenuCommands commands)
         {
-            commands.Commands.Add(new MenuCommand(TOGGLE_BREAKPOINT_COMMAND, "Toggle Breakpoint", System.Windows.Forms.Keys.F9, "ToggleBreakpointMenuIcon"));
-            commands.Commands.Add(new MenuCommand(SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND, "Switch to Matching Script or Header", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M));
+            commands.Commands.Add(new MenuCommand(TOGGLE_BREAKPOINT_COMMAND, "Toggle Breakpoint", Keys.F9, "ToggleBreakpointMenuIcon"));
+            commands.Commands.Add(new MenuCommand(SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND, "Switch to Matching Script or Header", Keys.Control | Keys.M));
         }
 
         protected override void AddCtxCommands(ContextMenuStrip menuStrip)
         {
             EventHandler onClick = new EventHandler(ContextMenuChooseOption2);
+            ToolStripMenuItem menuItem = new ToolStripMenuItem("Toggle Breakpoint", Factory.GUIController.ImageList.Images["ToggleBreakpointMenuIcon"], onClick, CONTEXT_MENU_TOGGLE_BREAKPOINT);
+            menuItem.ShortcutKeys = Keys.F9;
+
             menuStrip.Items.Add(new ToolStripSeparator());
-            menuStrip.Items.Add(new ToolStripMenuItem("Toggle Breakpoint", Factory.GUIController.ImageList.Images["ToggleBreakpointMenuIcon"], onClick, CONTEXT_MENU_TOGGLE_BREAKPOINT));
+            menuStrip.Items.Add(menuItem);
         }
 
         public void ActivateWindow()
@@ -513,7 +516,7 @@ namespace AGS.Editor
         protected override void OnKeyPressed(System.Windows.Forms.Keys keyData)
         {
             if (keyData.Equals(
-                System.Windows.Forms.Keys.Escape))
+                Keys.Escape))
             {
                 FindReplace.CloseDialogIfNeeded();
             }

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -172,7 +172,6 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(_menuCmdGoToDefinition);
             _extraMenu.Commands.Add(_menuCmdFindAllUsages);
             _extraMenu.Commands.Add(_menuCmdGoToSprite);
-            _extraMenu.Commands.Add(MenuCommand.Separator);
 
             AddEditMenuCommands(_extraMenu);
 

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -161,11 +161,11 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(new MenuCommand(MATCH_BRACE_COMMAND, "Match Brace", Keys.Control | Keys.B));
             _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Go to Line...", Keys.Control | Keys.G));
 
-            _menuCmdGoToDefinition = new MenuCommand(GO_TO_DEFINITION_COMMAND, "Go To Definition", Keys.F12);
+            _menuCmdGoToDefinition = new MenuCommand(GO_TO_DEFINITION_COMMAND, "Go to Definition", Keys.F12);
             _menuCmdGoToDefinition.Enabled = false;
             _menuCmdFindAllUsages = new MenuCommand(FIND_ALL_USAGES_COMMAND, "Find All Usages", Keys.Shift | Keys.F12);
             _menuCmdFindAllUsages.Enabled = false;
-            _menuCmdGoToSprite = new MenuCommand(GO_TO_SPRITE_COMMAND, "Go To Sprite", Keys.Shift | Keys.F7);
+            _menuCmdGoToSprite = new MenuCommand(GO_TO_SPRITE_COMMAND, "Go to Sprite", Keys.Shift | Keys.F7);
             _menuCmdGoToSprite.Enabled = false;
 
             _extraMenu.Commands.Add(MenuCommand.Separator);

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -145,16 +145,16 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(_menuCmdCopy);
             _extraMenu.Commands.Add(_menuCmdPaste);
             _extraMenu.Commands.Add(MenuCommand.Separator);
-            _extraMenu.Commands.Add(new MenuCommand(FIND_COMMAND, "Find...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F, "FindMenuIcon"));
-            _extraMenu.Commands.Add(new MenuCommand(FIND_NEXT_COMMAND, "Find next", System.Windows.Forms.Keys.F3, "FindNextMenuIcon"));
-            _extraMenu.Commands.Add(new MenuCommand(REPLACE_COMMAND, "Replace...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E));
+            _extraMenu.Commands.Add(new MenuCommand(FIND_COMMAND, "Find...", Keys.Control | Keys.F, "FindMenuIcon"));
+            _extraMenu.Commands.Add(new MenuCommand(FIND_NEXT_COMMAND, "Find next", Keys.F3, "FindNextMenuIcon"));
+            _extraMenu.Commands.Add(new MenuCommand(REPLACE_COMMAND, "Replace...", Keys.Control | Keys.E));
             _extraMenu.Commands.Add(MenuCommand.Separator);
-            _extraMenu.Commands.Add(new MenuCommand(FIND_ALL_COMMAND, "Find All...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F, "FindMenuIcon"));
-            _extraMenu.Commands.Add(new MenuCommand(REPLACE_ALL_COMMAND, "Replace All...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.E));
+            _extraMenu.Commands.Add(new MenuCommand(FIND_ALL_COMMAND, "Find All...", Keys.Control | Keys.Shift | Keys.F, "FindMenuIcon"));
+            _extraMenu.Commands.Add(new MenuCommand(REPLACE_ALL_COMMAND, "Replace All...", Keys.Control | Keys.Shift | Keys.E));
             _extraMenu.Commands.Add(MenuCommand.Separator);
-            _extraMenu.Commands.Add(new MenuCommand(SHOW_AUTOCOMPLETE_COMMAND, "Show Autocomplete", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Space, "ShowAutocompleteMenuIcon"));
-            _extraMenu.Commands.Add(new MenuCommand(MATCH_BRACE_COMMAND, "Match Brace", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B));
-            _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Go to Line...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G));
+            _extraMenu.Commands.Add(new MenuCommand(SHOW_AUTOCOMPLETE_COMMAND, "Show Autocomplete", Keys.Control | Keys.Space, "ShowAutocompleteMenuIcon"));
+            _extraMenu.Commands.Add(new MenuCommand(MATCH_BRACE_COMMAND, "Match Brace", Keys.Control | Keys.B));
+            _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Go to Line...", Keys.Control | Keys.G));
             AddEditMenuCommands(_extraMenu);
 
             _toolbarIcons.Add(_menuCmdCut);


### PR DESCRIPTION
The change contains several improvements to the context menu and the Edit menu for the script editor:

1. Context menu items display the shortcut keys next to them (e.g., Copy shows Ctrl+C)
2. Added new shortcut keys for Go To Definition, Find All Usages, and Go To Sprite (based on Visual Studio conventions)
3. Added those options to the Edit menu
4. Code cleanup

## Screenshots

(My Windows is in Spanish. Mayús. = Shift)
![image](https://github.com/adventuregamestudio/ags/assets/168664/e624855d-9a84-4be8-a642-b0a9f07bfe50)


![image](https://github.com/adventuregamestudio/ags/assets/168664/51f5d8c4-dacf-4982-9d3e-5d48649159ce)

