### PR TITLE
Add TurnWhenFacing character property (design-time and in script)

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -23,32 +23,35 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
+// Max inventory items in character's inventory
 #define MAX_INV             301
 // Character flags
-#define CHF_MANUALSCALING   1
-#define CHF_FIXVIEW         2     // between SetCharView and ReleaseCharView
-#define CHF_NOINTERACT      4
-#define CHF_NODIAGONAL      8
-#define CHF_ALWAYSIDLE      0x10
-#define CHF_NOLIGHTING      0x20
-#define CHF_NOTURNING       0x40
-#define CHF_NOWALKBEHINDS   0x80
-#define CHF_FLIPSPRITE      0x100  // ?? Is this used??
-#define CHF_NOBLOCKING      0x200
-#define CHF_SCALEMOVESPEED  0x400
-#define CHF_NOBLINKANDTHINK 0x800
-#define CHF_SCALEVOLUME     0x1000
-#define CHF_HASTINT         0x2000   // engine only
-#define CHF_BEHINDSHEPHERD  0x4000   // engine only
-#define CHF_AWAITINGMOVE    0x8000   // engine only
-#define CHF_MOVENOTWALK     0x10000   // engine only - do not do walk anim
-#define CHF_ANTIGLIDE       0x20000
-#define CHF_HASLIGHT        0x40000
+#define CHF_MANUALSCALING   1        // Use explicit scaling property rather than area parameters
+#define CHF_FIXVIEW         2        // View locked
+#define CHF_NOINTERACT      4        // Non-interactable (non-clickable)
+#define CHF_NODIAGONAL      8        // Don't use diagonal walking loops
+#define CHF_ALWAYSIDLE      0x10     // [UNUSED] meaning unknown
+#define CHF_NOLIGHTING      0x20     // Ignore Region lighting
+#define CHF_NOTURNING       0x40     // Do not turn step-by-step when walking
+#define CHF_NOWALKBEHINDS   0x80     // Ignore walk-behinds (always draw above)
+#define CHF_FLIPSPRITE      0x100    // [UNUSED] meaning unknown
+#define CHF_NOBLOCKING      0x200    // Not solid
+#define CHF_SCALEMOVESPEED  0x400    // Scale move speed with character scaling
+#define CHF_NOBLINKANDTHINK 0x800    // Don't do blink animation when "thinking"
+#define CHF_SCALEVOLUME     0x1000   // Scale animation volume with character scaling
+#define CHF_HASTINT         0x2000   // Use explicit tint rather than region tint
+#define CHF_BEHINDSHEPHERD  0x4000   // [INTERNAL] z-sort behind leader when following another char
+#define CHF_AWAITINGMOVE    0x8000   // [INTERNAL] (meaning not clear, investigate)
+#define CHF_MOVENOTWALK     0x10000  // [INTERNAL] do not play walking animation while moving
+#define CHF_ANTIGLIDE       0x20000  // Link movement to animation
+#define CHF_HASLIGHT        0x40000  // Use explicit lighting rather than region lighting
 #define CHF_TINTLIGHTMASK   (CHF_NOLIGHTING | CHF_HASTINT | CHF_HASLIGHT)
-// Speechcol is no longer part of the flags as of v2.5
+// Pre-v2.5 bit mask for when the speechcolor was stored in character flags
 #define OCHF_SPEECHCOL      0xff000000
 #define OCHF_SPEECHCOLSHIFT 24
+// Value of CharacterInfo::walkspeed_y that tells to use walkspeed_x
 #define UNIFORM_WALK_SPEED  0
+// Value of CharacterInfo::followinfo that tells to keep follower z-sorted above the leading char
 #define FOLLOW_ALWAYSONTOP  0x7ffe
 
 // Length of deprecated character name field, in bytes

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -26,13 +26,17 @@ using namespace AGS; // FIXME later
 // Max inventory items in character's inventory
 #define MAX_INV             301
 // Character flags
+// NOTE: flag meaning is inconsistent: some of them have positive (DO) meaning,
+// some older ones have negative (DON'T). TODO: bring them to consistency someday,
+// but remember that this involves updating game file formats and converting
+// after loading game data and restoring older saves.
 #define CHF_MANUALSCALING   1        // Use explicit scaling property rather than area parameters
 #define CHF_FIXVIEW         2        // View locked
 #define CHF_NOINTERACT      4        // Non-interactable (non-clickable)
 #define CHF_NODIAGONAL      8        // Don't use diagonal walking loops
 #define CHF_ALWAYSIDLE      0x10     // [UNUSED] meaning unknown
 #define CHF_NOLIGHTING      0x20     // Ignore Region lighting
-#define CHF_NOTURNING       0x40     // Do not turn step-by-step when walking
+#define CHF_NOTURNWHENWALK  0x40     // Do not turn step-by-step when walking
 #define CHF_NOWALKBEHINDS   0x80     // Ignore walk-behinds (always draw above)
 #define CHF_FLIPSPRITE      0x100    // [UNUSED] meaning unknown
 #define CHF_NOBLOCKING      0x200    // Not solid
@@ -46,6 +50,7 @@ using namespace AGS; // FIXME later
 #define CHF_ANTIGLIDE       0x20000  // Link movement to animation
 #define CHF_HASLIGHT        0x40000  // Use explicit lighting rather than region lighting
 #define CHF_TINTLIGHTMASK   (CHF_NOLIGHTING | CHF_HASTINT | CHF_HASLIGHT)
+#define CHF_TURNWHENFACE    0x80000  // Turn step-by-step when changing standing direction
 // Pre-v2.5 bit mask for when the speechcolor was stored in character flags
 #define OCHF_SPEECHCOL      0xff000000
 #define OCHF_SPEECHCOLSHIFT 24

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -118,6 +118,8 @@ In RTL mode all text is reversed, not only wrappable (labels etc).
 Disabled automatic SetRestartPoint.
 3.6.1.14:
 Extended game object names, resolving hard length limits.
+3.6.2:
+CHF_TURNWHENFACE flag.
 
 */
 
@@ -159,7 +161,8 @@ enum GameDataVersion
     kGameVersion_361            = 3060100,
     kGameVersion_361_10         = 3060110,
     kGameVersion_361_14         = 3060114,
-    kGameVersion_Current        = kGameVersion_361_14
+    kGameVersion_362            = 3060200,
+    kGameVersion_Current        = kGameVersion_362
 };
 
 // Data format version of the loaded game

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -48,7 +48,7 @@
 #define OPT_NOLOSEINV       15
 #define OPT_HIRES_FONTS     16
 #define OPT_SPLITRESOURCES  17
-#define OPT_ROTATECHARS     18
+#define OPT_CHARTURNWHENWALK 18 // characters turn step-by-step when changing walking direction
 #define OPT_FADETYPE        19
 #define OPT_HANDLEINVCLICKS 20
 #define OPT_MOUSEWHEEL      21
@@ -57,7 +57,7 @@
 #define OPT_CROSSFADEMUSIC  24
 #define OPT_ANTIALIASFONTS  25
 #define OPT_THOUGHTGUI      26
-#define OPT_TURNTOFACELOC   27
+#define OPT_CHARTURNWHENFACE 27  // characters turn step-by-step when facing new standing direction
 #define OPT_RIGHTLEFTWRITE  28  // right-to-left text writing
 #define OPT_DUPLICATEINV    29  // if they have 2 of the item, draw it twice
 #define OPT_SAVESCREENSHOT  30

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -600,6 +600,15 @@ void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
     auto &chars2 = game.chars2;
     const int numcharacters = game.numcharacters;
 
+    // Characters can always walk through each other on < 2.54
+    if (data_ver < kGameVersion_254)
+    {
+        for (int i = 0; i < numcharacters; i++)
+        {
+            chars[i].flags |= CHF_NOBLOCKING;
+        }
+    }
+
     // Fixup character script names for 2.x (EGO -> cEgo)
     if (data_ver <= kGameVersion_272)
     {
@@ -625,12 +634,13 @@ void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
         }
     }
 
-    // Characters can always walk through each other on < 2.54
-    if (data_ver < kGameVersion_254)
+    // < 3.6.2 characters always followed OPT_CHARTURNWHENFACE,
+    // so they have to have TURNWHENFACE enabled
+    if (data_ver < kGameVersion_362)
     {
         for (int i = 0; i < numcharacters; i++)
         {
-            chars[i].flags |= CHF_NOBLOCKING;
+            chars[i].flags |= CHF_TURNWHENFACE;
         }
     }
 }

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -104,8 +104,9 @@ namespace AGS.Editor
          * 3.6.1.9        - Settings.ScaleCharacterSpriteOffsets
          * 3.6.1.10       - SetRestartPoint() is no longer auto called in the engine,
          *                  add one into the global script when importing older games.
+         * 3.6.2          - Character.TurnWhenFacing
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060110;
+        public const int    LATEST_XML_VERSION_INDEX = 3060200;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -537,8 +537,8 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_SPLITRESOURCES] = game.Settings.SplitResources;
             options[NativeConstants.GameOptions.OPT_TWCUSTOM] = game.Settings.TextWindowGUI;
             options[NativeConstants.GameOptions.OPT_THOUGHTGUI] = game.Settings.ThoughtGUI;
-            options[NativeConstants.GameOptions.OPT_TURNTOFACELOC] = (game.Settings.TurnBeforeFacing ? 1 : 0);
-            options[NativeConstants.GameOptions.OPT_ROTATECHARS] = (game.Settings.TurnBeforeWalking ? 1 : 0);
+            options[NativeConstants.GameOptions.OPT_CHARTURNWHENFACE] = (game.Settings.TurnBeforeFacing ? 1 : 0);
+            options[NativeConstants.GameOptions.OPT_CHARTURNWHENWALK] = (game.Settings.TurnBeforeWalking ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_NATIVECOORDINATES] = (game.Settings.UseLowResCoordinatesInScript ? 0 : 1);
             options[NativeConstants.GameOptions.OPT_WALKONLOOK] = (game.Settings.WalkInLookMode ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_DISABLEOFF] = (int)game.Settings.WhenInterfaceDisabled;
@@ -1536,7 +1536,8 @@ namespace AGS.Editor
                 if (!character.DiagonalLoops) flags |= NativeConstants.CHF_NODIAGONAL;
                 if (character.MovementLinkedToAnimation) flags |= NativeConstants.CHF_ANTIGLIDE;
                 if (!character.Solid) flags |= NativeConstants.CHF_NOBLOCKING;
-                if (!character.TurnBeforeWalking) flags |= NativeConstants.CHF_NOTURNING;
+                if (!character.TurnBeforeWalking) flags |= NativeConstants.CHF_NOTURNWHENWALK;
+                if (character.TurnWhenFacing) flags |= NativeConstants.CHF_TURNWHENFACE;
                 if (!character.UseRoomAreaLighting) flags |= NativeConstants.CHF_NOLIGHTING;
                 if (!character.UseRoomAreaScaling) flags |= NativeConstants.CHF_MANUALSCALING;
                 writer.Write(character.NormalView - 1);                // defview

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2808,6 +2808,8 @@ builtin managed struct Character {
 #ifdef SCRIPT_API_v362
   /// Moves the character in a straight line as far as possible towards the co-ordinates, without walking animation. Useful for keyboard movement.
   import function MoveStraight(int x, int y, BlockingStyle=eNoBlock);
+  /// Gets/sets whether the character turns on the spot when ordered to face the new standing direction.
+  import attribute bool TurnWhenFacing;
 #endif
 #ifdef STRICT
   /// The character's current X-position.

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -22,11 +22,12 @@ namespace AGS.Editor
         public static readonly int CHF_NOINTERACT = (int)Factory.NativeProxy.GetNativeConstant("CHF_NOINTERACT");
         public static readonly int CHF_NODIAGONAL = (int)Factory.NativeProxy.GetNativeConstant("CHF_NODIAGONAL");
         public static readonly int CHF_NOLIGHTING = (int)Factory.NativeProxy.GetNativeConstant("CHF_NOLIGHTING");
-        public static readonly int CHF_NOTURNING = (int)Factory.NativeProxy.GetNativeConstant("CHF_NOTURNING");
+        public static readonly int CHF_NOTURNWHENWALK = (int)Factory.NativeProxy.GetNativeConstant("CHF_NOTURNWHENWALK");
         public static readonly int CHF_NOBLOCKING = (int)Factory.NativeProxy.GetNativeConstant("CHF_NOBLOCKING");
         public static readonly int CHF_SCALEMOVESPEED = (int)Factory.NativeProxy.GetNativeConstant("CHF_SCALEMOVESPEED");
         public static readonly int CHF_SCALEVOLUME = (int)Factory.NativeProxy.GetNativeConstant("CHF_SCALEVOLUME");
         public static readonly int CHF_ANTIGLIDE = (int)Factory.NativeProxy.GetNativeConstant("CHF_ANTIGLIDE");
+        public static readonly int CHF_TURNWHENFACE = (int)Factory.NativeProxy.GetNativeConstant("CHF_TURNWHENFACE");
         public static readonly int DFLG_ON = (int)Factory.NativeProxy.GetNativeConstant("DFLG_ON");
         public static readonly int DFLG_NOREPEAT = (int)Factory.NativeProxy.GetNativeConstant("DFLG_NOREPEAT");
         public static readonly int DTFLG_SHOWPARSER = (int)Factory.NativeProxy.GetNativeConstant("DTFLG_SHOWPARSER");
@@ -100,7 +101,7 @@ namespace AGS.Editor
             public static readonly int OPT_FIXEDINVCURSOR = (int)Factory.NativeProxy.GetNativeConstant("OPT_FIXEDINVCURSOR");
             public static readonly int OPT_HIRES_FONTS = (int)Factory.NativeProxy.GetNativeConstant("OPT_HIRES_FONTS");
             public static readonly int OPT_SPLITRESOURCES = (int)Factory.NativeProxy.GetNativeConstant("OPT_SPLITRESOURCES");
-            public static readonly int OPT_ROTATECHARS = (int)Factory.NativeProxy.GetNativeConstant("OPT_ROTATECHARS");
+            public static readonly int OPT_CHARTURNWHENWALK = (int)Factory.NativeProxy.GetNativeConstant("OPT_CHARTURNWHENWALK");
             public static readonly int OPT_FADETYPE = (int)Factory.NativeProxy.GetNativeConstant("OPT_FADETYPE");
             public static readonly int OPT_HANDLEINVCLICKS = (int)Factory.NativeProxy.GetNativeConstant("OPT_HANDLEINVCLICKS");
             public static readonly int OPT_MOUSEWHEEL = (int)Factory.NativeProxy.GetNativeConstant("OPT_MOUSEWHEEL");
@@ -108,7 +109,7 @@ namespace AGS.Editor
             public static readonly int OPT_DIALOGUPWARDS = (int)Factory.NativeProxy.GetNativeConstant("OPT_DIALOGUPWARDS");
             public static readonly int OPT_ANTIALIASFONTS = (int)Factory.NativeProxy.GetNativeConstant("OPT_ANTIALIASFONTS");
             public static readonly int OPT_THOUGHTGUI = (int)Factory.NativeProxy.GetNativeConstant("OPT_THOUGHTGUI");
-            public static readonly int OPT_TURNTOFACELOC = (int)Factory.NativeProxy.GetNativeConstant("OPT_TURNTOFACELOC");
+            public static readonly int OPT_CHARTURNWHENFACE = (int)Factory.NativeProxy.GetNativeConstant("OPT_CHARTURNWHENFACE");
             public static readonly int OPT_RIGHTLEFTWRITE = (int)Factory.NativeProxy.GetNativeConstant("OPT_RIGHTLEFTWRITE");
             public static readonly int OPT_DUPLICATEINV = (int)Factory.NativeProxy.GetNativeConstant("OPT_DUPLICATEINV");
             public static readonly int OPT_SAVESCREENSHOT = (int)Factory.NativeProxy.GetNativeConstant("OPT_SAVESCREENSHOT");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -760,11 +760,12 @@ namespace AGS
             if (name->Equals("CHF_NOINTERACT")) return CHF_NOINTERACT;
             if (name->Equals("CHF_NODIAGONAL")) return CHF_NODIAGONAL;
             if (name->Equals("CHF_NOLIGHTING")) return CHF_NOLIGHTING;
-            if (name->Equals("CHF_NOTURNING")) return CHF_NOTURNING;
+            if (name->Equals("CHF_NOTURNWHENWALK")) return CHF_NOTURNWHENWALK;
             if (name->Equals("CHF_NOBLOCKING")) return CHF_NOBLOCKING;
             if (name->Equals("CHF_SCALEMOVESPEED")) return CHF_SCALEMOVESPEED;
             if (name->Equals("CHF_SCALEVOLUME")) return CHF_SCALEVOLUME;
             if (name->Equals("CHF_ANTIGLIDE")) return CHF_ANTIGLIDE;
+            if (name->Equals("CHF_TURNWHENFACE")) return CHF_TURNWHENFACE;
             if (name->Equals("DFLG_ON")) return DFLG_ON;
             if (name->Equals("DFLG_NOREPEAT")) return DFLG_NOREPEAT;
             if (name->Equals("DTFLG_SHOWPARSER")) return DTFLG_SHOWPARSER;
@@ -832,7 +833,7 @@ namespace AGS
             if (name->Equals("OPT_FIXEDINVCURSOR")) return OPT_FIXEDINVCURSOR;
             if (name->Equals("OPT_HIRES_FONTS")) return OPT_HIRES_FONTS;
             if (name->Equals("OPT_SPLITRESOURCES")) return OPT_SPLITRESOURCES;
-            if (name->Equals("OPT_ROTATECHARS")) return OPT_ROTATECHARS;
+            if (name->Equals("OPT_CHARTURNWHENWALK")) return OPT_CHARTURNWHENWALK;
             if (name->Equals("OPT_FADETYPE")) return OPT_FADETYPE;
             if (name->Equals("OPT_HANDLEINVCLICKS")) return OPT_HANDLEINVCLICKS;
             if (name->Equals("OPT_MOUSEWHEEL")) return OPT_MOUSEWHEEL;
@@ -840,7 +841,7 @@ namespace AGS
             if (name->Equals("OPT_DIALOGUPWARDS")) return OPT_DIALOGUPWARDS;
             if (name->Equals("OPT_ANTIALIASFONTS")) return OPT_ANTIALIASFONTS;
             if (name->Equals("OPT_THOUGHTGUI")) return OPT_THOUGHTGUI;
-            if (name->Equals("OPT_TURNTOFACELOC")) return OPT_TURNTOFACELOC;
+            if (name->Equals("OPT_CHARTURNWHENFACE")) return OPT_CHARTURNWHENFACE;
             if (name->Equals("OPT_RIGHTLEFTWRITE")) return OPT_RIGHTLEFTWRITE;
             if (name->Equals("OPT_DUPLICATEINV")) return OPT_DUPLICATEINV;
             if (name->Equals("OPT_SAVESCREENSHOT")) return OPT_SAVESCREENSHOT;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3156,8 +3156,8 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 	game->Settings->SplitResources = thisgame.options[OPT_SPLITRESOURCES];
 	game->Settings->TextWindowGUI = thisgame.options[OPT_TWCUSTOM];
 	game->Settings->ThoughtGUI = thisgame.options[OPT_THOUGHTGUI];
-	game->Settings->TurnBeforeFacing = (thisgame.options[OPT_TURNTOFACELOC] != 0);
-	game->Settings->TurnBeforeWalking = (thisgame.options[OPT_ROTATECHARS] != 0);
+	game->Settings->TurnBeforeFacing = (thisgame.options[OPT_CHARTURNWHENFACE] != 0);
+	game->Settings->TurnBeforeWalking = (thisgame.options[OPT_CHARTURNWHENWALK] != 0);
 	game->Settings->WalkInLookMode = (thisgame.options[OPT_WALKONLOOK] != 0);
 	game->Settings->WhenInterfaceDisabled = (InterfaceDisabledAction)thisgame.options[OPT_DISABLEOFF];
 	game->Settings->UniqueID = thisgame.uniqueid;
@@ -3273,7 +3273,8 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 		character->StartX = thisgame.chars[i].x;
 		character->StartY = thisgame.chars[i].y;
     character->ThinkingView = (thisgame.chars[i].thinkview < 1) ? 0 : (thisgame.chars[i].thinkview + 1);
-		character->TurnBeforeWalking = !(thisgame.chars[i].flags & CHF_NOTURNING);
+		character->TurnBeforeWalking = !(thisgame.chars[i].flags & CHF_NOTURNWHENWALK);
+        character->TurnWhenFacing = (thisgame.chars[i].flags & CHF_TURNWHENFACE) != 0;
 		character->UniformMovementSpeed = (thisgame.chars[i].walkspeed_y == UNIFORM_WALK_SPEED);
 		character->UseRoomAreaLighting = !(thisgame.chars[i].flags & CHF_NOLIGHTING);
 		character->UseRoomAreaScaling = !(thisgame.chars[i].flags & CHF_MANUALSCALING);

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -40,6 +40,7 @@ namespace AGS.Types
         private bool _useRoomAreaScaling = true;
         private bool _useRoomAreaLighting = true;
         private bool _turnBeforeWalking = true;
+        private bool _turnWhenFacing = true;
         private bool _diagonalLoops = true;
         private bool _adjustSpeedWithScaling;
         private bool _adjustVolumeWithScaling;
@@ -292,12 +293,20 @@ namespace AGS.Types
             set { _useRoomAreaLighting = value; }
         }
 
-        [Description("Whether the character will turn to face their new direction before walking")]
+        [Description("Whether the character will turn on the spot to face their new direction before walking")]
         [Category("Movement")]
         public bool TurnBeforeWalking
         {
             get { return _turnBeforeWalking; }
             set { _turnBeforeWalking = value; }
+        }
+
+        [Description("Whether the character will turn on the spot to face the new standing direction")]
+        [Category("Movement")]
+        public bool TurnWhenFacing
+        {
+            get { return _turnWhenFacing; }
+            set { _turnWhenFacing = value; }
         }
 
         [Description("Specifies that the walking view is using loops 4-7 for diagonal directions")]

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1630,6 +1630,17 @@ void Character_SetTurnBeforeWalking(CharacterInfo *chaa, int on) {
         chaa->flags |= CHF_NOTURNWHENWALK;
 }
 
+int Character_GetTurnWhenFacing(CharacterInfo *chaa) {
+    return ((chaa->flags & CHF_TURNWHENFACE) != 0) ? 1 : 0;
+}
+
+void Character_SetTurnWhenFacing(CharacterInfo *chaa, int on) {
+    if (on)
+        chaa->flags |= CHF_TURNWHENFACE;
+    else
+        chaa->flags &= ~CHF_TURNWHENFACE;
+}
+
 int Character_GetView(CharacterInfo *chaa) {
     return chaa->view + 1;
 }
@@ -3883,6 +3894,16 @@ RuntimeScriptValue Sc_Character_SetTurnBeforeWalking(void *self, const RuntimeSc
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetTurnBeforeWalking);
 }
 
+RuntimeScriptValue Sc_Character_GetTurnWhenFacing (void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTurnWhenFacing );
+}
+
+RuntimeScriptValue Sc_Character_SetTurnWhenFacing (void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetTurnWhenFacing);
+}
+
 // int (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetView(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -4104,6 +4125,8 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
         { "Character::set_Transparency",          API_FN_PAIR(Character_SetTransparency) },
         { "Character::get_TurnBeforeWalking",     API_FN_PAIR(Character_GetTurnBeforeWalking) },
         { "Character::set_TurnBeforeWalking",     API_FN_PAIR(Character_SetTurnBeforeWalking) },
+        { "Character::get_TurnWhenFacing",        API_FN_PAIR(Character_GetTurnWhenFacing ) },
+        { "Character::set_TurnWhenFacing",        API_FN_PAIR(Character_SetTurnWhenFacing ) },
         { "Character::get_View",                  API_FN_PAIR(Character_GetView) },
         { "Character::get_WalkSpeedX",            API_FN_PAIR(Character_GetWalkSpeedX) },
         { "Character::get_WalkSpeedY",            API_FN_PAIR(Character_GetWalkSpeedY) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -401,7 +401,7 @@ void FaceDirectionalLoop(CharacterInfo *char1, int direction, int blockingStyle)
     // Change facing only if the desired direction is different
     if (direction != char1->loop)
     {
-        if ((game.options[OPT_TURNTOFACELOC] != 0) &&
+        if ((game.options[OPT_CHARTURNWHENFACE] != 0) && ((char1->flags & CHF_TURNWHENFACE) != 0) &&
             (in_enters_screen == 0))
         {
             const int no_diagonal = useDiagonal (char1);
@@ -1618,17 +1618,16 @@ void Character_SetTransparency(CharacterInfo *chaa, int trans) {
 }
 
 int Character_GetTurnBeforeWalking(CharacterInfo *chaa) {
-
-    if (chaa->flags & CHF_NOTURNING)
-        return 0;
-    return 1;  
+    // NOTE: this flag has inverse meaning
+    return ((chaa->flags & CHF_NOTURNWHENWALK) != 0) ? 0 : 1;
 }
 
-void Character_SetTurnBeforeWalking(CharacterInfo *chaa, int yesorno) {
-
-    chaa->flags &= ~CHF_NOTURNING;
-    if (!yesorno)
-        chaa->flags |= CHF_NOTURNING;
+void Character_SetTurnBeforeWalking(CharacterInfo *chaa, int on) {
+    // NOTE: this flag has inverse meaning
+    if (on)
+        chaa->flags &= ~CHF_NOTURNWHENWALK;
+    else
+        chaa->flags |= CHF_NOTURNWHENWALK;
 }
 
 int Character_GetView(CharacterInfo *chaa) {
@@ -1867,7 +1866,7 @@ void fix_player_sprite(MoveList*cmls,CharacterInfo*chinf) {
 
     const int useloop = GetDirectionalLoop(chinf, xpmove, ypmove);
 
-    if ((game.options[OPT_ROTATECHARS] == 0) || ((chinf->flags & CHF_NOTURNING) != 0)) {
+    if ((game.options[OPT_CHARTURNWHENWALK] == 0) || ((chinf->flags & CHF_NOTURNWHENWALK) != 0)) {
         chinf->loop = useloop;
         return;
     }


### PR DESCRIPTION
Following user's request, this adds a individual Character.TurnWhenFacing, complementing Character.TurnBeforeWalking and a global "Characters turn to face direction" (called internally "TurnBeforeFacing" by oversight, it seems) property from General Settings.

For consistency with "turn before walking", character only turns on spot when *both* global and this character's TurnWhenFacing setting is enabled.
