### PR TITLE
AGS 4: allow to import sprites as 8-bit image regardless of game color depth

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -400,7 +400,7 @@ HError SpriteCache::InitFile(std::unique_ptr<Stream> &&sprite_file,
 {
     Reset();
 
-    std::vector<Size> metrics;
+    std::vector<GraphicResolution> metrics;
     HError err = _file.OpenFile(std::move(sprite_file), std::move(index_file), metrics);
     if (!err)
         return err;
@@ -417,6 +417,7 @@ HError SpriteCache::InitFile(std::unique_ptr<Stream> &&sprite_file,
             _spriteData[i].Flags = SPRCACHEFLAG_ISASSET;
             _sprInfos[i].Width = metrics[i].Width;
             _sprInfos[i].Height = metrics[i].Height;
+            _sprInfos[i].ColorDepth = metrics[i].ColorDepth;
             Size newsz = _callbacks.AdjustSize(Size(metrics[i].Width, metrics[i].Height), _sprInfos[i].Flags);
             _sprInfos[i].Width = newsz.Width;
             _sprInfos[i].Height = newsz.Height;

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -17,8 +17,6 @@
 // accumulating index information, and may therefore be suitable for a variety
 // of situations.
 //
-// TODO: store extra Color Depth field per sprite in the sprite index.
-//
 //=============================================================================
 #ifndef __AGS_CN_AC__SPRFILE_H
 #define __AGS_CN_AC__SPRFILE_H
@@ -26,8 +24,8 @@
 #include <memory>
 #include <vector>
 #include "core/types.h"
+#include "gfx/gfx_def.h"
 #include "util/error.h"
-#include "util/geometry.h"
 #include "util/stream.h"
 #include "util/string.h"
 
@@ -58,7 +56,8 @@ enum SpriteIndexFileVersion
     kSpridxfVersion_Last32bit = 2,
     kSpridxfVersion_64bit = 10,
     kSpridxfVersion_HighSpriteLimit = 11,
-    kSpridxfVersion_Current = kSpridxfVersion_HighSpriteLimit
+    kSpridxfVersion_ColorDepths = 12,
+    kSpridxfVersion_Current = kSpridxfVersion_ColorDepths
 };
 
 // Instructions to how the sprites are allowed to be stored
@@ -97,6 +96,7 @@ struct SpriteFileIndex
     int SpriteFileIDCheck = 0; // tag matching sprite file and index file
     std::vector<int16_t> Widths;
     std::vector<int16_t> Heights;
+    std::vector<int8_t>  Depths;
     std::vector<soff_t>  Offsets;
 
     inline size_t GetCount() const { return Offsets.size(); }
@@ -134,7 +134,7 @@ public:
     // Loads sprite reference information and inits sprite stream
     HError      OpenFile(std::unique_ptr<Stream> &&sprite_file,
                          std::unique_ptr<Stream> &&index_file,
-                         std::vector<Size> &metrics);
+                         std::vector<GraphicResolution> &metrics);
     // Closes stream; no reading will be possible unless opened again
     void        Close();
 
@@ -147,7 +147,7 @@ public:
     // Loads sprite index file
     bool        LoadSpriteIndexFile(std::unique_ptr<Stream> &&index_file,
                                     int expectedFileID, soff_t spr_initial_offs,
-                                    sprkey_t topmost, std::vector<Size> &metrics);
+                                    sprkey_t topmost, std::vector<GraphicResolution> &metrics);
 
     // Loads an image data and creates a ready bitmap
     HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
@@ -156,7 +156,7 @@ public:
 
 private:
     // Rebuilds sprite index from the main sprite file
-    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost, std::vector<Size> &metrics);
+    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost, std::vector<GraphicResolution> &metrics);
     // Seek stream to sprite
     void        SeekToSprite(sprkey_t index);
 

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -14,6 +14,9 @@
 //
 // Graphic definitions and type/unit conversions.
 //
+// TODO: consider reorganizing this header; specifically move GraphicSpace to
+// some other header, as it brings a bunch of matrix headers with itself.
+//
 //=============================================================================
 #ifndef __AGS_CN_GFX__GFXDEF_H
 #define __AGS_CN_GFX__GFXDEF_H
@@ -49,6 +52,23 @@ enum BlendMode
     kBlend_Exclusion,
     kBlend_Dodge,
     kNumBlendModes
+};
+
+// GraphicResolution struct determines image size and color depth
+struct GraphicResolution : Size
+{
+    int32_t ColorDepth; // color depth in bits per pixel
+
+    GraphicResolution()
+        : ColorDepth(0) {}
+
+    GraphicResolution(int32_t width, int32_t height, int32_t color_depth)
+        : Size(width, height), ColorDepth(color_depth) {}
+
+    GraphicResolution(Size size, int32_t color_depth)
+        : Size(size), ColorDepth(color_depth) {}
+
+    inline bool IsValid() const { return Width > 0 && Height > 0 && ColorDepth > 0; }
 };
 
 

--- a/Editor/AGS.Editor.Tests/Types/SpriteTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/SpriteTests.cs
@@ -188,17 +188,20 @@ namespace AGS.Types
             Assert.That(_sprite.RemapToRoomPalette, Is.EqualTo(remapToRoomPalette));
         }
 
-        [TestCase(1, 25, 75, 8, false, 1, "sprite1.bmp", 1, 1, 1, 1, false, 1, false, false, SpriteImportTransparency.BottomLeft, false)]
-        [TestCase(2, 75, 25, 32, true, 2, "sprite2.bmp", 2, 2, 1, 1, true, 2, true, true, SpriteImportTransparency.BottomRight, true)]
+        [TestCase(1, 25, 75, 8, false, 1, "sprite1.bmp", SpriteImportColorDepth.Indexed8Bit, 1, 1, 1, 1, false, 1, false, false,
+            SpriteImportTransparency.BottomLeft)]
+        [TestCase(2, 75, 25, 32, true, 2, "sprite2.bmp", SpriteImportColorDepth.GameDefault, 2, 2, 1, 1, true, 2, true, true,
+            SpriteImportTransparency.BottomRight)]
         public void DeserializesFromXml(int slot, int width, int height, int colorDepth, bool alphaChannel,
-            int colorsLockedToRoom, string filename, int offsetX, int offsetY, int importHeight,
-            int importWidth, bool importAsTile, int frame, bool remapToGamePalette, bool remapToRoomPalette,
-            SpriteImportTransparency importMethod, bool importAlphaChannel)
+            int colorsLockedToRoom, string filename, SpriteImportColorDepth importColorDepth, int offsetX, int offsetY,
+            int importHeight, int importWidth, bool importAsTile, int frame, bool remapToGamePalette, bool remapToRoomPalette,
+            SpriteImportTransparency importMethod)
         {
             string xml = $@"
             <Sprite Slot=""{slot}"" Width=""{width}"" Height=""{height}"" ColorDepth=""{colorDepth}"" Resolution=""LowRes"" AlphaChannel=""{alphaChannel}"" ColoursLockedToRoom=""{colorsLockedToRoom}"">
                 <Source>
                     <FileName>{filename}</FileName>
+                    <ImportColorDepth>{importColorDepth}</ImportColorDepth>
                     <OffsetX>{offsetX}</OffsetX>
                     <OffsetY>{offsetY}</OffsetY>
                     <ImportHeight>{importHeight}</ImportHeight>
@@ -208,7 +211,6 @@ namespace AGS.Types
                     <RemapToGamePalette>{remapToGamePalette}</RemapToGamePalette>
                     <RemapToRoomPalette>{remapToRoomPalette}</RemapToRoomPalette>
                     <ImportMethod>{importMethod}</ImportMethod>
-                    <ImportAlphaChannel>{importAlphaChannel}</ImportAlphaChannel>
                 </Source>
             </Sprite>";
             XmlDocument doc = new XmlDocument();
@@ -222,6 +224,7 @@ namespace AGS.Types
             Assert.That(_sprite.AlphaChannel, Is.EqualTo(alphaChannel));
             Assert.That(_sprite.ColoursLockedToRoom, Is.EqualTo(colorsLockedToRoom));
             Assert.That(_sprite.SourceFile, Is.EqualTo(filename));
+            Assert.That(_sprite.ImportColorDepth, Is.EqualTo(importColorDepth));
             Assert.That(_sprite.OffsetX, Is.EqualTo(offsetX));
             Assert.That(_sprite.OffsetY, Is.EqualTo(offsetY));
             Assert.That(_sprite.ImportHeight, Is.EqualTo(importHeight));
@@ -231,15 +234,14 @@ namespace AGS.Types
             Assert.That(_sprite.RemapToGamePalette, Is.EqualTo(remapToGamePalette));
             Assert.That(_sprite.RemapToRoomPalette, Is.EqualTo(remapToRoomPalette));
             Assert.That(_sprite.TransparentColour, Is.EqualTo(importMethod));
-            Assert.That(_sprite.ImportAlphaChannel, Is.EqualTo(importAlphaChannel));
         }
 
-        [TestCase(1, 25, 75, 8, false, 1, "sprite1.bmp", 1, 1, 1, 1, false, 1, false, false, SpriteImportTransparency.BottomLeft, false)]
-        [TestCase(2, 75, 25, 32, true, 2, "sprite2.bmp", 2, 2, 1, 1, true, 2, true, true, SpriteImportTransparency.BottomRight, true)]
+        [TestCase(1, 25, 75, 8, false, 1, "sprite1.bmp", SpriteImportColorDepth.Indexed8Bit, 1, 1, 1, 1, false, 1, false, false, SpriteImportTransparency.BottomLeft)]
+        [TestCase(2, 75, 25, 32, true, 2, "sprite2.bmp", SpriteImportColorDepth.GameDefault, 2, 2, 1, 1, true, 2, true, true, SpriteImportTransparency.BottomRight)]
         public void SerializesToXml(int slot, int width, int height, int colorDepth, bool alphaChannel,
-            int colorsLockedToRoom, string filename, int offsetX, int offsetY, SpriteImportColorDepth importColorDepth, int importHeight,
+            int colorsLockedToRoom, string filename, SpriteImportColorDepth importColorDepth, int offsetX, int offsetY, int importHeight,
             int importWidth, bool importAsTile, int frame, bool remapToGamePalette, bool remapToRoomPalette,
-            SpriteImportTransparency importMethod, bool importAlphaChannel)
+            SpriteImportTransparency importMethod)
         {
             _sprite.Number = slot;
             _sprite.Width = width;
@@ -257,7 +259,6 @@ namespace AGS.Types
             _sprite.RemapToGamePalette = remapToGamePalette;
             _sprite.RemapToRoomPalette = remapToRoomPalette;
             _sprite.TransparentColour = importMethod;
-            _sprite.ImportAlphaChannel = importAlphaChannel;
             _sprite.ImportColorDepth = importColorDepth;
             XmlDocument doc = _sprite.ToXmlDocument();
 
@@ -270,6 +271,7 @@ namespace AGS.Types
             Assert.That(doc.SelectSingleNode("/Sprite").Attributes["ColoursLockedToRoom"].InnerText, Is.EqualTo(_sprite.ColoursLockedToRoom.ToString()));
 
             Assert.That(doc.SelectSingleNode("/Sprite/Source/FileName").InnerText, Is.EqualTo(_sprite.SourceFile.ToString()));
+            Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportColorDepth").InnerText, Is.EqualTo(_sprite.ImportColorDepth.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/OffsetX").InnerText, Is.EqualTo(_sprite.OffsetX.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/OffsetY").InnerText, Is.EqualTo(_sprite.OffsetY.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportHeight").InnerText, Is.EqualTo(_sprite.ImportHeight.ToString()));
@@ -279,8 +281,6 @@ namespace AGS.Types
             Assert.That(doc.SelectSingleNode("/Sprite/Source/RemapToGamePalette").InnerText, Is.EqualTo(_sprite.RemapToGamePalette.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/RemapToRoomPalette").InnerText, Is.EqualTo(_sprite.RemapToRoomPalette.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportMethod").InnerText, Is.EqualTo(_sprite.TransparentColour.ToString()));
-            Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportAlphaChannel").InnerText, Is.EqualTo(_sprite.ImportAlphaChannel.ToString()));
-            Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportColorDepth").InnerText, Is.EqualTo(_sprite.ImportColorDepth.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/SpriteTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/SpriteTests.cs
@@ -75,6 +75,14 @@ namespace AGS.Types
             Assert.That(_sprite.SourceFile, Is.EqualTo(sourceFile));
         }
 
+        [TestCase(SpriteImportColorDepth.GameDefault)]
+        [TestCase(SpriteImportColorDepth.Indexed8Bit)]
+        public void GetsAndSetsImportColorDepth(SpriteImportColorDepth importColorDepth)
+        {
+            _sprite.ImportColorDepth = importColorDepth;
+            Assert.That(_sprite.ImportColorDepth, Is.EqualTo(importColorDepth));
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void GetsAndSetsImportAlphaChannel(bool importAlphaChannel)
@@ -229,7 +237,7 @@ namespace AGS.Types
         [TestCase(1, 25, 75, 8, false, 1, "sprite1.bmp", 1, 1, 1, 1, false, 1, false, false, SpriteImportTransparency.BottomLeft, false)]
         [TestCase(2, 75, 25, 32, true, 2, "sprite2.bmp", 2, 2, 1, 1, true, 2, true, true, SpriteImportTransparency.BottomRight, true)]
         public void SerializesToXml(int slot, int width, int height, int colorDepth, bool alphaChannel,
-            int colorsLockedToRoom, string filename, int offsetX, int offsetY, int importHeight,
+            int colorsLockedToRoom, string filename, int offsetX, int offsetY, SpriteImportColorDepth importColorDepth, int importHeight,
             int importWidth, bool importAsTile, int frame, bool remapToGamePalette, bool remapToRoomPalette,
             SpriteImportTransparency importMethod, bool importAlphaChannel)
         {
@@ -250,6 +258,7 @@ namespace AGS.Types
             _sprite.RemapToRoomPalette = remapToRoomPalette;
             _sprite.TransparentColour = importMethod;
             _sprite.ImportAlphaChannel = importAlphaChannel;
+            _sprite.ImportColorDepth = importColorDepth;
             XmlDocument doc = _sprite.ToXmlDocument();
 
             Assert.That(doc.SelectSingleNode("/Sprite").Attributes["Slot"].InnerText, Is.EqualTo(_sprite.Number.ToString()));
@@ -271,6 +280,7 @@ namespace AGS.Types
             Assert.That(doc.SelectSingleNode("/Sprite/Source/RemapToRoomPalette").InnerText, Is.EqualTo(_sprite.RemapToRoomPalette.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportMethod").InnerText, Is.EqualTo(_sprite.TransparentColour.ToString()));
             Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportAlphaChannel").InnerText, Is.EqualTo(_sprite.ImportAlphaChannel.ToString()));
+            Assert.That(doc.SelectSingleNode("/Sprite/Source/ImportColorDepth").InnerText, Is.EqualTo(_sprite.ImportColorDepth.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -112,9 +112,10 @@ namespace AGS.Editor
          * 4.00.00.00     - Raised for org purposes without project changes
          * 4.00.00.03     - Distinct Character and Object Enabled and Visible properties;
          *                - FaceDirectionRatio
+         * 4.00.00.07     - Sprite.ImportColorDepth
          *
         */
-        public const int    LATEST_XML_VERSION_INDEX = 4000003;
+        public const int    LATEST_XML_VERSION_INDEX = 4000007;
         /// <summary>
         /// XML version index on the release of AGS 4.0.0, this constant be used to determine
         /// if upgrade of Rooms/Sprites/etc. to new format have been performed.

--- a/Editor/AGS.Editor/AGSEditorController.cs
+++ b/Editor/AGS.Editor/AGSEditorController.cs
@@ -82,7 +82,7 @@ namespace AGS.Editor
                 throw new AGSEditorException("Unable to find sprite " + spriteNumber + " in any sprite folders");
             }
 
-            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newImage, (SpriteImportTransparency)((int)transparencyType), true, false, useAlphaChannel);
+            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newImage, transparencyType, true, false, useAlphaChannel);
             if (sprite.ColorDepth < 32)
             {
                 sprite.AlphaChannel = false;
@@ -93,7 +93,7 @@ namespace AGS.Editor
 
         Sprite IAGSEditor.CreateNewSprite(ISpriteFolder inFolder, Bitmap newImage, SpriteImportTransparency transparencyType, bool useAlphaChannel)
         {
-            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(newImage, (SpriteImportTransparency)((int)transparencyType), true, false, useAlphaChannel);
+            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(newImage, transparencyType, true, false, useAlphaChannel);
             if (newSprite.ColorDepth < 32)
             {
                 newSprite.AlphaChannel = false;

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -141,10 +141,10 @@ namespace AGS.Editor
 			}
         }
 
-        public Sprite CreateSpriteFromBitmap(Bitmap bmp, int dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        public Sprite CreateSpriteFromBitmap(Bitmap bmp, SpriteImportColorDepth dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
             int spriteSlot = _native.GetFreeSpriteSlot();
-            return _native.SetSpriteFromBitmap(spriteSlot, bmp, dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+            return _native.SetSpriteFromBitmap(spriteSlot, bmp, (int)dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
         }
 
         public Sprite CreateSpriteFromBitmap(Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
@@ -153,9 +153,9 @@ namespace AGS.Editor
             return _native.SetSpriteFromBitmap(spriteSlot, bmp, 0, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
         }
 
-        public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, int dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, SpriteImportColorDepth dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
-            _native.ReplaceSpriteWithBitmap(spr, bmp, dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+            _native.ReplaceSpriteWithBitmap(spr, bmp, (int)dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
         }
 
         public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -141,15 +141,26 @@ namespace AGS.Editor
 			}
         }
 
+        public Sprite CreateSpriteFromBitmap(Bitmap bmp, int dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        {
+            int spriteSlot = _native.GetFreeSpriteSlot();
+            return _native.SetSpriteFromBitmap(spriteSlot, bmp, dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+        }
+
         public Sprite CreateSpriteFromBitmap(Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
             int spriteSlot = _native.GetFreeSpriteSlot();
-            return _native.SetSpriteFromBitmap(spriteSlot, bmp, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+            return _native.SetSpriteFromBitmap(spriteSlot, bmp, 0, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+        }
+
+        public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, int dstColorDepth, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        {
+            _native.ReplaceSpriteWithBitmap(spr, bmp, dstColorDepth, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
         }
 
         public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
-            _native.ReplaceSpriteWithBitmap(spr, bmp, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+            _native.ReplaceSpriteWithBitmap(spr, bmp, 0, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
         }
 
         public bool CropSpriteEdges(IList<Sprite> sprites, bool symettric)

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.Designer.cs
@@ -31,11 +31,11 @@ namespace AGS.Editor
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SpriteImportWindow));
             this.groupImportOptions = new System.Windows.Forms.GroupBox();
-            this.chkUseAlphaChannel = new System.Windows.Forms.CheckBox();
             this.chkRoomBackground = new System.Windows.Forms.CheckBox();
             this.chkRemapCols = new System.Windows.Forms.CheckBox();
             this.groupTransColour = new System.Windows.Forms.GroupBox();
             this.panelBottomRight = new System.Windows.Forms.Panel();
+            this.panelTopRight = new System.Windows.Forms.Panel();
             this.panelBottomLeft = new System.Windows.Forms.Panel();
             this.panelIndex0 = new System.Windows.Forms.Panel();
             this.panelTopLeft = new System.Windows.Forms.Panel();
@@ -71,7 +71,7 @@ namespace AGS.Editor
             this.numOffsetY = new System.Windows.Forms.NumericUpDown();
             this.previewPanel = new AGS.Editor.BufferedPanel();
             this.btnImportAll = new System.Windows.Forms.Button();
-            this.panelTopRight = new System.Windows.Forms.Panel();
+            this.cmbImportColorDepth = new System.Windows.Forms.ComboBox();
             this.groupImportOptions.SuspendLayout();
             this.groupTransColour.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.zoomSlider)).BeginInit();
@@ -87,7 +87,7 @@ namespace AGS.Editor
             // 
             // groupImportOptions
             // 
-            this.groupImportOptions.Controls.Add(this.chkUseAlphaChannel);
+            this.groupImportOptions.Controls.Add(this.cmbImportColorDepth);
             this.groupImportOptions.Controls.Add(this.chkRoomBackground);
             this.groupImportOptions.Controls.Add(this.chkRemapCols);
             this.groupImportOptions.Location = new System.Drawing.Point(12, 12);
@@ -96,18 +96,6 @@ namespace AGS.Editor
             this.groupImportOptions.TabIndex = 3;
             this.groupImportOptions.TabStop = false;
             this.groupImportOptions.Text = "Import options";
-            // 
-            // chkUseAlphaChannel
-            // 
-            this.chkUseAlphaChannel.AutoSize = true;
-            this.chkUseAlphaChannel.Checked = true;
-            this.chkUseAlphaChannel.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUseAlphaChannel.Location = new System.Drawing.Point(6, 20);
-            this.chkUseAlphaChannel.Name = "chkUseAlphaChannel";
-            this.chkUseAlphaChannel.Size = new System.Drawing.Size(189, 17);
-            this.chkUseAlphaChannel.TabIndex = 3;
-            this.chkUseAlphaChannel.Text = "Import alpha channel (if available)";
-            this.chkUseAlphaChannel.UseVisualStyleBackColor = true;
             // 
             // chkRoomBackground
             // 
@@ -159,6 +147,14 @@ namespace AGS.Editor
             this.panelBottomRight.Name = "panelBottomRight";
             this.panelBottomRight.Size = new System.Drawing.Size(78, 17);
             this.panelBottomRight.TabIndex = 12;
+            // 
+            // panelTopRight
+            // 
+            this.panelTopRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelTopRight.Location = new System.Drawing.Point(136, 135);
+            this.panelTopRight.Name = "panelTopRight";
+            this.panelTopRight.Size = new System.Drawing.Size(78, 17);
+            this.panelTopRight.TabIndex = 11;
             // 
             // panelBottomLeft
             // 
@@ -258,6 +254,7 @@ namespace AGS.Editor
             // 
             // btnClose
             // 
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnClose.Location = new System.Drawing.Point(12, 569);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(70, 30);
@@ -315,7 +312,7 @@ namespace AGS.Editor
             this.zoomSlider.Maximum = 20;
             this.zoomSlider.Minimum = 1;
             this.zoomSlider.Name = "zoomSlider";
-            this.zoomSlider.Size = new System.Drawing.Size(567, 45);
+            this.zoomSlider.Size = new System.Drawing.Size(567, 42);
             this.zoomSlider.TabIndex = 2;
             this.zoomSlider.Value = 1;
             this.zoomSlider.Scroll += new System.EventHandler(this.zoomSlider_Scroll);
@@ -573,20 +570,21 @@ namespace AGS.Editor
             this.btnImportAll.UseVisualStyleBackColor = true;
             this.btnImportAll.Click += new System.EventHandler(this.btnImportAll_Click);
             // 
-            // panelTopRight
+            // cmbImportColorDepth
             // 
-            this.panelTopRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelTopRight.Location = new System.Drawing.Point(136, 135);
-            this.panelTopRight.Name = "panelTopRight";
-            this.panelTopRight.Size = new System.Drawing.Size(78, 17);
-            this.panelTopRight.TabIndex = 11;
+            this.cmbImportColorDepth.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbImportColorDepth.FormattingEnabled = true;
+            this.cmbImportColorDepth.Location = new System.Drawing.Point(5, 17);
+            this.cmbImportColorDepth.Name = "cmbImportColorDepth";
+            this.cmbImportColorDepth.Size = new System.Drawing.Size(210, 21);
+            this.cmbImportColorDepth.TabIndex = 6;
             // 
             // SpriteImportWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnClose;
-            this.ClientSize = new System.Drawing.Size(824, 611);
+            this.ClientSize = new System.Drawing.Size(832, 618);
             this.Controls.Add(this.lblZoom);
             this.Controls.Add(this.zoomSlider);
             this.Controls.Add(this.btnImportAll);
@@ -637,7 +635,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Button btnImport;
         private System.Windows.Forms.Button btnClose;
         private System.Windows.Forms.ComboBox cmbFilenames;
-        private System.Windows.Forms.CheckBox chkUseAlphaChannel;
         private System.Windows.Forms.GroupBox groupTransColour;
         private System.Windows.Forms.RadioButton radTransColourNone;
         private System.Windows.Forms.RadioButton radTransColourLeaveAsIs;
@@ -668,5 +665,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblY;
         private System.Windows.Forms.Button btnImportAll;
         private System.Windows.Forms.Panel panelTopRight;
+        private System.Windows.Forms.ComboBox cmbImportColorDepth;
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -404,8 +404,8 @@ namespace AGS.Editor
 
             try
             {
-                SpriteTools.ReplaceSprite(replace, image, UseAlphaChannel, RemapToGamePalette,
-                    UseBackgroundSlots, SpriteImportMethod, filename, 0, spritesheet);
+                SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                    UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
             }
             catch (AGSEditorException ex)
             {
@@ -434,13 +434,13 @@ namespace AGS.Editor
                 if (frames == 1)
                 {
                     // in the interest of speed, import the existing bitmap if the file has a single frame
-                    SpriteTools.ImportNewSprites(folder, image, UseAlphaChannel, RemapToGamePalette,
-                        UseBackgroundSlots, SpriteImportMethod, filename, 0, spritesheet);
+                    SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                        UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
                 }
                 else
                 {
-                    SpriteTools.ImportNewSprites(folder, filename, UseAlphaChannel, RemapToGamePalette,
-                        UseBackgroundSlots, SpriteImportMethod, spritesheet);
+                    SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                        UseBackgroundSlots, SpriteImportMethod, filename), spritesheet);
                 }
             }
             catch (AGSEditorException ex)

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -38,12 +38,6 @@ namespace AGS.Editor
             set { chkRoomBackground.Checked = value; }
         }
 
-        public bool UseAlphaChannel
-        {
-            get { return chkUseAlphaChannel.Checked; }
-            set { chkUseAlphaChannel.Checked = value; }
-        }
-
         public bool TiledImport
         {
             get { return chkTiled.Checked; }
@@ -181,7 +175,6 @@ namespace AGS.Editor
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
-            UseAlphaChannel = replace.ImportAlphaChannel;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 
@@ -216,7 +209,6 @@ namespace AGS.Editor
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
-            UseAlphaChannel = replace.ImportAlphaChannel;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 
@@ -404,7 +396,7 @@ namespace AGS.Editor
 
             try
             {
-                SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(RemapToGamePalette,
                     UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
             }
             catch (AGSEditorException ex)
@@ -434,12 +426,12 @@ namespace AGS.Editor
                 if (frames == 1)
                 {
                     // in the interest of speed, import the existing bitmap if the file has a single frame
-                    SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                    SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(RemapToGamePalette,
                         UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
                 }
                 else
                 {
-                    SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
+                    SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(RemapToGamePalette,
                         UseBackgroundSlots, SpriteImportMethod, filename), spritesheet);
                 }
             }

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -26,6 +26,38 @@ namespace AGS.Editor
         // track whether anything was imported before the window was closed
         private bool hasImported = false;
 
+        private class ColorDepthItem
+        {
+            public string Text { get; set; }
+            public SpriteImportColorDepth Value { get; set; }
+            public ColorDepthItem(string text, SpriteImportColorDepth value)
+            {
+                Text = text;
+                Value = value;
+            }
+            public override string ToString()
+            {
+                return Text;
+            }
+        }
+
+        public SpriteImportColorDepth ImportColorDepth
+        {
+            get { return (cmbImportColorDepth.SelectedItem as ColorDepthItem).Value; }
+            set
+            {
+                for (int i = 0; i < cmbImportColorDepth.Items.Count; ++i)
+                {
+                    if ((cmbImportColorDepth.Items[i] as ColorDepthItem).Value == value)
+                    {
+                        cmbImportColorDepth.SelectedIndex = i;
+                        return;
+                    }
+                }
+                cmbImportColorDepth.SelectedIndex = -1;
+            }
+        }
+
         public bool RemapToGamePalette
         {
             get { return chkRemapCols.Checked; }
@@ -124,6 +156,7 @@ namespace AGS.Editor
         public SpriteImportWindow(string[] filenames, SpriteFolder folder)
         {
             InitializeComponent();
+            InitControls(); // extra init
 
             // take some defaults from Editor preferences
             SpriteImportMethod = (SpriteImportTransparency)Factory.AGSEditor.Settings.SpriteImportMethod;
@@ -151,6 +184,7 @@ namespace AGS.Editor
         public SpriteImportWindow(Bitmap bmp, SpriteFolder folder)
         {
             InitializeComponent();
+            InitControls(); // extra init
 
             // take some defaults from Editor preferences
             SpriteImportMethod = (SpriteImportTransparency)Factory.AGSEditor.Settings.SpriteImportMethod;
@@ -170,11 +204,13 @@ namespace AGS.Editor
         public SpriteImportWindow(string[] filenames, Sprite replace)
         {
             InitializeComponent();
+            InitControls(); // extra init
 
             // set defaults from the old sprite
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
+            ImportColorDepth = replace.ImportColorDepth;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 
@@ -204,11 +240,13 @@ namespace AGS.Editor
         public SpriteImportWindow(Bitmap bmp, Sprite replace)
         {
             InitializeComponent();
+            InitControls(); // extra init
 
             // set defaults from the old sprite
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
+            ImportColorDepth = replace.ImportColorDepth;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 
@@ -224,9 +262,21 @@ namespace AGS.Editor
             PostImageLoad();
         }
 
+        private void InitControls()
+        {
+            cmbImportColorDepth.Items.Add(new ColorDepthItem("In Game Color Depth", SpriteImportColorDepth.GameDefault));
+            cmbImportColorDepth.Items.Add(new ColorDepthItem("As 8-bit image", SpriteImportColorDepth.Indexed8Bit));
+        }
+
         private void OneTimeControlSetup()
         {
             bool gameUsesIndexedPalette = Factory.AGSEditor.CurrentGame.Settings.ColorDepth == AGS.Types.GameColorDepth.Palette;
+
+            // if import color depth was not selected, take the default option
+            if (cmbImportColorDepth.SelectedIndex == -1)
+            {
+                cmbImportColorDepth.SelectedIndex = 0;
+            }
 
             // if import method is for index 0 and this is not an indexed palette
             if (this.SpriteImportMethod == SpriteImportTransparency.PaletteIndex0 && !gameUsesIndexedPalette)
@@ -396,7 +446,7 @@ namespace AGS.Editor
 
             try
             {
-                SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(RemapToGamePalette,
+                SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(ImportColorDepth, RemapToGamePalette,
                     UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
             }
             catch (AGSEditorException ex)
@@ -426,12 +476,12 @@ namespace AGS.Editor
                 if (frames == 1)
                 {
                     // in the interest of speed, import the existing bitmap if the file has a single frame
-                    SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(RemapToGamePalette,
+                    SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(ImportColorDepth, RemapToGamePalette,
                         UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
                 }
                 else
                 {
-                    SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(RemapToGamePalette,
+                    SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(ImportColorDepth, RemapToGamePalette,
                         UseBackgroundSlots, SpriteImportMethod, filename), spritesheet);
                 }
             }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -913,7 +913,7 @@ namespace AGS.Editor
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)
-                    SpriteTools.ReplaceSprite(spr, spr.SourceFile, spr.Frame, spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spritesheet);
+                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
                 }
                 catch (Exception ex)
                 {

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -913,7 +913,7 @@ namespace AGS.Editor
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)
-                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
+                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
                 }
                 catch (Exception ex)
                 {

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -913,7 +913,8 @@ namespace AGS.Editor
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)
-                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
+                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.ImportColorDepth, spr.RemapToGamePalette,
+                        spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
                 }
                 catch (Exception ex)
                 {
@@ -1001,7 +1002,7 @@ namespace AGS.Editor
                 }
                 else
                 {
-                    Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newBmp, sprite.TransparentColour,
+                    Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newBmp, sprite.ImportColorDepth, sprite.TransparentColour,
                         sprite.RemapToGamePalette, sprite.RemapToRoomPalette, sprite.AlphaChannel);
                     RefreshSpriteDisplay();
                 }

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -81,6 +81,18 @@ namespace AGS.Editor
 
         /// <summary>
         /// Loads an image, checks if it is a PNG containing palette transparency, and if so, ensures it loads correctly.
+        /// </summary>
+        /// <param name="stream">Stream to load the image from</param>
+        /// <returns>The loaded image</returns>
+        public static Bitmap LoadBitmap(Stream stream)
+        {
+            Byte[] data = new Byte[stream.Length];
+            stream.Read(data, 0, (int)stream.Length);
+            return LoadBitmap(data);
+        }
+
+        /// <summary>
+        /// Loads an image, checks if it is a PNG containing palette transparency, and if so, ensures it loads correctly.
         /// The theory can be found at http://www.libpng.org/pub/png/book/chapter08.html
         /// </summary>
         /// <param name="data">File data to load</param>
@@ -362,6 +374,15 @@ namespace AGS.Editor
         public static Bitmap LoadNonLockedBitmap(string path)
         {
             return BitmapTransparencyFixUp.LoadBitmap(path);
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Bitmap"/> from stream, strictly keeping image format.
+        /// Suitable for loading indexed PNGs with varied palette size.
+        /// <returns></returns>
+        public static Bitmap LoadBitmapKeepingFormat(Stream stream)
+        {
+            return BitmapTransparencyFixUp.LoadBitmap(stream);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -93,7 +93,7 @@ namespace AGS.Editor.Utils
 
             try
             {
-                loadedBmp = (Bitmap)Bitmap.FromStream(fileStream);
+                loadedBmp = BitmapExtensions.LoadBitmapKeepingFormat(fileStream);
             }
             catch
             {

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -14,6 +14,7 @@ namespace AGS.Editor.Utils
 {
     public struct SpriteImportOptions
     {
+        public SpriteImportColorDepth ImportColorDepth;
         public bool RemapColours;
         public bool UseRoomBackground;
         public SpriteImportTransparency Transparency;
@@ -22,9 +23,10 @@ namespace AGS.Editor.Utils
         public Rectangle Selection;
         public bool Tile;
 
-        public SpriteImportOptions(bool remapColours, bool useRoomBackground,
+        public SpriteImportOptions(SpriteImportColorDepth colorDepth, bool remapColours, bool useRoomBackground,
             SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
+            ImportColorDepth = colorDepth;
             RemapColours = remapColours;
             UseRoomBackground = useRoomBackground;
             Transparency = transparency;
@@ -37,17 +39,17 @@ namespace AGS.Editor.Utils
         /// <summary>
         /// Initializes only most basic options.
         /// </summary>
-        public SpriteImportOptions(bool remapColours, bool useRoomBackground, SpriteImportTransparency transparency)
-            : this(remapColours, useRoomBackground, transparency, "", 0, Rectangle.Empty, false)
+        public SpriteImportOptions(SpriteImportColorDepth colorDepth, bool remapColours, bool useRoomBackground, SpriteImportTransparency transparency)
+            : this(colorDepth, remapColours, useRoomBackground, transparency, "", 0, Rectangle.Empty, false)
         {
         }
 
         /// <summary>
         /// Initializes options with a filename and optional frame (for multi-frame image formats).
         /// </summary>
-        public SpriteImportOptions(bool remapColours, bool useRoomBackground,
+        public SpriteImportOptions(SpriteImportColorDepth colorDepth, bool remapColours, bool useRoomBackground,
             SpriteImportTransparency transparency, string filename, int frame = 0)
-            : this(remapColours, useRoomBackground, transparency, filename, frame, Rectangle.Empty, false)
+            : this(colorDepth, remapColours, useRoomBackground, transparency, filename, frame, Rectangle.Empty, false)
         {
         }
 
@@ -55,7 +57,7 @@ namespace AGS.Editor.Utils
         /// Initializes options by copying existing options and applying new filename and frame.
         /// </summary>
         public SpriteImportOptions(SpriteImportOptions baseOptions, string filename, int frame = 0)
-            : this(baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
+            : this(baseOptions.ImportColorDepth, baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
                   filename, frame, Rectangle.Empty, false)
         {
         }
@@ -64,7 +66,7 @@ namespace AGS.Editor.Utils
         /// Initializes options by copying existing options and applying new tile selection.
         /// </summary>
         public SpriteImportOptions(SpriteImportOptions baseOptions, Rectangle selection, bool tile)
-            : this(baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
+            : this(baseOptions.ImportColorDepth, baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
                   baseOptions.Filename, baseOptions.Frame, selection, tile)
         {
         }
@@ -317,6 +319,7 @@ namespace AGS.Editor.Utils
 
         private static void SetSpriteImportOptions(Sprite sprite, SpriteImportOptions options)
         {
+            sprite.ImportColorDepth = options.ImportColorDepth;
             sprite.TransparentColour = options.Transparency;
             sprite.RemapToGamePalette = options.RemapColours;
             sprite.RemapToRoomPalette = options.UseRoomBackground;
@@ -355,7 +358,7 @@ namespace AGS.Editor.Utils
             AdjustImportParams(bmp, options, out useAlphaChannel, out remapColours, out useRoomBackground);
 
             // do replacement
-            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
+            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp, options.ImportColorDepth, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
             // resave import options
             SetSpriteImportOptions(sprite, options);
         }
@@ -400,7 +403,7 @@ namespace AGS.Editor.Utils
             AdjustImportParams(bmp, options, out useAlphaChannel, out remapColours, out useRoomBackground);
 
             // do import
-            Sprite sprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
+            Sprite sprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, options.ImportColorDepth, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
             // save import options
             SetSpriteImportOptions(sprite, options);
             // add sprite to the project

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -64,7 +64,7 @@ extern void drawSprite(int hdc, int x,int y, int spriteNum, bool flipImage);
 extern void drawSpriteStretch(int hdc, int x,int y, int width, int height, int spriteNum, bool flipImage);
 extern void drawBlockOfColour(int hdc, int x,int y, int width, int height, int colNum);
 extern void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
-extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitmap^ bmp, int destColorDepth, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 extern int GetSpriteAsHBitmap(int spriteSlot);
 extern Bitmap^ getSpriteAsBitmap(int spriteNum);
 extern Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height);
@@ -437,9 +437,9 @@ namespace AGS
             return 0; // FIXME: not working after moved to open room format
         }
 
-		Sprite^ NativeMethods::SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+		Sprite^ NativeMethods::SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int destColorDepth, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
 		{
-            SetNewSpriteFromBitmap(spriteSlot, bmp, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
+            SetNewSpriteFromBitmap(spriteSlot, bmp, destColorDepth, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
       int colDepth = GetSpriteColorDepth(spriteSlot);
 			Sprite^ newSprite = gcnew Sprite(spriteSlot, bmp->Width, bmp->Height, colDepth, alphaChannel);
       int roomNumber = GetCurrentlyLoadedRoomNumber();
@@ -450,9 +450,9 @@ namespace AGS
       return newSprite;
 		}
 
-		void NativeMethods::ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+		void NativeMethods::ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int destColorDepth, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
 		{
-            SetNewSpriteFromBitmap(spr->Number, bmp, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
+            SetNewSpriteFromBitmap(spr->Number, bmp, destColorDepth, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
 			spr->ColorDepth = GetSpriteColorDepth(spr->Number);
 			spr->Width = bmp->Width;
 			spr->Height = bmp->Height;

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -57,8 +57,8 @@ namespace Native
 			int  DrawFont(int hDC, int x, int y, int width, int fontNum);
 			void DrawBlockOfColour(int hDC, int x, int y, int width, int height, int colourNum);
 			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
-			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
-			void ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int destColorDepth, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+			void ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int destColorDepth, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 			Bitmap^ GetBitmapForSprite(int spriteSlot, int width, int height);
       Bitmap^ GetBitmapForSpritePreserveColDepth(int spriteSlot);
 			void DeleteSprite(int spriteSlot);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1878,17 +1878,24 @@ Common::Bitmap *CreateNativeBitmap(System::Drawing::Bitmap^ bmp, int destColorDe
             sort_out_palette(tempsprite, imgPalBuf, useRoomBackgroundColours, transcol);
     }
 
-    int flags = 0;
+    int flags = 0;// assign sprite flags as necessary
+
     if (alphaChannel)
     {
+        // For compatibility with the internal AGS bitmap format:
+        // change pixels with alpha 0 to MASK_COLOR_X
         if (tempsprite->GetColorDepth() == 32)
-        { // change pixels with alpha 0 to MASK_COLOR_32
+        {
             BitmapHelper::ReplaceAlphaWithRGBMask(tempsprite);
         }
     }
-    else if (tempsprite->GetColorDepth() == 32)
-    { // ensure that every pixel has full alpha (0xFF)
-        BitmapHelper::MakeOpaqueSkipMask(tempsprite);
+    else
+    {
+        // Ensure that every pixel has full alpha (0xFF)
+        if (tempsprite->GetColorDepth() == 32)
+        {
+            BitmapHelper::MakeOpaqueSkipMask(tempsprite);
+        }
     }
 
     if (out_flags)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1637,6 +1637,95 @@ void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<i
     doDrawViewLoop(hdc, frames, x, y, size, selected);
 }
 
+// Forces transparency color to the palette index 0
+// This must be done, because AGS (or rather Allegro 4) hardcodes transparent color index as 0.
+static void NormalizePaletteTransparency(AGSBitmap *dst, cli::array<System::Drawing::Color> ^bmpPalette)
+{
+    // Determine actual transparency index in the palette
+    int transparency_index = -1;
+    for (int i = 0; i < bmpPalette->Length; ++i)
+    {
+        if (bmpPalette[i].A == 0)
+        {
+            transparency_index = i;
+            break; // to avoid blank palette entries
+        }
+    }
+
+    // Find out if the transparency index is actually used in the image:
+    // some BMPs seem to fill unused palette entries with zeroed ARGB.
+    if (transparency_index > 0)
+    {
+        const uint8_t *px_ptr = dst->GetDataForWriting();
+        const uint8_t *px_end = px_ptr + dst->GetDataSize();
+        bool found_transparency_index = false;
+        for (; px_ptr != px_end; ++px_ptr)
+        {
+            if (*px_ptr == static_cast<uint8_t>(transparency_index))
+            {
+                found_transparency_index = true;
+                break;
+            }
+        }
+        if (!found_transparency_index)
+            transparency_index = -1; // reset and ignore
+    }
+    
+    // Swap found transparent color index with index 0
+    if (transparency_index > 0)
+    {
+        System::Drawing::Color toswap = bmpPalette[0];
+        bmpPalette[0] = bmpPalette[transparency_index];
+        bmpPalette[transparency_index] = toswap;
+
+        uint8_t *px_ptr = dst->GetDataForWriting();
+        uint8_t *px_end = px_ptr + dst->GetDataSize();
+        for (; px_ptr != px_end; ++px_ptr)
+        {
+            if (*px_ptr == 0)
+                *px_ptr = static_cast<uint8_t>(transparency_index);
+            else if (*px_ptr == static_cast<uint8_t>(transparency_index))
+                *px_ptr = 0;
+        }
+    }
+}
+
+// Converts imported image's palette to the native AGS format
+static void ConvertPaletteToNativeFormat(AGSBitmap *dst, RGB *imgpal, cli::array<System::Drawing::Color> ^bmpPalette,
+    bool normalizeTrans)
+{
+    if (normalizeTrans)
+    {
+        NormalizePaletteTransparency(dst, bmpPalette);
+    }
+    
+    // Copy palette, fixing colors if necessary
+    for (int i = 0; i < 256; i++)
+    {
+        if (i >= bmpPalette->Length)
+        {
+            // BMP files can have an arbitrary palette size, fill any
+            // missing colours with black
+            imgpal[i].r = 0;
+            imgpal[i].g = 0;
+            imgpal[i].b = 0;
+        }
+        else if (thisgame.color_depth == 1)
+        {
+            // allegro palette is 0-63
+            imgpal[i].r = bmpPalette[i].R / 4;
+            imgpal[i].g = bmpPalette[i].G / 4;
+            imgpal[i].b = bmpPalette[i].B / 4;
+        }
+        else
+        {
+            imgpal[i].r = bmpPalette[i].R;
+            imgpal[i].g = bmpPalette[i].G;
+            imgpal[i].b = bmpPalette[i].B;
+        }
+    }
+}
+
 Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, int *srcPalLen,
     bool fixColourDepth, int destColorDepth, bool keepTransparency, int *originalColDepth)
 {
@@ -1697,57 +1786,7 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
 
 	if (src_depth <= 8)
 	{
-		cli::array<System::Drawing::Color> ^bmpPalette = bmp->Palette->Entries;
-    
-    // determine actual transparency index, in case of GIF or other formats that can mark a specific palette entry
-    int transparency_index = 0;
-    for (int i = 0; i < bmpPalette->Length; ++i) {
-      if (bmpPalette[i].A == 0) {
-        transparency_index = i;
-        System::Drawing::Color toswap = bmpPalette[0];
-        bmpPalette[0] = bmpPalette[i];
-        bmpPalette[i] = toswap;
-        break; // to avoid blank palette entries
-      }
-    }
-    
-    // normalize tranparency to palette entry zero
-    if (transparency_index != 0)
-    {
-      for (int tt = 0; tt<tempsprite->GetWidth(); tt++) {
-        for (int uu = 0; uu<tempsprite->GetHeight(); uu++) {
-          const int pixel = tempsprite->GetPixel(tt, uu);
-          if (pixel == 0)
-            tempsprite->PutPixel(tt, uu, transparency_index);
-          else if (pixel == transparency_index)
-            tempsprite->PutPixel(tt, uu, 0);
-        }
-      }
-    }
-    
-		for (int i = 0; i < 256; i++) {
-      if (i >= bmpPalette->Length)
-      {
-        // BMP files can have an arbitrary palette size, fill any
-        // missing colours with black
-			  imgpal[i].r = 0;
-			  imgpal[i].g = 0;
-			  imgpal[i].b = 0;
-      }
-      else if (thisgame.color_depth == 1)
-      {
-        // allegro palette is 0-63
-        imgpal[i].r = bmpPalette[i].R / 4;
-        imgpal[i].g = bmpPalette[i].G / 4;
-        imgpal[i].b = bmpPalette[i].B / 4;
-      }
-      else
-      {
-			  imgpal[i].r = bmpPalette[i].R;
-			  imgpal[i].g = bmpPalette[i].G;
-			  imgpal[i].b = bmpPalette[i].B;
-      }
-		}
+        ConvertPaletteToNativeFormat(tempsprite, imgpal, bmp->Palette->Entries, true);
 	}
 
     // Test if destination bitmap will be not suitable for the game's color depth

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\BlendMode.cs" />
     <Compile Include="Enums\InputMotionMode.cs" />
+    <Compile Include="Enums\SpriteImportColorDepth.cs" />
     <Compile Include="Enums\TargetDropZone.cs" />
     <Compile Include="Enums\TouchToMouseEmulationType.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />

--- a/Editor/AGS.Types/Enums/SpriteImportColorDepth.cs
+++ b/Editor/AGS.Types/Enums/SpriteImportColorDepth.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public enum SpriteImportColorDepth
+    {
+        [Description("Convert to the game's color depth")]
+        GameDefault = 0,
+        [Description("Import as a 8-bit image")]
+        Indexed8Bit = 8
+    }
+}

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -24,6 +24,7 @@ namespace AGS.Types
         private int _offsetY;
         private int _importWidth;
         private int _importHeight;
+        private SpriteImportColorDepth _importColorDepth = SpriteImportColorDepth.GameDefault;
         private bool _remapToGamePalette;
         private bool _remapToRoomPalette;
         private bool _importAsTile;
@@ -107,6 +108,14 @@ namespace AGS.Types
 			get { return _sourceFile; }
 			set { _sourceFile = value; }
 		}
+
+        [Description("Import converting to this color depth")]
+        [Category("Import")]
+        public SpriteImportColorDepth ImportColorDepth
+        {
+            get { return _importColorDepth; }
+            set { _importColorDepth = value; }
+        }
 
         [Obsolete]
         [Browsable(false)]
@@ -262,6 +271,16 @@ namespace AGS.Types
                 {
                     _importAsTile = false;
                 }
+
+                // added in XML version 4.00.00.07
+                try
+                {
+                    _importColorDepth = (SpriteImportColorDepth)Enum.Parse(typeof(SpriteImportColorDepth), SerializeUtils.GetElementString(sourceNode, "ImportColorDepth"));
+                }
+                catch (InvalidDataException)
+                {
+                    _importColorDepth = SpriteImportColorDepth.GameDefault;
+                }
             }
         }
 
@@ -286,6 +305,7 @@ namespace AGS.Types
             writer.WriteElementString("OffsetY", _offsetY.ToString());
             writer.WriteElementString("ImportHeight", _importHeight.ToString());
             writer.WriteElementString("ImportWidth", _importWidth.ToString());
+            writer.WriteElementString("ImportColorDepth", _importColorDepth.ToString());
             writer.WriteElementString("ImportAsTile", _importAsTile.ToString());
             writer.WriteElementString("Frame", _frame.ToString());
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -26,7 +26,6 @@ namespace AGS.Types
         private int _importHeight;
         private bool _remapToGamePalette;
         private bool _remapToRoomPalette;
-        private bool _importAlphaChannel;
         private bool _importAsTile;
 
         public Sprite(int number, int width, int height, int colorDepth, bool alphaChannel)
@@ -109,12 +108,11 @@ namespace AGS.Types
 			set { _sourceFile = value; }
 		}
 
-        [Description("Import the alpha channel (if one is available)")]
-        [Category("Import")]
+        [Obsolete]
+        [Browsable(false)]
         public bool ImportAlphaChannel
         {
-            get { return _importAlphaChannel; }
-            set { _importAlphaChannel = value; }
+            get; set;
         }
 
 		[Browsable(false)]
@@ -243,16 +241,6 @@ namespace AGS.Types
                     // pass
                 }
 
-                // added with fixup task in XML version 20
-                try
-                {
-                    _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
-                }
-                catch (InvalidDataException)
-                {
-                    _importAlphaChannel = true;
-                }
-
                 // added with fixup task in XML Version 23
                 try
                 {
@@ -303,7 +291,6 @@ namespace AGS.Types
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());
             writer.WriteElementString("RemapToRoomPalette", _remapToRoomPalette.ToString());
             writer.WriteElementString("ImportMethod", _tranparentColour.ToString());
-            writer.WriteElementString("ImportAlphaChannel", _importAlphaChannel.ToString());
             writer.WriteEndElement(); // end source
 
             writer.WriteEndElement();

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -32,6 +32,8 @@ namespace AGS
 namespace Engine
 {
 
+using AGS::Common::GraphicResolution;
+
 // A base parent for the otherwise opaque texture object;
 // Texture refers to the pixel data itself, with no additional
 // properties. It may be shared between multiple sprites if necessary.

--- a/Engine/gfx/gfxdefines.h
+++ b/Engine/gfx/gfxdefines.h
@@ -15,29 +15,12 @@
 #define __AGS_EE_GFX__GFXDEFINES_H
 
 #include "core/types.h"
-#include "util/geometry.h"
+#include "gfx/gfx_def.h"
 
 namespace AGS
 {
 namespace Engine
 {
-
-// GraphicResolution struct determines image size and color depth
-struct GraphicResolution : Size
-{
-    int32_t ColorDepth; // color depth in bits per pixel
-
-    GraphicResolution()
-        : ColorDepth(0) {}
-
-    GraphicResolution(int32_t width, int32_t height, int32_t color_depth)
-        : Size(width, height), ColorDepth(color_depth) {}
-
-    GraphicResolution(Size size, int32_t color_depth)
-        : Size(size), ColorDepth(color_depth) {}
-
-    inline bool IsValid() const { return Width > 0 && Height > 0 && ColorDepth > 0; }
-};
 
 enum WindowMode
 {
@@ -47,7 +30,7 @@ enum WindowMode
 };
 
 // DisplayMode struct provides extended description of display mode
-struct DisplayMode : public GraphicResolution
+struct DisplayMode : public AGS::Common::GraphicResolution
 {
     int32_t RefreshRate = 0;
     bool    Vsync = false;

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -23,7 +23,7 @@
 #include "util/string.h"
 
 using AGS::Common::String;
-using AGS::Engine::GraphicResolution;
+using AGS::Common::GraphicResolution;
 using AGS::Engine::DisplayMode;
 using AGS::Engine::WindowMode;
 


### PR DESCRIPTION
This complements #2455.

Adds a combobox to the "Import Sprite" window that lets select whether to import the sprite, converting to game's default color depth (default choice), or import as a 8-bit image. This list may potentially be expanded, if necessary.
![spriteimport--importdepth2](https://github.com/adventuregamestudio/ags/assets/1833754/9201a080-10fd-410b-a661-00f80fe47b86)


The choices are currently named:
* "In Game Color Depth"
* "As 8-bit image"

At first I wanted the second option to be displayed only if the imported image is of indexed pixel format, but this may be complicated to do, as multiple different files may be selected at once.

Removed "Import alpha channel" option, as redundant.

Other things...
Sprite index file now stores additional array of bytes, defining sprite's color depth. This is to let know the sprite's color depth without loading it up.

---

**NOTE:** for testing 8-bit sprites as walkable masks following settings must be used:
* "As 8-bit image"
* Remap to game palette = FALSE
* Transparency = Leave As Is (otherwise color 0 is fixed to color 16 !!)