### PR TITLE
[ags4] Adjust Audio Clips imports to use handles

### DIFF
--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -780,7 +780,7 @@ namespace AGS.Editor
         {
             foreach (AudioClip clip in clips.AllItemsFlat)
             {
-                sb.AppendLine("import AudioClip " + clip.ScriptName + ";");
+                sb.AppendLine("import AudioClip *" + clip.ScriptName + ";");
             }
         }
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -97,6 +97,7 @@ std::vector<int> StaticWalkareaArray;
 std::vector<int> StaticWalkbehindArray;
 std::vector<int> StaticInventoryArray;
 std::vector<int> StaticDialogArray;
+std::vector<int> StaticAudioClipArray;
 
 
 namespace AGS
@@ -135,14 +136,16 @@ void InitAndRegisterAudioObjects(GameSetupStruct &game)
         ccRegisterPersistentObject(&scrAudioChannel[i], &ccDynamicAudio); // add internal ref
     }
 
+    StaticAudioClipArray.resize(game.audioClips.size());
     for (size_t i = 0; i < game.audioClips.size(); ++i)
     {
         // Note that as of 3.5.0 data format the clip IDs are still restricted
         // to actual item index in array, so we don't make any difference
         // between game versions, for now.
         game.audioClips[i].id = i;
-        ccRegisterPersistentObject(&game.audioClips[i], &ccDynamicAudioClip); // add internal ref
-        ccAddExternalScriptObject(game.audioClips[i].scriptName, &game.audioClips[i], &ccDynamicAudioClip);
+        int handle = ccRegisterPersistentObject(&game.audioClips[i], &ccDynamicAudioClip); // add internal ref
+        StaticAudioClipArray[i] = handle;
+        ccAddExternalScriptObject(game.audioClips[i].scriptName, &StaticAudioClipArray[i], &GlobalStaticManager);
     }
 }
 


### PR DESCRIPTION
Continuing from https://github.com/adventuregamestudio/ags/pull/2453#issuecomment-2203865445

I am leaving as a draft for now because I am trying to figure if something has to change in `Game.AudioClips[i]` script interface

https://github.com/adventuregamestudio/ags/blob/4d5d29e87e4f00aa800dd18a66e2219cf92f84b8/Engine/ac/game.cpp#L778-L783

and

https://github.com/adventuregamestudio/ags/blob/4d5d29e87e4f00aa800dd18a66e2219cf92f84b8/Editor/AGS.Editor/Resources/agsdefns.sh#L2473

The reason I ask is because I noticed it returns a pointer to `ScriptAudioClip` and wasn't sure if it would be the same.

