### PR TITLE
Editor: add support for sub items in file menu and move global messages upgrade actions to submenu

### DIFF
--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -63,13 +63,12 @@ namespace AGS.Editor.Components
             _guiController.AddMenuItems(this, commands);
 
             commands = new MenuCommands(GUIController.FILE_MENU_ID, 110);
-            MenuCommand subMenu = new MenuCommand(string.Empty, "Global Messages");
-            subMenu.SubCommands = new List<MenuCommand>
+            var subCommands = new List<MenuCommand>
             {
                 new MenuCommand(EXPORT_GLOBAL_MESSAGES_TO_SCRIPT_COMMAND, "Export Global Messages to script"),
                 new MenuCommand(REMOVE_GLOBAL_MESSAGES_COMMAND, "Remove Global Messages")
             };
-            commands.Commands.Add(subMenu);
+            commands.Commands.Add(new MenuCommand("Global Messages", subCommands));
             _guiController.AddMenuItems(this, commands);
 
             commands = new MenuCommands(GUIController.FILE_MENU_ID, 800);

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -59,11 +59,17 @@ namespace AGS.Editor.Components
 			commands.Commands.Add(new MenuCommand(MAKE_TEMPLATE_COMMAND, "&Make template from this game...", "MenuIconMakeTemplate"));
             commands.Commands.Add(new MenuCommand(AUTO_NUMBER_SPEECH_COMMAND, "&Auto-number speech lines...", "MenuIconAutoNumber"));
 			commands.Commands.Add(new MenuCommand(CREATE_VOICE_ACTING_SCRIPT_COMMAND, "Create &voice acting script...", "MenuIconVoiceActingScript"));
-            // TODO: I do not see any way to schedule sub-menus in this system!?
-            // but if it's supported, maybe put these 2 global messages commands int a submenu
-            commands.Commands.Add(new MenuCommand(EXPORT_GLOBAL_MESSAGES_TO_SCRIPT_COMMAND, "Export Global Messages to script"));
-            commands.Commands.Add(new MenuCommand(REMOVE_GLOBAL_MESSAGES_COMMAND, "Remove Global Messages"));
             commands.Commands.Add(new MenuCommand(RECREATE_SPRITEFILE_COMMAND, "Restore all sprites from sources"));
+            _guiController.AddMenuItems(this, commands);
+
+            commands = new MenuCommands(GUIController.FILE_MENU_ID, 110);
+            MenuCommand subMenu = new MenuCommand(string.Empty, "Global Messages");
+            subMenu.SubCommands = new List<MenuCommand>
+            {
+                new MenuCommand(EXPORT_GLOBAL_MESSAGES_TO_SCRIPT_COMMAND, "Export Global Messages to script"),
+                new MenuCommand(REMOVE_GLOBAL_MESSAGES_COMMAND, "Remove Global Messages")
+            };
+            commands.Commands.Add(subMenu);
             _guiController.AddMenuItems(this, commands);
 
             commands = new MenuCommands(GUIController.FILE_MENU_ID, 800);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -261,6 +261,16 @@ namespace AGS.Editor
                     {
                         RegisterMenuCommand(command.ID, plugin);
                     }
+
+                    if(command.SubCommands != null && command.SubCommands.Count > 0)
+                    {
+                        foreach (MenuCommand scommand in command.SubCommands)
+                        {
+                            RegisterMenuCommand(scommand.ID, plugin);
+                            scommand.IDPrefix = plugin.ComponentID + CONTROL_ID_SPLIT;
+                        }
+                    }
+
                     command.IDPrefix = plugin.ComponentID + CONTROL_ID_SPLIT;
                 }
 				_menuManager.AddMenuCommandGroup(commands);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -251,29 +251,30 @@ namespace AGS.Editor
 			_menuManager.AddMenu(id, title, insertAfterMenu);
 		}
 
-		public void AddMenuItems(IEditorComponent plugin, MenuCommands commands)
+        private void RegisterMenuItems(IEditorComponent plugin, IList<MenuCommand> commands)
+        {
+            foreach (MenuCommand command in commands)
+            {
+                if (command.ID != null)
+                {
+                    RegisterMenuCommand(command.ID, plugin);
+                }
+
+                command.IDPrefix = plugin.ComponentID + CONTROL_ID_SPLIT;
+
+                if (command.SubCommands != null && command.SubCommands.Count > 0)
+                {
+                    RegisterMenuItems(plugin, command.SubCommands);
+                }
+            }
+        }
+
+        public void AddMenuItems(IEditorComponent plugin, MenuCommands commands)
         {
             if (commands.Commands.Count > 0)
             {
-                foreach (MenuCommand command in commands.Commands)
-                {
-                    if (command.ID != null)
-                    {
-                        RegisterMenuCommand(command.ID, plugin);
-                    }
-
-                    if(command.SubCommands != null && command.SubCommands.Count > 0)
-                    {
-                        foreach (MenuCommand scommand in command.SubCommands)
-                        {
-                            RegisterMenuCommand(scommand.ID, plugin);
-                            scommand.IDPrefix = plugin.ComponentID + CONTROL_ID_SPLIT;
-                        }
-                    }
-
-                    command.IDPrefix = plugin.ComponentID + CONTROL_ID_SPLIT;
-                }
-				_menuManager.AddMenuCommandGroup(commands);
+                RegisterMenuItems(plugin, commands.Commands);
+                _menuManager.AddMenuCommandGroup(commands);
             }
         }
 

--- a/Editor/AGS.Editor/GUI/MainMenuManager.cs
+++ b/Editor/AGS.Editor/GUI/MainMenuManager.cs
@@ -36,8 +36,14 @@ namespace AGS.Editor
 			AddOrInsertMenu(newMenu, insertAfterMenuID);
 		}
 
-        private ToolStripItem AddMenuItem(string menu, string id, string name, Keys shortcutKeys, string iconKey, bool enabled)
+        private ToolStripItem AddMenuItem(string menu, MenuCommand command)
         {
+            string id = command.ID;
+            string name = command.Name;
+            Keys shortcutKeys = command.ShortcutKey;
+            string iconKey = command.IconKey;
+            bool enabled = command.Enabled;
+
             ToolStripItem[] results = _mainMenu.Items.Find(menu, false);
             if (results.Length == 0)
             {
@@ -49,6 +55,30 @@ namespace AGS.Editor
             if (name == MenuCommand.MENU_TEXT_SEPARATOR)
             {
                 newItem = new ToolStripSeparator();
+            }
+            else if (command.SubCommands != null && command.SubCommands.Count > 0)
+            {
+                ToolStripMenuItem subMenu = new ToolStripMenuItem(command.Name);
+                subMenu.Enabled = enabled;
+                foreach (var subCommand in command.SubCommands)
+                {
+                    string s_id = subCommand.ID;
+                    string s_name = subCommand.Name;
+                    Keys s_shortcutKeys = subCommand.ShortcutKey;
+                    string s_iconKey = subCommand.IconKey;
+                    bool s_enabled = subCommand.Enabled;
+
+                    ToolStripMenuItem s_newItem = new ToolStripMenuItem(s_name, null, _onClick, s_id);
+                    ((ToolStripMenuItem)s_newItem).ShortcutKeys = s_shortcutKeys;
+                    if (s_iconKey != null)
+                    {
+                        s_newItem.Image = Factory.GUIController.ImageList.Images[s_iconKey];
+                    }
+                    s_newItem.Enabled = s_enabled;
+
+                    subMenu.DropDownItems.Add(s_newItem);
+                }
+                newItem = subMenu;
             }
             else
             {
@@ -87,7 +117,7 @@ namespace AGS.Editor
 				}
 				foreach (MenuCommand command in commandGroup.Commands)
 				{
-					ToolStripItem newItem = AddMenuItem(menuName, command.ID, command.Name, command.ShortcutKey, command.IconKey, command.Enabled);
+					ToolStripItem newItem = AddMenuItem(menuName, command);
 					newItem.Tag = command;
 				}
 			}

--- a/Editor/AGS.Editor/GUI/MainMenuManager.cs
+++ b/Editor/AGS.Editor/GUI/MainMenuManager.cs
@@ -36,7 +36,7 @@ namespace AGS.Editor
 			AddOrInsertMenu(newMenu, insertAfterMenuID);
 		}
 
-        private ToolStripItem AddMenuItem(string menu, MenuCommand command)
+        private ToolStripItem AddMenuItem(MenuCommand command)
         {
             string id = command.ID;
             string name = command.Name;
@@ -44,12 +44,6 @@ namespace AGS.Editor
             string iconKey = command.IconKey;
             bool enabled = command.Enabled;
 
-            ToolStripItem[] results = _mainMenu.Items.Find(menu, false);
-            if (results.Length == 0)
-            {
-                throw new AGSEditorException("Menu " + menu + " not found");
-            }
-            ToolStripMenuItem topMenu = (ToolStripMenuItem)results[0];
             ToolStripItem newItem;
 
             if (name == MenuCommand.MENU_TEXT_SEPARATOR)
@@ -62,21 +56,7 @@ namespace AGS.Editor
                 subMenu.Enabled = enabled;
                 foreach (var subCommand in command.SubCommands)
                 {
-                    string s_id = subCommand.ID;
-                    string s_name = subCommand.Name;
-                    Keys s_shortcutKeys = subCommand.ShortcutKey;
-                    string s_iconKey = subCommand.IconKey;
-                    bool s_enabled = subCommand.Enabled;
-
-                    ToolStripMenuItem s_newItem = new ToolStripMenuItem(s_name, null, _onClick, s_id);
-                    ((ToolStripMenuItem)s_newItem).ShortcutKeys = s_shortcutKeys;
-                    if (s_iconKey != null)
-                    {
-                        s_newItem.Image = Factory.GUIController.ImageList.Images[s_iconKey];
-                    }
-                    s_newItem.Enabled = s_enabled;
-
-                    subMenu.DropDownItems.Add(s_newItem);
+                    subMenu.DropDownItems.Add(AddMenuItem(subCommand));
                 }
                 newItem = subMenu;
             }
@@ -88,10 +68,23 @@ namespace AGS.Editor
                 {
                     newItem.Image = Factory.GUIController.ImageList.Images[iconKey];
                 }
-				newItem.Enabled = enabled;
+                newItem.Enabled = enabled;
             }
+            return newItem;
+        }
+
+        private ToolStripItem AddTopMenuItem(string menu, MenuCommand command)
+        {
+            ToolStripItem[] results = _mainMenu.Items.Find(menu, false);
+            if (results.Length == 0)
+            {
+                throw new AGSEditorException("Menu " + menu + " not found");
+            }
+            ToolStripMenuItem topMenu = (ToolStripMenuItem)results[0];
+            ToolStripItem newItem = AddMenuItem(command);
+
             topMenu.DropDownItems.Add(newItem);
-			return newItem;
+            return newItem;
         }
 
 		private void RefreshMenu(string menuName)
@@ -117,7 +110,7 @@ namespace AGS.Editor
 				}
 				foreach (MenuCommand command in commandGroup.Commands)
 				{
-					ToolStripItem newItem = AddMenuItem(menuName, command);
+					ToolStripItem newItem = AddTopMenuItem(menuName, command);
 					newItem.Tag = command;
 				}
 			}

--- a/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
+++ b/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
@@ -49,6 +49,7 @@ namespace AGS.Types
 		private bool _checked;
 		private Keys _shortcutKey = Keys.None;
         private string _shortcutKeyDisplayString = string.Empty;
+		public List<MenuCommand> SubCommands { get; set; }
 
 		public bool IsSeparator
 		{

--- a/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
+++ b/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
@@ -14,6 +14,15 @@ namespace AGS.Types
 			get { return new MenuCommand(null, MenuCommand.MENU_TEXT_SEPARATOR); }
 		}
 
+		public MenuCommand(string itemName, List<MenuCommand> subCommands)
+		{
+			_id = null;
+			_name = itemName;
+			_iconKey = null;
+			_enabled = true;
+			_subCommands = subCommands;
+		}
+
 		public MenuCommand(string itemID, string itemName)
 		{
 			_id = itemID;
@@ -49,7 +58,7 @@ namespace AGS.Types
 		private bool _checked;
 		private Keys _shortcutKey = Keys.None;
         private string _shortcutKeyDisplayString = string.Empty;
-		public List<MenuCommand> SubCommands { get; set; }
+		private List<MenuCommand> _subCommands = null;
 
 		public bool IsSeparator
 		{
@@ -102,6 +111,10 @@ namespace AGS.Types
 		{
 			get { return _checked; }
 			set { _checked = value; }
+		}
+
+		public List<MenuCommand> SubCommands {
+			get { return _subCommands; }
 		}
 	}
 }


### PR DESCRIPTION
This is the minimal amount of code I could think that give support to submenus. The other approach would be to make the property read-only and then make so you can only pass such list in Constructor - which would make it more similar to the other properties.

I noticed the following todo:

```
// TODO: I do not see any way to schedule sub-menus in this system!?
// but if it's supported, maybe put these 2 global messages commands int a submenu
```

Decided to try to fix it. Not sure on the name of the group as "Global Messages upgrade".

![image](https://github.com/adventuregamestudio/ags/assets/2244442/db0e18d1-8a36-425b-99bf-a787b94780d2)
