### PR TITLE
Editor: add open recent games to file menu

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Utils\BitmapExtensions.cs" />
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
+    <Compile Include="Utils\Debounce.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\ScriptFileUtilities.cs" />
     <Compile Include="Utils\ScriptGeneration.cs" />

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -12,6 +12,7 @@ namespace AGS.Editor.Components
     class FileCommandsComponent : BaseComponent
     {
         private const string OPEN_GAME_COMMAND = "OpenGame";
+        private const string OPEN_RECENT_GAME_COMMAND = "OpenRecentGame";
         private const string SAVE_GAME_COMMAND = "SaveGame";
         private const string GAME_STATS_COMMAND = "GameStatistics";
         private const string JUMP_TO_EVENTS_TAB_COMMAND = "JumpToEventsTab";
@@ -50,6 +51,7 @@ namespace AGS.Editor.Components
 
             MenuCommands commands = new MenuCommands(GUIController.FILE_MENU_ID, 0);
             commands.Commands.Add(new MenuCommand(OPEN_GAME_COMMAND, "&Open...", Keys.Control | Keys.L, "MenuIconOpen"));
+            commands.Commands.Add(GetOpenRecentMenuCommand());
             commands.Commands.Add(new MenuCommand(SAVE_GAME_COMMAND, "&Save", Keys.Control | Keys.S, "MenuIconSave"));
             commands.Commands.Add(new MenuCommand(GAME_STATS_COMMAND, "&Game statistics", Keys.F2, "MenuIconStatistics"));
             commands.Commands.Add(new MenuCommand(JUMP_TO_EVENTS_TAB_COMMAND, "&Go to Events grid", Keys.F4, "MenuIconGoToEventsGrid"));
@@ -68,7 +70,7 @@ namespace AGS.Editor.Components
                 new MenuCommand(EXPORT_GLOBAL_MESSAGES_TO_SCRIPT_COMMAND, "Export Global Messages to script"),
                 new MenuCommand(REMOVE_GLOBAL_MESSAGES_COMMAND, "Remove Global Messages")
             };
-            commands.Commands.Add(new MenuCommand("Global Messages", subCommands));
+            commands.Commands.Add(new MenuCommand(null, "Global Messages", Keys.None, null, subCommands));
             _guiController.AddMenuItems(this, commands);
 
             commands = new MenuCommands(GUIController.FILE_MENU_ID, 800);
@@ -88,6 +90,58 @@ namespace AGS.Editor.Components
             _toolbarCommands.Add(openIcon);
             _toolbarCommands.Add(saveIcon);
             Factory.ToolBarManager.AddGlobalItems(this, _toolbarCommands);
+
+            Factory.AGSEditor.Settings.AfterRecentGamesChanged += FileCommandsComponent_AfterRecentGamesChanged;
+        }
+
+        private void FileCommandsComponent_AfterRecentGamesChanged(object sender)
+        {
+            RefreshRecentGamesMenu();
+        }
+
+        private string GetRecentGameText(string name, string path)
+        {
+            return name + "     (" + path + ")";
+        }
+
+        private string GetRecentGameMenuText(Preferences.RecentGame game, int maxPrintSize)
+        {
+            int maxPrintPathSize = maxPrintSize - GetRecentGameText(game.Name, string.Empty).Length;
+            string printablePath = game.Path.Length > maxPrintPathSize
+                ? "..." + game.Path.Substring(game.Path.Length - maxPrintPathSize)
+                : game.Path;
+
+            return GetRecentGameText(game.Name, printablePath);
+        }
+
+        private List<MenuCommand> GetRecentGamesSubcommands()
+        {
+            const int maxPrintSize = 80; // Maximum char length for recent games text
+            var subCommands = new List<MenuCommand>();
+            
+            // we start from index 1 because 0 is always currently open game
+            for (int i=1; i< Factory.AGSEditor.Settings.RecentGames.Count; i++)  
+            {
+                var game = Factory.AGSEditor.Settings.RecentGames[i];
+                string projectPath = Path.Combine(game.Path, AGSEditor.GAME_FILE_NAME);
+                if (Directory.Exists(game.Path) && File.Exists(projectPath))
+                {
+                    string cmdText = GetRecentGameMenuText(game, maxPrintSize);
+                    MenuCommand cmd = new MenuCommand(OPEN_RECENT_GAME_COMMAND + i.ToString(), cmdText);
+                    subCommands.Add(cmd);
+                }
+            }
+            return subCommands;
+        }
+
+        private MenuCommand GetOpenRecentMenuCommand()
+        {
+            return new MenuCommand(OPEN_RECENT_GAME_COMMAND, "Open Recent", Keys.None, null, GetRecentGamesSubcommands());
+        }
+
+        private void RefreshRecentGamesMenu()
+        {
+            _guiController.ReplaceMenuItem(this, OPEN_RECENT_GAME_COMMAND, GetOpenRecentMenuCommand());
         }
 
         public override string ComponentID
@@ -95,14 +149,26 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.FileCommands; }
         }
 
+        private void LoadGame(string projectPath = null)
+        {
+            if (_guiController.QueryWhetherToSaveGameBeforeContinuing("Do you want to save the current game before loading a different one?"))
+            {
+                if(string.IsNullOrEmpty(projectPath))
+                {
+                    _guiController.InteractiveTasks.BrowseForAndLoadGame();
+                }
+                else
+                {
+                    _guiController.InteractiveTasks.LoadGame(projectPath);
+                }
+            }
+        }
+
         public override void CommandClick(string controlID)
         {
             if (controlID == OPEN_GAME_COMMAND)
             {
-				if (_guiController.QueryWhetherToSaveGameBeforeContinuing("Do you want to save the current game before loading a different one?"))
-				{
-					_guiController.InteractiveTasks.BrowseForAndLoadGame();
-				}
+                LoadGame();
             }
             else if (controlID == SAVE_GAME_COMMAND)
             {
@@ -189,6 +255,13 @@ namespace AGS.Editor.Components
             else if (controlID == EXIT_COMMAND)
             {
                 _guiController.ExitApplication();
+            }
+            else if (controlID.StartsWith(OPEN_RECENT_GAME_COMMAND) && controlID.Length > OPEN_RECENT_GAME_COMMAND.Length)
+            {
+                int index = int.Parse(controlID.Split(new string[] { OPEN_RECENT_GAME_COMMAND }, StringSplitOptions.None)[1]);
+                var game = Factory.AGSEditor.Settings.RecentGames[index];
+                string projectPath = Path.Combine(game.Path, AGSEditor.GAME_FILE_NAME);                
+                LoadGame(projectPath);
             }
         }
 
@@ -311,5 +384,9 @@ namespace AGS.Editor.Components
             _guiController.SetTitleBarPrefix("[Running] ");
         }
 
+        public override void EditorShutdown()
+        {
+            Factory.AGSEditor.Settings.AfterRecentGamesChanged -= FileCommandsComponent_AfterRecentGamesChanged;
+        }
     }
 }

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -141,7 +141,7 @@ namespace AGS.Editor.Components
 
         private void RefreshRecentGamesMenu()
         {
-            _guiController.ReplaceMenuItem(this, OPEN_RECENT_GAME_COMMAND, GetOpenRecentMenuCommand());
+            _guiController.ReplaceMenuSubCommands(this, OPEN_RECENT_GAME_COMMAND, GetRecentGamesSubcommands());
         }
 
         public override string ComponentID

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -119,6 +119,14 @@ namespace AGS.Editor.Components
             const int maxPrintSize = 80; // Maximum char length for recent games text
             var subCommands = new List<MenuCommand>();
             
+            if(Factory.AGSEditor.Settings.RecentGames.Count <= 1)
+            {
+                MenuCommand cmd = new MenuCommand(null, "(empty)");
+                cmd.Enabled = false;
+                subCommands.Add(cmd);
+                return subCommands;
+            }
+
             // we start from index 1 because 0 is always currently open game
             for (int i=1; i< Factory.AGSEditor.Settings.RecentGames.Count; i++)  
             {

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -241,13 +241,14 @@ namespace AGS.Editor
             _menuManager.SetMenuItemEnabled(commandID, enabled);
         }
 
-        public void ReplaceMenuItem(IEditorComponent plugin, string oldCommandId, MenuCommand menuCommand)
+        public void ReplaceMenuSubCommands(IEditorComponent plugin, string oldCommandId, IList<MenuCommand> commands)
         {
             string commandID = GetMenuCommandID(oldCommandId, plugin);
-            MenuCommand oldMenuCommand = _menuManager.GetCommandById(commandID);
-            UnregisterMenuItem(oldMenuCommand);
-            RegisterMenuItems(plugin, new List<MenuCommand> { menuCommand }); // fixes command ID prefixes
-            _menuManager.ReplaceMenuItem(commandID, menuCommand);
+            MenuCommand menuCommand = _menuManager.GetCommandById(commandID);
+            UnregisterMenuItems(menuCommand.SubCommands);
+            RegisterMenuItems(plugin, commands); // fixes command ID prefixes
+            menuCommand.SubCommands = commands;
+            _menuManager.ReplaceMenuItemSubcommands(commandID, commands);
         }
 
         public void AddMenu(IEditorComponent plugin, string id, string title)
@@ -294,10 +295,6 @@ namespace AGS.Editor
             }
         }
 
-        private void UnregisterMenuItem(MenuCommand command)
-        {
-            UnregisterMenuItems(new List<MenuCommand> { command });
-        }
 
         public void AddMenuItems(IEditorComponent plugin, MenuCommands commands)
         {

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -241,6 +241,15 @@ namespace AGS.Editor
             _menuManager.SetMenuItemEnabled(commandID, enabled);
         }
 
+        public void ReplaceMenuItem(IEditorComponent plugin, string oldCommandId, MenuCommand menuCommand)
+        {
+            string commandID = GetMenuCommandID(oldCommandId, plugin);
+            MenuCommand oldMenuCommand = _menuManager.GetCommandById(commandID);
+            UnregisterMenuItem(oldMenuCommand);
+            RegisterMenuItems(plugin, new List<MenuCommand> { menuCommand }); // fixes command ID prefixes
+            _menuManager.ReplaceMenuItem(commandID, menuCommand);
+        }
+
         public void AddMenu(IEditorComponent plugin, string id, string title)
         {
             _menuManager.AddMenu(id, title);
@@ -267,6 +276,27 @@ namespace AGS.Editor
                     RegisterMenuItems(plugin, command.SubCommands);
                 }
             }
+        }
+
+        private void UnregisterMenuItems(IList<MenuCommand> commands)
+        {
+            foreach (MenuCommand command in commands)
+            {
+                if (command.ID != null)
+                {
+                    UnregisterMenuCommand(command.ID);
+                }
+
+                if (command.SubCommands != null && command.SubCommands.Count > 0)
+                {
+                    UnregisterMenuItems(command.SubCommands);
+                }
+            }
+        }
+
+        private void UnregisterMenuItem(MenuCommand command)
+        {
+            UnregisterMenuItems(new List<MenuCommand> { command });
         }
 
         public void AddMenuItems(IEditorComponent plugin, MenuCommands commands)
@@ -1533,6 +1563,11 @@ namespace AGS.Editor
                 id = component.ComponentID + CONTROL_ID_SPLIT + id;
             }
             return id;
+        }
+
+        private void UnregisterMenuCommand(string id)
+        {
+            _menuItems.Remove(id);
         }
 
         private string RegisterMenuCommand(string id, IEditorComponent component)

--- a/Editor/AGS.Editor/GUI/MainMenuManager.cs
+++ b/Editor/AGS.Editor/GUI/MainMenuManager.cs
@@ -1,6 +1,7 @@
 using AGS.Types;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
@@ -52,7 +53,7 @@ namespace AGS.Editor
             }
             else if (command.SubCommands != null && command.SubCommands.Count > 0)
             {
-                ToolStripMenuItem subMenu = new ToolStripMenuItem(command.Name);
+                ToolStripMenuItem subMenu = new ToolStripMenuItem(name, null, null, id);
                 subMenu.Enabled = enabled;
                 foreach (var subCommand in command.SubCommands)
                 {
@@ -146,6 +147,44 @@ namespace AGS.Editor
 			}
         }
 
+        public MenuCommand GetCommandById(string commandId)
+        {
+            List<string> keyList = new List<string>(_menuCommandGroups.Keys);
+            foreach (string key in keyList)
+            {
+                foreach (MenuCommands menuCommands in _menuCommandGroups[key])
+                {
+                    for (int i = 0; i < menuCommands.Commands.Count; i++)
+                    {
+                        if (menuCommands.Commands[i].ID == commandId)
+                        {
+                            return menuCommands.Commands[i];
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private void ReplaceCommandInCommandGroup(string commandId, MenuCommand newCommand)
+        {
+            List<string> keyList = new List<string>(_menuCommandGroups.Keys);
+            foreach (string key in keyList)
+            {
+                foreach (MenuCommands menuCommands in _menuCommandGroups[key])
+                {
+                    for(int i=0; i< menuCommands.Commands.Count; i++ )
+                    {
+                        if(menuCommands.Commands[i].ID == commandId)
+                        {
+                            menuCommands.Commands[i] = newCommand;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         public void SetMenuItemEnabled(string id, bool enabled)
         {
             ToolStripItem[] results = _mainMenu.Items.Find(id, true);
@@ -229,6 +268,27 @@ namespace AGS.Editor
 				_mainMenu.Items.Add(newMenu);
 			}
 		}
+
+        // TO-DO: this can't replace commands nested in subCommands for now
+        public void ReplaceMenuItem(string commandId, MenuCommand newCommand)
+        {
+            // Find the existing menu item
+            ToolStripItem[] results = _mainMenu.Items.Find(commandId, true);
+            if (results.Length == 0)
+            {
+                throw new AGSEditorException("Menu item does not exist: " + commandId);
+            }
+
+            ToolStripItem oldItem = results[0];
+            ToolStripMenuItem parentMenu = (ToolStripMenuItem)oldItem.OwnerItem;
+
+            ReplaceCommandInCommandGroup(commandId, newCommand);
+            int oldIndex = parentMenu.DropDownItems.IndexOf(oldItem);
+            parentMenu.DropDownItems.Remove(oldItem);
+
+            ToolStripItem newItem = AddMenuItem(newCommand);
+            parentMenu.DropDownItems.Insert(oldIndex, newItem);
+        }
 
         private void RemoveItemsFromLastPane()
         {

--- a/Editor/AGS.Editor/GUI/MainMenuManager.cs
+++ b/Editor/AGS.Editor/GUI/MainMenuManager.cs
@@ -147,6 +147,7 @@ namespace AGS.Editor
 			}
         }
 
+        // TO-DO: this can't go down in subcommands
         public MenuCommand GetCommandById(string commandId)
         {
             List<string> keyList = new List<string>(_menuCommandGroups.Keys);
@@ -164,25 +165,6 @@ namespace AGS.Editor
                 }
             }
             return null;
-        }
-
-        private void ReplaceCommandInCommandGroup(string commandId, MenuCommand newCommand)
-        {
-            List<string> keyList = new List<string>(_menuCommandGroups.Keys);
-            foreach (string key in keyList)
-            {
-                foreach (MenuCommands menuCommands in _menuCommandGroups[key])
-                {
-                    for(int i=0; i< menuCommands.Commands.Count; i++ )
-                    {
-                        if(menuCommands.Commands[i].ID == commandId)
-                        {
-                            menuCommands.Commands[i] = newCommand;
-                            return;
-                        }
-                    }
-                }
-            }
         }
 
         public void SetMenuItemEnabled(string id, bool enabled)
@@ -269,8 +251,7 @@ namespace AGS.Editor
 			}
 		}
 
-        // TO-DO: this can't replace commands nested in subCommands for now
-        public void ReplaceMenuItem(string commandId, MenuCommand newCommand)
+        public void ReplaceMenuItemSubcommands(string commandId, IList<MenuCommand> commands)
         {
             // Find the existing menu item
             ToolStripItem[] results = _mainMenu.Items.Find(commandId, true);
@@ -282,11 +263,12 @@ namespace AGS.Editor
             ToolStripItem oldItem = results[0];
             ToolStripMenuItem parentMenu = (ToolStripMenuItem)oldItem.OwnerItem;
 
-            ReplaceCommandInCommandGroup(commandId, newCommand);
+            MenuCommand parentCommand = GetCommandById(commandId);
+            parentCommand.SubCommands = commands;
             int oldIndex = parentMenu.DropDownItems.IndexOf(oldItem);
             parentMenu.DropDownItems.Remove(oldItem);
 
-            ToolStripItem newItem = AddMenuItem(newCommand);
+            ToolStripItem newItem = AddMenuItem(parentCommand);
             parentMenu.DropDownItems.Insert(oldIndex, newItem);
         }
 

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -48,8 +48,13 @@ namespace AGS.Editor
 
         public bool BrowseForAndLoadGame()
         {
-            bool loadedSuccessfully = false;
             string gameToLoad = Factory.GUIController.ShowOpenFileDialog("Select game to open", "AGS game files (*.agf, ac2game.dta)|*.agf;ac2game.dta|AGS 3.x games (*.agf)|*.agf|AGS 2.72 games (*.dta)|ac2game.dta", false);
+            return LoadGame(gameToLoad);
+        }
+
+        public bool LoadGame(string gameToLoad)
+        {
+            bool loadedSuccessfully = false;            
             if (gameToLoad != null)
             {
                 try

--- a/Editor/AGS.Editor/Utils/Debounce.cs
+++ b/Editor/AGS.Editor/Utils/Debounce.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AGS.Editor.Utils
+{
+    // Found in SO: https://stackoverflow.com/a/47933557
+    class Debouncer
+    {
+        private List<CancellationTokenSource> StepperCancelTokens = new List<CancellationTokenSource>();
+        private readonly int MillisecondsToWait;
+        private readonly object _lockThis = new object(); // Use a locking object to prevent the debouncer to trigger again while the func is still running
+
+        public Debouncer(int millisecondsToWait = 150)
+        {
+            this.MillisecondsToWait = millisecondsToWait;
+        }
+
+        public void Debounce(Action func)
+        {
+            CancelAllStepperTokens();
+            var newTokenSrc = new CancellationTokenSource();
+            lock (_lockThis)
+            {
+                StepperCancelTokens.Add(newTokenSrc);
+            }
+            Task.Delay(MillisecondsToWait, newTokenSrc.Token).ContinueWith(task => // Create new request
+            {
+                if (!newTokenSrc.IsCancellationRequested) // if it hasn't been cancelled
+                {
+                    CancelAllStepperTokens(); // Cancel any that remain (there shouldn't be any)
+                    StepperCancelTokens = new List<CancellationTokenSource>(); // set to new list
+                    lock (_lockThis)
+                    {
+                        func(); // run
+                    }
+                }
+            }, TaskScheduler.FromCurrentSynchronizationContext());
+        }
+
+        private void CancelAllStepperTokens()
+        {
+            foreach (var token in StepperCancelTokens)
+            {
+                if (!token.IsCancellationRequested)
+                {
+                    token.Cancel();
+                }
+            }
+        }
+    }
+}

--- a/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
+++ b/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
@@ -112,6 +112,7 @@ namespace AGS.Types
 		public IList<MenuCommand> SubCommands
 		{
 			get { return _subCommands; }
+			set { _subCommands = value; }
 		}
 	}
 }

--- a/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
+++ b/Editor/AGS.Types/EditorFeatures/MenuCommand.cs
@@ -14,15 +14,6 @@ namespace AGS.Types
 			get { return new MenuCommand(null, MenuCommand.MENU_TEXT_SEPARATOR); }
 		}
 
-		public MenuCommand(string itemName, IList<MenuCommand> subCommands)
-		{
-			_id = null;
-			_name = itemName;
-			_iconKey = null;
-			_enabled = true;
-			_subCommands = subCommands;
-		}
-
 		public MenuCommand(string itemID, string itemName)
 		{
 			_id = itemID;
@@ -44,10 +35,15 @@ namespace AGS.Types
 		}
 
 		public MenuCommand(string itemID, string itemName, Keys shortcutKey, string iconKey)
-			: this(itemID, itemName)
+			: this(itemID, itemName, shortcutKey)
 		{
-			_shortcutKey = shortcutKey;
 			_iconKey = iconKey;
+		}
+
+		public MenuCommand(string itemID, string itemName, Keys shortcutKey, string iconKey, IList<MenuCommand> subCommands)
+			: this(itemID, itemName, shortcutKey, iconKey)
+		{
+			_subCommands = subCommands;
 		}
 
 		private string _id;


### PR DESCRIPTION
Adds a lot of machinery to allow replacing menu commands enough so that recent games can be updated

This adds the following menu

![image](https://github.com/adventuregamestudio/ags/assets/2244442/70a5c2b7-bbfc-4c66-9474-1d520b4e3013)

Please review this carefully as I had to do a lot of bolting between different things for this to work. This is also new surface of bugs, if we decided this is unwanted, it's alright! An alternative could be to have an entry to bring up the initial screen of AGS.

The good: it actually works
The bad: code is a mess (I couldn't figure what should be in GUIController and what should be in main menu manager!)

Still, I thought it was a good things to have in the editor to easily alternate between games in the editor.

Edit: actually I think I can always hide the most recent game as it will always be the one being edited