### PR TITLE
Editor: fix global variables and text parser pane scaling

### DIFF
--- a/Editor/AGS.Editor/Panes/GlobalVariablesEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GlobalVariablesEditor.Designer.cs
@@ -54,12 +54,13 @@ namespace AGS.Editor
             this.clmName,
             this.clmType,
             this.clmDefaultValue});
+            this.lvwWords.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvwWords.FullRowSelect = true;
             this.lvwWords.HideSelection = false;
-            this.lvwWords.Location = new System.Drawing.Point(17, 50);
+            this.lvwWords.Location = new System.Drawing.Point(3, 75);
             this.lvwWords.MultiSelect = false;
             this.lvwWords.Name = "lvwWords";
-            this.lvwWords.Size = new System.Drawing.Size(478, 458);
+            this.lvwWords.Size = new System.Drawing.Size(504, 436);
             this.lvwWords.TabIndex = 1;
             this.lvwWords.UseCompatibleStateImageBehavior = false;
             this.lvwWords.View = System.Windows.Forms.View.Details;
@@ -84,21 +85,24 @@ namespace AGS.Editor
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(14, 17);
-            this.label1.MaximumSize = new System.Drawing.Size(480, 0);
+            this.label1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label1.Location = new System.Drawing.Point(3, 20);
+            this.label1.MaximumSize = new System.Drawing.Size(502, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(433, 26);
+            this.label1.Padding = new System.Windows.Forms.Padding(3, 9, 3, 12);
+            this.label1.Size = new System.Drawing.Size(500, 55);
             this.label1.TabIndex = 0;
             this.label1.Text = "Global variables allow you to create variables which you can access from all your" +
     " scripts. Right-click in the list to add, modify and delete variables.";
             // 
             // GlobalVariablesEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.mainFrame);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "GlobalVariablesEditor";
+            this.Padding = new System.Windows.Forms.Padding(3);
             this.Size = new System.Drawing.Size(531, 519);
             this.Load += new System.EventHandler(this.GlobalVariablesEditor_Load);
             this.SizeChanged += new System.EventHandler(this.TextParserEditor_SizeChanged);

--- a/Editor/AGS.Editor/Panes/TextParserEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/TextParserEditor.Designer.cs
@@ -43,7 +43,7 @@ namespace AGS.Editor
             this.mainFrame.Controls.Add(this.label1);
             this.mainFrame.Location = new System.Drawing.Point(5, 4);
             this.mainFrame.Name = "mainFrame";
-            this.mainFrame.Size = new System.Drawing.Size(376, 514);
+            this.mainFrame.Size = new System.Drawing.Size(510, 514);
             this.mainFrame.TabIndex = 0;
             this.mainFrame.TabStop = false;
             this.mainFrame.Text = "Text Parser word list";
@@ -54,51 +54,56 @@ namespace AGS.Editor
             this.clmWordGroup,
             this.clmWord,
             this.clmWordType});
+            this.lvwWords.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvwWords.FullRowSelect = true;
             this.lvwWords.HideSelection = false;
-            this.lvwWords.Location = new System.Drawing.Point(15, 42);
+            this.lvwWords.Location = new System.Drawing.Point(3, 58);
             this.lvwWords.MultiSelect = false;
             this.lvwWords.Name = "lvwWords";
-            this.lvwWords.Size = new System.Drawing.Size(350, 458);
+            this.lvwWords.Size = new System.Drawing.Size(504, 453);
             this.lvwWords.TabIndex = 1;
             this.lvwWords.UseCompatibleStateImageBehavior = false;
             this.lvwWords.View = System.Windows.Forms.View.Details;
             this.lvwWords.ItemActivate += new System.EventHandler(this.lvwWords_ItemActivate);
-            this.lvwWords.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvwWords_MouseClick);
             this.lvwWords.SelectedIndexChanged += new System.EventHandler(this.lvwWords_SelectedIndexChanged);
+            this.lvwWords.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvwWords_MouseClick);
             this.lvwWords.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lvwWords_MouseUp);
             // 
             // clmWordGroup
             // 
             this.clmWordGroup.Text = "Word Group";
-            this.clmWordGroup.Width = 70;
+            this.clmWordGroup.Width = 126;
             // 
             // clmWord
             // 
             this.clmWord.Text = "Word";
-            this.clmWord.Width = 150;
+            this.clmWord.Width = 166;
             // 
             // clmWordType
             // 
             this.clmWordType.Text = "Type";
-            this.clmWordType.Width = 110;
+            this.clmWordType.Width = 137;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(14, 17);
+            this.label1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label1.Location = new System.Drawing.Point(3, 20);
+            this.label1.MaximumSize = new System.Drawing.Size(502, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(283, 13);
+            this.label1.Padding = new System.Windows.Forms.Padding(3, 9, 3, 12);
+            this.label1.Size = new System.Drawing.Size(366, 38);
             this.label1.TabIndex = 0;
             this.label1.Text = "To modify an item or add new words, right-click in the list.";
             // 
             // TextParserEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.mainFrame);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "TextParserEditor";
+            this.Padding = new System.Windows.Forms.Padding(3);
             this.Size = new System.Drawing.Size(531, 519);
             this.Load += new System.EventHandler(this.TextParserEditor_Load);
             this.SizeChanged += new System.EventHandler(this.TextParserEditor_SizeChanged);


### PR DESCRIPTION
prevents text from being cut vertically, both panes are very similar (a group with a label and a control), so I just used docking at top for label and fill for the main control.

this is a minimal fix part of #2087