### PR TITLE
Editor: resize room masks when changing the background to a different size instead of just resetting them.

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -166,6 +166,12 @@
     <Compile Include="Entities\LogBufferEventArgs.cs" />
     <Compile Include="Entities\MultiSelectAction.cs" />
     <Compile Include="Entities\ScriptModuleDef.cs" />
+    <Compile Include="GUI\AdjustMasksDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\AdjustMasksDialog.Designer.cs">
+      <DependentUpon>AdjustMasksDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\AssignToView.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -438,6 +444,9 @@
     <Compile Include="Utils\ScriptGeneration.cs" />
     <Compile Include="Utils\StdConsoleWriter.cs" />
     <Compile Include="Utils\Validation.cs" />
+    <EmbeddedResource Include="GUI\AdjustMasksDialog.resx">
+      <DependentUpon>AdjustMasksDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>
       <DependentUpon>frmMain.cs</DependentUpon>

--- a/Editor/AGS.Editor/GUI/AdjustMasksDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/AdjustMasksDialog.Designer.cs
@@ -1,0 +1,245 @@
+﻿namespace AGS.Editor
+{
+    partial class AdjustMasksDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.descLabel = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.radioScale = new System.Windows.Forms.RadioButton();
+            this.radioResize = new System.Windows.Forms.RadioButton();
+            this.radioReset = new System.Windows.Forms.RadioButton();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.yOffset = new System.Windows.Forms.NumericUpDown();
+            this.xOffset = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.yOffset)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.xOffset)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // descLabel
+            // 
+            this.descLabel.AutoSize = true;
+            this.descLabel.Location = new System.Drawing.Point(28, 26);
+            this.descLabel.MaximumSize = new System.Drawing.Size(500, 0);
+            this.descLabel.Name = "descLabel";
+            this.descLabel.Size = new System.Drawing.Size(488, 26);
+            this.descLabel.TabIndex = 0;
+            this.descLabel.Text = "The new background has a different size.  All the room masks will have to be resi" +
+    "zed.  Please decide what to do with their contents:";
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.radioScale);
+            this.groupBox1.Controls.Add(this.radioResize);
+            this.groupBox1.Controls.Add(this.radioReset);
+            this.groupBox1.Location = new System.Drawing.Point(32, 84);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(483, 159);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            // 
+            // radioScale
+            // 
+            this.radioScale.AutoSize = true;
+            this.radioScale.Location = new System.Drawing.Point(17, 114);
+            this.radioScale.Name = "radioScale";
+            this.radioScale.Size = new System.Drawing.Size(253, 17);
+            this.radioScale.TabIndex = 2;
+            this.radioScale.Text = "Rescale (stretch existing areas to the new size)";
+            this.radioScale.UseVisualStyleBackColor = true;
+            // 
+            // radioResize
+            // 
+            this.radioResize.AutoSize = true;
+            this.radioResize.Checked = true;
+            this.radioResize.Location = new System.Drawing.Point(17, 69);
+            this.radioResize.Name = "radioResize";
+            this.radioResize.Size = new System.Drawing.Size(289, 17);
+            this.radioResize.TabIndex = 1;
+            this.radioResize.TabStop = true;
+            this.radioResize.Text = "Resize canvas (extend or crop, keeping existing areas)";
+            this.radioResize.UseVisualStyleBackColor = true;
+            // 
+            // radioReset
+            // 
+            this.radioReset.AutoSize = true;
+            this.radioReset.Location = new System.Drawing.Point(17, 26);
+            this.radioReset.Name = "radioReset";
+            this.radioReset.Size = new System.Drawing.Size(134, 17);
+            this.radioReset.TabIndex = 0;
+            this.radioReset.Text = "Reset (erase all areas)";
+            this.radioReset.UseVisualStyleBackColor = true;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.panel1);
+            this.groupBox2.Location = new System.Drawing.Point(32, 263);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(483, 132);
+            this.groupBox2.TabIndex = 2;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Mask Offset";
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.yOffset);
+            this.panel1.Controls.Add(this.xOffset);
+            this.panel1.Controls.Add(this.label2);
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Location = new System.Drawing.Point(17, 35);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(224, 85);
+            this.panel1.TabIndex = 1;
+            // 
+            // yOffset
+            // 
+            this.yOffset.Location = new System.Drawing.Point(81, 46);
+            this.yOffset.Maximum = new decimal(new int[] {
+            999999999,
+            0,
+            0,
+            0});
+            this.yOffset.Minimum = new decimal(new int[] {
+            999999999,
+            0,
+            0,
+            -2147483648});
+            this.yOffset.Name = "yOffset";
+            this.yOffset.Size = new System.Drawing.Size(120, 21);
+            this.yOffset.TabIndex = 3;
+            // 
+            // xOffset
+            // 
+            this.xOffset.Location = new System.Drawing.Point(81, 7);
+            this.xOffset.Maximum = new decimal(new int[] {
+            999999999,
+            0,
+            0,
+            0});
+            this.xOffset.Minimum = new decimal(new int[] {
+            999999999,
+            0,
+            0,
+            -2147483648});
+            this.xOffset.Name = "xOffset";
+            this.xOffset.Size = new System.Drawing.Size(120, 21);
+            this.xOffset.TabIndex = 2;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(8, 48);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(51, 13);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Y Offset:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(8, 9);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(51, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "X Offset:";
+            // 
+            // btnOK
+            // 
+            this.btnOK.Location = new System.Drawing.Point(32, 404);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(140, 40);
+            this.btnOK.TabIndex = 3;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(190, 404);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(140, 40);
+            this.btnCancel.TabIndex = 4;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // AdjustMasksDialog
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(550, 465);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.descLabel);
+            this.Font = new System.Drawing.Font("Tahoma", 8.25F);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "AdjustMasksDialog";
+            this.ShowIcon = false;
+            this.Text = "Adjust Masks to the new Room background";
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.yOffset)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.xOffset)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label descLabel;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.RadioButton radioScale;
+        private System.Windows.Forms.RadioButton radioResize;
+        private System.Windows.Forms.RadioButton radioReset;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.NumericUpDown yOffset;
+        private System.Windows.Forms.NumericUpDown xOffset;
+    }
+}

--- a/Editor/AGS.Editor/GUI/AdjustMasksDialog.cs
+++ b/Editor/AGS.Editor/GUI/AdjustMasksDialog.cs
@@ -1,0 +1,55 @@
+﻿using AGS.Types;
+using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public partial class AdjustMasksDialog : Form
+    {
+        private AdjustMaskOptions _maskOption = AdjustMaskOptions.ResetMask;
+        private int _xOffset = 0;
+        private int _yOffset = 0;
+
+        public AdjustMasksDialog()
+        {
+            InitializeComponent();
+        }
+
+        public AdjustMaskOptions MaskOption
+        {
+            get { return _maskOption; }
+        }
+
+        public int XOffset
+        {
+            get { return _xOffset; }
+        }
+
+        public int YOffset
+        {
+            get { return _yOffset; }
+        }
+
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            if (radioResize.Checked)
+            {
+                _maskOption = AdjustMaskOptions.ResizeMaskCanvas;
+            }
+            else if (radioScale.Checked)
+            {
+                _maskOption = AdjustMaskOptions.ScaleMaskImage;
+            }
+            else
+            {
+                _maskOption = AdjustMaskOptions.ResetMask;
+            }
+
+            _xOffset = (int)xOffset.Value;
+            _yOffset = (int)yOffset.Value;
+
+            this.DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/AdjustMasksDialog.resx
+++ b/Editor/AGS.Editor/GUI/AdjustMasksDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -142,6 +142,7 @@
     <Compile Include="EditorFeatures\MenuCommands.cs" />
     <Compile Include="EditorFeatures\MessageBoxIconType.cs" />
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
+    <Compile Include="Enums\AdjustMaskOptions.cs" />
     <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\BlendMode.cs" />
     <Compile Include="Enums\InputMotionMode.cs" />

--- a/Editor/AGS.Types/Enums/AdjustMaskOptions.cs
+++ b/Editor/AGS.Types/Enums/AdjustMaskOptions.cs
@@ -1,0 +1,10 @@
+
+namespace AGS.Types
+{
+    public enum AdjustMaskOptions
+    {
+        ResetMask = 0,
+        ResizeMaskCanvas = 1,
+        ScaleMaskImage = 2
+    }
+}

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -58,6 +58,21 @@ namespace AGS.Types
         /// <param name="bmp">The mask to set.</param>
         void SetMask(RoomAreaMaskType mask, Bitmap bmp);
         /// <summary>
+        /// Resets all of the masks in the room back to their default clear value.  This change is not permanent until <see cref="IRoomController.Save"/>
+        /// is invoked.
+        /// </summary>
+        void ResetMasks();
+        /// <summary>
+        /// Resizes all of the masks in the room.  This change is not permanent until <see cref="IRoomController.Save"/>
+        /// is invoked.
+        /// </summary>
+        /// <param name="doScale">If the mask image should be scaled to the new size or if just the the canvas size should change </param>
+        /// <param name="newWidth">The width to resize the masks to.</param>
+        /// <param name="newHeight">The height to resize the masks to.</param>
+        /// <param name="xOffset">The amount to shift the mask image along the x axis relative to the left side of the mask.</param>
+        /// <param name="yOffset">The amount to shift the mask along the y axis relative to the top of the mask.</param>
+        void ResizeMasks(bool doScale, int newWidth, int newHeight, int xOffset, int yOffset);
+        /// <summary>
         /// Gets the area number on the specified room mask at (x,y)
         /// RequiredAGSVersion: 3.0.1.35
         /// </summary>


### PR DESCRIPTION
	modified:   Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs

	Make it so that room masks are resized instead of reset when the resolution of the background changes