### PR TITLE
Pass mouse position into "on_mouse_click" script callback

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -140,7 +140,7 @@ void Character_AddInventory(CharacterInfo *chaa, ScriptInvItem *invi, int addInd
             if (charextra[charid].invorder[ee] == inum) {
                 // They already have the item, so don't add it to the list
                 if (chaa == playerchar)
-                    run_on_event (GE_ADD_INV, RuntimeScriptValue().SetInt32(inum));
+                    run_on_event (kScriptEvent_InventoryAdd, RuntimeScriptValue().SetInt32(inum));
                 return;
             }
         }
@@ -164,7 +164,7 @@ void Character_AddInventory(CharacterInfo *chaa, ScriptInvItem *invi, int addInd
     charextra[charid].invorder_count++;
     GUIE::MarkInventoryForUpdate(charid, charid == game.playercharacter);
     if (chaa == playerchar)
-        run_on_event (GE_ADD_INV, RuntimeScriptValue().SetInt32(inum));
+        run_on_event (kScriptEvent_InventoryAdd, RuntimeScriptValue().SetInt32(inum));
 }
 
 void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
@@ -736,7 +736,7 @@ void Character_LoseInventory(CharacterInfo *chap, ScriptInvItem *invi) {
     GUIE::MarkInventoryForUpdate(charid, charid == game.playercharacter);
 
     if (chap == playerchar)
-        run_on_event (GE_LOSE_INV, RuntimeScriptValue().SetInt32(inum));
+        run_on_event (kScriptEvent_InventoryLose, RuntimeScriptValue().SetInt32(inum));
 }
 
 void Character_PlaceOnWalkableArea(CharacterInfo *chap) 

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -443,7 +443,7 @@ private:
     // Process single key event; returns if handled
     bool RunKey(const KeyInput &ki);
     // Process single mouse event; returns if handled
-    bool RunMouse(eAGSMouseButton mbut);
+    bool RunMouse(eAGSMouseButton mbut, int mx, int my);
     // Process mouse wheel scroll
     bool RunMouseWheel(int mwheelz);
 
@@ -1024,8 +1024,9 @@ bool DialogOptions::RunControls()
         else if (type == kInputMouse)
         {
             eAGSMouseButton mbut;
-            if (run_service_mb_controls(mbut) && !play.IsIgnoringInput() &&
-                RunMouse(mbut))
+            Point mpos;
+            if (run_service_mb_controls(mbut, &mpos) && !play.IsIgnoringInput() &&
+                RunMouse(mbut, mpos.X, mpos.Y))
             {
                 return true; // handled
             }
@@ -1100,7 +1101,7 @@ bool DialogOptions::RunKey(const KeyInput &ki)
     return false; // not handled
 }
 
-bool DialogOptions::RunMouse(eAGSMouseButton mbut)
+bool DialogOptions::RunMouse(eAGSMouseButton mbut, int mx, int my)
 {
     if (mbut > kMouseNone)
     {
@@ -1123,6 +1124,8 @@ bool DialogOptions::RunMouse(eAGSMouseButton mbut)
         {
             runDialogOptionMouseClickHandlerFunc.params[0].SetScriptObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
             runDialogOptionMouseClickHandlerFunc.params[1].SetInt32(mbut);
+            runDialogOptionMouseClickHandlerFunc.params[2].SetInt32(mx);
+            runDialogOptionMouseClickHandlerFunc.params[3].SetInt32(my);
             run_function_on_non_blocking_thread(&runDialogOptionMouseClickHandlerFunc);
         }
         else if (usingCustomRendering)

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -66,7 +66,7 @@ ScriptEventCallback ScriptEventCb[kTS_Num] = {
     { nullptr, 0u },
     { REP_EXEC_NAME, 0u },
     { "on_key_press", 2u },
-    { "on_mouse_click", 1u },
+    { "on_mouse_click", 3u },
     { "on_text_input", 1u }
 };
 
@@ -158,7 +158,7 @@ void process_event(const AGSEvent *evp)
             quit("process_event: kAGSEvent_Script: unknown callback type");
             return;
         }
-        RuntimeScriptValue params[2]{ ts.Arg1 , ts.Arg2 };
+        RuntimeScriptValue params[3]{ ts.Arg1, ts.Arg2, ts.Arg3 };
         QueueScriptFunction(kScInstGame, ScriptEventCb[ts.CbType].FnName, ScriptEventCb[ts.CbType].ArgCount, params);
     }
     else if (evp->Type == kAGSEvent_NewRoom)

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -123,11 +123,11 @@ enum AGSScriptEventType
 struct AGSEvent_Script
 {
     ScriptCallbackType CbType = kTS_None;
-    int Arg1 = 0, Arg2 = 0;
+    int Arg1 = 0, Arg2 = 0, Arg3 = 0;
 
     AGSEvent_Script() = default;
-    AGSEvent_Script(ScriptCallbackType cb, int arg1 = 0, int arg2 = 0)
-        : CbType(cb), Arg1(arg1), Arg2(arg2) {}
+    AGSEvent_Script(ScriptCallbackType cb, int arg1 = 0, int arg2 = 0, int arg3 = 0)
+        : CbType(cb), Arg1(arg1), Arg2(arg2), Arg3(arg3) {}
 };
 
 // AGSEvent_Interaction describes a scheduled call to a object interaction event

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -218,7 +218,14 @@ extern std::vector<AGSEvent> events;
 
 extern int eventClaimed;
 
-extern const char*tsnames[kTS_Num];
+// ScriptEventCallback describes a predefined script function callback
+struct ScriptEventCallback
+{
+    const char *FnName;
+    uint32_t ArgCount;
+};
+
+extern ScriptEventCallback ScriptEventCb[kTS_Num];
 
 #endif // __AGS_EE_AC__EVENT_H
 

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -12,93 +12,190 @@
 //
 //=============================================================================
 //
-//
+// AGS game events definitions.
 //
 //=============================================================================
 #ifndef __AGS_EE_AC__EVENT_H
 #define __AGS_EE_AC__EVENT_H
 
+#include "ac/keycode.h" // eAGSMouseButton
 #include "ac/runtime_defines.h"
 #include "script/runtimescriptvalue.h"
 
-// parameters to run_on_event
-#define GE_LEAVE_ROOM    1
-#define GE_ENTER_ROOM    2
-// #define GE_MAN_DIES 3 // ancient obsolete event
-#define GE_GOT_SCORE     4
-#define GE_GUI_MOUSEDOWN 5
-#define GE_GUI_MOUSEUP   6
-#define GE_ADD_INV       7
-#define GE_LOSE_INV      8
-#define GE_RESTORE_GAME  9
-#define GE_ENTER_ROOM_AFTERFADE 10
-#define GE_LEAVE_ROOM_AFTERFADE 11
-#define GE_SAVE_GAME     12
 
-// Game event types:
-// common script callback
-#define EV_TEXTSCRIPT 1
-// room event
-#define EV_RUNEVBLOCK 2
-// fade-in event
-#define EV_FADEIN     3
-// gui click
-#define EV_IFACECLICK 4
-// new room event
-#define EV_NEWROOM    5
-// Text script callback types:
-enum kTS_CallbackTypes {
-    kTS_None = 0,
-// repeatedly execute
-    kTS_Repeat,
-// on key press
-    kTS_KeyPress,
-// mouse click
-    kTS_MouseClick,
-// on text input
-    kTS_TextInput,
-// script callback types number
+// AGS Game event types,
+// these events are scheduled during game update to be run in the end of
+// the update, after the rest of the game logic has been resolved.
+// Event type defines which parameters are used to describe event,
+// and whether to run any script callback.
+enum AGSGameEventType
+{
+    kAGSEvent_None              = 0,
+    // global script callback (call predefined function in script)
+    kAGSEvent_Script            = 1,
+    // interaction callback (run function attached to object event table)
+    kAGSEvent_Interaction       = 2,
+    // fade-in event
+    kAGSEvent_FadeIn            = 3,
+    // gui interaction
+    kAGSEvent_GUI               = 4,
+    // new room event
+    kAGSEvent_NewRoom           = 5
+};
+
+// Text script event callback subtypes:
+enum ScriptCallbackType
+{
+    kTS_None                    = 0,
+    // repeatedly execute
+    kTS_Repeat                  = 1,
+    // on key press
+    kTS_KeyPress                = 2,
+    // mouse click
+    kTS_MouseClick              = 3,
+    // on text input
+    kTS_TextInput               = 4,
+    // script callback types number
     kTS_Num
 };
 
-// Room event types:
-// hotspot event
-#define EVB_HOTSPOT   1
-// room own event
-#define EVB_ROOM      2
-// Room event sub-types:
-// room edge crossing
-#define EVROM_EDGELEFT     0
-#define EVROM_EDGERIGHT    1
-#define EVROM_EDGEBOTTOM   2
-#define EVROM_EDGETOP      3
-// first time enters room
-#define EVROM_FIRSTENTER   4
-// load room; aka before fade-in
-#define EVROM_BEFOREFADEIN 5
-// room's rep-exec
-#define EVROM_REPEXEC      6
-// after fade-in
-#define EVROM_AFTERFADEIN  7
-// leave room (before fade-out)
-#define EVROM_LEAVE        8
-// unload room; aka after fade-out
-#define EVROM_AFTERFADEOUT 9
-// Hotspot event types:
-// player stands on hotspot
-#define EVHOT_STANDSON  0
-// cursor is over hotspot
-#define EVHOT_MOUSEOVER 6
-
-struct EventHappened
+// Interaction event types (more like an object type)
+enum InteractionEventType
 {
-    int type = 0;
-    int data1 = 0, data2 = 0, data3 = 0;
-    int player = -1;
+    kIntEventType_None          = 0,
+    kIntEventType_Hotspot       = 1,
+    kIntEventType_Room          = 2,
+};
 
-    EventHappened() = default;
-    EventHappened(int type_, int data1_, int data2_, int data3_, int player_)
-        : type(type_), data1(data1_), data2(data2_), data3(data3_), player(player_) {}
+// Room event sub-types
+enum RoomEventType
+{
+    // room edge crossing
+    kRoomEvent_EdgeLeft         = 0,
+    kRoomEvent_EdgeRight        = 1,
+    kRoomEvent_EdgeBottom       = 2,
+    kRoomEvent_EdgeTop          = 3,
+    // first time enters room
+    kRoomEvent_FirstEnter       = 4,
+    // load room; aka before fade-in
+    kRoomEvent_BeforeFadein     = 5,
+    // room's rep-exec
+    kRoomEvent_Repexec          = 6,
+    // after fade-in
+    kRoomEvent_AfterFadein      = 7,
+    // leave room (before fade-out)
+    kRoomEvent_BeforeFadeout    = 8,
+    // unload room; aka after fade-out
+    kRoomEvent_AfterFadeout     = 9,
+};
+
+// Hotspot event sub-types
+enum HotspotEventSubtype
+{
+    // player stands on hotspot
+    kHotspotEvent_StandOn       = 0,
+    // cursor is over hotspot
+    kHotspotEvent_MouseOver     = 6,
+};
+
+// AGS Script events are events reported by a "on_event" callback.
+enum AGSScriptEventType
+{
+    kScriptEvent_RoomLeave      = 1, // before fade-in
+    kScriptEvent_RoomEnter      = 2, // before fade-out, right after loaded
+    // kScriptEvent_PlayerDies = 3 // ancient obsolete event
+    kScriptEvent_Score          = 4,
+    kScriptEvent_MouseDown      = 5,
+    kScriptEvent_MouseUp        = 6,
+    kScriptEvent_InventoryAdd   = 7,
+    kScriptEvent_InventoryLose  = 8,
+    kScriptEvent_GameRestored   = 9,
+    kScriptEvent_RoomAfterFadein = 10, // enter after fade-in
+    kScriptEvent_RoomAfterFadeout = 11, // after fade-out, right before unloading
+    kScriptEvent_GameSaved      = 12,
+};
+
+
+//-----------------------------------------------------------------------------
+// AGSEvent_* structs, used to configure a parent AGSEvent (see below)
+//
+// AGSEvent_Script describes a scheduled call to a global script callback
+struct AGSEvent_Script
+{
+    ScriptCallbackType CbType = kTS_None;
+    int Arg1 = 0, Arg2 = 0;
+
+    AGSEvent_Script() = default;
+    AGSEvent_Script(ScriptCallbackType cb, int arg1 = 0, int arg2 = 0)
+        : CbType(cb), Arg1(arg1), Arg2(arg2) {}
+};
+
+// AGSEvent_Interaction describes a scheduled call to a object interaction event
+struct AGSEvent_Interaction
+{
+    InteractionEventType IntEvType = kIntEventType_None;
+    int ObjID = 0;
+    int ObjEvent = 0; // object event identifier, depends on ObjID
+    int Player = -1; // optional player character id, if event requires that
+
+    AGSEvent_Interaction() = default;
+    AGSEvent_Interaction(InteractionEventType inttype, int obj_id, int obj_event, int player = -1)
+        : IntEvType(inttype), ObjID(obj_id), ObjEvent(obj_event), Player(player) {}
+};
+
+// AGSEvent_GUI describes a scheduled call to a GUI interaction event
+struct AGSEvent_GUI
+{
+    int GuiID = 0; // parent gui's id
+    int GuiObjID = 0; // gui child control's id
+    eAGSMouseButton Mbtn = kMouseNone;
+
+    AGSEvent_GUI() = default;
+    AGSEvent_GUI(int gui_id, int guiobj_id, eAGSMouseButton mbut = kMouseNone)
+        : GuiID(gui_id), GuiObjID(guiobj_id), Mbtn(mbut) {}
+};
+
+// AGSEvent_NewRoom describes a scheduled call to a NewRoom
+struct AGSEvent_NewRoom
+{
+    int RoomID = -1;
+
+    AGSEvent_NewRoom() = default;
+    AGSEvent_NewRoom(int room) : RoomID(room) {}
+};
+
+// AGSEvent struct describes one of many possible AGS game events,
+// using a union of sub-event structs
+struct AGSEvent
+{
+    // general event type
+    AGSGameEventType Type = kAGSEvent_None;
+    union EventData
+    {
+        AGSEvent_Script         Script;
+        AGSEvent_Interaction    Inter;
+        AGSEvent_GUI            Gui;
+        AGSEvent_NewRoom        Newroom;
+
+        EventData() {}
+        EventData(const AGSEvent_Script &par) : Script(par) {}
+        EventData(const AGSEvent_Interaction &par) : Inter(par) {}
+        EventData(const AGSEvent_GUI &par) : Gui(par) {}
+        EventData(const AGSEvent_NewRoom &par) : Newroom(par) {}
+    } Data;
+
+    AGSEvent() = default;
+    // Parameterless event, defined by the type only
+    AGSEvent(AGSGameEventType type)
+        : Type(type) {}
+    AGSEvent(const AGSEvent_Script &evt)
+        : Type(kAGSEvent_Script), Data(evt) {}
+    AGSEvent(const AGSEvent_Interaction &evt)
+        : Type(kAGSEvent_Interaction), Data(evt) {}
+    AGSEvent(const AGSEvent_GUI &evt)
+        : Type(kAGSEvent_GUI), Data(evt) {}
+    AGSEvent(const AGSEvent_NewRoom &evt)
+        : Type(kAGSEvent_NewRoom), Data(evt) {}
 };
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed);
@@ -106,10 +203,10 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
 void run_on_event (int evtype, RuntimeScriptValue &wparam);
 void run_room_event(int id);
 // event list functions
-void setevent(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);
-void force_event(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);
-void process_event(const EventHappened *evp);
-void runevent_now (int evtyp, int ev1, int ev2, int ev3);
+void setevent(const AGSEvent &evt);
+void force_event(const AGSEvent &evt);
+void runevent_now(const AGSEvent &evt);
+void process_event(const AGSEvent *evp);
 void processallevents();
 // end event list functions
 void ClaimEvent();
@@ -117,7 +214,7 @@ void ClaimEvent();
 extern int in_enters_screen,done_es_error;
 extern int in_leaves_screen;
 
-extern std::vector<EventHappened> events;
+extern std::vector<AGSEvent> events;
 
 extern int eventClaimed;
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -972,7 +972,7 @@ void save_game(int slotn, const char*descript)
     // Save dynamic game data
     SaveGameState(out.get());
     // call "After Save" event callback
-    run_on_event(GE_SAVE_GAME, RuntimeScriptValue().SetInt32(slotn));
+    run_on_event(kScriptEvent_GameSaved, RuntimeScriptValue().SetInt32(slotn));
 }
 
 int gameHasBeenRestored = 0;
@@ -1090,7 +1090,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
     // ensure input state is reset
     ags_clear_input_state();
     // call "After Restore" event callback
-    run_on_event(GE_RESTORE_GAME, RuntimeScriptValue().SetInt32(slotNumber));
+    run_on_event(kScriptEvent_GameRestored, RuntimeScriptValue().SetInt32(slotNumber));
     return HSaveError::None();
 }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -96,7 +96,7 @@ void GiveScore(int amnt)
     if ((amnt > 0) && (play.score_sound >= 0))
         play_audio_clip_by_index(play.score_sound);
 
-    run_on_event (GE_GOT_SCORE, RuntimeScriptValue().SetInt32(amnt));
+    run_on_event (kScriptEvent_Score, RuntimeScriptValue().SetInt32(amnt));
 }
 
 void restart_game() {

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -103,7 +103,7 @@ void NewRoom(int nrnum) {
         in_leaves_screen = nrnum;
     }
     else if (in_enters_screen) {
-        setevent(EV_NEWROOM,nrnum);
+        setevent(AGSEvent_NewRoom(nrnum));
         return;
     }
     else if (in_inv_screen) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -728,7 +728,7 @@ void gui_on_mouse_hold(const int wasongui, const int wasbutdown)
         if (guis[wasongui].GetControlType(i)!=kGUISlider) continue;
         // GUI Slider repeatedly activates while being dragged
         guio->IsActivated = false;
-        force_event(EV_IFACECLICK, wasongui, i, wasbutdown);
+        force_event(AGSEvent_GUI(wasongui, i, static_cast<eAGSMouseButton>(wasbutdown)));
         break;
     }
 }
@@ -745,7 +745,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown, const int mx, con
 
         int cttype=guis[wasongui].GetControlType(i);
         if ((cttype == kGUIButton) || (cttype == kGUISlider) || (cttype == kGUIListBox)) {
-            force_event(EV_IFACECLICK, wasongui, i, wasbutdown);
+            force_event(AGSEvent_GUI(wasongui, i, static_cast<eAGSMouseButton>(wasbutdown)));
         }
         else if (cttype == kGUIInvWindow) {
             mouse_ifacebut_xoffs=mx-(guio->X)-guis[wasongui].X;
@@ -756,7 +756,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown, const int mx, con
                 if (game.options[OPT_HANDLEINVCLICKS]) {
                     // Let the script handle the click
                     // LEFTINV is 5, RIGHTINV is 6
-                    force_event(EV_TEXTSCRIPT, kTS_MouseClick, wasbutdown + 4);
+                    force_event(AGSEvent_Script(kTS_MouseClick, wasbutdown + 4));
                 }
                 else if (wasbutdown == kMouseRight) // right-click is always Look
                     RunInventoryInteraction(iit, MODE_LOOK);
@@ -772,7 +772,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown, const int mx, con
         break;
     }
 
-    run_on_event(GE_GUI_MOUSEUP, RuntimeScriptValue().SetInt32(wasongui));
+    run_on_event(kScriptEvent_MouseUp, RuntimeScriptValue().SetInt32(wasongui));
 }
 
 void gui_on_mouse_down(const int guin, const int mbut, const int mx, const int my)
@@ -781,9 +781,9 @@ void gui_on_mouse_down(const int guin, const int mbut, const int mx, const int m
     guis[guin].OnMouseButtonDown(mx, my);
     // run GUI click handler if not on any control
     if ((guis[guin].MouseDownCtrl < 0) && (!guis[guin].OnClickHandler.IsEmpty()))
-        force_event(EV_IFACECLICK, guin, -1, mbut);
+        force_event(AGSEvent_GUI(guin, -1, static_cast<eAGSMouseButton>(mbut)));
 
-    run_on_event(GE_GUI_MOUSEDOWN, RuntimeScriptValue().SetInt32(guin));
+    run_on_event(kScriptEvent_MouseDown, RuntimeScriptValue().SetInt32(guin));
 }
 
 //=============================================================================

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -756,7 +756,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown, const int mx, con
                 if (game.options[OPT_HANDLEINVCLICKS]) {
                     // Let the script handle the click
                     // LEFTINV is 5, RIGHTINV is 6
-                    force_event(AGSEvent_Script(kTS_MouseClick, wasbutdown + 4));
+                    force_event(AGSEvent_Script(kTS_MouseClick, wasbutdown + 4, mx, my));
                 }
                 else if (wasbutdown == kMouseRight) // right-click is always Look
                     RunInventoryInteraction(iit, MODE_LOOK);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -267,9 +267,9 @@ void unload_old_room() {
     current_fade_out_effect();
 
     // room unloaded callback
-    run_room_event(EVROM_AFTERFADEOUT);
+    run_room_event(kRoomEvent_AfterFadeout);
     // global room unloaded event
-    run_on_event(GE_LEAVE_ROOM_AFTERFADE, RuntimeScriptValue().SetInt32(displayed_room));
+    run_on_event(kScriptEvent_RoomAfterFadeout, RuntimeScriptValue().SetInt32(displayed_room));
 
     debug_script_log("Unloading room %d", displayed_room);
 
@@ -918,9 +918,9 @@ void new_room(int newnum,CharacterInfo*forchar) {
     in_leaves_screen = newnum;
 
     // player leaves screen event
-    run_room_event(EVROM_LEAVE);
+    run_room_event(kRoomEvent_BeforeFadeout);
     // Run the global OnRoomLeave event
-    run_on_event (GE_LEAVE_ROOM, RuntimeScriptValue().SetInt32(displayed_room));
+    run_on_event (kScriptEvent_RoomLeave, RuntimeScriptValue().SetInt32(displayed_room));
 
     pl_run_plugin_hooks(AGSE_LEAVEROOM, displayed_room);
 
@@ -988,7 +988,7 @@ void first_room_initialization() {
 void check_new_room() {
     // if they're in a new room, run Player Enters Screen and on_event(ENTER_ROOM)
     if ((in_new_room>0) & (in_new_room!=3)) {
-        EventHappened evh(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_BEFOREFADEIN, game.playercharacter);
+        AGSEvent evh(AGSEvent_Interaction(kIntEventType_Room, 0, kRoomEvent_BeforeFadein, game.playercharacter));
         // make sure that any script calls don't re-call enters screen
         int newroom_was = in_new_room;
         in_new_room = 0;

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -66,9 +66,24 @@ namespace Mouse
     void SetSysPosition(int x, int y);
 }
 
+Point Mouse::SysToGamePos(int sys_mx, int sys_my)
+{
+    // Clamp to control rect, and optionally script bounds
+    int mx = Math::Clamp(sys_mx, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
+    int my = Math::Clamp(sys_my, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
+    if (!ignore_bounds)
+    {
+        mx = Math::Clamp(mx, boundx1, boundx2);
+        my = Math::Clamp(my, boundy1, boundy2);
+    }
+    // Convert to virtual coordinates
+    Mouse::WindowToGame(mx, my);
+    return Point(mx, my);
+}
+
 void Mouse::Poll()
 {
-    // TODO: [sonneveld] find out where mgetgraphpos is needed, are events polled before that?
+    // TODO: [sonneveld] find out where Poll is needed, are events polled before that?
     sys_evt_process_pending();
 
     if (switched_away)
@@ -82,9 +97,8 @@ void Mouse::Poll()
     // Set new in-game cursor position, convert to the in-game logic coordinates
     mousex = real_mouse_x;
     mousey = real_mouse_y;
+    // Optionally apply script bounds
     if (!ignore_bounds &&
-        // When applying script bounds we only do so while cursor is inside game viewport
-        Mouse::ControlRect.IsInside(mousex, mousey) &&
         (mousex < boundx1 || mousey < boundy1 || mousex > boundx2 || mousey > boundy2))
     {
         mousex = Math::Clamp(mousex, boundx1, boundx2);

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -52,6 +52,10 @@ namespace Mouse
     // parameter must be in native game coordinates
     void SetMoveLimit(const Rect &r);
 
+    // Translates system mouse position to a position inside a game viewport,
+    // note that this can clamp to game cursor bounds.
+    Point SysToGamePos(int sys_mx, int sys_my);
+
     // Polls the cursor position, updates mousex, mousey
     void Poll();
     // Set actual OS cursor position on screen; in native game coordinates

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -225,8 +225,8 @@ static void game_loop_do_early_script_update()
     if (in_new_room == 0) {
         // Run the room and game script repeatedly_execute
         run_function_on_non_blocking_thread(&repExecAlways);
-        setevent(EV_TEXTSCRIPT, kTS_Repeat);
-        setevent(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_REPEXEC);
+        setevent(AGSEvent_Script(kTS_Repeat));
+        setevent(AGSEvent_Interaction(kIntEventType_Room, 0, kRoomEvent_Repexec));
     }
 }
 
@@ -246,7 +246,7 @@ static bool game_loop_check_ground_level_interactions()
         // check if he's standing on a hotspot
         int hotspotThere = get_hotspot_at(playerchar->x, playerchar->y);
         // run Stands on Hotspot event
-        setevent(EV_RUNEVBLOCK, EVB_HOTSPOT, hotspotThere, EVHOT_STANDSON);
+        setevent(AGSEvent_Interaction(kIntEventType_Hotspot, hotspotThere, kHotspotEvent_StandOn));
 
         // check current region
         int onRegion = GetRegionIDAtRoom(playerchar->x, playerchar->y);
@@ -343,9 +343,9 @@ static void check_mouse_state(int &was_mouse_on_iface)
 
     int mwheelz = ags_check_mouse_wheel();
     if (mwheelz < 0)
-        setevent (EV_TEXTSCRIPT, kTS_MouseClick, 9);
+        setevent(AGSEvent_Script(kTS_MouseClick, 9));
     else if (mwheelz > 0)
-        setevent (EV_TEXTSCRIPT, kTS_MouseClick, 8);
+        setevent(AGSEvent_Script(kTS_MouseClick, 8));
 }
 
 // Runs default mouse button handling
@@ -378,7 +378,7 @@ static void check_mouse_controls(const int was_mouse_on_iface)
             wasongui = was_mouse_on_iface;
             wasbutdown = mbut;
         }
-        else setevent(EV_TEXTSCRIPT, kTS_MouseClick, mbut);
+        else setevent(AGSEvent_Script(kTS_MouseClick, mbut));
     }
 }
 
@@ -632,7 +632,8 @@ static void check_keyboard_controls()
 
                 if (guitex->IsActivated) {
                     guitex->IsActivated = false;
-                    setevent(EV_IFACECLICK, guiIndex, controlIndex, 1);
+                    // FIXME: review this, are we abusing "mouse button" arg here in order to pass a different data?
+                    setevent(AGSEvent_GUI(guiIndex, controlIndex, static_cast<eAGSMouseButton>(1)));
                 }
             }
         }
@@ -656,12 +657,12 @@ static void check_keyboard_controls()
     if (old_keyhandle || (ki.UChar == 0))
     {
         debug_script_log("Running on_key_press keycode %d, mod %d", sckey, sckeymod);
-        setevent(EV_TEXTSCRIPT, kTS_KeyPress, sckey, sckeymod);
+        setevent(AGSEvent_Script(kTS_KeyPress, sckey, sckeymod));
     }
     if (!old_keyhandle && (ki.UChar > 0))
     {
         debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);
-        setevent(EV_TEXTSCRIPT, kTS_TextInput, ki.UChar);
+        setevent(AGSEvent_Script(kTS_TextInput, ki.UChar));
     }
 }
 
@@ -724,7 +725,7 @@ static void check_room_edges(size_t numevents_was)
 
                     for (int ii = 0; ii < 4; ii++) {
                         if (edgesActivated[ii])
-                            setevent(EV_RUNEVBLOCK, EVB_ROOM, 0, ii);
+                            setevent(AGSEvent_Interaction(kIntEventType_Room, 0, ii));
                     }
             }
     }
@@ -864,7 +865,7 @@ static void update_cursor_over_location(int mwasatx, int mwasaty)
         if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT) {
             int onhs = getloctype_index;
 
-            setevent(EV_RUNEVBLOCK, EVB_HOTSPOT, onhs, EVHOT_MOUSEOVER);
+            setevent(AGSEvent_Interaction(kIntEventType_Hotspot, onhs, kHotspotEvent_MouseOver));
         }
     }
 
@@ -876,7 +877,7 @@ static void game_loop_update_events()
 {
     new_room_was = in_new_room;
     if (in_new_room>0)
-        setevent(EV_FADEIN,0,0,0);
+        setevent({ kAGSEvent_FadeIn });
     in_new_room=0;
     processallevents();
     if ((new_room_was > 0) && (in_new_room == 0)) {
@@ -884,9 +885,9 @@ static void game_loop_update_events()
         // then queue the Enters Screen scripts
         // run these next time round, when it's faded in
         if (new_room_was==2)  // first time enters screen
-            setevent(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_FIRSTENTER);
+            setevent(AGSEvent_Interaction(kIntEventType_Room, 0, kRoomEvent_FirstEnter));
         if (new_room_was!=3)   // enters screen after fadein
-            setevent(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_AFTERFADEIN);
+            setevent(AGSEvent_Interaction(kIntEventType_Room, 0, kRoomEvent_AfterFadein));
     }
 }
 

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -54,7 +54,7 @@ float get_real_fps();
 bool run_service_key_controls(KeyInput &kgn);
 // Runs service mouse controls, returns false if mouse input was claimed by the engine,
 // otherwise returns true and provides mouse button code.
-bool run_service_mb_controls(eAGSMouseButton &mbut);
+bool run_service_mb_controls(eAGSMouseButton &mbut, Point *mpos = nullptr);
 // Polls few things (exit flag and debugger messages)
 // TODO: refactor this
 void update_polled_stuff();

--- a/Engine/script/nonblockingscriptfunction.h
+++ b/Engine/script/nonblockingscriptfunction.h
@@ -27,7 +27,7 @@ struct NonBlockingScriptFunction
 {
     const char* functionName;
     int numParameters;
-    RuntimeScriptValue params[3];
+    RuntimeScriptValue params[4];
     bool roomHasFunction;
     bool globalScriptHasFunction;
     std::vector<bool> moduleHasFunction;

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -71,7 +71,7 @@ NonBlockingScriptFunction lateRepExecAlways(LATE_REP_EXEC_ALWAYS_NAME, 0);
 NonBlockingScriptFunction getDialogOptionsDimensionsFunc("dialog_options_get_dimensions", 1);
 NonBlockingScriptFunction renderDialogOptionsFunc("dialog_options_render", 1);
 NonBlockingScriptFunction getDialogOptionUnderCursorFunc("dialog_options_get_active", 1);
-NonBlockingScriptFunction runDialogOptionMouseClickHandlerFunc("dialog_options_mouse_click", 2);
+NonBlockingScriptFunction runDialogOptionMouseClickHandlerFunc("dialog_options_mouse_click", 4);
 NonBlockingScriptFunction runDialogOptionKeyPressHandlerFunc("dialog_options_key_press", 3);
 NonBlockingScriptFunction runDialogOptionTextInputHandlerFunc("dialog_options_text_input", 2);
 NonBlockingScriptFunction runDialogOptionRepExecFunc("dialog_options_repexec", 1);

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -496,8 +496,9 @@ int RunScriptFunctionAuto(ScriptInstType sc_inst, const char *tsname, size_t par
     }
     // Claimable event is run in all the script modules and room script,
     // before running in the globalscript instance
-    if ((strcmp(tsname, tsnames[kTS_KeyPress]) == 0) || (strcmp(tsname, tsnames[kTS_MouseClick]) == 0) ||
-        (strcmp(tsname, tsnames[kTS_TextInput]) == 0) || (strcmp(tsname, "on_event") == 0))
+    // FIXME: make this condition a callback parameter?
+    if ((strcmp(tsname, ScriptEventCb[kTS_KeyPress].FnName) == 0) || (strcmp(tsname, ScriptEventCb[kTS_MouseClick].FnName) == 0) ||
+        (strcmp(tsname, ScriptEventCb[kTS_TextInput].FnName) == 0) || (strcmp(tsname, "on_event") == 0))
     {
         return RunClaimableEvent(tsname, param_count, params);
     }


### PR DESCRIPTION
Resolves #2468

1. Refactored "game events" code inside the engine. This is the first big commit, details may be found in commit's description. Functionality must remain the same, but the event parameters are stored more explicitly now.
2. Added coordinate parameters to "on_mouse_click" callback, now it should be declared as:
```
function on_mouse_click(MouseButton button, int mx, int my)
```
3. Added similar parameters to "dialog_options_mouse_click", now it should be declared as:
```
function dialog_options_mouse_click(DialogOptionsRenderingInfo *info, MouseButton button, int mx, int my)
```
These changes are fully backwards compatible, as the engine was previously taught to skip trailing parameters if the script has declared these functions with less number of arguments.

