### PR TITLE
Editor: fix count negative on too big message

### DIFF
--- a/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
+++ b/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
@@ -54,7 +54,8 @@ namespace AGS.Editor
 
         private static void ClearPrint(string msg)
         {
-            Console.WriteLine($"\r{msg}{new String(' ', Console.BufferWidth - msg.Length)}");
+            int count = Math.Max(Console.BufferWidth - msg.Length, 0);
+            Console.WriteLine($"\r{msg}{new String(' ', count)}");
         }
 
         [System.Runtime.InteropServices.DllImport("kernel32.dll")]


### PR DESCRIPTION
When making the console printer in the editor, I made a function to work around a quirk of the Windows terminal with non console applications.

In the editor, in the part that prints messages to the command line, when an warn/error message is too big AND it's the first line to be print an exception will happen here. This fix will prevent this. 