### PR TITLE
Backport RouteFinder refactor to ags3 branch

### DIFF
--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -147,7 +147,7 @@ bool Bitmap::ResizeSubBitmap(int width, int height)
     return true;
 }
 
-bool Bitmap::CreateCopy(Bitmap *src, int color_depth)
+bool Bitmap::CreateCopy(const Bitmap *src, int color_depth)
 {
     if (src == this || src->_alBitmap == _alBitmap)
         return false; // cannot create a copy of yourself

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -64,7 +64,7 @@ public:
     bool    ResizeSubBitmap(int width, int height);
     // Creates a plain copy of the given bitmap, optionally converting to a different color depth;
     // pass color depth 0 to keep the original one.
-    bool	CreateCopy(Bitmap *src, int color_depth = 0);
+    bool	CreateCopy(const Bitmap *src, int color_depth = 0);
     // TODO: this is a temporary solution for plugin support
     // Wraps a raw allegro BITMAP object, optionally owns it (will delete on disposal)
     bool    WrapAllegroBitmap(BITMAP *al_bmp, bool shared_data);
@@ -82,6 +82,11 @@ public:
     // TODO: This is temporary solution for cases when we cannot replace
 	// use of raw BITMAP struct with Bitmap
     inline BITMAP *GetAllegroBitmap()
+    {
+        return _alBitmap;
+    }
+
+    inline const BITMAP *GetAllegroBitmap() const
     {
         return _alBitmap;
     }

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -86,7 +86,7 @@ Bitmap *CreateSubBitmap(Bitmap *src, const Rect &rc)
 	return bitmap;
 }
 
-Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth)
+Bitmap *CreateBitmapCopy(const Bitmap *src, int color_depth)
 {
     Bitmap *bitmap = new Bitmap();
 	if (!bitmap->CreateCopy(src, color_depth))

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -74,7 +74,7 @@ namespace BitmapHelper
 	Bitmap *CreateSubBitmap(Bitmap *src, const Rect &rc);
     // Creates a plain copy of the given bitmap, optionally converting to a different color depth;
     // pass color depth 0 to keep the original one.
-    Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth = 0);
+    Bitmap *CreateBitmapCopy(const Bitmap *src, int color_depth = 0);
 
     // Creates Bitmap of wanted color depth from a raw pixel array of a (possibly different)
     // specified color depth.

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -119,6 +119,30 @@ struct Point
         return Point(X - p.X, Y - p.Y);
     }
 
+    inline Point operator *(int mul) const
+    {
+        return Point(X * mul, Y * mul);
+    }
+
+    inline Point operator /(int div) const
+    {
+        return Point(X / div, Y / div);
+    }
+
+    inline Point &operator *=(int mul)
+    {
+        X *= mul;
+        Y *= mul;
+        return *this;
+    }
+
+    inline Point &operator /=(int div)
+    {
+        X /= div;
+        Y /= div;
+        return *this;
+    }
+
     inline bool Equals(const int x, const int y) const
     {
         return X == x && Y == y;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -179,11 +179,6 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
     }
 
     MoveList &cmls = mls[chaa->walking % TURNING_AROUND];
-    if (cmls.numstage >= MAXNEEDSTAGES)
-    {
-        debug_script_warn("Character::AddWaypoint: move is too complex, cannot add any further paths");
-        return;
-    }
 
     // They're already walking there anyway
     const Point &last_pos = cmls.GetLastPos();
@@ -201,7 +196,7 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
     // so we do this trick: convert last step to game resolution, before calling
     // a pathfinder api, and then we'll convert old and new last step back.
     // TODO: figure out a better way of processing this!
-    const int last_stage = cmls.numstage - 1;
+    const uint32_t last_stage = cmls.GetNumStages() - 1;
     cmls.pos[last_stage] = { data_to_game_coord(last_pos.X), data_to_game_coord(last_pos.Y) };
     const int dst_x = data_to_game_coord(x);
     const int dst_y = data_to_game_coord(y);
@@ -1414,7 +1409,7 @@ int Character_GetMoving(CharacterInfo *chaa) {
 int Character_GetDestinationX(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1].X;
+        return cmls->pos.back().X;
     }
     else
         return chaa->x;
@@ -1423,7 +1418,7 @@ int Character_GetDestinationX(CharacterInfo *chaa) {
 int Character_GetDestinationY(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1].Y;
+        return cmls->pos.back().Y;
     }
     else
         return chaa->y;
@@ -1868,8 +1863,8 @@ void start_character_turning (CharacterInfo *chinf, int useloop, int no_diagonal
 }
 
 void fix_player_sprite(MoveList*cmls,CharacterInfo*chinf) {
-    const fixed xpmove = cmls->xpermove[cmls->onstage];
-    const fixed ypmove = cmls->ypermove[cmls->onstage];
+    const fixed xpmove = cmls->permove[cmls->onstage].X;
+    const fixed ypmove = cmls->permove[cmls->onstage].Y;
 
     // if not moving, do nothing
     if ((xpmove == 0) && (ypmove == 0))

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -205,7 +205,7 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
     cmls->pos[last_stage] = { room_to_mask_coord(last_pos.X), room_to_mask_coord(last_pos.Y) };
     const int dst_x = room_to_mask_coord(x);
     const int dst_y = room_to_mask_coord(y);
-    if (add_waypoint_direct(cmls, dst_x, dst_y, move_speed_x, move_speed_y))
+    if (Pathfinding::AddWaypointDirect(*cmls, dst_x, dst_y, move_speed_x, move_speed_y))
     {
         convert_move_path_to_room_resolution(cmls, last_stage, last_stage + 1);
     }
@@ -952,10 +952,9 @@ void Character_SetSpeed(CharacterInfo *chaa, int xspeed, int yspeed) {
 
     if (chaa->walking > 0)
     {
-        recalculate_move_speeds(&mls[chaa->walking % TURNING_AROUND], old_speedx, old_speedy, xspeed, yspeed);
+        Pathfinding::RecalculateMoveSpeeds(mls[chaa->walking % TURNING_AROUND], old_speedx, old_speedy, xspeed, yspeed);
     }
 }
-
 
 void Character_StopMoving(CharacterInfo *charp) {
 

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -164,7 +164,7 @@ int     Character_GetSpeakingFrame(CharacterInfo *chaa);
 
 //=============================================================================
 
-struct MoveList;
+class MoveList;
 namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2938,7 +2938,7 @@ void update_room_debug()
             if (game.chars[debugMoveListChar].walking >= TURNING_AROUND)
                 mlsnum %= TURNING_AROUND;
             const MoveList &cmls = mls[mlsnum];
-            for (int i = 0; i < cmls.numstage - 1; i++) {
+            for (uint32_t i = 0; i < cmls.GetNumStages() - 1; i++) {
                 short srcx = cmls.pos[i].X;
                 short srcy = cmls.pos[i].Y;
                 short targetx = cmls.pos[i + 1].X;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -39,6 +39,7 @@
 #include "ac/overlay.h"
 #include "ac/path_helper.h"
 #include "ac/sys_events.h"
+#include "ac/room.h"
 #include "ac/roomstatus.h"
 #include "ac/sprite.h"
 #include "ac/spritecache.h"
@@ -496,6 +497,8 @@ void unload_game()
     get_overlays().clear();
 
     resetRoomStatuses();
+
+    dispose_room_pathfinder();
 
     // Free game state and game struct
     play = GamePlayState();

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -22,23 +22,23 @@ using namespace AGS::Engine;
 
 float MoveList::GetStepLength() const
 {
-    assert(numstage > 0);
-    float permove_x = fixtof(xpermove[onstage]);
-    float permove_y = fixtof(ypermove[onstage]);
+    assert(GetNumStages() > 0);
+    float permove_x = fixtof(permove[onstage].X);
+    float permove_y = fixtof(permove[onstage].Y);
     return std::sqrt(permove_x * permove_x + permove_y * permove_y);
 }
 
 float MoveList::GetPixelUnitFraction() const
 {
-    assert(numstage > 0);
-    float distance = GetStepLength() * onpart;
+    assert(GetNumStages() > 0);
+    const float distance = GetStepLength() * onpart;
     return distance - std::floor(distance);
 }
 
 void MoveList::SetPixelUnitFraction(float frac)
 {
-    assert(numstage > 0);
-    float permove_dist = GetStepLength();
+    assert(GetNumStages() > 0);
+    const float permove_dist = GetStepLength();
     onpart = permove_dist > 0.f ? (1.f / permove_dist) * frac : 0.f;
 }
 
@@ -51,16 +51,12 @@ HSaveError MoveList::ReadFromSavegame(Stream *in, int32_t cmp_ver)
     }
 
     *this = MoveList(); // reset struct
-    numstage = in->ReadInt32();
+    uint32_t numstage = in->ReadInt32();
+    pos.resize(numstage);
+    permove.resize(numstage);
     if ((numstage == 0) && cmp_ver >= kMoveSvgVersion_36109)
     {
         return HSaveError::None();
-    }
-    // TODO: reimplement MoveList stages as vector to avoid these limits
-    if (numstage > MAXNEEDSTAGES)
-    {
-        return new SavegameError(kSvgErr_IncompatibleEngine,
-            String::FromFormat("Incompatible number of movelist steps (count: %d, max : %d).", numstage, MAXNEEDSTAGES));
     }
 
     from.X = in->ReadInt32();
@@ -72,13 +68,19 @@ HSaveError MoveList::ReadFromSavegame(Stream *in, int32_t cmp_ver)
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 
-    for (int i = 0; i < numstage; ++i)
+    for (uint32_t i = 0; i < numstage; ++i)
     { // X & Y was packed as high/low shorts, and hence reversed in lo-end
         pos[i].Y = in->ReadInt16();
         pos[i].X = in->ReadInt16();
     }
-    in->ReadArrayOfInt32(xpermove, numstage);
-    in->ReadArrayOfInt32(ypermove, numstage);
+    for (uint32_t i = 0; i < numstage; ++i)
+    {
+        permove[i].X = in->ReadInt32();
+    }
+    for (uint32_t i = 0; i < numstage; ++i)
+    {
+        permove[i].Y = in->ReadInt32();
+    }
 
     // Some variables require conversion depending on a save version
     if (cmp_ver < kMoveSvgVersion_36109)
@@ -91,6 +93,7 @@ HSaveError MoveList::ReadFromSavegame(Stream *in, int32_t cmp_ver)
 
 void MoveList::WriteToSavegame(Stream *out) const
 {
+    const uint32_t numstage = GetNumStages();
     out->WriteInt32(numstage);
     if (numstage == 0)
         return;
@@ -104,11 +107,17 @@ void MoveList::WriteToSavegame(Stream *out) const
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
 
-    for (int i = 0; i < numstage; ++i)
+    for (uint32_t i = 0; i < numstage; ++i)
     { // X & Y was packed as high/low shorts, and hence reversed in lo-end
         out->WriteInt16(pos[i].Y);
         out->WriteInt16(pos[i].X);
     }
-    out->WriteArrayOfInt32(xpermove, numstage);
-    out->WriteArrayOfInt32(ypermove, numstage);
+    for (uint32_t i = 0; i < numstage; ++i)
+    {
+        out->WriteInt32(permove[i].X);
+    }
+    for (uint32_t i = 0; i < numstage; ++i)
+    {
+        out->WriteInt32(permove[i].Y);
+    }
 }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -449,11 +449,14 @@ void move_object(int objj,int tox,int toy,int spee,int ignwal) {
     const int dst_x = room_to_mask_coord(tox);
     const int dst_y = room_to_mask_coord(toy);
 
-    int mslot = find_route(src_x, src_y, dst_x, dst_y, spee, spee, prepare_walkable_areas(-1), objj+1, 1, ignwal);
-    if (mslot>0) {
+    const int mslot = objj + 1;
+    MaskRouteFinder *pathfind = get_room_pathfinder();
+    pathfind->SetWalkableArea(prepare_walkable_areas(-1));
+    if (Pathfinding::FindRoute(mls[mslot], pathfind, src_x, src_y, dst_x, dst_y, spee, spee, false, ignwal))
+    {
         objs[objj].moving = mslot;
         mls[mslot].direct = ignwal;
-        convert_move_path_to_room_resolution(&mls[mslot]);
+        convert_move_path_to_room_resolution(mls[mslot]);
     }
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -427,36 +427,37 @@ int Object_GetIgnoreWalkbehinds(ScriptObject *chaa) {
     return 0;
 }
 
-void move_object(int objj,int tox,int toy,int spee,int ignwal) {
+void move_object(int objj, int tox, int toy, int speed, int ignwal) {
 
     if (!is_valid_object(objj))
         quit("!MoveObject: invalid object number");
 
+    auto &obj = objs[objj];
     // AGS <= 2.61 uses MoveObject with spp=-1 internally instead of SetObjectPosition
-    if ((loaded_game_file_version <= kGameVersion_261) && (spee == -1))
+    if ((loaded_game_file_version <= kGameVersion_261) && (speed == -1))
     {
-        objs[objj].x = tox;
-        objs[objj].y = toy;
+        obj.x = tox;
+        obj.y = toy;
         return;
     }
 
     debug_script_log("Object %d start move to %d,%d", objj, tox, toy);
 
-    // Convert src and dest coords to the mask resolution, for pathfinder
     // NOTE: for old games we assume the input coordinates are in the "data" coordinate system
-    const int src_x = room_to_mask_coord(objs[objj].x);
-    const int src_y = room_to_mask_coord(objs[objj].y);
-    const int dst_x = room_to_mask_coord(tox);
-    const int dst_y = room_to_mask_coord(toy);
+    const int src_x = data_to_game_coord(objs[objj].x);
+    const int src_y = data_to_game_coord(objs[objj].y);
+    const int dst_x = data_to_game_coord(tox);
+    const int dst_y = data_to_game_coord(toy);
 
     const int mslot = objj + 1;
     MaskRouteFinder *pathfind = get_room_pathfinder();
-    pathfind->SetWalkableArea(prepare_walkable_areas(-1));
-    if (Pathfinding::FindRoute(mls[mslot], pathfind, src_x, src_y, dst_x, dst_y, spee, spee, false, ignwal))
+    pathfind->SetWalkableArea(prepare_walkable_areas(-1), thisroom.MaskResolution);
+    if (Pathfinding::FindRoute(mls[mslot], pathfind, src_x, src_y, dst_x, dst_y,
+        speed, speed, false, ignwal != 0))
     {
         objs[objj].moving = mslot;
         mls[mslot].direct = ignwal;
-        convert_move_path_to_room_resolution(mls[mslot]);
+        convert_move_path_to_data_resolution(mls[mslot]);
     }
 }
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1087,7 +1087,7 @@ int mask_to_room_coord(int coord)
     return coord * thisroom.MaskResolution / game.GetDataUpscaleMult();
 }
 
-void convert_move_path_to_room_resolution(MoveList &mls, int from_step, int to_step)
+void convert_move_path_to_data_resolution(MoveList &mls, int from_step, int to_step)
 {
     if (to_step < 0)
         to_step = mls.numstage;
@@ -1103,29 +1103,27 @@ void convert_move_path_to_room_resolution(MoveList &mls, int from_step, int to_s
             mls.ypermove[i] = game_to_data_coord(mls.ypermove[i]);
         }
     }
-
-    // Skip the conversion if these are equal, as they are multiplier and divisor
-    if (thisroom.MaskResolution == game.GetDataUpscaleMult())
-        return;
-
-    if (from_step == 0)
-    {
-        mls.from = { mask_to_room_coord(mls.from.X), mask_to_room_coord(mls.from.Y) };
-    }
-
-    for (int i = from_step; i <= to_step; i++)
-    {
-        mls.pos[i] = { mask_to_room_coord(mls.pos[i].X), mask_to_room_coord(mls.pos[i].Y) };
-    }
-
     // If speed is scaling with MaskResolution...
-    if (game.options[OPT_WALKSPEEDABSOLUTE] == 0)
+    else if (game.options[OPT_WALKSPEEDABSOLUTE] == 0)
     {
         for (int i = from_step; i <= to_step; i++)
         {
             mls.xpermove[i] = mask_to_room_coord(mls.xpermove[i]);
             mls.ypermove[i] = mask_to_room_coord(mls.ypermove[i]);
         }
+    }
+
+    if (game.GetDataUpscaleMult() == 1)
+        return;
+
+    if (from_step == 0)
+    {
+        mls.from = { game_to_data_coord(mls.from.X), game_to_data_coord(mls.from.Y) };
+    }
+
+    for (int i = from_step; i <= to_step; i++)
+    {
+        mls.pos[i] = { game_to_data_coord(mls.pos[i].X), game_to_data_coord(mls.pos[i].Y) };
     }
 }
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1087,20 +1087,18 @@ int mask_to_room_coord(int coord)
     return coord * thisroom.MaskResolution / game.GetDataUpscaleMult();
 }
 
-void convert_move_path_to_data_resolution(MoveList &mls, int from_step, int to_step)
+void convert_move_path_to_data_resolution(MoveList &mls, uint32_t from_step, uint32_t to_step)
 {
-    if (to_step < 0)
-        to_step = mls.numstage;
-    to_step = Math::Clamp(to_step, 0, mls.numstage - 1);
-    from_step = Math::Clamp(from_step, 0, to_step);
+    to_step = Math::Clamp(to_step, 0u, mls.GetNumStages() - 1);
+    from_step = Math::Clamp(from_step, 0u, to_step);
 
     // If speed is independent from MaskResolution...
     if ((game.options[OPT_WALKSPEEDABSOLUTE] != 0) && game.GetDataUpscaleMult() > 1)
     {
         for (int i = from_step; i <= to_step; i++)
         { // ...we still need to convert from game to data coords
-            mls.xpermove[i] = game_to_data_coord(mls.xpermove[i]);
-            mls.ypermove[i] = game_to_data_coord(mls.ypermove[i]);
+            mls.permove[i].X = game_to_data_coord(mls.permove[i].X);
+            mls.permove[i].Y = game_to_data_coord(mls.permove[i].Y);
         }
     }
     // If speed is scaling with MaskResolution...
@@ -1108,8 +1106,8 @@ void convert_move_path_to_data_resolution(MoveList &mls, int from_step, int to_s
     {
         for (int i = from_step; i <= to_step; i++)
         {
-            mls.xpermove[i] = mask_to_room_coord(mls.xpermove[i]);
-            mls.ypermove[i] = mask_to_room_coord(mls.ypermove[i]);
+            mls.permove[i].X = mask_to_room_coord(mls.permove[i].X);
+            mls.permove[i].Y = mask_to_room_coord(mls.permove[i].Y);
         }
     }
 

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -11,15 +11,12 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-//
-//
-//
-//=============================================================================
 #ifndef __AGS_EE_AC__ROOM_H
 #define __AGS_EE_AC__ROOM_H
 
 #include "ac/dynobj/scriptdrawingsurface.h"
 #include "ac/characterinfo.h"
+#include "ac/route_finder.h"
 #include "script/runtimescriptvalue.h"
 #include "game/roomstruct.h"
 
@@ -59,6 +56,10 @@ void  compile_room_script();
 void  on_background_frame_change ();
 // Clear the current room pointer if room status is no longer valid
 void  croom_ptr_clear();
+void  init_room_pathfinder();
+void  dispose_room_pathfinder();
+// Gets current room's pathfinder object
+AGS::Engine::MaskRouteFinder *get_room_pathfinder();
 
 // Following functions convert coordinates between room resolution and region mask.
 // Region masks can be 1:N of the room size: 1:1, 1:2 etc.
@@ -74,8 +75,9 @@ int mask_to_room_coord(int coord);
 
 struct MoveList;
 // Convert move path from room's mask resolution to room resolution
-void convert_move_path_to_room_resolution(MoveList *ml, int from_step = 0, int to_step = -1);
+void convert_move_path_to_room_resolution(MoveList &mls, int from_step = 0, int to_step = -1);
 
+// The single global "current room" instance
 extern AGS::Common::RoomStruct thisroom;
 
 #endif // __AGS_EE_AC__ROOM_H

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -74,8 +74,9 @@ int room_to_mask_coord(int coord);
 int mask_to_room_coord(int coord);
 
 struct MoveList;
-// Convert move path from room's mask resolution to room resolution
-void convert_move_path_to_room_resolution(MoveList &mls, int from_step = 0, int to_step = -1);
+// Convert move path from room (eq. game) resolution to data resolution;
+// applies move speed factor, according to the game settings
+void convert_move_path_to_data_resolution(MoveList &mls, int from_step = 0, int to_step = -1);
 
 // The single global "current room" instance
 extern AGS::Common::RoomStruct thisroom;

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -73,10 +73,10 @@ int room_to_mask_coord(int coord);
 // coordinate conversion (room mask) ---> game ---> (data)
 int mask_to_room_coord(int coord);
 
-struct MoveList;
+class MoveList;
 // Convert move path from room (eq. game) resolution to data resolution;
 // applies move speed factor, according to the game settings
-void convert_move_path_to_data_resolution(MoveList &mls, int from_step = 0, int to_step = -1);
+void convert_move_path_to_data_resolution(MoveList &mls, uint32_t from_step = 0, uint32_t to_step = UINT32_MAX);
 
 // The single global "current room" instance
 extern AGS::Common::RoomStruct thisroom;

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -13,6 +13,8 @@
 //=============================================================================
 #include "ac/route_finder.h"
 #include <memory>
+#include <allegro.h>
+#include "ac/movelist.h"
 #include "ac/route_finder_impl.h"
 #include "ac/route_finder_impl_legacy.h"
 #include "debug/out.h"
@@ -31,9 +33,6 @@ public:
     virtual void get_lastcpos(int &lastcx, int &lastcy) = 0;
     virtual int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
         Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0) = 0;
-    // Append a waypoint to the move list, skip pathfinding
-    virtual bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y) = 0;
-    virtual void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) = 0;
 };
 
 class AGSRouteFinder : public IRouteFinder 
@@ -65,14 +64,6 @@ public:
         return AGS::Engine::RouteFinder::find_route(srcx, srcy, xx, yy,
             move_speed_x, move_speed_y, onscreen, movlst, nocross, ignore_walls); 
     }
-    bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y) override
-    {
-        return AGS::Engine::RouteFinder::add_waypoint_direct(mlsp, x, y, move_speed_x, move_speed_y); 
-    }
-    void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) override
-    {
-        AGS::Engine::RouteFinder::recalculate_move_speeds(mlsp, old_speed_x, old_speed_y, new_speed_x, new_speed_y);
-    }
 };
 
 class AGSLegacyRouteFinder : public IRouteFinder 
@@ -103,14 +94,6 @@ public:
     { 
         return AGS::Engine::RouteFinderLegacy::find_route(srcx, srcy, xx, yy,
             move_speed_x, move_speed_y, onscreen, movlst, nocross, ignore_walls); 
-    }
-    bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y) override
-    {
-        return AGS::Engine::RouteFinderLegacy::add_waypoint_direct(mlsp, x, y, move_speed_x, move_speed_y); 
-    }
-    void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) override
-    {
-        assert(false); // not supported
     }
 };
 
@@ -160,12 +143,187 @@ int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int
         onscreen, movlst, nocross, ignore_walls);
 }
 
-bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y)
+namespace Pathfinding
 {
-    return route_finder_impl->add_waypoint_direct(mlsp, x, y, move_speed_x, move_speed_y);
+
+inline fixed input_speed_to_fixed(int speed_val)
+{
+    // negative move speeds like -2 get converted to 1/2
+    if (speed_val < 0)
+        return itofix(1) / (-speed_val);
+    else
+        return itofix(speed_val);
 }
 
-void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y)
+inline fixed calc_move_speed_at_angle(fixed speed_x, fixed speed_y, fixed xdist, fixed ydist)
 {
-    route_finder_impl->recalculate_move_speeds(mlsp, old_speed_x, old_speed_y, new_speed_x, new_speed_y);
+    fixed useMoveSpeed;
+    if (speed_x == speed_y)
+    {
+        useMoveSpeed = speed_x;
+    }
+    else
+    {
+        // different X and Y move speeds
+        // the X proportion of the movement is (x / (x + y))
+        fixed xproportion = fixdiv(xdist, (xdist + ydist));
+
+        if (speed_x > speed_y)
+        {
+            // speed = y + ((1 - xproportion) * (x - y))
+            useMoveSpeed = speed_y + fixmul(xproportion, speed_x - speed_y);
+        }
+        else
+        {
+            // speed = x + (xproportion * (y - x))
+            useMoveSpeed = speed_x + fixmul(itofix(1) - xproportion, speed_y - speed_x);
+        }
+    }
+    return useMoveSpeed;
 }
+
+// Calculates the X and Y per game loop, for this stage of the movelist
+void calculate_move_stage(MoveList &mls, uint32_t stage, fixed move_speed_x, fixed move_speed_y)
+{
+    // work out the x & y per move. First, opp/adj=tan, so work out the angle
+    if (mls.pos[stage] == mls.pos[stage + 1])
+    {
+        mls.xpermove[stage] = 0;
+        mls.ypermove[stage] = 0;
+        return;
+    } 
+
+    int ourx = mls.pos[stage].X;
+    int oury = mls.pos[stage].Y;
+    int destx = mls.pos[stage + 1].X;
+    int desty = mls.pos[stage + 1].Y;
+
+    // Special case for vertical and horizontal movements
+    if (ourx == destx)
+    {
+        mls.xpermove[stage] = 0;
+        mls.ypermove[stage] = move_speed_y;
+        if (desty < oury)
+            mls.ypermove[stage] = -mls.ypermove[stage];
+        return;
+    }
+
+    if (oury == desty)
+    {
+        mls.xpermove[stage] = move_speed_x;
+        mls.ypermove[stage] = 0;
+        if (destx < ourx)
+            mls.xpermove[stage] = -mls.xpermove[stage];
+        return;
+    }
+
+    fixed xdist = itofix(abs(ourx - destx));
+    fixed ydist = itofix(abs(oury - desty));
+
+    fixed useMoveSpeed = calc_move_speed_at_angle(move_speed_x, move_speed_y, xdist, ydist);
+
+    fixed angl = fixatan(fixdiv(ydist, xdist));
+
+    // now, since new opp=hyp*sin, work out the Y step size
+    //fixed newymove = useMoveSpeed * fsin(angl);
+    fixed newymove = fixmul(useMoveSpeed, fixsin(angl));
+
+    // since adj=hyp*cos, work out X step size
+    //fixed newxmove = useMoveSpeed * fcos(angl);
+    fixed newxmove = fixmul(useMoveSpeed, fixcos(angl));
+
+    if (destx < ourx)
+        newxmove = -newxmove;
+    if (desty < oury)
+        newymove = -newymove;
+
+    mls.xpermove[stage] = newxmove;
+    mls.ypermove[stage] = newymove;
+
+#ifdef DEBUG_PATHFINDER
+  AGS::Common::Debug::Printf("stage %d from %d,%d to %d,%d Xpermove:%X Ypm:%X", stage, ourx, oury, destx, desty, newxmove, newymove);
+#endif
+}
+
+bool CalculateMoveList(MoveList &mls, const std::vector<Point> path, int move_speed_x, int move_speed_y)
+{
+    // Ensure that it does not exceed MoveList limit
+    const size_t stage_count = std::min((size_t)MAXNEEDSTAGES, path.size());
+
+    MoveList mlist;
+    mlist.numstage = stage_count;
+    std::copy(path.begin(), path.begin() + stage_count, &mlist.pos[0]);
+
+    const fixed fix_speed_x = input_speed_to_fixed(move_speed_x);
+    const fixed fix_speed_y = input_speed_to_fixed(move_speed_y);
+    for (uint32_t i = 0; i < stage_count - 1; i++)
+        calculate_move_stage(mlist, i, fix_speed_x, fix_speed_y);
+
+    mlist.from = mlist.pos[0];
+    mls = mlist;
+    return true;
+}
+
+bool AddWaypointDirect(MoveList &mls, int x, int y, int move_speed_x, int move_speed_y)
+{
+    if (mls.numstage >= MAXNEEDSTAGES)
+        return false;
+
+    const fixed fix_speed_x = input_speed_to_fixed(move_speed_x);
+    const fixed fix_speed_y = input_speed_to_fixed(move_speed_y);
+    mls.pos[mls.numstage] = { x, y };
+    calculate_move_stage(mls, mls.numstage - 1, fix_speed_x, fix_speed_y);
+    mls.numstage++;
+    return true;
+}
+
+void RecalculateMoveSpeeds(MoveList &mls, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y)
+{
+    const fixed old_movspeed_x = input_speed_to_fixed(old_speed_x);
+    const fixed old_movspeed_y = input_speed_to_fixed(old_speed_y);
+    const fixed new_movspeed_x = input_speed_to_fixed(new_speed_x);
+    const fixed new_movspeed_y = input_speed_to_fixed(new_speed_y);
+    // save current stage's step lengths, for later onpart's update
+    const fixed old_stage_xpermove = mls.xpermove[mls.onstage];
+    const fixed old_stage_ypermove = mls.ypermove[mls.onstage];
+
+    for (int i = 0; (i < mls.numstage) && ((mls.xpermove[i] != 0) || (mls.ypermove[i] != 0)); ++i)
+    {
+        // First three cases where the speed is a plain factor, therefore
+        // we may simply divide on old one and multiple on a new one
+        if ((old_movspeed_x == old_movspeed_y) || // diagonal move at straight 45 degrees
+            (mls.xpermove[i] == 0) || // straight vertical move
+            (mls.ypermove[i] == 0))   // straight horizontal move
+        {
+            mls.xpermove[i] = fixdiv(fixmul(mls.xpermove[i], new_movspeed_x), old_movspeed_x);
+            mls.ypermove[i] = fixdiv(fixmul(mls.ypermove[i], new_movspeed_y), old_movspeed_y);
+        }
+        else
+        {
+            // Move at angle has adjusted speed factor, which we must recalculate first
+            int ourx = mls.pos[i].X;
+            int oury = mls.pos[i].Y;
+            int destx = mls.pos[i + 1].X;
+            int desty = mls.pos[i + 1].Y;
+
+            fixed xdist = itofix(abs(ourx - destx));
+            fixed ydist = itofix(abs(oury - desty));
+            fixed old_speed_at_angle = calc_move_speed_at_angle(old_movspeed_x, old_movspeed_y, xdist, ydist);
+            fixed new_speed_at_angle = calc_move_speed_at_angle(new_movspeed_x, new_movspeed_y, xdist, ydist);
+
+            mls.xpermove[i] = fixdiv(fixmul(mls.xpermove[i], new_speed_at_angle), old_speed_at_angle);
+            mls.ypermove[i] = fixdiv(fixmul(mls.ypermove[i], new_speed_at_angle), old_speed_at_angle);
+        }
+    }
+
+    // now adjust current passed stage fraction
+    if (mls.onpart >= 0.f)
+    {
+        if (old_stage_xpermove != 0)
+            mls.onpart = (mls.onpart * fixtof(old_stage_xpermove)) / fixtof(mls.xpermove[mls.onstage]);
+        else
+            mls.onpart = (mls.onpart * fixtof(old_stage_ypermove)) / fixtof(mls.ypermove[mls.onstage]);
+    }
+}
+
+} // namespace Pathfinding

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -18,133 +18,41 @@
 #include "ac/route_finder_impl.h"
 #include "ac/route_finder_impl_legacy.h"
 #include "debug/out.h"
+#include "util/memory_compat.h"
 
-using AGS::Common::Bitmap;
+using namespace AGS::Common;
 
-class IRouteFinder 
+namespace AGS
 {
-public:
-    virtual ~IRouteFinder() = default;
-
-    virtual void init_pathfinder() = 0;
-    virtual void shutdown_pathfinder() = 0;
-    virtual void set_wallscreen(Bitmap *wallscreen) = 0;
-    virtual int can_see_from(int x1, int y1, int x2, int y2) = 0;
-    virtual void get_lastcpos(int &lastcx, int &lastcy) = 0;
-    virtual int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-        Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0) = 0;
-};
-
-class AGSRouteFinder : public IRouteFinder 
+namespace Engine
 {
-public:
-    void init_pathfinder() override
-    { 
-        AGS::Engine::RouteFinder::init_pathfinder(); 
-    }
-    void shutdown_pathfinder() override
-    { 
-        AGS::Engine::RouteFinder::shutdown_pathfinder(); 
-    }
-    void set_wallscreen(Bitmap *wallscreen) override
-    { 
-        AGS::Engine::RouteFinder::set_wallscreen(wallscreen);
-    }
-    int can_see_from(int x1, int y1, int x2, int y2) override
-    { 
-        return AGS::Engine::RouteFinder::can_see_from(x1, y1, x2, y2); 
-    }
-    void get_lastcpos(int &lastcx, int &lastcy) override
-    { 
-        AGS::Engine::RouteFinder::get_lastcpos(lastcx, lastcy); 
-    }
-    int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-        Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0) override
-    { 
-        return AGS::Engine::RouteFinder::find_route(srcx, srcy, xx, yy,
-            move_speed_x, move_speed_y, onscreen, movlst, nocross, ignore_walls); 
-    }
-};
 
-class AGSLegacyRouteFinder : public IRouteFinder 
+namespace Pathfinding
 {
-public:
-    void init_pathfinder() override
-    { 
-        AGS::Engine::RouteFinderLegacy::init_pathfinder(); 
-    }
-    void shutdown_pathfinder() override
-    { 
-        AGS::Engine::RouteFinderLegacy::shutdown_pathfinder(); 
-    }
-    void set_wallscreen(Bitmap *wallscreen) override
-    { 
-        AGS::Engine::RouteFinderLegacy::set_wallscreen(wallscreen); 
-    }
-    int can_see_from(int x1, int y1, int x2, int y2) override
-    { 
-        return AGS::Engine::RouteFinderLegacy::can_see_from(x1, y1, x2, y2); 
-    }
-    void get_lastcpos(int &lastcx, int &lastcy) override
-    { 
-        AGS::Engine::RouteFinderLegacy::get_lastcpos(lastcx, lastcy); 
-    }
-    int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-        Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0) override
-    { 
-        return AGS::Engine::RouteFinderLegacy::find_route(srcx, srcy, xx, yy,
-            move_speed_x, move_speed_y, onscreen, movlst, nocross, ignore_walls); 
-    }
-};
 
-std::unique_ptr<IRouteFinder> route_finder_impl;
-
-void init_pathfinder(GameDataVersion game_file_version)
+std::unique_ptr<MaskRouteFinder> CreateDefaultMaskPathfinder(GameDataVersion game_ver)
 {
-    if (game_file_version >= kGameVersion_350) 
+    if (game_ver >= kGameVersion_350) 
     {
-        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Info, "Initialize path finder library");
-        route_finder_impl.reset(new AGSRouteFinder());
+        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Info, "Initialize path finder");
+        return std::make_unique<JPSRouteFinder>();
     } 
     else 
     {
         AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Info, "Initialize legacy path finder library");
-        route_finder_impl.reset(new AGSLegacyRouteFinder());
+        return std::make_unique<LegacyRouteFinder>();
     }
-
-    route_finder_impl->init_pathfinder();
 }
 
-void shutdown_pathfinder()
+bool FindRoute(MoveList &mls, IRouteFinder *finder, int srcx, int srcy, int dstx, int dsty,
+    int move_speed_x, int move_speed_y, bool exact_dest, bool ignore_walls)
 {
-    if (route_finder_impl)
-        route_finder_impl->shutdown_pathfinder();
-}
+    std::vector<Point> path;
+    if (!finder->FindRoute(path, srcx, srcy, dstx, dsty, exact_dest, ignore_walls))
+        return false;
 
-void set_wallscreen(Bitmap *wallscreen)
-{
-    route_finder_impl->set_wallscreen(wallscreen);
+    return CalculateMoveList(mls, path, move_speed_x, move_speed_y);
 }
-
-int can_see_from(int x1, int y1, int x2, int y2)
-{
-    return route_finder_impl->can_see_from(x1, y1, x2, y2);
-}
-
-void get_lastcpos(int &lastcx, int &lastcy)
-{
-    route_finder_impl->get_lastcpos(lastcx, lastcy);
-}
-
-int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-    Bitmap *onscreen, int movlst, int nocross, int ignore_walls)
-{
-    return route_finder_impl->find_route(srcx, srcy, xx, yy, move_speed_x, move_speed_y,
-        onscreen, movlst, nocross, ignore_walls);
-}
-
-namespace Pathfinding
-{
 
 inline fixed input_speed_to_fixed(int speed_val)
 {
@@ -327,3 +235,6 @@ void RecalculateMoveSpeeds(MoveList &mls, int old_speed_x, int old_speed_y, int 
 }
 
 } // namespace Pathfinding
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -27,6 +27,58 @@ namespace AGS
 namespace Engine
 {
 
+bool MaskRouteFinder::CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx, int *lastcy)
+{
+    if (!_walkablearea)
+        return false;
+
+    // convert input to the mask coords
+    srcx /= _coordScale;
+    srcy /= _coordScale;
+    dstx /= _coordScale;
+    dsty /= _coordScale;
+
+    int last_valid_x, last_valid_y;
+    bool result = CanSeeFromImpl(srcx, srcy, dstx, dsty, &last_valid_x, &last_valid_y);
+
+    // convert output from the mask coords
+    if (lastcx)
+        *lastcx = last_valid_x * _coordScale;
+    if (lastcy)
+        *lastcy = last_valid_y * _coordScale;
+    return result;
+}
+
+bool MaskRouteFinder::FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+    bool exact_dest, bool ignore_walls)
+{
+    if (!_walkablearea)
+        return false;
+
+    // convert input to the mask coords
+    srcx /= _coordScale;
+    srcy /= _coordScale;
+    dstx /= _coordScale;
+    dsty /= _coordScale;
+
+    if (!FindRouteImpl(path, srcx, srcy, dstx, dsty, exact_dest, ignore_walls))
+        return false;
+    
+    // convert output from the mask coords
+    for (auto &pt : path)
+        pt *= _coordScale;
+    return true;
+}
+
+void MaskRouteFinder::SetWalkableArea(const AGS::Common::Bitmap *walkablearea, uint32_t coord_scale)
+{
+    _walkablearea = walkablearea;
+    assert(coord_scale > 0);
+    _coordScale = std::max(1u, coord_scale);
+    OnSetWalkableArea();
+}
+
+
 namespace Pathfinding
 {
 

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -55,9 +55,32 @@ public:
 class MaskRouteFinder : public IRouteFinder
 {
 public:
-    // Assign a walkable mask;
+    // Traces a straight line between two points, returns if it's fully passable;
+    // optionally assigns last found passable position.
+    bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) override;
+    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
+    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
+    //              otherwise pathfinder will try to find the closest possible end point.
+    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
+    bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest = false, bool ignore_walls = false) override;
+
+    // Assign a walkable mask, and an optional coordinate scale factor which will be used
+    // to convert (divide) input coordinates, and resulting path back (multiply).
     // Note that this may make routefinder to generate additional data, taking more time.
-    virtual void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) = 0;
+    void SetWalkableArea(const AGS::Common::Bitmap *walkablearea, uint32_t coord_scale = 1);
+
+protected:
+    // Update the implementation after a new walkable area is set
+    virtual void OnSetWalkableArea() = 0;
+    // CanSeeFrom implementation
+    virtual bool CanSeeFromImpl(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) = 0;
+    // FindRoute implementation
+    virtual bool FindRouteImpl(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest, bool ignore_walls) = 0;
+
+    const Common::Bitmap *_walkablearea = nullptr;
+    uint32_t _coordScale = 1;
 };
 
 //

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -19,7 +19,7 @@
 #include "ac/game_version.h"
 #include "util/geometry.h"
 
-struct MoveList;
+class MoveList;
 
 namespace AGS
 {

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -14,30 +14,63 @@
 #ifndef __AC_ROUTEFND_H
 #define __AC_ROUTEFND_H
 
+#include <memory>
 #include <vector>
 #include "ac/game_version.h"
 #include "util/geometry.h"
 
-// Forward declaration
-namespace AGS { namespace Common { class Bitmap; }}
 struct MoveList;
 
-void init_pathfinder(GameDataVersion game_file_version);
-void shutdown_pathfinder();
+namespace AGS
+{
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+namespace Common { class Bitmap; }
 
-int can_see_from(int x1, int y1, int x2, int y2);
-void get_lastcpos(int &lastcx, int &lastcy);
+namespace Engine
+{
 
-int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-    AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
+// IRouteFinder: a basic pathfinding interface.
+// FIXME: separate finding a path and calculating MoveLists! The latter must not depend on a pathfinder impl.
+class IRouteFinder 
+{
+public:
+    virtual ~IRouteFinder() = default;
+
+    // Configure pathfinder for the particular game data version
+    virtual void Configure(GameDataVersion game_ver) = 0;
+    // Traces a straight line between two points, returns if it's fully passable;
+    // optionally assigns last found passable position.
+    virtual bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) = 0;
+    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
+    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
+    //              otherwise pathfinder will try to find the closest possible end point.
+    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
+    virtual bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest = false, bool ignore_walls = false) = 0;
+};
+
+// MaskRouteFinder: a mask-based RouteFinder.
+// Works with a 8-bit mask, where each color index represents certain walkable area,
+// while index 0 represents a wall (impassable).
+class MaskRouteFinder : public IRouteFinder
+{
+public:
+    // Assign a walkable mask;
+    // Note that this may make routefinder to generate additional data, taking more time.
+    virtual void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) = 0;
+};
 
 //
 // Various additional pathfinding functions and helpers.
 // Manages converting navigation paths into MoveLists.
 namespace Pathfinding
 {
+    // Creates a default engine's MaskRouteFinder implementation
+    std::unique_ptr<MaskRouteFinder> CreateDefaultMaskPathfinder(GameDataVersion game_ver);
+
+    // Find route using a provided IRouteFinder, and calculate the MoveList using move speeds
+    bool FindRoute(MoveList &mls, IRouteFinder *finder, int srcx, int srcy, int dstx, int dsty,
+        int move_speed_x, int move_speed_y, bool exact_dest, bool ignore_walls);
     // Calculate the MoveList from the given navigation path and move speeds.
     bool CalculateMoveList(MoveList &mls, const std::vector<Point> path, int move_speed_x, int move_speed_y);
     // Append a waypoint to the move list, skip pathfinding
@@ -45,5 +78,8 @@ namespace Pathfinding
     // Recalculates MoveList's step speeds
     void RecalculateMoveSpeeds(MoveList &mls, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
 }
+
+} // namespace Engine
+} // namespace AGS
 
 #endif // __AC_ROUTEFND_H

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -11,11 +11,12 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_ROUTEFND_H
 #define __AC_ROUTEFND_H
 
+#include <vector>
 #include "ac/game_version.h"
+#include "util/geometry.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Bitmap; }}
@@ -31,8 +32,18 @@ void get_lastcpos(int &lastcx, int &lastcy);
 
 int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
     AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
-// Append a waypoint to the move list, skip pathfinding
-bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y);
-void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
+
+//
+// Various additional pathfinding functions and helpers.
+// Manages converting navigation paths into MoveLists.
+namespace Pathfinding
+{
+    // Calculate the MoveList from the given navigation path and move speeds.
+    bool CalculateMoveList(MoveList &mls, const std::vector<Point> path, int move_speed_x, int move_speed_y);
+    // Append a waypoint to the move list, skip pathfinding
+    bool AddWaypointDirect(MoveList &mls, int x, int y, int move_speed_x, int move_speed_y);
+    // Recalculates MoveList's step speeds
+    void RecalculateMoveSpeeds(MoveList &mls, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
+}
 
 #endif // __AC_ROUTEFND_H

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -15,19 +15,15 @@
 // New jump point search (JPS) A* pathfinder by Martin Sedlak.
 //
 //=============================================================================
-
 #include "ac/route_finder_impl.h"
-
 #include <string.h>
 #include <math.h>
-
-#include "ac/common.h"   // quit()
-#include "ac/movelist.h"     // MoveList
+#include "ac/movelist.h"
 #include "ac/common_defines.h"
+#include "ac/route_finder.h"
+#include "ac/route_finder_jps.inl"
 #include "gfx/bitmap.h"
 #include "debug/out.h"
-
-#include "route_finder_jps.inl"
 
 extern std::vector<MoveList> mls;
 
@@ -40,8 +36,7 @@ namespace Engine {
 namespace RouteFinder {
 
 static const int MAXNAVPOINTS = MAXNEEDSTAGES;
-static Point navpoints[MAXNAVPOINTS];
-static int num_navpoints;
+static std::vector<Point> navpoints;
 static Navigation nav;
 static Bitmap *wallscreen;
 static int lastcx, lastcy;
@@ -99,7 +94,7 @@ static int find_route_jps(int fromx, int fromy, int destx, int desty)
   if (nav.NavigateRefined(fromx, fromy, destx, desty, path, cpath) == Navigation::NAV_UNREACHABLE)
     return 0;
 
-  num_navpoints = 0;
+  navpoints.clear();
 
   // new behavior: cut path if too complex rather than abort with error message
   int count = std::min<int>((int)cpath.size(), MAXNAVPOINTS);
@@ -108,167 +103,23 @@ static int find_route_jps(int fromx, int fromy, int destx, int desty)
   {
     int x, y;
     nav.UnpackSquare(cpath[i], x, y);
-
-    navpoints[num_navpoints++] = { x, y };
+    navpoints.emplace_back( x, y );
   }
 
   return 1;
 }
-
-inline fixed input_speed_to_fixed(int speed_val)
-{
-  // negative move speeds like -2 get converted to 1/2
-  if (speed_val < 0) {
-    return itofix(1) / (-speed_val);
-  }
-  else {
-    return itofix(speed_val);
-  }
-}
-
-inline fixed calc_move_speed_at_angle(fixed speed_x, fixed speed_y, fixed xdist, fixed ydist)
-{
-  fixed useMoveSpeed;
-  if (speed_x == speed_y) {
-    useMoveSpeed = speed_x;
-  }
-  else {
-    // different X and Y move speeds
-    // the X proportion of the movement is (x / (x + y))
-    fixed xproportion = fixdiv(xdist, (xdist + ydist));
-
-    if (speed_x > speed_y) {
-      // speed = y + ((1 - xproportion) * (x - y))
-      useMoveSpeed = speed_y + fixmul(xproportion, speed_x - speed_y);
-    }
-    else {
-      // speed = x + (xproportion * (y - x))
-      useMoveSpeed = speed_x + fixmul(itofix(1) - xproportion, speed_y - speed_x);
-    }
-  }
-  return useMoveSpeed;
-}
-
-// Calculates the X and Y per game loop, for this stage of the movelist
-void calculate_move_stage(MoveList *mlsp, int aaa, fixed move_speed_x, fixed move_speed_y)
-{
-  // work out the x & y per move. First, opp/adj=tan, so work out the angle
-  if (mlsp->pos[aaa] == mlsp->pos[aaa + 1]) {
-    mlsp->xpermove[aaa] = 0;
-    mlsp->ypermove[aaa] = 0;
-    return;
-  }
-
-  short ourx = mlsp->pos[aaa].X;
-  short oury = mlsp->pos[aaa].Y;
-  short destx = mlsp->pos[aaa + 1].X;
-  short desty = mlsp->pos[aaa + 1].Y;
-
-  // Special case for vertical and horizontal movements
-  if (ourx == destx) {
-    mlsp->xpermove[aaa] = 0;
-    mlsp->ypermove[aaa] = move_speed_y;
-    if (desty < oury)
-      mlsp->ypermove[aaa] = -mlsp->ypermove[aaa];
-
-    return;
-  }
-
-  if (oury == desty) {
-    mlsp->xpermove[aaa] = move_speed_x;
-    mlsp->ypermove[aaa] = 0;
-    if (destx < ourx)
-      mlsp->xpermove[aaa] = -mlsp->xpermove[aaa];
-
-    return;
-  }
-
-  fixed xdist = itofix(abs(ourx - destx));
-  fixed ydist = itofix(abs(oury - desty));
-
-  fixed useMoveSpeed = calc_move_speed_at_angle(move_speed_x, move_speed_y, xdist, ydist);
-
-  fixed angl = fixatan(fixdiv(ydist, xdist));
-
-  // now, since new opp=hyp*sin, work out the Y step size
-  //fixed newymove = useMoveSpeed * fsin(angl);
-  fixed newymove = fixmul(useMoveSpeed, fixsin(angl));
-
-  // since adj=hyp*cos, work out X step size
-  //fixed newxmove = useMoveSpeed * fcos(angl);
-  fixed newxmove = fixmul(useMoveSpeed, fixcos(angl));
-
-  if (destx < ourx)
-    newxmove = -newxmove;
-  if (desty < oury)
-    newymove = -newymove;
-
-  mlsp->xpermove[aaa] = newxmove;
-  mlsp->ypermove[aaa] = newymove;
-}
-
-void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y)
-{
-  const fixed old_movspeed_x = input_speed_to_fixed(old_speed_x);
-  const fixed old_movspeed_y = input_speed_to_fixed(old_speed_y);
-  const fixed new_movspeed_x = input_speed_to_fixed(new_speed_x);
-  const fixed new_movspeed_y = input_speed_to_fixed(new_speed_y);
-  // save current stage's step lengths, for later onpart's update
-  const fixed old_stage_xpermove = mlsp->xpermove[mlsp->onstage];
-  const fixed old_stage_ypermove = mlsp->ypermove[mlsp->onstage];
-
-  for (int i = 0; (i < mlsp->numstage) && ((mlsp->xpermove[i] != 0) || (mlsp->ypermove[i] != 0)); ++i)
-  {
-    // First three cases where the speed is a plain factor, therefore
-    // we may simply divide on old one and multiple on a new one
-    if ((old_movspeed_x == old_movspeed_y) || // diagonal move at straight 45 degrees
-        (mlsp->xpermove[i] == 0) || // straight vertical move
-        (mlsp->ypermove[i] == 0))   // straight horizontal move
-    {
-      mlsp->xpermove[i] = fixdiv(fixmul(mlsp->xpermove[i], new_movspeed_x), old_movspeed_x);
-      mlsp->ypermove[i] = fixdiv(fixmul(mlsp->ypermove[i], new_movspeed_y), old_movspeed_y);
-    }
-    else
-    {
-      // Move at angle has adjusted speed factor, which we must recalculate first
-      short ourx = mlsp->pos[i].X;
-      short oury = mlsp->pos[i].Y;
-      short destx = mlsp->pos[i + 1].X;
-      short desty = mlsp->pos[i + 1].Y;
-
-      fixed xdist = itofix(abs(ourx - destx));
-      fixed ydist = itofix(abs(oury - desty));
-      fixed old_speed_at_angle = calc_move_speed_at_angle(old_movspeed_x, old_movspeed_y, xdist, ydist);
-      fixed new_speed_at_angle = calc_move_speed_at_angle(new_movspeed_x, new_movspeed_y, xdist, ydist);
-
-      mlsp->xpermove[i] = fixdiv(fixmul(mlsp->xpermove[i], new_speed_at_angle), old_speed_at_angle);
-      mlsp->ypermove[i] = fixdiv(fixmul(mlsp->ypermove[i], new_speed_at_angle), old_speed_at_angle);
-    }
-  }
-
-  // now adjust current passed stage fraction
-  if (mlsp->onpart >= 0.f)
-  {
-    if (old_stage_xpermove != 0)
-      mlsp->onpart = (mlsp->onpart * fixtof(old_stage_xpermove)) / fixtof(mlsp->xpermove[mlsp->onstage]);
-    else
-      mlsp->onpart = (mlsp->onpart * fixtof(old_stage_ypermove)) / fixtof(mlsp->ypermove[mlsp->onstage]);
-  }
-}
-
 
 int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
     Bitmap *onscreen, int move_id, int nocross, int ignore_walls)
 {
   wallscreen = onscreen;
 
-  num_navpoints = 0;
+  navpoints.clear();
 
   if (ignore_walls || can_see_from(srcx, srcy, xx, yy))
   {
-    num_navpoints = 2;
-    navpoints[0] = { srcx, srcy };
-    navpoints[1] = { xx, yy };
+    navpoints.emplace_back( srcx, srcy );
+    navpoints.emplace_back( xx, yy );
   } else {
     if ((nocross == 0) && (wallscreen->GetPixel(xx, yy) == 0))
       return 0; // clicked on a wall
@@ -276,49 +127,24 @@ int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int
     find_route_jps(srcx, srcy, xx, yy);
   }
 
-  if (!num_navpoints)
+  if (navpoints.empty())
     return 0;
 
   // FIXME: really necessary?
-  if (num_navpoints == 1)
-    navpoints[num_navpoints++] = navpoints[0];
+  if (navpoints.size() == 1)
+    navpoints.push_back(navpoints[0]);
 
-  assert(num_navpoints <= MAXNAVPOINTS);
+  assert(navpoints.size() <= MAXNAVPOINTS);
 
 #ifdef DEBUG_PATHFINDER
-  AGS::Common::Debug::Printf("Route from %d,%d to %d,%d - %d stages", srcx,srcy,xx,yy,num_navpoints);
+  AGS::Common::Debug::Printf("Route from %d,%d to %d,%d - %zu stages", srcx,srcy,xx,yy,navpoints.size());
 #endif
 
   MoveList mlist;
-  mlist.numstage = num_navpoints;
-  memcpy(&mlist.pos[0], &navpoints[0], sizeof(Point) * num_navpoints);
-#ifdef DEBUG_PATHFINDER
-  AGS::Common::Debug::Printf("stages: %d\n",num_navpoints);
-#endif
-
-  const fixed fix_speed_x = input_speed_to_fixed(move_speed_x);
-  const fixed fix_speed_y = input_speed_to_fixed(move_speed_y);
-  for (int i=0; i<num_navpoints-1; i++)
-    calculate_move_stage(&mlist, i, fix_speed_x, fix_speed_y);
-
-  mlist.from = { srcx, srcy };
+  Pathfinding::CalculateMoveList(mlist, navpoints, move_speed_x, move_speed_y);
   mls[move_id] = mlist;
   return move_id;
 }
-
-bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y)
-{
-  if (mlsp->numstage >= MAXNEEDSTAGES)
-    return false;
-
-  const fixed fix_speed_x = input_speed_to_fixed(move_speed_x);
-  const fixed fix_speed_y = input_speed_to_fixed(move_speed_y);
-  mlsp->pos[mlsp->numstage] = { x, y };
-  calculate_move_stage(mlsp, mlsp->numstage - 1, fix_speed_x, fix_speed_y);
-  mlsp->numstage++;
-  return true;
-}
-
 
 } // namespace RouteFinder
 } // namespace Engine

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -87,10 +87,7 @@ bool JPSRouteFinder::FindRouteJPS(std::vector<Point> &nav_path, int fromx, int f
 
     nav_path.clear();
 
-    // new behavior: cut path if too complex rather than abort with error message
-    int count = std::min<int>((int)cpath.size(), MAXNAVPOINTS);
-
-    for (int i = 0; i < count; i++)
+    for (int i = 0; i < cpath.size(); i++)
     {
         int x, y;
         nav.UnpackSquare(cpath[i], x, y);
@@ -124,8 +121,6 @@ bool JPSRouteFinder::FindRouteImpl(std::vector<Point> &nav_path, int srcx, int s
     // Ensure it has at least 2 points (start-end), necessary for the move algorithm
     if (nav_path.size() == 1)
         nav_path.push_back(nav_path[0]);
-
-    assert(nav_path.size() <= MAXNAVPOINTS);
 
 #ifdef DEBUG_PATHFINDER
     AGS::Common::Debug::Printf("Route from %d,%d to %d,%d - %zu stages", srcx,srcy,xx,yy,nav_path.size());

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -33,26 +33,21 @@ public:
     ~JPSRouteFinder();
 
     void Configure(GameDataVersion game_ver) override;
-    // Traces a straight line between two points, returns if it's fully passable;
-    // optionally assigns last found passable position.
-    bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) override;
-    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
-    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
-    //              otherwise pathfinder will try to find the closest possible end point.
-    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
-    bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
-        bool exact_dest = false, bool ignore_walls = false) override;
-    // Assign a walkable mask;
-    // Note that this may make routefinder to generate additional data, taking more time.
-    void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) override;
 
 private:
+    // Update the implementation after a new walkable area is set
+    void OnSetWalkableArea() override;
+    // CanSeeFrom implementation
+    bool CanSeeFromImpl(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr)  override;
+    // FindRoute implementation
+    bool FindRouteImpl(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest, bool ignore_walls)  override;
+
     void SyncNavWalkablearea();
     bool FindRouteJPS(std::vector<Point> &nav_path, int fromx, int fromy, int destx, int desty);
 
     static const int MAXNAVPOINTS = MAXNEEDSTAGES;
     Navigation &nav; // declare as reference, because we must hide real Navigation decl here
-    const Bitmap *walkablearea = nullptr;
     std::vector<int> path, cpath;
 };
 

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -35,8 +35,6 @@ void get_lastcpos(int &lastcx, int &lastcy);
 
 int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
     AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
-bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y);
-void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
 
 } // namespace RouteFinder
 } // namespace Engine

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -46,7 +46,6 @@ private:
     void SyncNavWalkablearea();
     bool FindRouteJPS(std::vector<Point> &nav_path, int fromx, int fromy, int destx, int desty);
 
-    static const int MAXNAVPOINTS = MAXNEEDSTAGES;
     Navigation &nav; // declare as reference, because we must hide real Navigation decl here
     std::vector<int> path, cpath;
 };

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -11,33 +11,52 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
+#ifndef __AGS_EN_AC__ROUTEFINDER_IMPL_H
+#define __AGS_EN_AC__ROUTEFINDER_IMPL_H
 
-#ifndef __AC_ROUTE_FINDER_IMPL
-#define __AC_ROUTE_FINDER_IMPL
+#include "ac/movelist.h"
+#include "ac/route_finder.h"
+#include "util/geometry.h"
 
-#include "ac/game_version.h"
+namespace AGS
+{
+namespace Engine
+{
 
-// Forward declaration
-namespace AGS { namespace Common { class Bitmap; }}
-struct MoveList;
+class Navigation;
 
-namespace AGS {
-namespace Engine {
-namespace RouteFinder {
+// JPSRouteFinder: a jump point search (JPS) A* pathfinder by Martin Sedlak.
+class JPSRouteFinder : public MaskRouteFinder
+{
+public:
+    JPSRouteFinder();
+    ~JPSRouteFinder();
 
-void init_pathfinder();
-void shutdown_pathfinder();
+    void Configure(GameDataVersion game_ver) override;
+    // Traces a straight line between two points, returns if it's fully passable;
+    // optionally assigns last found passable position.
+    bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) override;
+    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
+    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
+    //              otherwise pathfinder will try to find the closest possible end point.
+    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
+    bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest = false, bool ignore_walls = false) override;
+    // Assign a walkable mask;
+    // Note that this may make routefinder to generate additional data, taking more time.
+    void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) override;
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+private:
+    void SyncNavWalkablearea();
+    bool FindRouteJPS(std::vector<Point> &nav_path, int fromx, int fromy, int destx, int desty);
 
-int can_see_from(int x1, int y1, int x2, int y2);
-void get_lastcpos(int &lastcx, int &lastcy);
+    static const int MAXNAVPOINTS = MAXNEEDSTAGES;
+    Navigation &nav; // declare as reference, because we must hide real Navigation decl here
+    const Bitmap *walkablearea = nullptr;
+    std::vector<int> path, cpath;
+};
 
-int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-    AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
-
-} // namespace RouteFinder
 } // namespace Engine
 } // namespace AGS
 
-#endif // __AC_ROUTE_FINDER_IMPL
+#endif // __AGS_EN_AC__ROUTEFINDER_IMPL_H

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -736,8 +736,6 @@ stage_again:
 
     if ( (nearestpos.X + nearestpos.Y) > 0) { // NOTE: we only deal with positive coordinates here
       path.push_back(nearestpos);
-      if (path.size() >= MAXNEEDSTAGES - 1)
-        quit("too many stages for auto-walk");
       srcx = nearestpos.X;
       srcy = nearestpos.Y;
 #ifdef DEBUG_PATHFINDER

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -83,11 +83,8 @@ void LegacyRouteFinder::Configure(GameDataVersion game_ver)
     _pfc.ShortSweepGranularity = (game_ver > kGameVersion_300) ? 3 : 1;
 }
 
-// Assign a walkable mask;
-// Note that this may make routefinder to generate additional data, taking more time.
-void LegacyRouteFinder::SetWalkableArea(const Bitmap *walkablearea)
+void LegacyRouteFinder::OnSetWalkableArea()
 {
-    wallscreen = walkablearea;
 }
 
 static int line_failed = 0;
@@ -644,12 +641,9 @@ findroutebk:
   return 1;
 }
 
-bool LegacyRouteFinder::CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx, int *lastcy)
+bool LegacyRouteFinder::CanSeeFromImpl(int srcx, int srcy, int dstx, int dsty, int *lastcx, int *lastcy)
 {
-    if (!wallscreen)
-        return false;
-    
-    bool result = can_see_from(wallscreen, srcx, srcy, dstx, dsty) != 0;
+    bool result = can_see_from(_walkablearea, srcx, srcy, dstx, dsty) != 0;
     if (lastcx)
         *lastcx = line_lastcx;
     if (lastcy)
@@ -657,17 +651,16 @@ bool LegacyRouteFinder::CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *
     return result;
 }
 
-bool LegacyRouteFinder::FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+bool LegacyRouteFinder::FindRouteImpl(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
         bool exact_dest, bool ignore_walls)
 {
-    if (!wallscreen)
-        return false;
-
   assert(pathbackx != nullptr);
   assert(pathbacky != nullptr);
 
   leftorright = 0;
   int aaa;
+
+  const auto *wallscreen = _walkablearea;
 
   if (wallscreen->GetHeight() > beenhere_array_size)
   {

--- a/Engine/ac/route_finder_impl_legacy.h
+++ b/Engine/ac/route_finder_impl_legacy.h
@@ -11,31 +11,59 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_ROUTE_FINDER_IMPL_LEGACY
 #define __AC_ROUTE_FINDER_IMPL_LEGACY
+
+#include "ac/route_finder.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Bitmap; }}
 struct MoveList;
 
-namespace AGS {
-namespace Engine {
-namespace RouteFinderLegacy {
+namespace AGS
+{
+namespace Engine
+{
 
-void init_pathfinder();
-void shutdown_pathfinder();
+// LegacyRouteFinder: a flood-fill search pathfinder.
+class LegacyRouteFinder : public MaskRouteFinder
+{
+public:
+    LegacyRouteFinder();
+    ~LegacyRouteFinder();
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+    void Configure(GameDataVersion game_ver) override;
+    // Traces a straight line between two points, returns if it's fully passable;
+    // optionally assigns last found passable position.
+    bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) override;
+    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
+    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
+    //              otherwise pathfinder will try to find the closest possible end point.
+    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
+    bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest = false, bool ignore_walls = false) override;
+    // Assign a walkable mask;
+    // Note that this may make routefinder to generate additional data, taking more time.
+    void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) override;
 
-int can_see_from(int x1, int y1, int x2, int y2);
-void get_lastcpos(int &lastcx, int &lastcy);
+    // Configuration for the pathfinder
+    struct PathfinderConfig
+    {
+        const int MaxGranularity = 3;
 
-int find_route(short srcx, short srcy, short xx, short yy, int move_speed_x, int move_speed_y,
-    AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
-bool add_waypoint_direct(MoveList * mlsp, short x, short y, int move_speed_x, int move_speed_y);
+        // Short sweep is performed in certain radius around requested destination,
+        // when searching for a nearest walkable area in the vicinity
+        const int ShortSweepRadius = 50;
+        int ShortSweepGranularity = 3; // variable, depending on loaded game version
+        // Full sweep is performed over a whole walkable area
+        const int FullSweepGranularity = 5;
+    };
 
-} // namespace RouteFinderLegacy
+private:
+    const AGS::Common::Bitmap *wallscreen = nullptr;
+    PathfinderConfig _pfc;
+};
+
 } // namespace Engine
 } // namespace AGS
 

--- a/Engine/ac/route_finder_impl_legacy.h
+++ b/Engine/ac/route_finder_impl_legacy.h
@@ -33,18 +33,6 @@ public:
     ~LegacyRouteFinder();
 
     void Configure(GameDataVersion game_ver) override;
-    // Traces a straight line between two points, returns if it's fully passable;
-    // optionally assigns last found passable position.
-    bool CanSeeFrom(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr) override;
-    // Search for a route between (srcx,y) and (destx,y), and calculate the MoveList using given speeds.
-    // exact_dest - tells to fail if the destination is inside the wall and cannot be reached;
-    //              otherwise pathfinder will try to find the closest possible end point.
-    // ignore_walls - tells to ignore impassable areas (builds a straight line path).
-    bool FindRoute(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
-        bool exact_dest = false, bool ignore_walls = false) override;
-    // Assign a walkable mask;
-    // Note that this may make routefinder to generate additional data, taking more time.
-    void SetWalkableArea(const AGS::Common::Bitmap *walkablearea) override;
 
     // Configuration for the pathfinder
     struct PathfinderConfig
@@ -60,7 +48,14 @@ public:
     };
 
 private:
-    const AGS::Common::Bitmap *wallscreen = nullptr;
+    // Update the implementation after a new walkable area is set
+    void OnSetWalkableArea() override;
+    // CanSeeFrom implementation
+    bool CanSeeFromImpl(int srcx, int srcy, int dstx, int dsty, int *lastcx = nullptr, int *lastcy = nullptr)  override;
+    // FindRoute implementation
+    bool FindRouteImpl(std::vector<Point> &path, int srcx, int srcy, int dstx, int dsty,
+        bool exact_dest, bool ignore_walls)  override;
+
     PathfinderConfig _pfc;
 };
 

--- a/Engine/ac/route_finder_impl_legacy.h
+++ b/Engine/ac/route_finder_impl_legacy.h
@@ -18,7 +18,6 @@
 
 // Forward declaration
 namespace AGS { namespace Common { class Bitmap; }}
-struct MoveList;
 
 namespace AGS
 {

--- a/Engine/ac/route_finder_jps.inl
+++ b/Engine/ac/route_finder_jps.inl
@@ -16,7 +16,8 @@
 // (c) 2018 Martin Sedlak
 //
 //=============================================================================
-
+#ifndef __AGS_EN_AC__ROUTEFINDER_JPS_INL
+#define __AGS_EN_AC__ROUTEFINDER_JPS_INL
 #include <queue>
 #include <vector>
 #include <algorithm>
@@ -24,6 +25,11 @@
 #include <assert.h>
 #include <stddef.h>
 #include <math.h>
+
+namespace AGS
+{
+namespace Engine
+{
 
 // TODO: this could be cleaned up/simplified ...
 
@@ -924,3 +930,8 @@ bool Navigation::TraceLine(int srcx, int srcy, int targx, int targy, std::vector
 
 	return false;
 }
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EN_AC__ROUTEFINDER_JPS_INL

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -443,18 +443,6 @@ void engine_init_exit_handler()
     atexit(atexit_handler);
 }
 
-void engine_init_pathfinder()
-{
-    init_pathfinder(loaded_game_file_version);
-}
-
-void engine_pre_init_gfx()
-{
-    //Debug::Printf("Initialize gfx");
-
-    //platform->InitialiseAbufAtStartup();
-}
-
 int engine_load_game_data()
 {
     Debug::Printf("Load game data");
@@ -1275,8 +1263,6 @@ int initialize_engine(const ConfigTree &startup_opts)
     set_our_eip(-10);
 
     engine_init_exit_handler();
-
-    engine_init_pathfinder();
 
     set_game_speed(40);
 

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -202,15 +202,10 @@ void quit(const char *quitmsg)
     quit_stop_cd();
     if (use_cdplayer)
         platform->ShutdownCDPlayer();
-
-    set_our_eip(9019);
-
     video_shutdown();
     quit_shutdown_audio();
 
     set_our_eip(9908);
-
-    shutdown_pathfinder();
 
     // Release game data and unregister assets
     quit_check_dynamic_sprites(qreason);

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -112,9 +112,9 @@ static void movelist_handle_remainer(const fixed xpermove, const fixed ypermove,
 // Handle remaining move fixup, but only if necessary
 static void movelist_handle_remainer(MoveList &m)
 {
-    assert(m.numstage > 0);
-    const fixed xpermove = m.xpermove[m.onstage];
-    const fixed ypermove = m.ypermove[m.onstage];
+    assert(m.GetNumStages() > 0);
+    const fixed xpermove = m.permove[m.onstage].X;
+    const fixed ypermove = m.permove[m.onstage].Y;
     const Point target = m.pos[m.onstage + 1];
     // Apply remainer to movelists where LONGER axis was completed, and SHORTER remains
     if ((xpermove != 0) && (ypermove != 0))
@@ -161,8 +161,8 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
 
     int need_to_fix_sprite = 0; // TODO: find out what this value means and refactor
     MoveList &cmls = mls[mslot];
-    const fixed xpermove = cmls.xpermove[cmls.onstage];
-    const fixed ypermove = cmls.ypermove[cmls.onstage];
+    const fixed xpermove = cmls.permove[cmls.onstage].X;
+    const fixed ypermove = cmls.permove[cmls.onstage].Y;
     const fixed fin_move = cmls.fin_move;
     const float main_onpart = (cmls.fin_from_part > 0.f) ? cmls.fin_from_part : cmls.onpart;
     const float fin_onpart = cmls.onpart - main_onpart;
@@ -211,15 +211,15 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
         cmls.fin_from_part = 0.f;
         cmls.fin_move = 0;
         cmls.doneflag = 0;
-        if (cmls.onstage < cmls.numstage)
+        if (cmls.onstage < cmls.GetNumStages())
         {
             xps = cmls.from.X;
             yps = cmls.from.Y;
         }
 
-        if (cmls.onstage >= cmls.numstage - 1)
+        if (cmls.onstage >= cmls.GetNumStages() - 1)
         {  // last stage is just dest pos
-            cmls.numstage=0;
+            cmls = {};
             mslot = 0;
             need_to_fix_sprite = 1; // TODO: find out what this means
         }
@@ -241,7 +241,7 @@ void restore_movelists()
     // Recalculate move remainer fixups, where necessary
     for (auto &m : mls)
     {
-        if (m.numstage > 0)
+        if (m.GetNumStages() > 0)
             movelist_handle_remainer(m);
     }
 }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -736,7 +736,7 @@ void IAGSEngine::SimulateMouseClick(int32 button) {
 }
 
 int IAGSEngine::GetMovementPathWaypointCount(int32 pathId) {
-    return mls[pathId % TURNING_AROUND].numstage;
+    return mls[pathId % TURNING_AROUND].GetNumStages();
 }
 
 int IAGSEngine::GetMovementPathLastWaypoint(int32 pathId) {
@@ -749,8 +749,8 @@ void IAGSEngine::GetMovementPathWaypointLocation(int32 pathId, int32 waypoint, i
 }
 
 void IAGSEngine::GetMovementPathWaypointSpeed(int32 pathId, int32 waypoint, int32 *xSpeed, int32 *ySpeed) {
-    *xSpeed = mls[pathId % TURNING_AROUND].xpermove[waypoint];
-    *ySpeed = mls[pathId % TURNING_AROUND].ypermove[waypoint];
+    *xSpeed = mls[pathId % TURNING_AROUND].permove[waypoint].X;
+    *ySpeed = mls[pathId % TURNING_AROUND].permove[waypoint].Y;
 }
 
 int IAGSEngine::IsRunningUnderDebugger()

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -950,6 +950,7 @@
     <Image Include="..\..\Engine\resource\game-1.ico" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\Engine\ac\route_finder_jps.inl" />
     <None Include="..\..\Engine\resource\tintshader.fxo" />
     <None Include="..\..\Engine\resource\tintshaderLegacy.fxo" />
   </ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1647,6 +1647,9 @@
     <None Include="..\..\Engine\resource\tintshaderLegacy.fxo">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="..\..\Engine\ac\route_finder_jps.inl">
+      <Filter>Header Files\ac</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\Engine\resource\version.rc">


### PR DESCRIPTION
This backports code refactor related to IRouteFinder interface from ags4 to ags3 branch (parts of #2441), while keeping existing functionality intact. The purpose is a cleaner code, and keeping ags3 code closer to ags4 in terms of structure (where possible).

Planned tests:
- [x] - Character.Walk and Move
- [x] - Character.WalkStraight
- [x] - Character.AddWaypoint
- [x] - Object.Move
- [x] - Character walk speeds in a game with "Scale movement speed with mask resolution", and 1:2 mask resolutions.
- [x] - Character walk or move in a game with legacy low-res script coordinates
