### PR TITLE
AGS 4: Script API: add Overlay.Tint and SetLevel, complying to character and object settings

### DIFF
--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -220,7 +220,7 @@ int RoomStruct::GetRegionLightLevel(int id) const
 int RoomStruct::GetRegionTintLuminance(int id) const
 {
     if (id >= 0 && id < MAX_ROOM_REGIONS)
-        return HasRegionTint(id) ? (Regions[id].Light * 10) / 25 : 0;
+        return HasRegionTint(id) ? GfxDef::Value250ToValue100(Regions[id].Light) : 0;
     return 0;
 }
 

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -124,6 +124,20 @@ private:
 
 namespace GfxDef
 {
+    // Converts value from range of 100 to range of 250 (sic!);
+    // uses formula that reduces precision loss and supports flawless forth &
+    // reverse conversion for multiplies of 10%
+    inline int Value100ToValue250(int value100)
+    {
+        return (value100 * 25) / 10;
+    }
+
+    // Converts value from range of 250 to range of 100
+    inline int Value250ToValue100(int value100)
+    {
+        return (value100 * 10) / 25;
+    }
+
     // Converts percentage of transparency into alpha
     inline int Trans100ToAlpha255(int transparency)
     {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1123,6 +1123,30 @@ builtin managed struct Overlay {
   /// Gets/sets the overlay's image rotation in degrees.
   import attribute float Rotation;
 #endif
+#ifdef SCRIPT_API_v400
+  /// Tints the overlay to the specified colour.
+  import void     Tint(int red, int green, int blue, int saturation, int luminance);
+  /// Sets the light level for this overlay.
+  import function SetLightLevel(int light_level);
+  /// Removes an existing colour tint or light level from this overlay.
+  import void     RemoveTint();
+  /// Gets whether the overlay has a tint set.
+  readonly import attribute bool HasTint;
+  /// Gets whether the overlay has a light level set.
+  readonly import attribute bool HasLightLevel;
+  /// Gets the individual light level for this character.
+  readonly import attribute int  LightLevel;
+  /// Gets the Blue component of this overlay's colour tint.
+  readonly import attribute int  TintBlue;
+  /// Gets the Green component of this overlay's colour tint.
+  readonly import attribute int  TintGreen;
+  /// Gets the Red component of this overlay's colour tint.
+  readonly import attribute int  TintRed;
+  /// Gets the Saturation of this overlay's colour tint.
+  readonly import attribute int  TintSaturation;
+  /// Gets the Luminance of this overlay's colour tint.
+  readonly import attribute int  TintLuminance;
+#endif
 };
 
 #ifdef SCRIPT_API_v400

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1124,12 +1124,12 @@ builtin managed struct Overlay {
   import attribute float Rotation;
 #endif
 #ifdef SCRIPT_API_v400
-  /// Tints the overlay to the specified colour.
-  import void     Tint(int red, int green, int blue, int saturation, int luminance);
-  /// Sets the light level for this overlay.
-  import function SetLightLevel(int light_level);
+  /// Tints the overlay to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
+  import void Tint(int red, int green, int blue, int saturation, int luminance);
+  /// Sets the light level for this overlay, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
+  import void SetLightLevel(int light_level);
   /// Removes an existing colour tint or light level from this overlay.
-  import void     RemoveTint();
+  import void RemoveTint();
   /// Gets whether the overlay has a tint set.
   readonly import attribute bool HasTint;
   /// Gets whether the overlay has a light level set.
@@ -1191,7 +1191,7 @@ builtin managed struct DynamicSprite {
   import void Rotate(int angle, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE);
   /// Saves the sprite to a BMP or PCX file.
   import int  SaveToFile(const string filename);
-  /// Permanently tints the sprite to the specified colour.
+  /// Permanently tints the sprite to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
   import void Tint(int red, int green, int blue, int saturation, int luminance);
   /// Gets the colour depth of this sprite.
   readonly import attribute int ColorDepth;
@@ -1214,9 +1214,9 @@ import void CyclePalette(int start, int end);
 import void SetPalRGB(int slot, int r, int g, int b);
 /// Updates the screen with manual changes to the palette. (8-bit games only)
 import void UpdatePalette();
-/// Tints the whole screen to the specified colour.
+/// Tints the whole screen to the specified colour. RGB values must be in 0-255 range.
 import void TintScreen (int red, int green, int blue);
-/// Sets an ambient tint that affects all objects and characters in the room.
+/// Sets an ambient tint that affects all objects and characters in the room. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
 import void SetAmbientTint(int red, int green, int blue, int saturation, int luminance);
 /// Returns a random number between 0 and MAX, inclusive.
 import int  Random(int max);
@@ -1704,13 +1704,13 @@ builtin managed struct Region {
   import static Region* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
   /// Runs the event handler for the specified event for this region.
   import void RunInteraction(int event);
-  /// Sets the region tint which will apply to characters that are standing on the region.
+  /// Sets the region tint which will apply to characters that are standing on the region. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
   import void Tint(int red, int green, int blue, int amount, int luminance = 100);
   /// Gets/sets whether this region is enabled.
   import attribute bool Enabled;
   /// Gets the ID number for this region.
   readonly import attribute int ID;
-  /// Gets/sets the light level for this region.
+  /// Gets/sets the light level for this region. Valid values are from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
   import attribute int  LightLevel;
   /// Gets whether a colour tint is set for this region.
   readonly import attribute bool TintEnabled;
@@ -2082,7 +2082,7 @@ builtin managed struct Object {
   import function StopAnimating();
   /// Stops any currently running move on the object.
   import function StopMoving();
-  /// Tints the object to the specified colour.
+  /// Tints the object to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
   import function Tint(int red, int green, int blue, int saturation, int luminance);
   /// Gets whether the object is currently animating.
   readonly import attribute bool Animating;
@@ -2119,9 +2119,9 @@ builtin managed struct Object {
   /// Gets/sets the Y co-ordinate of the object's bottom-left hand corner.
   import attribute int  Y;
   /// Checks whether an event handler has been registered for clicking on this object in the specified cursor mode.
-  import bool     IsInteractionAvailable(CursorMode);
-  /// Sets the individual light level for this object.
-  import function SetLightLevel(int light_level);
+  import bool IsInteractionAvailable(CursorMode);
+  /// Sets the individual light level for this object, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
+  import void SetLightLevel(int light_level);
   /// Sets an integer custom property for this object.
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this object.
@@ -2274,7 +2274,7 @@ builtin managed struct Character {
   import function StopMoving();
   /// The specified text is displayed in a thought-bubble GUI.
   import function Think(const string message, ...);
-  /// Tints the character to the specified colour.
+  /// Tints the character to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
   import void     Tint(int red, int green, int blue, int saturation, int luminance);
   /// Unlocks the view after an animation has finished.
   import function UnlockView(StopMovementStyle=eStopMoving);
@@ -2375,9 +2375,9 @@ builtin managed struct Character {
   /// Sets a text custom property for this character.
   import bool SetTextProperty(const string property, const string value);
   /// Checks whether an event handler has been registered for clicking on this character in the specified cursor mode.
-  import bool     IsInteractionAvailable(CursorMode);
-  /// Sets the individual light level for this character.
-  import function SetLightLevel(int light_level);
+  import bool IsInteractionAvailable(CursorMode);
+  /// Sets the individual light level for this character, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
+  import void SetLightLevel(int light_level);
   /// Gets the X position this character is currently moving towards.
   readonly import attribute int DestinationX;
   /// Gets the Y position this character is currently moving towards.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -909,7 +909,7 @@ int Character_GetTintSaturation(CharacterInfo *ch)
 
 int Character_GetTintLuminance(CharacterInfo *ch)
 {
-    return ch->has_explicit_tint() ? ((charextra[ch->index_id].tint_light * 10) / 25) : 0;
+    return ch->has_explicit_tint() ? GfxDef::Value250ToValue100(charextra[ch->index_id].tint_light) : 0;
 }
 
 void Character_SetOption(CharacterInfo *chaa, int flag, int yesorno) {
@@ -996,7 +996,7 @@ void Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opaci
     charextra[chaa->index_id].tint_g = green;
     charextra[chaa->index_id].tint_b = blue;
     charextra[chaa->index_id].tint_level = opacity;
-    charextra[chaa->index_id].tint_light = (luminance * 25) / 10;
+    charextra[chaa->index_id].tint_light = GfxDef::Value100ToValue250(luminance);
     chaa->flags &= ~CHF_HASLIGHT;
     chaa->flags |= CHF_HASTINT;
 }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -988,7 +988,11 @@ void Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opaci
         (red > 255) || (green > 255) || (blue > 255) ||
         (opacity < 0) || (opacity > 100) ||
         (luminance < 0) || (luminance > 100))
-        quit("!Character.Tint: invalid parameter. R,G,B must be 0-255, opacity & luminance 0-100");
+    {
+        debug_script_warn("Character.Tint: invalid parameter(s). R,G,B must be 0-255 (passed: %d,%d,%d), opacity & luminance 0-100 (passed: %d,%d)",
+            red, green, blue, opacity, luminance);
+        return;
+    }
 
     debug_script_log("Set %s tint RGB(%d,%d,%d) %d%%", chaa->scrname.GetCStr(), red, green, blue, opacity);
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2019,7 +2019,7 @@ void prepare_and_add_object_gfx(
                 actsp.Ddb->SetLightLevel(0);
         }
         else if (objsav.lightlev != 0)
-            actsp.Ddb->SetLightLevel((objsav.lightlev * 25) / 10 + 256);
+            actsp.Ddb->SetLightLevel(GfxDef::Value100ToValue250(objsav.lightlev) + 256);
         else
             actsp.Ddb->SetLightLevel(0);
     }
@@ -2118,7 +2118,7 @@ void tint_image (Bitmap *ds, Bitmap *srcimg, int red, int grn, int blu, int ligh
     else {
         // light_level is between -100 and 100 normally; 0-100 in
         // this case when it's a RGB tint
-        light_level = (light_level * 25) / 10;
+        light_level = GfxDef::Value100ToValue250(light_level);
 
         // Copy the image to the new bitmap
         ds->Blit(srcimg, 0, 0, 0, 0, srcimg->GetWidth(), srcimg->GetHeight());

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -225,7 +225,7 @@ void DynamicSprite_Tint(ScriptDynamicSprite *sds, int red, int green, int blue, 
     std::unique_ptr<Bitmap> new_pic(
         BitmapHelper::CreateBitmap(source->GetWidth(), source->GetHeight(), source->GetColorDepth()));
 
-    tint_image(new_pic.get(), source, red, green, blue, saturation, (luminance * 25) / 10);
+    tint_image(new_pic.get(), source, red, green, blue, saturation, GfxDef::Value100ToValue250(luminance));
 
     add_dynamic_sprite(sds->slot, std::move(new_pic));
     game_sprite_updated(sds->slot);

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -103,14 +103,18 @@ int GetObjectIDAtRoom(int roomx, int roomy)
 }
 
 void SetObjectTint(int obj, int red, int green, int blue, int opacity, int luminance) {
+    if (!is_valid_object(obj))
+        quit("!SetObjectTint: invalid object number specified");
+
     if ((red < 0) || (green < 0) || (blue < 0) ||
         (red > 255) || (green > 255) || (blue > 255) ||
         (opacity < 0) || (opacity > 100) ||
         (luminance < 0) || (luminance > 100))
-        quit("!SetObjectTint: invalid parameter. R,G,B must be 0-255, opacity & luminance 0-100");
-
-    if (!is_valid_object(obj))
-        quit("!SetObjectTint: invalid object number specified");
+    {
+        debug_script_warn("Object.Tint: invalid parameter(s). R,G,B must be 0-255 (passed: %d,%d,%d), opacity & luminance 0-100 (passed: %d,%d)",
+            red, green, blue, opacity, luminance);
+        return;
+    }
 
     debug_script_log("Set object %d tint RGB(%d,%d,%d) %d%%", obj, red, green, blue, opacity);
 

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -118,7 +118,7 @@ void SetObjectTint(int obj, int red, int green, int blue, int opacity, int lumin
     objs[obj].tint_g = green;
     objs[obj].tint_b = blue;
     objs[obj].tint_level = opacity;
-    objs[obj].tint_light = (luminance * 25) / 10;
+    objs[obj].tint_light = GfxDef::Value100ToValue250(luminance);
     objs[obj].flags &= ~OBJF_HASLIGHT;
     objs[obj].flags |= OBJF_HASTINT;
 }

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -95,7 +95,7 @@ void SetRegionTint (int area, int red, int green, int blue, int amount, int lumi
                                    ((green & 0xFF) << 8) |
                                    ((blue & 0XFF) << 16) |
                                    ((amount & 0xFF) << 24);
-    thisroom.Regions[area].Light = (luminance * 25) / 10;
+    thisroom.Regions[area].Light = GfxDef::Value100ToValue250(luminance);
 }
 
 void DisableRegion(int hsnum) {

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -55,7 +55,7 @@ void SetAmbientTint (int red, int green, int blue, int opacity, int luminance) {
     play.rtint_green = green;
     play.rtint_blue = blue;
     play.rtint_level = opacity;
-    play.rtint_light = (luminance * 25) / 10;
+    play.rtint_light = GfxDef::Value100ToValue250(luminance);
 }
 
 void SetAmbientLightLevel(int light_level)

--- a/Engine/ac/global_screen.cpp
+++ b/Engine/ac/global_screen.cpp
@@ -158,9 +158,9 @@ void TintScreen(int red, int grn, int blu) {
         play.screen_tint = -1;
         return;
     }
-    red = (red * 25) / 10;
-    grn = (grn * 25) / 10;
-    blu = (blu * 25) / 10;
+    red = GfxDef::Value100ToValue250(red);
+    grn = GfxDef::Value100ToValue250(grn);
+    blu = GfxDef::Value100ToValue250(blu);
     play.screen_tint = red + (grn << 8) + (blu << 16);
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -278,7 +278,7 @@ int Object_GetTintSaturation(ScriptObject *obj)
 
 int Object_GetTintLuminance(ScriptObject *obj)
 {
-    return objs[obj->id].has_explicit_tint() ? ((objs[obj->id].tint_light * 10) / 25) : 0;
+    return objs[obj->id].has_explicit_tint() ? GfxDef::Value250ToValue100(objs[obj->id].tint_light) : 0;
 }
 
 void Object_SetPosition(ScriptObject *objj, int xx, int yy) {

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -345,6 +345,107 @@ void Overlay_SetZOrder(ScriptOverlay *scover, int zorder) {
     over->zorder = zorder;
 }
 
+void Overlay_Tint(ScriptOverlay *scover, int red, int green, int blue, int opacity, int luminance)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+
+    if ((red < 0) || (green < 0) || (blue < 0) ||
+        (red > 255) || (green > 255) || (blue > 255) ||
+        (opacity < 0) || (opacity > 100) ||
+        (luminance < 0) || (luminance > 100))
+    {
+        debug_script_warn("Overlay.Tint: invalid parameter(s). R,G,B must be 0-255 (passed: %d,%d,%d), opacity & luminance 0-100 (passed: %d,%d)",
+            red, green, blue, opacity, luminance);
+        return;
+    }
+
+    over->SetTint(red, green, blue, opacity, GfxDef::Value100ToValue250(luminance));
+}
+
+void Overlay_SetLightLevel(ScriptOverlay *scover, int light_level)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+
+    over->SetLightLevel(Math::Clamp(light_level, -100, 100));
+}
+
+void Overlay_RemoveTint(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+
+    over->RemoveTint();
+}
+
+bool Overlay_GetHasLight(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasLightLevel();
+}
+
+bool Overlay_GetHasTint(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint();
+}
+
+int Overlay_GetLightLevel(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasLightLevel() ? over->tint_light : 0;
+}
+
+int Overlay_GetTintRed(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint() ? over->tint_r : 0;
+}
+
+int Overlay_GetTintGreen(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint() ? over->tint_g : 0;
+}
+
+int Overlay_GetTintBlue(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint() ? over->tint_b : 0;
+}
+
+int Overlay_GetTintSaturation(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint() ? over->tint_level : 0;
+}
+
+int Overlay_GetTintLuminance(ScriptOverlay *scover)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    return over->HasTint() ? GfxDef::Value250ToValue100(over->tint_light) : 0;
+}
+
 //=============================================================================
 
 // Creates and registers a managed script object for existing overlay object;
@@ -792,7 +893,6 @@ RuntimeScriptValue Sc_Overlay_SetTransparency(void *self, const RuntimeScriptVal
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetTransparency);
 }
 
-
 RuntimeScriptValue Sc_Overlay_GetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetZOrder);
@@ -801,6 +901,61 @@ RuntimeScriptValue Sc_Overlay_GetZOrder(void *self, const RuntimeScriptValue *pa
 RuntimeScriptValue Sc_Overlay_SetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetZOrder);
+}
+
+RuntimeScriptValue Sc_Overlay_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT5(ScriptOverlay, Overlay_Tint);
+}
+
+RuntimeScriptValue Sc_Overlay_SetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetLightLevel);
+}
+
+RuntimeScriptValue Sc_Overlay_RemoveTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptOverlay, Overlay_RemoveTint);
+}
+
+RuntimeScriptValue Sc_Overlay_GetHasLight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptOverlay, Overlay_GetHasLight);
+}
+
+RuntimeScriptValue Sc_Overlay_GetHasTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptOverlay, Overlay_GetHasTint);
+}
+
+RuntimeScriptValue Sc_Overlay_GetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetLightLevel);
+}
+
+RuntimeScriptValue Sc_Overlay_GetTintBlue(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetTintBlue);
+}
+
+RuntimeScriptValue Sc_Overlay_GetTintGreen(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetTintGreen);
+}
+
+RuntimeScriptValue Sc_Overlay_GetTintRed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetTintRed);
+}
+
+RuntimeScriptValue Sc_Overlay_GetTintSaturation(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetTintSaturation);
+}
+
+RuntimeScriptValue Sc_Overlay_GetTintLuminance(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetTintLuminance);
 }
 
 //=============================================================================
@@ -842,6 +997,9 @@ void RegisterOverlayAPI()
         { "Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual, ScPl_Overlay_CreateRoomTextual },
         { "Overlay::SetText^104",         Sc_Overlay_SetText, ScPl_Overlay_SetText },
         { "Overlay::Remove^0",            API_FN_PAIR(Overlay_Remove) },
+        { "Overlay::Tint^5",              API_FN_PAIR(Overlay_Tint) },
+        { "Overlay::SetLightLevel^1",     API_FN_PAIR(Overlay_SetLightLevel) },
+        { "Overlay::RemoveTint^0",        API_FN_PAIR(Overlay_RemoveTint) },
         { "Overlay::get_Valid",           API_FN_PAIR(Overlay_GetValid) },
         { "Overlay::get_X",               API_FN_PAIR(Overlay_GetX) },
         { "Overlay::set_X",               API_FN_PAIR(Overlay_SetX) },
@@ -860,6 +1018,14 @@ void RegisterOverlayAPI()
         { "Overlay::set_Transparency",    API_FN_PAIR(Overlay_SetTransparency) },
         { "Overlay::get_ZOrder",          API_FN_PAIR(Overlay_GetZOrder) },
         { "Overlay::set_ZOrder",          API_FN_PAIR(Overlay_SetZOrder) },
+        { "Overlay::get_HasLight",        API_FN_PAIR(Overlay_GetHasLight) },
+        { "Overlay::get_HasTint",         API_FN_PAIR(Overlay_GetHasTint) },
+        { "Overlay::get_LightLevel",      API_FN_PAIR(Overlay_GetLightLevel) },
+        { "Overlay::get_TintBlue",        API_FN_PAIR(Overlay_GetTintBlue) },
+        { "Overlay::get_TintGreen",       API_FN_PAIR(Overlay_GetTintGreen) },
+        { "Overlay::get_TintRed",         API_FN_PAIR(Overlay_GetTintRed) },
+        { "Overlay::get_TintSaturation",  API_FN_PAIR(Overlay_GetTintSaturation) },
+        { "Overlay::get_TintLuminance",   API_FN_PAIR(Overlay_GetTintLuminance) },
 
         { "Overlay::get_BlendMode",       API_FN_PAIR(Overlay_GetBlendMode) },
         { "Overlay::set_BlendMode",       API_FN_PAIR(Overlay_SetBlendMode) },

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -93,6 +93,33 @@ void ScreenOverlay::SetSpriteNum(int sprnum, int offx, int offy)
     MarkChanged();
 }
 
+void ScreenOverlay::SetTint(int red, int green, int blue, int opacity, int luminance)
+{
+    tint_r = red;
+    tint_g = green;
+    tint_b = blue;
+    tint_level = opacity;
+    tint_light = luminance;
+    _flags &= ~kOver_HasLightLevel;
+    _flags |= kOver_HasTint;
+    MarkChanged();
+}
+
+void ScreenOverlay::SetLightLevel(int light_level)
+{
+    tint_level = tint_r = tint_g = tint_b = 0;
+    tint_light = light_level;
+    _flags &= ~kOver_HasTint;
+    _flags |= kOver_HasLightLevel;
+    MarkChanged();
+}
+
+void ScreenOverlay::RemoveTint()
+{
+    _flags &= ~(kOver_HasTint | kOver_HasLightLevel);
+    MarkChanged();
+}
+
 void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_ver)
 {
     ResetImage();
@@ -146,8 +173,12 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
         blendMode = (BlendMode)in->ReadInt32();
         // Reserved for colour options
         in->ReadInt32(); // colour flags
-        in->ReadInt32(); // tint rgb + s
-        in->ReadInt32(); // tint light (or light level)
+        // tint rgb + s (4 uint8)
+        tint_r = in->ReadInt8();
+        tint_g = in->ReadInt8();
+        tint_b = in->ReadInt8();
+        tint_level = in->ReadInt8();
+        tint_light = in->ReadInt32(); // tint light (or light level)
         // Reserved for transform options
         in->ReadInt32(); // sprite transform flags1
         in->ReadInt32(); // sprite transform flags2
@@ -196,8 +227,12 @@ void ScreenOverlay::WriteToSavegame(Stream *out) const
     out->WriteInt32(blendMode);
     // Reserved for colour options
     out->WriteInt32(0); // colour flags
-    out->WriteInt32(0); // tint rgb + s
-    out->WriteInt32(0); // tint light (or light level)
+    // tint rgb + s (4 uint8)
+    out->WriteInt8(tint_r);
+    out->WriteInt8(tint_g);
+    out->WriteInt8(tint_b);
+    out->WriteInt8(tint_level);
+    out->WriteInt32(tint_light); // tint light (or light level)
     // Reserved for transform options
     out->WriteInt32(0); // sprite transform flags1
     out->WriteInt32(0); // sprite transform flags2

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -48,6 +48,8 @@ enum OverlayFlags
     kOver_RoomLayer        = 0x0004, // work in room layer (as opposed to UI)
     kOver_SpriteShared     = 0x0008, // reference shared sprite (as opposed to exclusive)
     kOver_AutoPosition     = 0x0010, // autoposition over a linked Character (speech)
+    kOver_HasTint          = 0x0020,
+    kOver_HasLightLevel    = 0x0040,
 };
 
 enum OverlaySvgVersion
@@ -81,6 +83,8 @@ struct ScreenOverlay
     int associatedOverlayHandle = 0; // script obj handle
     int zorder = INT_MIN;
     float rotation = 0.f;
+    uint8_t tint_r = 0u, tint_g = 0u, tint_b = 0u, tint_level = 0u;
+    int tint_light = 0; // -100 to 100 (comply to objects and characters)
     Common::BlendMode blendMode = Common::kBlend_Normal;
     int transparency = 0;
     Common::GraphicSpace _gs;
@@ -96,6 +100,8 @@ struct ScreenOverlay
     bool IsSpriteShared() const { return (_flags & kOver_SpriteShared) != 0; }
     bool IsAutoPosition() const { return (_flags & kOver_AutoPosition) != 0; }
     bool IsRoomLayer() const { return (_flags & kOver_RoomLayer) != 0; }
+    bool HasTint() const { return (_flags & kOver_HasTint) != 0; }
+    bool HasLightLevel() const { return (_flags & kOver_HasLightLevel) != 0; }
     void SetAutoPosition(int for_character)
     {
         _flags |= kOver_AutoPosition;
@@ -122,6 +128,12 @@ struct ScreenOverlay
     void SetImage(std::unique_ptr<Common::Bitmap> pic, int offx = 0, int offy = 0);
     // Assigns a shared sprite to this overlay
     void SetSpriteNum(int sprnum, int offx = 0, int offy = 0);
+    // Assigns tint settings
+    void SetTint(int red, int green, int blue, int opacity, int luminance);
+    // Assigns light level
+    void SetLightLevel(int light_level);
+    // Removes tint and light level
+    void RemoveTint();
     // Tells if Overlay has graphically changed recently
     bool HasChanged() const { return _hasChanged; }
     // Manually marks GUI as graphically changed


### PR DESCRIPTION
Support for tinting overlay, for consistency with characters and objects.

Added following to the Overlay struct in script:
```
  /// Tints the overlay to the specified colour.
  import void     Tint(int red, int green, int blue, int saturation, int luminance);
  /// Sets the light level for this overlay.
  import void     SetLightLevel(int light_level);
  /// Removes an existing colour tint or light level from this overlay.
  import void     RemoveTint();
  /// Gets whether the overlay has a tint set.
  readonly import attribute bool HasTint;
  /// Gets whether the overlay has a light level set.
  readonly import attribute bool HasLightLevel;
  /// Gets the individual light level for this character.
  readonly import attribute int  LightLevel;
  /// Gets the Blue component of this overlay's colour tint.
  readonly import attribute int  TintBlue;
  /// Gets the Green component of this overlay's colour tint.
  readonly import attribute int  TintGreen;
  /// Gets the Red component of this overlay's colour tint.
  readonly import attribute int  TintRed;
  /// Gets the Saturation of this overlay's colour tint.
  readonly import attribute int  TintSaturation;
  /// Gets the Luminance of this overlay's colour tint.
  readonly import attribute int  TintLuminance;
```
