### PR TITLE
Script API: added helper functions Overlay.SetPosition and SetSize

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1124,6 +1124,10 @@ builtin managed struct Overlay {
   import attribute float Rotation;
 #endif
 #ifdef SCRIPT_API_v400
+  /// Sets this overlay's position, and optionally its size.
+  import void SetPosition(int x, int y, int width = 0, int height = 0);
+  /// Changes the size of the overlay.
+  import void SetSize(int width, int height);
   /// Tints the overlay to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
   import void Tint(int red, int green, int blue, int saturation, int luminance);
   /// Sets the light level for this overlay, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -345,6 +345,33 @@ void Overlay_SetZOrder(ScriptOverlay *scover, int zorder) {
     over->zorder = zorder;
 }
 
+void Overlay_SetPosition(ScriptOverlay *scover, int x, int y, int width, int height)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    over->SetFixedPosition(x, y);
+    // width and height are optional here
+    if (width > 0 || height > 0)
+    {
+        if (width <= 0)
+            width = over->scaleWidth;
+        if (height <= 0)
+            height = over->scaleHeight;
+        over->scaleWidth = width;
+        over->scaleHeight = height;
+        over->MarkChanged();
+    }
+}
+
+void Overlay_SetSize(ScriptOverlay *scover, int width, int height)
+{
+    auto *over = get_overlay(scover->overlayId);
+    if (!over)
+        quit("!invalid overlay ID specified");
+    Overlay_SetScaledSize(*over, width, height);
+}
+
 void Overlay_Tint(ScriptOverlay *scover, int red, int green, int blue, int opacity, int luminance)
 {
     auto *over = get_overlay(scover->overlayId);
@@ -903,6 +930,16 @@ RuntimeScriptValue Sc_Overlay_SetZOrder(void *self, const RuntimeScriptValue *pa
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetZOrder);
 }
 
+RuntimeScriptValue Sc_Overlay_SetPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT4(ScriptOverlay, Overlay_SetPosition);
+}
+
+RuntimeScriptValue Sc_Overlay_SetSize(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT2(ScriptOverlay, Overlay_SetSize);
+}
+
 RuntimeScriptValue Sc_Overlay_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT5(ScriptOverlay, Overlay_Tint);
@@ -997,6 +1034,8 @@ void RegisterOverlayAPI()
         { "Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual, ScPl_Overlay_CreateRoomTextual },
         { "Overlay::SetText^104",         Sc_Overlay_SetText, ScPl_Overlay_SetText },
         { "Overlay::Remove^0",            API_FN_PAIR(Overlay_Remove) },
+        { "Overlay::SetPosition^4",       API_FN_PAIR(Overlay_SetPosition) },
+        { "Overlay::SetSize^2",           API_FN_PAIR(Overlay_SetSize) },
         { "Overlay::Tint^5",              API_FN_PAIR(Overlay_Tint) },
         { "Overlay::SetLightLevel^1",     API_FN_PAIR(Overlay_SetLightLevel) },
         { "Overlay::RemoveTint^0",        API_FN_PAIR(Overlay_RemoveTint) },


### PR DESCRIPTION
This is my proposal:

```
/// Sets this overlay's position, and optionally its size.
import void SetPosition(int x, int y, int width = 0, int height = 0);
/// Changes the size of the overlay.
import void SetSize(int width, int height);
```

In SetPosition() width and height are optional parameters, if they are not set (or rather <= 0), then the old size is kept.
Having them combined in SetPosition makes 1 function less, and also we might expand existing SetPosition for other objects with optional width and height too.
But if someone thinks that this is not a good idea, i may reduce SetPosition to strictly x,y and make a third function that has 4 parameters.
