### PR TITLE
AGS 4: Script API: add global events for Dialogs, and properties to read current dialog state

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1812,6 +1812,14 @@ builtin managed struct Dialog {
   /// Gets the script name of this dialog.
   import readonly attribute String ScriptName;
 #endif
+#ifdef SCRIPT_API_v362
+  /// Gets the currently running dialog, returns null if no dialog is run
+  import static readonly attribute Dialog* CurrentDialog; // $AUTOCOMPLETESTATICONLY$
+  /// Gets the currently executed dialog option, or -1 if none is
+  import static readonly attribute int ExecutedOption; // $AUTOCOMPLETESTATICONLY$
+  /// Gets if the dialog options are currently displayed on screen
+  import static readonly attribute bool AreOptionsDisplayed; // $AUTOCOMPLETESTATICONLY$
+#endif
 
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1327,6 +1327,13 @@ enum EventType {
   eEventLeaveRoomAfterFadeout = 11,
   eEventGameSaved = 12,
 #endif
+#ifdef SCRIPT_API_v400
+  eEventDialogStart = 13,
+  eEventDialogStop = 14,
+  eEventDialogRun = 15,
+  eEventDialogOptionsOpen = 16,
+  eEventDialogOptionsClose = 17,
+#endif
 };
 
 #ifdef SCRIPT_API_v350

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -54,6 +54,7 @@
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
+struct DialogExec;
 
 extern GameSetupStruct game;
 extern int in_new_room;
@@ -66,6 +67,7 @@ extern IGraphicsDriver *gfxDriver;
 std::vector<DialogTopic> dialog;
 ScriptDialogOptionsRendering ccDialogOptionsRendering;
 ScriptDrawingSurface* dialogOptionsRenderingSurface;
+std::unique_ptr<DialogExec> dialogExec; // current running dialog
 
 int said_speech_line; // used while in dialog to track whether screen needs updating
 
@@ -1155,6 +1157,7 @@ int show_dialog_options(int dlgnum, bool runGameLoopsInBackground)
 }
 
 // Dialog execution state
+// TODO: reform into GameState implementation, similar to DialogOptions!
 struct DialogExec
 {
     int DlgNum = -1;
@@ -1163,6 +1166,8 @@ struct DialogExec
     bool IsFirstEntry = true;
     // nested dialogs "stack"
     std::stack<int> TopicHist;
+    int ExecutedOption = -1; // option which is currently run (or -1)
+    bool AreOptionsDisplayed = false; // if dialog options are displayed on screen
 
     DialogExec(int start_dlgnum) : DlgNum(start_dlgnum) {}
     int HandleDialogResult(int res);
@@ -1203,8 +1208,10 @@ void DialogExec::Run()
         // If a new dialog topic: run dialog entry point
         if (DlgNum != DlgWas)
         {
+            ExecutedOption = 0;
             res = run_dialog_entry(DlgNum);
             DlgWas = DlgNum;
+            ExecutedOption = -1;
 
             // Handle the dialog entry's result
             res = HandleDialogResult(res);
@@ -1216,7 +1223,9 @@ void DialogExec::Run()
         }
 
         // Show current dialog's options
+        AreOptionsDisplayed = true;
         int chose = show_dialog_options(DlgNum, (game.options[OPT_RUNGAMEDLGOPTS] != 0));
+        AreOptionsDisplayed = false;
 
         if (chose == CHOSE_TEXTPARSER)
         {
@@ -1233,8 +1242,10 @@ void DialogExec::Run()
         }
         else if (chose >= 0)
         {
+            ExecutedOption = chose;
             // chose some option - handle it and run its script
             res = run_dialog_option(DlgNum, chose, SAYCHOSEN_USEFLAG, true /* run script */);
+            ExecutedOption = -1;
         }
         else
         {
@@ -1256,10 +1267,10 @@ void do_conversation(int dlgnum)
     // Run the global DialogStart event
     run_on_event(kScriptEvent_DialogStart, RuntimeScriptValue().SetInt32(dlgnum));
 
-    DialogExec dlgexec(dlgnum);
-    dlgexec.Run();
+    dialogExec.reset(new DialogExec(dlgnum));
+    dialogExec->Run();
     // CHECKME: find out if this is safe to do always, regardless of number of iterations
-    if (dlgexec.IsFirstEntry)
+    if (dialogExec->IsFirstEntry)
     {
         // bail out from first startup script
         remove_screen_overlay(OVER_COMPLETE);
@@ -1267,7 +1278,8 @@ void do_conversation(int dlgnum)
     }
 
     // Run the global DialogStop event; NOTE: DlgNum may be different in the end
-    run_on_event(kScriptEvent_DialogStop, RuntimeScriptValue().SetInt32(dlgexec.DlgNum));
+    run_on_event(kScriptEvent_DialogStop, RuntimeScriptValue().SetInt32(dialogExec->DlgNum));
+    dialogExec = {};
 }
 
 // end dialog manager
@@ -1292,10 +1304,39 @@ ScriptDialog *Dialog_GetByName(const char *name)
     return static_cast<ScriptDialog*>(ccGetScriptObjectAddress(name, ccDynamicDialog.GetType()));
 }
 
+ScriptDialog *Dialog_GetCurrentDialog()
+{
+    return dialogExec ? &scrDialog[dialogExec->DlgNum] : nullptr;
+}
+
+int Dialog_GetExecutedOption()
+{
+    return dialogExec ? dialogExec->ExecutedOption : -1;
+}
+
+bool Dialog_GetAreOptionsDisplayed()
+{
+    return dialogExec ? dialogExec->AreOptionsDisplayed : false;
+}
 
 RuntimeScriptValue Sc_Dialog_GetByName(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJ_POBJ(ScriptDialog, ccDynamicDialog, Dialog_GetByName, const char);
+}
+
+RuntimeScriptValue Sc_Dialog_GetCurrentDialog(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(ScriptDialog, ccDynamicDialog, Dialog_GetCurrentDialog);
+}
+
+RuntimeScriptValue Sc_Dialog_GetExecutedOption(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Dialog_GetExecutedOption);
+}
+
+RuntimeScriptValue Sc_Dialog_GetAreOptionsDisplayed(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_BOOL(Dialog_GetAreOptionsDisplayed);
 }
 
 // int (ScriptDialog *sd)
@@ -1366,6 +1407,9 @@ void RegisterDialogAPI()
 {
     ScFnRegister dialog_api[] = {
         { "Dialog::GetByName",            API_FN_PAIR(Dialog_GetByName) },
+        { "Dialog::get_CurrentDialog",    API_FN_PAIR(Dialog_GetCurrentDialog) },
+        { "Dialog::get_ExecutedOption",   API_FN_PAIR(Dialog_GetExecutedOption) },
+        { "Dialog::get_AreOptionsDisplayed", API_FN_PAIR(Dialog_GetAreOptionsDisplayed) },
         { "Dialog::get_ID",               API_FN_PAIR(Dialog_GetID) },
         { "Dialog::get_OptionCount",      API_FN_PAIR(Dialog_GetOptionCount) },
         { "Dialog::get_ScriptName",       API_FN_PAIR(Dialog_GetScriptName) },

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -20,6 +20,7 @@
 #include "ac/dialogtopic.h"
 #include "ac/display.h"
 #include "ac/draw.h"
+#include "ac/event.h"
 #include "ac/gamestate.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/global_character.h"
@@ -1069,7 +1070,8 @@ void DialogOptions::End()
 int run_dialog_entry(int dlgnum)
 {
     DialogTopic *dialog_topic = &dialog[dlgnum];
-    // Run global event kScriptEvent_DialogRun
+    // Run global event kScriptEvent_DialogRun for the startup entry (index 0)
+    run_on_event(kScriptEvent_DialogRun, RuntimeScriptValue().SetInt32(dlgnum), RuntimeScriptValue().SetInt32(0));
     return run_dialog_script(dlgnum, dialog_topic->startupentrypoint, 0);
 }
 
@@ -1079,6 +1081,9 @@ int run_dialog_option(int dlgnum, int dialog_choice, int sayChosenOption, bool r
     DialogTopic *dialog_topic = &dialog[dlgnum];
     int &option_flags = dialog_topic->optionflags[dialog_choice];
     const char *option_name = dialog_topic->optionnames[dialog_choice];
+
+    // Run global event kScriptEvent_DialogRun for the new option
+    run_on_event(kScriptEvent_DialogRun, RuntimeScriptValue().SetInt32(dlgnum), RuntimeScriptValue().SetInt32(dialog_choice + 1));
 
     option_flags |= DFLG_HASBEENCHOSEN;
     bool sayTheOption = false;
@@ -1137,9 +1142,14 @@ int show_dialog_options(int dlgnum, bool runGameLoopsInBackground)
     return last_opt; // only one choice, so select it
   }
 
+  // Run the global DialogOptionsOpen event
+  run_on_event(kScriptEvent_DialogOptionsOpen, RuntimeScriptValue().SetInt32(dlgnum));
+
   DialogOptions dlgopt(dtop, dlgnum, runGameLoopsInBackground);
   dlgopt.Show();
 
+  // Run the global DialogOptionsClose event
+  run_on_event(kScriptEvent_DialogOptionsClose, RuntimeScriptValue().SetInt32(dlgnum), RuntimeScriptValue().SetInt32(dlgopt.GetChosenOption()));
 
   return dlgopt.GetChosenOption();
 }
@@ -1243,6 +1253,9 @@ void do_conversation(int dlgnum)
 {
     EndSkippingUntilCharStops();
 
+    // Run the global DialogStart event
+    run_on_event(kScriptEvent_DialogStart, RuntimeScriptValue().SetInt32(dlgnum));
+
     DialogExec dlgexec(dlgnum);
     dlgexec.Run();
     // CHECKME: find out if this is safe to do always, regardless of number of iterations
@@ -1252,6 +1265,9 @@ void do_conversation(int dlgnum)
         remove_screen_overlay(OVER_COMPLETE);
         play.in_conversation--;
     }
+
+    // Run the global DialogStop event; NOTE: DlgNum may be different in the end
+    run_on_event(kScriptEvent_DialogStop, RuntimeScriptValue().SetInt32(dlgexec.DlgNum));
 }
 
 // end dialog manager

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -106,10 +106,10 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
 }
 
 // runs the global script on_event function
-void run_on_event(int evtype, RuntimeScriptValue &wparam)
+void run_on_event(AGSScriptEventType evtype, const RuntimeScriptValue &data1, const RuntimeScriptValue &data2)
 {
-    RuntimeScriptValue params[]{ evtype , wparam };
-    QueueScriptFunction(kScInstGame, "on_event", 2, params);
+    RuntimeScriptValue params[]{ evtype , data1, data2 };
+    QueueScriptFunction(kScInstGame, "on_event", 3, params);
 }
 
 void run_room_event(int id) {

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -113,6 +113,11 @@ enum AGSScriptEventType
     kScriptEvent_RoomAfterFadein = 10, // enter after fade-in
     kScriptEvent_RoomAfterFadeout = 11, // after fade-out, right before unloading
     kScriptEvent_GameSaved      = 12,
+    kScriptEvent_DialogStart    = 13, // before game enters a "dialog" state
+    kScriptEvent_DialogStop     = 14, // after game returns from a "dialog" state
+    kScriptEvent_DialogRun      = 15, // a dialog option is run
+    kScriptEvent_DialogOptionsOpen = 16, // before dialog options are displayed on screen
+    kScriptEvent_DialogOptionsClose = 17, // after dialog options are removed from screen
 };
 
 
@@ -199,8 +204,8 @@ struct AGSEvent
 };
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed);
-// runs the global script on_event fnuction
-void run_on_event (int evtype, RuntimeScriptValue &wparam);
+// runs the global script on_event function
+void run_on_event(AGSScriptEventType evtype, const RuntimeScriptValue &data1 = RuntimeScriptValue(), const RuntimeScriptValue &data2 = RuntimeScriptValue());
 void run_room_event(int id);
 // event list functions
 void setevent(const AGSEvent &evt);

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -427,7 +427,7 @@ int RunScriptFunctionInRoom(const char *tsname, size_t param_count, const Runtim
 {
     // Some room callbacks are considered to be obligatory; for historical reasons these are
     // identified by having no parameters;
-    // TODO: this is a hack, this should be defined either by function type, or as an arg
+    // FIXME: this is a hack, this should be defined either by function type, or as an arg
     const bool strict_room_event = (param_count == 0);
     int toret = RunScriptFunction(roominst.get(), tsname, param_count, params);
     // If it's a obligatory room event, and return code means missing function - error
@@ -670,9 +670,10 @@ void post_script_cleanup() {
     for (const auto &script : copyof.ScFnQueue) {
         old_room_number = displayed_room;
         RunScriptFunctionAuto(script.Instance, script.FnName.GetCStr(), script.ParamCount, script.Params);
+        // FIXME: this is some bogus hack for "on_call" event handler
+        // don't use instance + param count, instead find a way to save actual callback name!
         if (script.Instance == kScInstRoom && script.ParamCount == 1)
         {
-            // some bogus hack for "on_call" event handler
             play.roomscript_finished = 1;
         }
 


### PR DESCRIPTION
Resolves #1328

This adds following EventTypes for use in "on_event" callback:

```
eEventDialogStart.
eEventDialogStop,
eEventDialogRun,
eEventDialogOptionsOpen,
eEventDialogOptionsClose,
```

* eEventDialogStart - run when the dialog state begins; arg1 = dialog number;
* eEventDialogStop - run when the dialog state ends; arg1 = last dialog number;
* eEventDialogRun - run when any dialog's entry is executed, whether starting entry or one of the options; arg1 = dialog number, arg2 = option number (0 = starting entry);
* eEventDialogOptionsOpen - run right before the dialog options are shown on screen; arg1 = dialog number
* eEventDialogOptionsClose - run right after the dialog options are removed from the screen; arg1 = dialog number, arg2 = chosen option number

Additionally, added following properties to a Dialog struct:
```
/// Gets the currently running dialog, returns null if no dialog is run
static readonly attribute Dialog* CurrentDialog;
/// Gets the currently executed dialog option, or -1 if none is
static readonly attribute int ExecutedOption;
/// Gets if the dialog options are currently displayed on screen
static readonly attribute bool AreOptionsDisplayed;
```

These may be accessible in dialog script, any functions called from dialog script, custom dialog option callbacks, and "repeatedly_execute_always" either when there's a waiting inside a dialog script or during options and "run game loops while dialog options" is enabled.