### PR TITLE
Support reading saves from older game version

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3360,6 +3360,7 @@ enum RestoredSaveResult
 managed struct RestoredSaveInfo
 {
   import attribute bool Cancel;
+  import attribute SaveComponentSelection RetryWithoutComponents;
   import readonly attribute RestoredSaveResult Result;
   import readonly attribute String EngineVersion;
   import readonly attribute int AudioClipTypeCount;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3362,6 +3362,9 @@ managed struct RestoredSaveInfo
   import attribute bool Cancel;
   import attribute SaveComponentSelection RetryWithoutComponents;
   import readonly attribute RestoredSaveResult Result;
+
+  import readonly attribute int Slot;
+  import readonly attribute String Description;
   import readonly attribute String EngineVersion;
   import readonly attribute int AudioClipTypeCount;
   import readonly attribute int CharacterCount;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3349,6 +3349,35 @@ enum SaveComponentSelection
     eSaveCmp_Plugins        = 0x00002000
 };
 
+#ifdef SCRIPT_API_v362
+enum RestoredSaveResult
+{
+  eRestoredSave_ClearData   = 0x01,
+  eRestoredSave_MissingData = 0x08,
+  eRestoredSave_ExtraData   = 0x10
+};
+
+managed struct RestoredSaveInfo
+{
+  import attribute bool Cancel;
+  import readonly attribute RestoredSaveResult Result;
+  import readonly attribute int AudioClipTypeCount;
+  import readonly attribute int CharacterCount;
+  import readonly attribute int DialogCount;
+  import readonly attribute int GUICount;
+  import readonly attribute int GUIControlCount[];
+  import readonly attribute int InventoryItemCount;
+  import readonly attribute int CursorCount;
+  import readonly attribute int ViewCount;
+  import readonly attribute int ViewLoopCount[];
+  import readonly attribute int ViewFrameCount[];
+  import readonly attribute int GlobalScriptDataSize;
+  import readonly attribute int ScriptModuleCount;
+  import readonly attribute int ScriptModuleDataSize[];
+  import readonly attribute int RoomScriptDataSize;
+};
+#endif
+
 
 
 import readonly Character *player;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3361,6 +3361,7 @@ managed struct RestoredSaveInfo
 {
   import attribute bool Cancel;
   import readonly attribute RestoredSaveResult Result;
+  import readonly attribute String EngineVersion;
   import readonly attribute int AudioClipTypeCount;
   import readonly attribute int CharacterCount;
   import readonly attribute int DialogCount;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -108,6 +108,7 @@ target_sources(engine
     ac/dynobj/scriptoverlay.cpp
     ac/dynobj/scriptoverlay.h
     ac/dynobj/scriptregion.h
+    ac/dynobj/scriptrestoredsaveinfo.h
     ac/dynobj/scriptset.cpp
     ac/dynobj/scriptset.h
     ac/dynobj/scriptstring.cpp

--- a/Engine/ac/dynobj/scriptrestoredsaveinfo.h
+++ b/Engine/ac/dynobj/scriptrestoredsaveinfo.h
@@ -15,6 +15,7 @@
 #define __AC_SCRIPTRESTOREDSAVEINFO_H
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
+#include "game/savegame.h"
 #include "game/savegame_internal.h"
 
 class ScriptRestoredSaveInfo final : public CCBasicObject
@@ -22,6 +23,7 @@ class ScriptRestoredSaveInfo final : public CCBasicObject
 public:
     using SaveRestorationFlags = AGS::Engine::SaveRestorationFlags;
     using SaveRestoredDataCounts = AGS::Engine::SaveRestoredDataCounts;
+    using SaveCmpSelection = AGS::Engine::SaveCmpSelection;
 
     ScriptRestoredSaveInfo(SaveRestorationFlags result,
         const SaveRestoredDataCounts &counts, bool default_cancel)
@@ -39,6 +41,8 @@ public:
 
     bool GetCancel() const { return _cancel; }
     void SetCancel(bool cancel) { _cancel = cancel; }
+    SaveCmpSelection GetRetryWithoutComponents() const { return _retryWithoutComponents; }
+    void SetRetryWithoutComponents(SaveCmpSelection cmp) { _retryWithoutComponents = cmp; }
     SaveRestorationFlags GetResult() const { return _result; }
     const SaveRestoredDataCounts &GetCounts() const { return _counts; }
 
@@ -46,6 +50,7 @@ private:
     SaveRestorationFlags _result;
     SaveRestoredDataCounts _counts;
     bool _cancel = false;
+    SaveCmpSelection _retryWithoutComponents = SaveCmpSelection::kSaveCmp_None;
 };
 
 #endif // __AC_SCRIPTRESTOREDSAVEINFO_H

--- a/Engine/ac/dynobj/scriptrestoredsaveinfo.h
+++ b/Engine/ac/dynobj/scriptrestoredsaveinfo.h
@@ -22,12 +22,14 @@ class ScriptRestoredSaveInfo final : public CCBasicObject
 {
 public:
     using SaveRestorationFlags = AGS::Engine::SaveRestorationFlags;
+    using SavegameDescription = AGS::Engine::SavegameDescription;
     using SaveRestoredDataCounts = AGS::Engine::SaveRestoredDataCounts;
     using SaveCmpSelection = AGS::Engine::SaveCmpSelection;
 
-    ScriptRestoredSaveInfo(SaveRestorationFlags result,
-        const SaveRestoredDataCounts &counts, bool default_cancel)
+    ScriptRestoredSaveInfo(SaveRestorationFlags result, const SavegameDescription &save_desc,
+            const SaveRestoredDataCounts &counts, bool default_cancel)
         : _result(result)
+        , _desc(save_desc)
         , _counts(counts)
         , _cancel(default_cancel)
     {}
@@ -44,9 +46,11 @@ public:
     SaveCmpSelection GetRetryWithoutComponents() const { return _retryWithoutComponents; }
     void SetRetryWithoutComponents(SaveCmpSelection cmp) { _retryWithoutComponents = cmp; }
     SaveRestorationFlags GetResult() const { return _result; }
+    const SavegameDescription &GetDesc() const { return _desc; }
     const SaveRestoredDataCounts &GetCounts() const { return _counts; }
 
 private:
+    SavegameDescription _desc;
     SaveRestorationFlags _result;
     SaveRestoredDataCounts _counts;
     bool _cancel = false;

--- a/Engine/ac/dynobj/scriptrestoredsaveinfo.h
+++ b/Engine/ac/dynobj/scriptrestoredsaveinfo.h
@@ -1,0 +1,51 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AC_SCRIPTRESTOREDSAVEINFO_H
+#define __AC_SCRIPTRESTOREDSAVEINFO_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "game/savegame_internal.h"
+
+class ScriptRestoredSaveInfo final : public CCBasicObject
+{
+public:
+    using SaveRestorationFlags = AGS::Engine::SaveRestorationFlags;
+    using SaveRestoredDataCounts = AGS::Engine::SaveRestoredDataCounts;
+
+    ScriptRestoredSaveInfo(SaveRestorationFlags result,
+        const SaveRestoredDataCounts &counts, bool default_cancel)
+        : _result(result)
+        , _counts(counts)
+        , _cancel(default_cancel)
+    {}
+
+    const char *GetType() override { return "RestoredSaveInfo"; }
+    int Dispose(void *address, bool force) override
+    {
+        delete (ScriptRestoredSaveInfo*)address;
+        return 1;
+    }
+
+    bool GetCancel() const { return _cancel; }
+    void SetCancel(bool cancel) { _cancel = cancel; }
+    SaveRestorationFlags GetResult() const { return _result; }
+    const SaveRestoredDataCounts &GetCounts() const { return _counts; }
+
+private:
+    SaveRestorationFlags _result;
+    SaveRestoredDataCounts _counts;
+    bool _cancel = false;
+};
+
+#endif // __AC_SCRIPTRESTOREDSAVEINFO_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1055,7 +1055,8 @@ HSaveError load_game(const String &path, int slotNumber, bool startup, bool &dat
     HSaveError err;
     SavegameSource src;
     SavegameDescription desc;
-    err = OpenSavegame(path, src, desc, kSvgDesc_EnvInfo);
+    desc.Slot = slotNumber;
+    err = OpenSavegame(path, src, desc, (SavegameDescElem)(kSvgDesc_EnvInfo | kSvgDesc_UserText));
 
     // saved in incompatible enviroment
     if (!err)
@@ -1100,8 +1101,8 @@ HSaveError load_game(const String &path, int slotNumber, bool startup, bool &dat
 
     // Do the actual game state restore
     SaveRestoreFeedback feedback;
-    err = RestoreGameState(src.InputStream.get(),
-        RestoreGameStateOptions(src.Version, desc.EngineVersion.LongString,
+    err = RestoreGameState(src.InputStream.get(), desc,
+        RestoreGameStateOptions(src.Version,
             (SaveCmpSelection)(kSaveCmp_All & ~(game.options[OPT_SAVECOMPONENTSIGNORE] & kSaveCmp_ScriptIgnoreMask)),
             startup), feedback);
     src.InputStream.reset();

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1098,7 +1098,7 @@ HSaveError load_game(const String &path, int slotNumber, bool startup, bool &dat
     }
 
     // Do the actual game state restore
-    err = RestoreGameState(src.InputStream.get(), src.Version,
+    err = RestoreGameState(src.InputStream.get(), src.Version, desc.EngineVersion.LongString,
         (SaveCmpSelection)(kSaveCmp_All & ~(game.options[OPT_SAVECOMPONENTSIGNORE] & kSaveCmp_ScriptIgnoreMask)),
         startup);
     src.InputStream.reset();

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -169,8 +169,8 @@ bool read_savedgame_description(const Common::String &savedgame, Common::String 
 std::unique_ptr<Common::Bitmap> read_savedgame_screenshot(const Common::String &savedgame);
 // Tries to restore saved game and displays an error on failure; if the error occured
 // too late, when the game data was already overwritten, shuts engine down.
-bool try_restore_save(int slot);
-bool try_restore_save(const Common::String &path, int slot);
+bool try_restore_save(int slot, bool startup = false);
+bool try_restore_save(const Common::String &path, int slot, bool startup = false);
 void serialize_bitmap(const Common::Bitmap *thispic, Common::Stream *out);
 Common::Bitmap *read_serialized_bitmap(Common::Stream *in);
 void skip_serialized_bitmap(Common::Stream *in);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -404,7 +404,7 @@ int RunAGSGame(const String &newgame, unsigned int mode, int data) {
     play.screen_is_faded_out = 1;
 
     if (load_new_game_restore >= 0) {
-        try_restore_save(load_new_game_restore);
+        try_restore_save(load_new_game_restore, true);
         load_new_game_restore = -1;
     }
     else

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -575,6 +575,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     else croom=&troom;
 
     // Decide what to do if we have been or not in this room before
+    const bool been_here = croom->beenhere > 0;
     if (croom->beenhere > 0)
     {
         // if we've been here before, save the Times Run information
@@ -737,12 +738,22 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     roominst=nullptr;
     if (debug_flags & DBG_NOSCRIPT) ;
-    else if (thisroom.CompiledScript!=nullptr) {
+    else if (thisroom.CompiledScript)
+    {
         compile_room_script();
-        if (croom->tsdatasize>0) {
-            if (croom->tsdatasize != roominst->globaldatasize)
-                quit("room script data segment size has changed");
-            memcpy(&roominst->globaldata[0],croom->tsdata.data(),croom->tsdatasize);
+        if (been_here)
+        {
+            if (croom->tsdatasize > roominst->globaldatasize)
+            {
+                quitprintf("Restored Room %d script data size exceeds current script data (%zu vs %zu bytes).",
+                    newnum, croom->tsdatasize, roominst->globaldatasize);
+            }
+            else if (croom->tsdatasize < roominst->globaldatasize)
+            {
+                Debug::Printf(kDbgMsg_Warn, "WARNING: Restored Room %d script data size is less than the current script data (%zu vs %zu bytes)",
+                    newnum, croom->tsdatasize, roominst->globaldatasize);
+            }
+            memcpy(roominst->globaldata, croom->tsdata.data(), std::min<uint32_t>(croom->tsdatasize, roominst->globaldatasize));
         }
     }
     set_our_eip(207);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -588,6 +588,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
         dynamicallyCreatedSurfaces[i] = std::move(r_data.DynamicSurfaces[i]);
     }
 
+    // Rebuild GUI links to child controls
+    GUIRefCollection guictrl_refs(guibuts, guiinv, guilabels, guilist, guislider, guitext);
+    GUI::RebuildGUI(guis, guictrl_refs);
+
     // Re-export any missing audio channel script objects, e.g. if restoring old save
     export_missing_audiochans();
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -648,9 +648,14 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
 
     // load the room the game was saved in
     if (displayed_room >= 0)
+    {
         load_new_room(displayed_room, nullptr);
+        r_data.DataCounts.RoomScriptDataSz = croom->tsdatasize;
+    }
     else
+    {
         set_room_placeholder();
+    }
 
     // Reapply few parameters after room load
     play.gscript_timer = gstimer;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -151,6 +151,7 @@ String GetSavegameErrorText(SavegameErrorType err)
     case kSvgErr_UnsupportedComponentVersion:
         return "Component data version not supported.";
     case kSvgErr_GameContentAssertion:
+    case kSvgErr_GameContentAssert_RequireClearReload:
         return "Saved content does not match current game.";
     case kSvgErr_InconsistentData:
         return "Inconsistent save data, or file is corrupted.";
@@ -727,13 +728,17 @@ static SaveCmpSelection FixupCmpSelection(SaveCmpSelection select_cmp)
         kSaveCmp_ObjectSprites * ((select_cmp & kSaveCmp_DynamicSprites) == 0));
 }
 
-HSaveError RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSelection select_cmp)
+HSaveError RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSelection select_cmp, bool is_game_clear)
 {
     select_cmp = FixupCmpSelection(select_cmp);
 
     PreservedParams pp;
     RestoredData r_data;
     DoBeforeRestore(pp, select_cmp);
+
+    // Mark the clear game data state for restoration process
+    r_data.RestoreFlags = (SaveRestorationFlags)(kSaveRestore_ClearData * is_game_clear);
+
     HSaveError err = SavegameComponents::ReadAll(in, svg_version, select_cmp, pp, r_data);
     if (!err)
         return err;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -535,8 +535,8 @@ static void ValidateDynamicSprite(int handle, IScriptObject *obj)
 // Call a scripting event to let user validate the restored save
 static HSaveError ValidateRestoredSave(const RestoredData &r_data)
 {
-    auto *saveinfo = new ScriptRestoredSaveInfo(r_data.RestoreFlags, r_data.DataCounts,
-        (r_data.RestoreFlags & kSaveRestore_MismatchMask) != 0);
+    auto *saveinfo = new ScriptRestoredSaveInfo(r_data.Result.RestoreFlags, r_data.DataCounts,
+        (r_data.Result.RestoreFlags & kSaveRestore_MismatchMask) != 0);
     int handle = ccRegisterManagedObject(saveinfo, saveinfo);
     ccAddObjectReference(handle); // add internal ref
 
@@ -547,7 +547,7 @@ static HSaveError ValidateRestoredSave(const RestoredData &r_data)
     ccReleaseObjectReference(handle); // rem internal ref
 
     if (do_cancel)
-        return new SavegameError(kSvgErr_GameContentAssertion);
+        return new SavegameError(kSvgErr_GameContentAssertion, r_data.Result.FirstMismatchError);
 
     return HSaveError::None();
 }
@@ -772,7 +772,7 @@ HSaveError RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSele
     DoBeforeRestore(pp, select_cmp);
 
     // Mark the clear game data state for restoration process
-    r_data.RestoreFlags = (SaveRestorationFlags)((kSaveRestore_ClearData * is_game_clear)
+    r_data.Result.RestoreFlags = (SaveRestorationFlags)((kSaveRestore_ClearData * is_game_clear)
         | kSaveRestore_AllowMismatchLess); // allow less data in saves
 
     HSaveError err = SavegameComponents::ReadAll(in, svg_version, select_cmp, pp, r_data);

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -214,7 +214,7 @@ HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
 HSaveError     OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 // Reads the game data from the save stream and reinitializes game state;
 // is_game_clear - tells whether the game is in clean default state
-HSaveError     RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSelection select_cmp, bool is_game_clear);
+HSaveError     RestoreGameState(Stream *in, SavegameVersion svg_version, const String &engine_ver, SaveCmpSelection select_cmp, bool is_game_clear);
 // Opens savegame for writing and puts in savegame description
 std::unique_ptr<Stream> StartSavegame(const String &filename, const String &user_text, const Bitmap *user_image);
 // Prepares game for saving state and writes game data into the save stream

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -82,6 +82,9 @@ enum SavegameErrorType
     kSvgErr_InconsistentFormat,
     kSvgErr_UnsupportedComponentVersion,
     kSvgErr_GameContentAssertion,
+    // Game content assertion failed, but we're allowed to retry
+    // after clearing game data to defaults
+    kSvgErr_GameContentAssert_RequireClearReload,
     kSvgErr_InconsistentData,
     kSvgErr_InconsistentPlugin,
     kSvgErr_DifferentColorDepth,
@@ -209,8 +212,9 @@ HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
                             SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 // Opens savegame and reads the savegame description
 HSaveError     OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
-// Reads the game data from the save stream and reinitializes game state
-HSaveError     RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSelection select_cmp);
+// Reads the game data from the save stream and reinitializes game state;
+// is_game_clear - tells whether the game is in clean default state
+HSaveError     RestoreGameState(Stream *in, SavegameVersion svg_version, SaveCmpSelection select_cmp, bool is_game_clear);
 // Opens savegame for writing and puts in savegame description
 std::unique_ptr<Stream> StartSavegame(const String &filename, const String &user_text, const Bitmap *user_image);
 // Prepares game for saving state and writes game data into the save stream

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -127,6 +127,8 @@ enum SavegameDescElem
 // it was created in, and custom data provided by user
 struct SavegameDescription
 {
+    // Savegame's slot number
+    int                 Slot = -1;
     // Name of the engine that saved the game
     String              EngineName;
     // Version of the engine that saved the game
@@ -134,7 +136,7 @@ struct SavegameDescription
     // Guid of the game which made this save
     String              GameGuid;
     // Legacy uniqueid of the game, for use in older games with no GUID
-    int                 LegacyID;
+    int                 LegacyID = 0;
     // Title of the game which made this save
     String              GameTitle;
     // Name of the main data file used; this is needed to properly
@@ -142,15 +144,17 @@ struct SavegameDescription
     String              MainDataFilename;
     // Game's main data version; should be checked early to know
     // if the save was made for the supported game format
-    GameDataVersion     MainDataVersion;
+    GameDataVersion     MainDataVersion = kGameVersion_Undefined;
     // Native color depth of the game; this is required to
     // properly restore dynamic graphics from the save
-    int                 ColorDepth;
-    
+    int                 ColorDepth = 0;
+
     String              UserText;
     std::unique_ptr<Bitmap> UserImage;
 
-    SavegameDescription();
+    SavegameDescription() = default;
+    SavegameDescription(SavegameDescription &&desc) = default;
+    SavegameDescription(const SavegameDescription &desc);
 };
 
 // SaveCmpSelection flags tell which save components to restore, and which to skip.
@@ -206,13 +210,13 @@ enum SaveCmpSelection
 struct RestoreGameStateOptions
 {
     SavegameVersion SaveVersion = kSvgVersion_Undefined;
-    String          EngineVersion;
     SaveCmpSelection SelectedComponents = kSaveCmp_All;
     bool            IsGameClear = false;
 
     RestoreGameStateOptions() = default;
-    RestoreGameStateOptions(SavegameVersion svg_ver, const String &eng_ver, SaveCmpSelection select_cmp, bool game_clear)
-        : SaveVersion(svg_ver), EngineVersion(eng_ver), SelectedComponents(select_cmp), IsGameClear(game_clear) {}
+    RestoreGameStateOptions(SavegameVersion svg_ver, SaveCmpSelection select_cmp, bool game_clear)
+        : SaveVersion(svg_ver), SelectedComponents(select_cmp), IsGameClear(game_clear)
+    {}
 };
 
 // SaveRestoreFeedback - provide an optional instruction to the engine
@@ -231,7 +235,7 @@ HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
 HSaveError     OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 // Reads the game data from the save stream and reinitializes game state;
 // is_game_clear - tells whether the game is in clean default state
-HSaveError     RestoreGameState(Stream *in, const RestoreGameStateOptions &options, SaveRestoreFeedback &feedback);
+HSaveError     RestoreGameState(Stream *in, const SavegameDescription &desc, const RestoreGameStateOptions &options, SaveRestoreFeedback &feedback);
 // Opens savegame for writing and puts in savegame description
 std::unique_ptr<Stream> StartSavegame(const String &filename, const String &user_text, const Bitmap *user_image);
 // Prepares game for saving state and writes game data into the save stream

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -82,9 +82,6 @@ enum SavegameErrorType
     kSvgErr_InconsistentFormat,
     kSvgErr_UnsupportedComponentVersion,
     kSvgErr_GameContentAssertion,
-    // Game content assertion failed, but we're allowed to retry
-    // after clearing game data to defaults
-    kSvgErr_GameContentAssert_RequireClearReload,
     kSvgErr_InconsistentData,
     kSvgErr_InconsistentPlugin,
     kSvgErr_DifferentColorDepth,
@@ -206,6 +203,26 @@ enum SaveCmpSelection
         | kSaveCmp_Plugins
 };
 
+struct RestoreGameStateOptions
+{
+    SavegameVersion SaveVersion = kSvgVersion_Undefined;
+    String          EngineVersion;
+    SaveCmpSelection SelectedComponents = kSaveCmp_All;
+    bool            IsGameClear = false;
+
+    RestoreGameStateOptions() = default;
+    RestoreGameStateOptions(SavegameVersion svg_ver, const String &eng_ver, SaveCmpSelection select_cmp, bool game_clear)
+        : SaveVersion(svg_ver), EngineVersion(eng_ver), SelectedComponents(select_cmp), IsGameClear(game_clear) {}
+};
+
+// SaveRestoreFeedback - provide an optional instruction to the engine
+// after trying to restore a save.
+struct SaveRestoreFeedback
+{
+    bool             RetryWithClearGame = false;
+    SaveCmpSelection RetryWithoutComponents = kSaveCmp_None;
+};
+
 
 // Opens savegame for reading; optionally reads description, if any is provided
 HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
@@ -214,7 +231,7 @@ HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
 HSaveError     OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 // Reads the game data from the save stream and reinitializes game state;
 // is_game_clear - tells whether the game is in clean default state
-HSaveError     RestoreGameState(Stream *in, SavegameVersion svg_version, const String &engine_ver, SaveCmpSelection select_cmp, bool is_game_clear);
+HSaveError     RestoreGameState(Stream *in, const RestoreGameStateOptions &options, SaveRestoreFeedback &feedback);
 // Opens savegame for writing and puts in savegame description
 std::unique_ptr<Stream> StartSavegame(const String &filename, const String &user_text, const Bitmap *user_image);
 // Prepares game for saving state and writes game data into the save stream

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1367,8 +1367,6 @@ HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Pres
     if (!in->ReadBool())
         troom.ReadFromSavegame(in, loaded_game_file_version, (RoomStatSvgVersion)cmp_ver);
 
-    r_data.DataCounts.RoomScriptDataSz = troom.tsdatasize;
-
     return HSaveError::None();
 }
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -178,7 +178,9 @@ inline bool HandleGameContentMismatch(HSaveError &err, const uint32_t new_val, c
         restore_flags = (SaveRestorationFlags)(restore_flags | kSaveRestore_MissingDataInSave);
         if ((restore_flags & kSaveRestore_ClearData) == 0)
         {
-            err = new SavegameError(kSvgErr_GameContentAssert_RequireClearReload);
+            result.Feedback.RetryWithClearGame = true;
+            result.Feedback.RetryWithoutComponents = kSaveCmp_All;
+            err = new SavegameError(kSvgErr_GameContentAssertion);
             return false; // mismatch is allowed, but we require a clear game data to proceed
         }
     }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -734,7 +734,7 @@ HSaveError ReadGUI(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Preserved
     // NOTE: although we read ctrl refs here, this data is discarded.
     // We'd need a proper support for reading old mismatching control arrays into new ones for this data to matter.
     std::vector<std::vector<GUIMain::ControlRef>> guictrl_refs(guis_read);
-    for (int i = 0; i < guis_read; ++i)
+    for (uint32_t i = 0; i < guis_read; ++i)
         guis[i].ReadFromSavegame(in, svg_ver, guictrl_refs[i]);
 
     r_data.DataCounts.GUIControls.resize(guis_read);
@@ -1095,7 +1095,8 @@ HSaveError ReadScriptModules(Stream *in, int32_t cmp_ver, soff_t cmp_size, const
     if (!AssertGameContent(err, modules_read, numScriptModules, "Script Modules", r_data.RestoreFlags, r_data.DataCounts.ScriptModules))
         return err;
     std::vector<bool> modules_match(pp.ScriptModuleNames.size());
-    r_data.DataCounts.ScriptDataSz.resize(modules_read);
+    r_data.DataCounts.ScriptModules = modules_read;
+    r_data.DataCounts.ScriptModuleDataSz.resize(modules_read);
     for (size_t i = 0; i < modules_read; ++i)
     {
         const String module_name = (cmp_ver < kScriptModulesSvgVersion_36200) ?
@@ -1116,7 +1117,7 @@ HSaveError ReadScriptModules(Stream *in, int32_t cmp_ver, soff_t cmp_size, const
         if (game_module_index < UINT32_MAX)
         {
             // Found matching module in the game
-            if (!AssertGameObjectContent(err, data_len, pp.ScMdDataSize[i], "script module data", "module", i, r_data.RestoreFlags, r_data.DataCounts.ScriptDataSz[i]))
+            if (!AssertGameObjectContent(err, data_len, pp.ScMdDataSize[i], "script module data", "module", i, r_data.RestoreFlags, r_data.DataCounts.ScriptModuleDataSz[i]))
                 return err;
             modules_match[game_module_index] = true;
         }
@@ -1285,6 +1286,8 @@ HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Pres
     // read the current troom state, in case they saved in temporary room
     if (!in->ReadBool())
         troom.ReadFromSavegame(in, loaded_game_file_version, (RoomStatSvgVersion)cmp_ver);
+
+    r_data.DataCounts.RoomScriptDataSz = troom.tsdatasize;
 
     return HSaveError::None();
 }

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -38,6 +38,8 @@ typedef std::shared_ptr<Bitmap> PBitmap;
 // loading save data
 struct PreservedParams
 {
+    SavegameDescription Desc;
+
     // Whether speech and audio packages available
     bool SpeechVOX = false;
     bool MusicVOX = false;
@@ -48,7 +50,9 @@ struct PreservedParams
     std::vector<String> ScriptModuleNames;
     std::vector<size_t> ScMdDataSize;
 
-    PreservedParams();
+    PreservedParams() = default;
+    PreservedParams(const SavegameDescription &desc)
+        : Desc(desc) {}
 };
 
 enum GameViewCamFlags
@@ -126,8 +130,6 @@ struct SaveRestoredDataCounts
     uint32_t ScriptModules = 0u;
     std::vector<uint32_t> ScriptModuleDataSz;
     uint32_t RoomScriptDataSz = 0u; // current room's script data size
-
-    String   EngineVersion; // engine this save was written by
 };
 
 // RestoredData keeps certain temporary data to help with

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -74,17 +74,24 @@ enum SaveRestorationFlags
     // This indicates that if any game entities do not have a match in the
     // restored save, then they will be presented in their default state
     // (which they have when the game starts).
-    kSaveRestore_ClearData          = 0x01,
+    kSaveRestore_ClearData          = 0x0001,
     // Allow save entries mismatching game contents:
     // - more entries, less entries, etc
-    kSaveRestore_AllowMismatchExtra = 0x02,
-    kSaveRestore_AllowMismatchLess  = 0x04,
+    kSaveRestore_AllowMismatchExtra = 0x0002,
+    kSaveRestore_AllowMismatchLess  = 0x0004,
     // We detected that the save file has less data of certain type
     // than the game requires.
-    kSaveRestore_MissingDataInSave  = 0x08,
+    kSaveRestore_MissingDataInSave  = 0x0008,
     // We detected that the save file has more data of certain type
     // than the game requires.
-    kSaveRestore_ExtraDataInSave    = 0x10,
+    kSaveRestore_ExtraDataInSave    = 0x0010,
+    // Mask for finding out if save has any mismatches
+    kSaveRestore_MismatchMask       = kSaveRestore_MissingDataInSave
+                                    | kSaveRestore_ExtraDataInSave,
+    // Mask for the restoration result flags
+    kSaveRestore_ResultMask         = kSaveRestore_ClearData
+                                    | kSaveRestore_MissingDataInSave
+                                    | kSaveRestore_ExtraDataInSave
 };
 
 // SaveRestoredDataCounts contains numbers of different types of data
@@ -105,7 +112,8 @@ struct SaveRestoredDataCounts
     std::vector<uint32_t> ViewFrames;
     uint32_t GlobalScriptDataSz = 0u;
     uint32_t ScriptModules = 0u;
-    std::vector<uint32_t> ScriptDataSz;
+    std::vector<uint32_t> ScriptModuleDataSz;
+    uint32_t RoomScriptDataSz = 0u; // current room's script data size
 };
 
 // RestoredData keeps certain temporary data to help with

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -103,6 +103,7 @@ struct SaveRestoreResult
     // save validation fails after restoring full save
     // NOTE: may expand this to a vector if desired to record ALL mismatches.
     String FirstMismatchError;
+    SaveRestoreFeedback Feedback;
 };
 
 // SaveRestoredDataCounts contains numbers of different types of data

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -125,6 +125,8 @@ struct SaveRestoredDataCounts
     uint32_t ScriptModules = 0u;
     std::vector<uint32_t> ScriptModuleDataSz;
     uint32_t RoomScriptDataSz = 0u; // current room's script data size
+
+    String   EngineVersion; // engine this save was written by
 };
 
 // RestoredData keeps certain temporary data to help with

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -66,10 +66,55 @@ enum ViewportSaveFlags
     kSvgViewportVisible = 0x01
 };
 
+// SaveRestorationFlags mark the specifics of a restored save
+enum SaveRestorationFlags
+{
+    kSaveRestore_Default           = 0,
+    // Game data has been cleared to initial state prior to reading a save.
+    // This indicates that if any game entities do not have a match in the
+    // restored save, then they will be presented in their default state
+    // (which they have when the game starts).
+    kSaveRestore_ClearData          = 0x01,
+    // Allow save entries mismatching game contents:
+    // - more entries, less entries, etc
+    kSaveRestore_AllowMismatchExtra = 0x02,
+    kSaveRestore_AllowMismatchLess  = 0x04,
+    // We detected that the save file has less data of certain type
+    // than the game requires.
+    kSaveRestore_MissingDataInSave  = 0x08,
+    // We detected that the save file has more data of certain type
+    // than the game requires.
+    kSaveRestore_ExtraDataInSave    = 0x10,
+};
+
+// SaveRestoredDataCounts contains numbers of different types of data
+// found in the save file. This information may be passed to the game script,
+// letting it detect whether save is applicable to the current game version.
+struct SaveRestoredDataCounts
+{
+    uint32_t Dummy = 0u; // a dummy integer, used to record something that we are not interested in
+    uint32_t AudioClipTypes = 0u;
+    uint32_t Characters = 0u;
+    uint32_t Dialogs = 0u;
+    uint32_t GUIs = 0u;
+    std::vector<uint32_t> GUIControls;
+    uint32_t InventoryItems = 0u;
+    uint32_t Cursors = 0u;
+    uint32_t Views = 0u;
+    std::vector<uint32_t> ViewLoops;
+    std::vector<uint32_t> ViewFrames;
+    uint32_t GlobalScriptDataSz = 0u;
+    uint32_t ScriptModules = 0u;
+    std::vector<uint32_t> ScriptDataSz;
+};
+
 // RestoredData keeps certain temporary data to help with
 // the restoration process
 struct RestoredData
 {
+    SaveRestorationFlags    RestoreFlags = kSaveRestore_Default;
+    SaveRestoredDataCounts  DataCounts;
+
     int                     FPS;
     // Unserialized bitmaps for dynamic surfaces
     std::vector<std::unique_ptr<Bitmap>> DynamicSurfaces;

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -94,6 +94,17 @@ enum SaveRestorationFlags
                                     | kSaveRestore_ExtraDataInSave
 };
 
+// SaveRestoreResult records allowances for the save restoration
+// and the general result of the restoration process
+struct SaveRestoreResult
+{
+    SaveRestorationFlags RestoreFlags = kSaveRestore_Default;
+    // Recorded first data mismatch error, this will be reported if
+    // save validation fails after restoring full save
+    // NOTE: may expand this to a vector if desired to record ALL mismatches.
+    String FirstMismatchError;
+};
+
 // SaveRestoredDataCounts contains numbers of different types of data
 // found in the save file. This information may be passed to the game script,
 // letting it detect whether save is applicable to the current game version.
@@ -120,7 +131,7 @@ struct SaveRestoredDataCounts
 // the restoration process
 struct RestoredData
 {
-    SaveRestorationFlags    RestoreFlags = kSaveRestore_Default;
+    SaveRestoreResult       Result;
     SaveRestoredDataCounts  DataCounts;
 
     int                     FPS;

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -52,7 +52,7 @@ void start_game_load_savegame_on_startup(const String &load_save)
         int slot = 1000;
         get_save_slotnum(load_save, slot);
         current_fade_out_effect();
-        try_restore_save(load_save, slot);
+        try_restore_save(load_save, slot, true);
     }
 }
 

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -53,6 +53,7 @@ extern void RegisterSystemAPI();
 extern void RegisterTextBoxAPI();
 extern void RegisterViewFrameAPI();
 extern void RegisterViewportAPI();
+extern void RegisterSaveInfoAPI();
 
 extern void RegisterStaticObjects();
 
@@ -93,6 +94,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterTextBoxAPI();
     RegisterViewFrameAPI();
     RegisterViewportAPI();
+    RegisterSaveInfoAPI();
 
     RegisterStaticObjects();
 }

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -762,6 +762,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptoverlay.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptregion.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptrestoredsaveinfo.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptstring.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptsystem.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1658,6 +1658,9 @@
     <ClInclude Include="..\..\Engine\platform\windows\setup\advancedpagedialog.h">
       <Filter>Header Files\setup</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptrestoredsaveinfo.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\Engine\resource\game-1.ico">


### PR DESCRIPTION
### Overview

This is a rough draft made as a proof of concept. The purpose of this feature is to let engine load saves from older versions of same game into the newer version, and correctly apply only data that existed in the old version.

It's important to underline that this current feature is intentionally done as a **minimal possible** solution for the problem, which would also be suitable for the backwards compatible branch (ags3). It is meant to work only if user's changes to the game satisfy certain requirements (see below). It's not meant as a "final" or "perfect" solution: that remains a matter for another time (in ags4, I suppose).

Saves are a huge problem, so here's only **for a quick reference**: historically AGS saves do not identify objects by a unique id, but rather by their index in certain array. There are multiple reasons why is it so, including lack of planning, perhaps, but also technical ones. For instance, AGS editor does not enforce unique ids (script names) at all, and it's possible to have unnamed objects. Another, more complicated issue is that script variables are not distinguished by their names after script is compiled, for the outside viewer they are presented just as a single "array" of bytes. There are other less obvious things, but I won't go deep into this now.

What this current feature is intended for:
1. Let game load a save made in a previous version if:
    * The older version had **LESS** data than the new one, in any type.
    * The **ORDER** of old data did not change.
2. Let game developer react for the restoration of "mismatching" save, by writing a validation / data fixup in script.

In other words, this functionality is primarily meant for patching released games. It's less suitable during early stage of development, when the things change alot en mass.

---

### Solution

How this goal is achieved here.

1. Engine reads the save, and compares the entries in a save with the game data, for consistency.
2. If an inconsistency is found (e.g. number of entries or size of data is different),
   2.1. If save has less data then the engine, then
       a) engine marks and remembers this fact;
       b) engine aborts reading save, and *reloads the game* in order to clear all its data to the *initial state*.
       c) after reloading the game, engine restarts reading same save once again, but keeps in memory the fact that it is being read after clean reset.
       d) if there's a marker of a clean reset, then the above restart does not happen, and reading continues.
   2.2 If save has more data, then currently this is not permitted, and engine will bail with error.
3. Save is read, and game data reinitialized as necessary.
4. Engine tries to run a script callback, named **"validate_restored_save"**.
   4.1. If such callback does not exist, and there's no indication of save being inconsistent, then the game is simply continued as normal.
   4.2. If such callback does not exist, and there's a recorded indication about save being inconsistent, then the game is aborted with error message.
   4.3. If such callback exists in script, then it is run.
5. The script callback receives a struct called **"RestoredSaveInfo"**, containing information about the restored save:
   - a Result variable telling if save is inconsistent, and how (using a set of flags);
   - a group of variables that tell counts of entries per object type: how many characters, gui, etc was read from this save.
   - a "Cancel" field that user may write to in order to change the default engine's decision.
   - a "RetryWithoutComponents" field that user may write to in order to ignore certain save components (see `SaveComponentSelection`)
   This information, as well as a read script data, may be used by game developer to decide what to do with this save.
   Developer's decision may be passed to the engine by changing the "Cancel" field before returning from the callback.
   Besides letting the engine to quit with error, user may optionally keep the save, and handle this situation in their own way after the game scripts start running again (e.g. display the error in-game, and suggest to load another save, or fallback to a reserved "restart" slot).

From the scripting perspective, there's a new callback and a new struct:

```
enum RestoredSaveResult
{
  eRestoredSave_ClearData   = 0x01,
  eRestoredSave_MissingData = 0x08,
  eRestoredSave_ExtraData   = 0x10
};

managed struct RestoredSaveInfo
{
  import attribute bool Cancel;
  import attribute SaveComponentSelection RetryWithoutComponents;
  import readonly attribute RestoredSaveResult Result;
  import readonly attribute String EngineVersion;
  import readonly attribute int AudioClipTypeCount;
  import readonly attribute int CharacterCount;
  import readonly attribute int DialogCount;
  import readonly attribute int GUICount;
  import readonly attribute int GUIControlCount[];
  import readonly attribute int InventoryItemCount;
  import readonly attribute int CursorCount;
  import readonly attribute int ViewCount;
  import readonly attribute int ViewLoopCount[];
  import readonly attribute int ViewFrameCount[];
  import readonly attribute int GlobalScriptDataSize;
  import readonly attribute int ScriptModuleCount;
  import readonly attribute int ScriptModuleDataSize[];
  import readonly attribute int RoomScriptDataSize;
};
```

Note that I made this a struct with plain fields, rather than properties, thinking that maybe it's going to be simpler. Unfortunately I forgot that ags3 cannot have dynamic arrays in a managed struct, so I had to still add functions that return dynamic arrays with gui control count (per gui), view loop and frames count (per view), etc.
This struct may be reviewed and changed.

The callback is optional and is defined as:

```
function validate_restored_save(RestoredSaveInfo* saveInfo)
{
  // check saveInfo and decide what to do
}
```

Here user may script a "compatible" or "incompatible" save detection, and set the saveInfo.Cancel field.

The Cancel field will default to false if no mismatches were found, and to true if there are mismatches. This is done in case this callback is not present in script: in that case the engine will always fail.

I shall repeat that a user does not have to "Cancel" the save with default error message. It's possible to handle this in a custom way, let save to restore, and then display error in game in a more pretty way.

### Specifics

The GUI controls appeared to be an interesting problem. In AGS data they are saved not as nested entries of their parent GUIs, a tree structure, but as linear array housing all controls of particular type.

For them to load correctly from the "old" save, I had to code an algorithm that would calculate the ranges of indexes occupied by controls belonging to each GUI in the old and new version of a game, and then apply the "old" controls into correct slots of the new arrays.

### TODO

