### PR TITLE
Editor: Fix room editor flood fill

### DIFF
--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -623,7 +623,7 @@ namespace AGS.Editor
         public void FillArea(int color, Point position, double scale)
         {
             Point positionScaled = new Point((int)(position.X * scale), (int)(position.Y * scale));
-            FloodFillImage(_pixels, positionScaled, _bmp.Size, _pixels[(positionScaled.Y * _bmp.Width) + positionScaled.X], (byte)color);
+            FloodFillImage(_pixels, _paddedWidth, positionScaled, _bmp.Size, _pixels[(positionScaled.Y * _paddedWidth) + positionScaled.X], (byte)color);
         }
 
         private static IEnumerable<Point> CalculatRecanglePixels(Point origin, Size size)
@@ -691,12 +691,16 @@ namespace AGS.Editor
         /// Flood fill algorithm with for-loop instead of recursion to avoid stack overflow issues.
         /// </summary>
         /// <param name="image">The raw byte array of the image.</param>
+        /// <param name="paddedWidth">The padded width of the image.</param>
         /// <param name="position">The starting position for the fill.</param>
         /// <param name="size">The dimensions of the image.</param>
         /// <param name="initial">The color of the starting position.</param>
         /// <param name="replacement">The color to replace the pixels with.</param>
-        private static void FloodFillImage(byte[] image, Point position, Size size, byte initial, byte replacement)
+        private static void FloodFillImage(byte[] image, int paddedWidth, Point position, Size size, byte initial, byte replacement)
         {
+            if  (initial == replacement)
+                return;
+
             Queue<Point> queue = new Queue<Point>();
             queue.Enqueue(position);
 
@@ -706,9 +710,9 @@ namespace AGS.Editor
 
                 if (position.X >= 0 && position.X < size.Width && position.Y >= 0 && position.Y < size.Height)
                 {
-                    int i = (position.Y * size.Width) + position.X;
+                    int i = (position.Y * paddedWidth) + position.X;
 
-                    if (image[i] == initial && image[i] != replacement)
+                    if (image[i] == initial)
                     {
                         image[i] = replacement;
 


### PR DESCRIPTION
-It looks like images can have a different _paddedWidth that needs to be taken into account when calculating where in the byte array we are.  The flood fill algorithm was using the normal width instead of the padded width, so it would basically always flood the entire screen since the pixels would be off.

-Also, added a minor optimization.  In our inner loop were were checking image[i] == initial && image[i] != replacement.  The only time you could ever pass the initial check but fail the replacement check is if initial == replacement.  In that case you're just doing if (a == b && a != b), so we can just skip the entire function for cases where the initial and replacement values are the same.