### PR TITLE
AGS 4: add custom properties to GUI Controls

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -28,6 +28,7 @@
 #include "game/customproperties.h"
 #include "game/interactions.h"
 #include "game/main_game_file.h" // TODO: constants to separate header or split out reading functions
+#include "gui/guidefines.h"
 
 namespace AGS
 {
@@ -65,6 +66,7 @@ struct GameSetupStruct : public GameSetupStructBase
     std::vector<AGS::Common::StringIMap> audioclipProps;
     std::vector<AGS::Common::StringIMap> dialogProps;
     std::vector<AGS::Common::StringIMap> guiProps;
+    std::vector<AGS::Common::StringIMap> guicontrolProps[AGS::Common::kGUIControlTypeNum];
     // NOTE: although the view names are stored in game data, they are never
     // used, nor registered as script exports; numeric IDs are used to
     // reference views instead.

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -93,7 +93,8 @@ enum GUIControlType
     kGUIInvWindow   = 3,
     kGUISlider      = 4,
     kGUITextBox     = 5,
-    kGUIListBox     = 6
+    kGUIListBox     = 6,
+    kGUIControlTypeNum
 };
 
 // GUIControl general style and behavior flags

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -659,6 +659,12 @@ namespace AGS.Editor
                     FilePutString(TextProperty(pair.Value.Value), writer);
                 }
             }
+
+            public static void WriteEmpty(BinaryWriter writer)
+            {
+                writer.Write(NativeConstants.CustomPropertyVersion.Current);
+                writer.Write((int)0);
+            }
         }
 
         private class CompiledCustomProperties
@@ -869,22 +875,30 @@ namespace AGS.Editor
             }
         }
 
-        class GUIsWriter
+        /// <summary>
+        /// GUIControlsCollection stores flat lists of all controls of all GUIs.
+        /// This is necessary because GUI controls (and some of the extended data)
+        /// are saved as flat arrays into the compiled game.
+        /// </summary>
+        class GUIControlsCollection
         {
-            private List<GUIButtonOrTextWindowEdge> GUIButtonsAndTextWindowEdges = new List<GUIButtonOrTextWindowEdge>();
-            private List<GUILabel> GUILabels = new List<GUILabel>();
-            private List<GUIInventory> GUIInvWindows = new List<GUIInventory>();
-            private List<GUISlider> GUISliders = new List<GUISlider>();
-            private List<GUITextBox> GUITextBoxes = new List<GUITextBox>();
-            private List<GUIListBox> GUIListBoxes = new List<GUIListBox>();
-            private BinaryWriter writer;
-            private Game game;
-
-            public GUIsWriter(BinaryWriter writer, Game game)
+            public GUIControlsCollection()
             {
-                this.writer = writer;
-                this.game = game;
             }
+
+            private List<GUIButtonOrTextWindowEdge> _guiButtons = new List<GUIButtonOrTextWindowEdge>();
+            private List<GUILabel> _guiLabels = new List<GUILabel>();
+            private List<GUIInventory> _guiInvWindows = new List<GUIInventory>();
+            private List<GUISlider> _guiSliders = new List<GUISlider>();
+            private List<GUITextBox> _guiTextBoxes = new List<GUITextBox>();
+            private List<GUIListBox> _guiListBoxes = new List<GUIListBox>();
+
+            public List<GUIButtonOrTextWindowEdge> GUIButtons { get { return _guiButtons; } }
+            public List<GUILabel> GUILabels { get { return _guiLabels; } }
+            public List<GUIInventory> GUIInvWindows { get { return _guiInvWindows; } }
+            public List<GUISlider> GUISliders { get { return _guiSliders; } }
+            public List<GUITextBox> GUITextBoxes { get { return _guiTextBoxes; } }
+            public List<GUIListBox> GUIListBoxes { get { return _guiListBoxes; } }
 
             /// <summary>
             /// The engine treats GUITextWindowEdges as GUIButtons, and they
@@ -896,7 +910,7 @@ namespace AGS.Editor
             /// GUIControl that is neither a GUIButton nor a GUITextWindowEdge
             /// is cast to this type then null is returned.
             /// </summary>
-            private class GUIButtonOrTextWindowEdge
+            public class GUIButtonOrTextWindowEdge
             {
                 private GUIControl _ctrl;
 
@@ -1053,6 +1067,18 @@ namespace AGS.Editor
                     }
                 }
             }
+        }
+
+        class GUIsWriter : GUIControlsCollection
+        {
+            private BinaryWriter writer;
+            private Game game;
+
+            public GUIsWriter(BinaryWriter writer, Game game)
+            {
+                this.writer = writer;
+                this.game = game;
+            }
 
             private int MakeCommonGUIControlFlags(GUIControl control)
             {
@@ -1092,8 +1118,8 @@ namespace AGS.Editor
 
             private void WriteAllButtonsAndTextWindowEdges()
             {
-                writer.Write(GUIButtonsAndTextWindowEdges.Count);
-                foreach (GUIButtonOrTextWindowEdge ctrl in GUIButtonsAndTextWindowEdges)
+                writer.Write(GUIButtons.Count);
+                foreach (GUIButtonOrTextWindowEdge ctrl in GUIButtons)
                 {
                     int flags;
                     flags = (ctrl.ClipImage ? NativeConstants.GUIF_CLIP : 0);
@@ -1221,8 +1247,8 @@ namespace AGS.Editor
                         GUITextWindowEdge textWindowEdge = control as GUITextWindowEdge;
                         if ((button != null) || (textWindowEdge != null))
                         {
-                            objrefptrs[gui.ID][numobjs] = (NativeConstants.GOBJ_BUTTON << 16) | GUIButtonsAndTextWindowEdges.Count;
-                            GUIButtonsAndTextWindowEdges.Add(button != null ?
+                            objrefptrs[gui.ID][numobjs] = (NativeConstants.GOBJ_BUTTON << 16) | GUIButtons.Count;
+                            GUIButtons.Add(button != null ?
                                 (GUIButtonOrTextWindowEdge)button :
                                 (GUIButtonOrTextWindowEdge)textWindowEdge);
                         }
@@ -1720,12 +1746,14 @@ namespace AGS.Editor
             writer.Write((uint)ext_off);
             writer.Seek((int)ext_off, SeekOrigin.Begin);
 
-            WriteExtension("v360_fonts", WriteExt_360Fonts, writer, game, errors);
-            WriteExtension("v360_cursors", WriteExt_360Cursors, writer, game, errors);
-            WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, game, errors);
-            WriteExtension("ext_ags399", WriteExt_Ags399, writer, game, errors);
-            WriteExtension("v400_gameopts", WriteExt_400GameOpts, writer, game, errors);
-            WriteExtension("v400_customprops", WriteExt_400CustomProps, writer, game, errors);
+            WriteExtEntities gameEnts = new WriteExtEntities(game, guisWriter);
+
+            WriteExtension("v360_fonts", WriteExt_360Fonts, writer, gameEnts, errors);
+            WriteExtension("v360_cursors", WriteExt_360Cursors, writer, gameEnts, errors);
+            WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, gameEnts, errors);
+            WriteExtension("ext_ags399", WriteExt_Ags399, writer, gameEnts, errors);
+            WriteExtension("v400_gameopts", WriteExt_400GameOpts, writer, gameEnts, errors);
+            WriteExtension("v400_customprops", WriteExt_400CustomProps, writer, gameEnts, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1736,8 +1764,9 @@ namespace AGS.Editor
         }
         
         // >= 3.6.0: font outline properties
-        private static void WriteExt_360Fonts(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_360Fonts(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             // adjustable font outlines
             for (int i = 0; i < game.Fonts.Count; ++i)
             {
@@ -1752,8 +1781,9 @@ namespace AGS.Editor
         }
 
         // >= 3.6.0: extended cursor properties
-        private static void WriteExt_360Cursors(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_360Cursors(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             // adjustable font outlines
             for (int i = 0; i < game.Cursors.Count; ++i)
             {
@@ -1767,8 +1797,9 @@ namespace AGS.Editor
         
         // >= 3.6.1: object script names and names of unrestricted length
         // this saves only those properties that were restricted in length previously
-        private static void WriteExt_361ObjNames(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_361ObjNames(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             FilePutString(game.Settings.GameName, writer);
             FilePutString(game.Settings.SaveGameFolderName, writer);
             // Characters
@@ -1801,8 +1832,9 @@ namespace AGS.Editor
         }
 
         // Early development version of "ags4"
-        private static void WriteExt_Ags399(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_Ags399(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             // new character properties
             foreach (var ch in game.Characters)
             {
@@ -1824,16 +1856,18 @@ namespace AGS.Editor
             }
         }
 
-        private static void WriteExt_400GameOpts(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_400GameOpts(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             writer.Write((float)game.Settings.FaceDirectionRatio);
             // reserve more 32-bit values for a total of 10
             for (int i = 0; i < 9; ++i)
                 writer.Write((int)0);
         }
 
-        private static void WriteExt_400CustomProps(BinaryWriter writer, Game game, CompileMessages errors)
+        private static void WriteExt_400CustomProps(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            Game game = ents.Game;
             // Audio clip properties
             writer.Write((int)game.AudioClips.Count);
             for (int i = 0; i < game.AudioClips.Count; ++i)
@@ -1852,11 +1886,64 @@ namespace AGS.Editor
             {
                 CustomPropertiesWriter.Write(writer, game.GUIs[i].Properties);
             }
+
+            // GUI control properties
+            GUIControlsCollection guiControls = ents.GUIControls;
+            writer.Write((int)guiControls.GUIButtons.Count);
+            for (int i = 0; i < guiControls.GUIButtons.Count; ++i)
+            {
+                GUIButton button = guiControls.GUIButtons[i];
+                GUITextWindowEdge edge = guiControls.GUIButtons[i];
+                if (button != null)
+                    CustomPropertiesWriter.Write(writer, button.Properties);
+                else
+                    CustomPropertiesWriter.WriteEmpty(writer);
+            }
+            writer.Write((int)guiControls.GUILabels.Count);
+            for (int i = 0; i < guiControls.GUILabels.Count; ++i)
+            {
+                CustomPropertiesWriter.Write(writer, guiControls.GUILabels[i].Properties);
+            }
+            writer.Write((int)guiControls.GUIInvWindows.Count);
+            for (int i = 0; i < guiControls.GUIInvWindows.Count; ++i)
+            {
+                CustomPropertiesWriter.Write(writer, guiControls.GUIInvWindows[i].Properties);
+            }
+            writer.Write((int)guiControls.GUISliders.Count);
+            for (int i = 0; i < guiControls.GUISliders.Count; ++i)
+            {
+                CustomPropertiesWriter.Write(writer, guiControls.GUISliders[i].Properties);
+            }
+            writer.Write((int)guiControls.GUITextBoxes.Count);
+            for (int i = 0; i < guiControls.GUITextBoxes.Count; ++i)
+            {
+                CustomPropertiesWriter.Write(writer, guiControls.GUITextBoxes[i].Properties);
+            }
+            writer.Write((int)guiControls.GUIListBoxes.Count);
+            for (int i = 0; i < guiControls.GUIListBoxes.Count; ++i)
+            {
+                CustomPropertiesWriter.Write(writer, guiControls.GUIListBoxes[i].Properties);
+            }
         }
 
-        private delegate void WriteExtensionProc(BinaryWriter writer, Game game, CompileMessages errors);
+        /// <summary>
+        /// Helper struct for gathering objects that may be useful when writing extensions.
+        /// </summary>
+        private struct WriteExtEntities
+        {
+            public readonly Game Game;
+            public readonly GUIControlsCollection GUIControls;
 
-        private static void WriteExtension(string ext_id, WriteExtensionProc proc, BinaryWriter writer, Game game, CompileMessages errors)
+            public WriteExtEntities(Game game, GUIControlsCollection guiControls)
+            {
+                Game = game;
+                GUIControls = guiControls;
+            }
+        }
+
+        private delegate void WriteExtensionProc(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors);
+
+        private static void WriteExtension(string ext_id, WriteExtensionProc proc, BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
             // The block meta format:
             //    - 1 byte - an old-style unsigned numeric ID, for compatibility with room file format:
@@ -1869,7 +1956,7 @@ namespace AGS.Editor
             var data_len_pos = writer.BaseStream.Position;
             writer.Write((long)0);
             var start_pos = writer.BaseStream.Position;
-            proc(writer, game, errors);
+            proc(writer, ents, errors);
             var end_pos = writer.BaseStream.Position;
             var data_len = end_pos - start_pos;
             writer.Seek((int)data_len_pos, SeekOrigin.Begin);

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.Designer.cs
@@ -29,17 +29,20 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.schemaList = new System.Windows.Forms.ListView();
-            this.columnHeader1 = new System.Windows.Forms.ColumnHeader();
-            this.columnHeader2 = new System.Windows.Forms.ColumnHeader();
-            this.columnHeader3 = new System.Windows.Forms.ColumnHeader();
-            this.columnHeader4 = new System.Windows.Forms.ColumnHeader();
+            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnOK = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
-            this.columnHeader5 = new System.Windows.Forms.ColumnHeader();
             this.SuspendLayout();
             // 
             // schemaList
             // 
+            this.schemaList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.schemaList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader2,
@@ -50,7 +53,7 @@ namespace AGS.Editor
             this.schemaList.Location = new System.Drawing.Point(8, 25);
             this.schemaList.MultiSelect = false;
             this.schemaList.Name = "schemaList";
-            this.schemaList.Size = new System.Drawing.Size(542, 239);
+            this.schemaList.Size = new System.Drawing.Size(593, 269);
             this.schemaList.TabIndex = 0;
             this.schemaList.UseCompatibleStateImageBehavior = false;
             this.schemaList.View = System.Windows.Forms.View.Details;
@@ -76,10 +79,16 @@ namespace AGS.Editor
             this.columnHeader4.Text = "Default value";
             this.columnHeader4.Width = 100;
             // 
+            // columnHeader5
+            // 
+            this.columnHeader5.Text = "Applies to";
+            this.columnHeader5.Width = 100;
+            // 
             // btnOK
             // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnOK.Location = new System.Drawing.Point(12, 274);
+            this.btnOK.Location = new System.Drawing.Point(12, 304);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(109, 29);
             this.btnOK.TabIndex = 1;
@@ -96,17 +105,13 @@ namespace AGS.Editor
             this.label1.TabIndex = 2;
             this.label1.Text = "Right-click below to add or edit properties";
             // 
-            // columnHeader5
-            // 
-            this.columnHeader5.Text = "Applies to";
-            // 
             // CustomPropertySchemaEditor
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnOK;
-            this.ClientSize = new System.Drawing.Size(562, 310);
+            this.ClientSize = new System.Drawing.Size(613, 340);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.schemaList);

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.resx
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.Designer.cs
@@ -50,6 +50,7 @@ namespace AGS.Editor
             this.chkHotspots = new System.Windows.Forms.CheckBox();
             this.chkObjects = new System.Windows.Forms.CheckBox();
             this.chkCharacters = new System.Windows.Forms.CheckBox();
+            this.chkGUIControls = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -98,16 +99,20 @@ namespace AGS.Editor
             // 
             // txtDescription
             // 
+            this.txtDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtDescription.Location = new System.Drawing.Point(96, 45);
             this.txtDescription.Name = "txtDescription";
-            this.txtDescription.Size = new System.Drawing.Size(380, 21);
+            this.txtDescription.Size = new System.Drawing.Size(441, 21);
             this.txtDescription.TabIndex = 5;
             // 
             // txtDefaultValue
             // 
+            this.txtDefaultValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtDefaultValue.Location = new System.Drawing.Point(96, 99);
             this.txtDefaultValue.Name = "txtDefaultValue";
-            this.txtDefaultValue.Size = new System.Drawing.Size(380, 21);
+            this.txtDefaultValue.Size = new System.Drawing.Size(441, 21);
             this.txtDefaultValue.TabIndex = 7;
             // 
             // cmbType
@@ -126,7 +131,7 @@ namespace AGS.Editor
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnOK.Location = new System.Drawing.Point(15, 249);
+            this.btnOK.Location = new System.Drawing.Point(15, 264);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(92, 26);
             this.btnOK.TabIndex = 8;
@@ -138,7 +143,7 @@ namespace AGS.Editor
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(129, 249);
+            this.btnCancel.Location = new System.Drawing.Point(113, 264);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(92, 26);
             this.btnCancel.TabIndex = 9;
@@ -151,6 +156,7 @@ namespace AGS.Editor
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.chkGUIControls);
             this.groupBox1.Controls.Add(this.chkWalkareas);
             this.groupBox1.Controls.Add(this.chkRegions);
             this.groupBox1.Controls.Add(this.chkAudioClips);
@@ -164,7 +170,7 @@ namespace AGS.Editor
             this.groupBox1.Controls.Add(this.chkCharacters);
             this.groupBox1.Location = new System.Drawing.Point(15, 129);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(461, 104);
+            this.groupBox1.Size = new System.Drawing.Size(522, 119);
             this.groupBox1.TabIndex = 11;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Applies To";
@@ -172,7 +178,7 @@ namespace AGS.Editor
             // chkWalkareas
             // 
             this.chkWalkareas.AutoSize = true;
-            this.chkWalkareas.Location = new System.Drawing.Point(316, 68);
+            this.chkWalkareas.Location = new System.Drawing.Point(346, 64);
             this.chkWalkareas.Name = "chkWalkareas";
             this.chkWalkareas.Size = new System.Drawing.Size(100, 17);
             this.chkWalkareas.TabIndex = 21;
@@ -182,7 +188,7 @@ namespace AGS.Editor
             // chkRegions
             // 
             this.chkRegions.AutoSize = true;
-            this.chkRegions.Location = new System.Drawing.Point(246, 68);
+            this.chkRegions.Location = new System.Drawing.Point(253, 64);
             this.chkRegions.Name = "chkRegions";
             this.chkRegions.Size = new System.Drawing.Size(64, 17);
             this.chkRegions.TabIndex = 20;
@@ -192,7 +198,7 @@ namespace AGS.Editor
             // chkAudioClips
             // 
             this.chkAudioClips.AutoSize = true;
-            this.chkAudioClips.Location = new System.Drawing.Point(358, 41);
+            this.chkAudioClips.Location = new System.Drawing.Point(13, 87);
             this.chkAudioClips.Name = "chkAudioClips";
             this.chkAudioClips.Size = new System.Drawing.Size(78, 17);
             this.chkAudioClips.TabIndex = 19;
@@ -202,7 +208,7 @@ namespace AGS.Editor
             // chkGUIs
             // 
             this.chkGUIs.AutoSize = true;
-            this.chkGUIs.Location = new System.Drawing.Point(175, 41);
+            this.chkGUIs.Location = new System.Drawing.Point(182, 41);
             this.chkGUIs.Name = "chkGUIs";
             this.chkGUIs.Size = new System.Drawing.Size(49, 17);
             this.chkGUIs.TabIndex = 18;
@@ -222,7 +228,7 @@ namespace AGS.Editor
             // chkRooms
             // 
             this.chkRooms.AutoSize = true;
-            this.chkRooms.Location = new System.Drawing.Point(13, 68);
+            this.chkRooms.Location = new System.Drawing.Point(13, 64);
             this.chkRooms.Name = "chkRooms";
             this.chkRooms.Size = new System.Drawing.Size(58, 17);
             this.chkRooms.TabIndex = 16;
@@ -241,7 +247,7 @@ namespace AGS.Editor
             // chkInventory
             // 
             this.chkInventory.AutoSize = true;
-            this.chkInventory.Location = new System.Drawing.Point(246, 41);
+            this.chkInventory.Location = new System.Drawing.Point(346, 41);
             this.chkInventory.Name = "chkInventory";
             this.chkInventory.Size = new System.Drawing.Size(104, 17);
             this.chkInventory.TabIndex = 14;
@@ -251,7 +257,7 @@ namespace AGS.Editor
             // chkHotspots
             // 
             this.chkHotspots.AutoSize = true;
-            this.chkHotspots.Location = new System.Drawing.Point(175, 68);
+            this.chkHotspots.Location = new System.Drawing.Point(182, 64);
             this.chkHotspots.Name = "chkHotspots";
             this.chkHotspots.Size = new System.Drawing.Size(69, 17);
             this.chkHotspots.TabIndex = 13;
@@ -261,7 +267,7 @@ namespace AGS.Editor
             // chkObjects
             // 
             this.chkObjects.AutoSize = true;
-            this.chkObjects.Location = new System.Drawing.Point(98, 68);
+            this.chkObjects.Location = new System.Drawing.Point(98, 64);
             this.chkObjects.Name = "chkObjects";
             this.chkObjects.Size = new System.Drawing.Size(63, 17);
             this.chkObjects.TabIndex = 12;
@@ -278,13 +284,23 @@ namespace AGS.Editor
             this.chkCharacters.Text = "Characters";
             this.chkCharacters.UseVisualStyleBackColor = true;
             // 
+            // chkGUIControls
+            // 
+            this.chkGUIControls.AutoSize = true;
+            this.chkGUIControls.Location = new System.Drawing.Point(253, 41);
+            this.chkGUIControls.Name = "chkGUIControls";
+            this.chkGUIControls.Size = new System.Drawing.Size(87, 17);
+            this.chkGUIControls.TabIndex = 22;
+            this.chkGUIControls.Text = "GUI Controls";
+            this.chkGUIControls.UseVisualStyleBackColor = true;
+            // 
             // CustomPropertySchemaItemEditor
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(490, 287);
+            this.ClientSize = new System.Drawing.Size(551, 302);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
@@ -334,5 +350,6 @@ namespace AGS.Editor
         private System.Windows.Forms.CheckBox chkAudioClips;
         private System.Windows.Forms.CheckBox chkWalkareas;
         private System.Windows.Forms.CheckBox chkRegions;
+        private System.Windows.Forms.CheckBox chkGUIControls;
     }
 }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
@@ -31,6 +31,7 @@ namespace AGS.Editor
             chkAudioClips.DataBindings.Add("Checked", _copyOfItem, "AppliesToAudioClips", true, DataSourceUpdateMode.OnPropertyChanged);
             chkDialogs.DataBindings.Add("Checked", _copyOfItem, "AppliesToDialogs", true, DataSourceUpdateMode.OnPropertyChanged);
             chkGUIs.DataBindings.Add("Checked", _copyOfItem, "AppliesToGUIs", true, DataSourceUpdateMode.OnPropertyChanged);
+            chkGUIControls.DataBindings.Add("Checked", _copyOfItem, "AppliesToGUIControls", true, DataSourceUpdateMode.OnPropertyChanged);
             chkRegions.DataBindings.Add("Checked", _copyOfItem, "AppliesToRegions", true, DataSourceUpdateMode.OnPropertyChanged);
             chkWalkareas.DataBindings.Add("Checked", _copyOfItem, "AppliesToWalkableAreas", true, DataSourceUpdateMode.OnPropertyChanged);
             cmbType.SelectedIndex = ((int)_copyOfItem.Type) - 1;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1484,6 +1484,10 @@ namespace AGS.Editor
             {
                 propertyTypes = CustomPropertyAppliesTo.GUIs;
             }
+            else if (objectThatHasProperties is GUIControl)
+            {
+                propertyTypes = CustomPropertyAppliesTo.GUIControls;
+            }
             else if (objectThatHasProperties is InventoryItem)
             {
                 propertyTypes = CustomPropertyAppliesTo.InventoryItems;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1425,6 +1425,16 @@ builtin managed struct GUIControl {
   /// Gets the script name of this control.
   import readonly attribute String ScriptName;
 #endif
+#ifdef SCRIPT_API_v400
+  /// Gets an integer custom property for this GUI.
+  import int  GetProperty(const string property);
+  /// Gets a text custom property for this GUI.
+  import String GetTextProperty(const string property);
+  /// Sets an integer custom property for this GUI.
+  import bool SetProperty(const string property, int value);
+  /// Sets a text custom property for this GUI.
+  import bool SetTextProperty(const string property, const string value);
+#endif
 };
 
 builtin managed struct Label extends GUIControl {

--- a/Editor/AGS.Types/CustomPropertySchemaItem.cs
+++ b/Editor/AGS.Types/CustomPropertySchemaItem.cs
@@ -94,6 +94,12 @@ namespace AGS.Types
             set { _appliesTo = value ? (_appliesTo | CustomPropertyAppliesTo.GUIs) : (_appliesTo & ~CustomPropertyAppliesTo.GUIs); }
         }
 
+        public bool AppliesToGUIControls
+        {
+            get { return _appliesTo.HasFlag(CustomPropertyAppliesTo.GUIControls); }
+            set { _appliesTo = value ? (_appliesTo | CustomPropertyAppliesTo.GUIControls) : (_appliesTo & ~CustomPropertyAppliesTo.GUIControls); }
+        }
+
         public bool AppliesToRegions
         {
             get { return _appliesTo.HasFlag(CustomPropertyAppliesTo.Regions); }
@@ -122,6 +128,7 @@ namespace AGS.Types
                 toReturn += AppliesToCharacters ? "C" : "  ";
                 toReturn += AppliesToDialogs ? "D" : "  ";
                 toReturn += AppliesToGUIs ? "G" : "  ";
+                toReturn += AppliesToGUIControls ? "Gc" : "  ";
                 toReturn += AppliesToInvItems ? "I" : "  ";
                 toReturn += AppliesToRooms ? "R" : "  ";
                 toReturn += AppliesToHotspots ? "H" : "  ";

--- a/Editor/AGS.Types/Enums/CustomPropertyAppliesTo.cs
+++ b/Editor/AGS.Types/Enums/CustomPropertyAppliesTo.cs
@@ -18,6 +18,7 @@ namespace AGS.Types
         GUIs            = 0x00000080,
         Regions         = 0x00000100,
         WalkableAreas   = 0x00000200,
+        GUIControls     = 0x00000400,
         Everything      = 0x0FFFFFFF
     }
 }

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -41,6 +41,7 @@ namespace AGS.Types
         private bool _enabled = true;
         private bool _visible = true;
         private bool _translated = true;
+        private CustomProperties _properties = new CustomProperties();
 
         [AGSNoSerialize]
         private GUIControlGroup _memberOf;
@@ -166,6 +167,16 @@ namespace AGS.Types
         {
             get { return _translated; }
             set { _translated = value; }
+        }
+
+        [AGSSerializeClass()]
+        [Description("Custom properties for this Control")]
+        [Category("Properties")]
+        [EditorAttribute(typeof(CustomPropertiesUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public CustomProperties Properties
+        {
+            get { return _properties; }
+            protected set { _properties = value; }
         }
 
         [Browsable(false)]

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -27,6 +27,7 @@
 #include "game/roomstruct.h"
 #include "game/viewport.h"
 #include "gfx/graphicsdriver.h"
+#include "gui/guidefines.h"
 #include "media/audio/queuedaudioitem.h"
 #include "util/geometry.h"
 #include "util/string_types.h"
@@ -250,6 +251,7 @@ struct GamePlayState
     std::vector<AGS::Common::StringIMap> charProps;
     std::vector<AGS::Common::StringIMap> dialogProps;
     std::vector<AGS::Common::StringIMap> guiProps;
+    std::vector<AGS::Common::StringIMap> guicontrolProps[AGS::Common::kGUIControlTypeNum];
     AGS::Common::StringIMap              invProps[MAX_INV];
     // NOTE: audioclip custom properties are not written into game saves;
     // this is done on purpose, as audio clips are resources and not a part of a game state.

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -13,10 +13,13 @@
 //=============================================================================
 #include <vector>
 #include "ac/common.h"
+#include "ac/gamesetupstruct.h"
+#include "ac/gamestate.h"
 #include "ac/global_gui.h"
 #include "ac/gui.h"
 #include "ac/guicontrol.h"
 #include "ac/mouse.h"
+#include "ac/properties.h"
 #include "ac/string.h"
 #include "debug/debug_log.h"
 #include "script/runtimescriptvalue.h"
@@ -25,6 +28,7 @@
 
 using namespace AGS::Common;
 
+extern GameSetupStruct game;
 extern std::vector<ScriptGUI> scrGui;
 extern CCGUI ccDynamicGUI;
 extern CCGUIObject ccDynamicGUIObject;
@@ -211,6 +215,34 @@ void GUIControl_SetTransparency(GUIObject *guio, int trans) {
     if ((trans < 0) | (trans > 100))
         quit("!SetGUITransparency: transparency value must be between 0 and 100");
     guio->SetTransparency(GfxDef::Trans100ToLegacyTrans255(trans));
+}
+
+int GUIControl_GetProperty(GUIObject *guio, const char *property)
+{
+    int ctrl_type = guis[guio->ParentId].GetControlType(guio->Id);
+    int ctrl_id = guis[guio->ParentId].GetControlID(guio->Id);
+    return get_int_property(game.guicontrolProps[ctrl_type][ctrl_id], play.guicontrolProps[ctrl_type][ctrl_id], property);
+}
+
+const char* GUIControl_GetTextProperty(GUIObject *guio, const char *property)
+{
+    int ctrl_type = guis[guio->ParentId].GetControlType(guio->Id);
+    int ctrl_id = guis[guio->ParentId].GetControlID(guio->Id);
+    return get_text_property_dynamic_string(game.guicontrolProps[ctrl_type][ctrl_id], play.guicontrolProps[ctrl_type][ctrl_id], property);
+}
+
+bool GUIControl_SetProperty(GUIObject *guio, const char *property, int value)
+{
+    int ctrl_type = guis[guio->ParentId].GetControlType(guio->Id);
+    int ctrl_id = guis[guio->ParentId].GetControlID(guio->Id);
+    return set_int_property(play.guicontrolProps[ctrl_type][ctrl_id], property, value);
+}
+
+bool GUIControl_SetTextProperty(GUIObject *guio, const char *property, const char *value)
+{
+    int ctrl_type = guis[guio->ParentId].GetControlType(guio->Id);
+    int ctrl_id = guis[guio->ParentId].GetControlID(guio->Id);
+    return set_text_property(play.guicontrolProps[ctrl_type][ctrl_id], property, value);
 }
 
 //=============================================================================
@@ -423,6 +455,25 @@ RuntimeScriptValue Sc_GUIControl_SetTransparency(void *self, const RuntimeScript
     API_OBJCALL_VOID_PINT(GUIObject, GUIControl_SetTransparency);
 }
 
+RuntimeScriptValue Sc_GUIControl_GetProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_POBJ(GUIObject, GUIControl_GetProperty, const char);
+}
+
+RuntimeScriptValue Sc_GUIControl_GetTextProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ_POBJ(GUIObject, const char, myScriptStringImpl, GUIControl_GetTextProperty, const char);
+}
+
+RuntimeScriptValue Sc_GUIControl_SetProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL_POBJ_PINT(GUIObject, GUIControl_SetProperty, const char);
+}
+
+RuntimeScriptValue Sc_GUIControl_SetTextProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL_POBJ2(GUIObject, GUIControl_SetTextProperty, const char, const char);
+}
 
 
 void RegisterGUIControlAPI()
@@ -435,6 +486,10 @@ void RegisterGUIControlAPI()
         { "GUIControl::SendToBack^0",     API_FN_PAIR(GUIControl_SendToBack) },
         { "GUIControl::SetPosition^2",    API_FN_PAIR(GUIControl_SetPosition) },
         { "GUIControl::SetSize^2",        API_FN_PAIR(GUIControl_SetSize) },
+        { "GUIControl::GetProperty^1",    API_FN_PAIR(GUIControl_GetProperty) },
+        { "GUIControl::GetTextProperty^1", API_FN_PAIR(GUIControl_GetTextProperty) },
+        { "GUIControl::SetProperty^2",    API_FN_PAIR(GUIControl_SetProperty) },
+        { "GUIControl::SetTextProperty^2", API_FN_PAIR(GUIControl_SetTextProperty) },
         { "GUIControl::get_AsButton",     API_FN_PAIR(GUIControl_GetAsButton) },
         { "GUIControl::get_AsInvWindow",  API_FN_PAIR(GUIControl_GetAsInvWindow) },
         { "GUIControl::get_AsLabel",      API_FN_PAIR(GUIControl_GetAsLabel) },

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -452,6 +452,12 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     play.charProps.resize(game.numcharacters);
     play.dialogProps.resize(game.numdialog);
     play.guiProps.resize(game.numgui);
+    play.guicontrolProps[kGUIButton].resize(guibuts.size());
+    play.guicontrolProps[kGUILabel].resize(guilabels.size());
+    play.guicontrolProps[kGUIInvWindow].resize(guiinv.size());
+    play.guicontrolProps[kGUISlider].resize(guislider.size());
+    play.guicontrolProps[kGUITextBox].resize(guitext.size());
+    play.guicontrolProps[kGUIListBox].resize(guilist.size());
     dialog = std::move(ents.Dialogs);
     // Set number of game channels corresponding to the loaded game version
     game.numGameChannels = MAX_GAME_CHANNELS;

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -525,33 +525,51 @@ HSaveError WriteGUI(Stream *out)
 
     WriteFormatTag(out, "GUIButtons");
     out->WriteInt32(static_cast<int32_t>(guibuts.size()));
-    for (const auto &but : guibuts)
-        but.WriteToSavegame(out);
+    for (size_t i = 0; i < guibuts.size(); ++i)
+    {
+        guibuts[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUIButton][i], out);
+    }
 
     WriteFormatTag(out, "GUILabels");
     out->WriteInt32(static_cast<int32_t>(guilabels.size()));
-    for (const auto &label : guilabels)
-        label.WriteToSavegame(out);
+    for (size_t i = 0; i < guilabels.size(); ++i)
+    {
+        guilabels[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUILabel][i], out);
+    }
 
     WriteFormatTag(out, "GUIInvWindows");
     out->WriteInt32(static_cast<int32_t>(guiinv.size()));
-    for (const auto &inv : guiinv)
-        inv.WriteToSavegame(out);
+    for (size_t i = 0; i < guiinv.size(); ++i)
+    {
+        guiinv[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUIInvWindow][i], out);
+    }
 
     WriteFormatTag(out, "GUISliders");
     out->WriteInt32(static_cast<int32_t>(guislider.size()));
-    for (const auto &slider : guislider)
-        slider.WriteToSavegame(out);
+    for (size_t i = 0; i < guislider.size(); ++i)
+    {
+        guislider[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUISlider][i], out);
+    }
 
     WriteFormatTag(out, "GUITextBoxes");
     out->WriteInt32(static_cast<int32_t>(guitext.size()));
-    for (const auto &tb : guitext)
-        tb.WriteToSavegame(out);
+    for (size_t i = 0; i < guitext.size(); ++i)
+    {
+        guitext[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUITextBox][i], out);
+    }
 
     WriteFormatTag(out, "GUIListBoxes");
     out->WriteInt32(static_cast<int32_t>(guilist.size()));
-    for (const auto &list : guilist)
-        list.WriteToSavegame(out);
+    for (size_t i = 0; i < guilist.size(); ++i)
+    {
+        guilist[i].WriteToSavegame(out);
+        Properties::WriteValues(play.guicontrolProps[kGUIListBox][i], out);
+    }
 
     // Animated buttons
     WriteFormatTag(out, "AnimatedButtons");
@@ -582,43 +600,67 @@ HSaveError ReadGUI(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Preserved
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guibuts.size(), "GUI Buttons"))
         return err;
-    for (auto &but : guibuts)
-        but.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guibuts.size(); ++i)
+    {
+        guibuts[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUIButton][i], in);
+    }
 
     if (!AssertFormatTagStrict(err, in, "GUILabels"))
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guilabels.size(), "GUI Labels"))
         return err;
-    for (auto &label : guilabels)
-        label.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guilabels.size(); ++i)
+    {
+        guilabels[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUILabel][i], in);
+    }
 
     if (!AssertFormatTagStrict(err, in, "GUIInvWindows"))
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guiinv.size(), "GUI InvWindows"))
         return err;
-    for (auto &inv : guiinv)
-        inv.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guiinv.size(); ++i)
+    {
+        guiinv[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUIInvWindow][i], in);
+    }
 
     if (!AssertFormatTagStrict(err, in, "GUISliders"))
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guislider.size(), "GUI Sliders"))
         return err;
-    for (auto &slider : guislider)
-        slider.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guislider.size(); ++i)
+    {
+        guislider[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUISlider][i], in);
+    }
 
     if (!AssertFormatTagStrict(err, in, "GUITextBoxes"))
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guitext.size(), "GUI TextBoxes"))
         return err;
-    for (auto &tb : guitext)
-        tb.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guitext.size(); ++i)
+    {
+        guitext[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUITextBox][i], in);
+    }
 
     if (!AssertFormatTagStrict(err, in, "GUIListBoxes"))
         return err;
     if (!AssertGameContent(err, static_cast<size_t>(in->ReadInt32()), guilist.size(), "GUI ListBoxes"))
         return err;
-    for (auto &list : guilist)
-        list.ReadFromSavegame(in, svg_ver);
+    for (size_t i = 0; i < guilist.size(); ++i)
+    {
+        guilist[i].ReadFromSavegame(in, svg_ver);
+        if (svg_ver >= kGuiSvgVersion_40008)
+            Properties::ReadValues(play.guicontrolProps[kGUIListBox][i], in);
+    }
 
     // Animated buttons
     if (!AssertFormatTagStrict(err, in, "AnimatedButtons"))


### PR DESCRIPTION
A complementary change to #2479.

This adds custom properties functionality to GUI Controls.

In terms of Script API, only parent GUIControl class received new methods, but they may be used by any descendants.