### PR TITLE
Editor: fix case recent games menu error on null path

### DIFF
--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -131,8 +131,11 @@ namespace AGS.Editor.Components
             for (int i=1; i< Factory.AGSEditor.Settings.RecentGames.Count; i++)  
             {
                 var game = Factory.AGSEditor.Settings.RecentGames[i];
+                if (string.IsNullOrEmpty(game.Path) || !Directory.Exists(game.Path))
+                    continue;
+
                 string projectPath = Path.Combine(game.Path, AGSEditor.GAME_FILE_NAME);
-                if (Directory.Exists(game.Path) && File.Exists(projectPath))
+                if (File.Exists(projectPath))
                 {
                     string cmdText = GetRecentGameMenuText(game, maxPrintSize);
                     MenuCommand cmd = new MenuCommand(OPEN_RECENT_GAME_COMMAND + i.ToString(), cmdText);


### PR DESCRIPTION
Not sure, but possible fix for https://www.adventuregamestudio.co.uk/forums/ags-engine-editor-releases/ags-4-0-early-alpha-for-public-test/msg636665024/#msg636665024

Edit:

OK, to cause the error it's not that the path tag is empty but that it doesn't exist at all. I had only tested it for it being empty, which instead makes it be an empty string instead of null.