### PR TITLE
Engine: IndexOf add string index, count and case sensitivity params

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -337,5 +337,21 @@ size_t StrUtil::ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t 
     return len;
 }
 
+std::unique_ptr<char[]> StrUtil::Duplicate(const char *cstr)
+{
+    size_t len = strlen(cstr);
+    std::unique_ptr<char[]> buf(new char[len + 1]);
+    memcpy(buf.get(), cstr, len + 1);
+    return std::move(buf);
+}
+
+std::unique_ptr<char[]> StrUtil::Substring(const char *cstr, size_t start, size_t length)
+{
+    std::unique_ptr<char[]> buf(new char[length + 1]);
+    memcpy(buf.get(), cstr + start, length);
+    buf[length] = 0;
+    return std::move(buf);
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_CN_UTIL__STRINGUTILS_H
 #define __AGS_CN_UTIL__STRINGUTILS_H
 
+#include <memory>
 #include "util/string_types.h"
 
 namespace AGS
@@ -126,6 +127,10 @@ namespace StrUtil
     // Convert wide-string to utf-8 string;
     // writes into out_mbstr buffer limited by out_sz *bytes*; returns *bytes* written.
     size_t ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t out_sz);
+    // Creates a copy of a c string similar to strdup
+    std::unique_ptr<char[]> Duplicate(const char *cstr);
+    // Creates a substring with a partial copy of a c string
+    std::unique_ptr<char[]> Substring(const char *cstr, size_t start, size_t length);
 }
 } // namespace Common
 } // namespace AGS

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -570,8 +570,8 @@ internalstring autoptr builtin managed struct String {
   import int     Contains(const string needle);   // $AUTOCOMPLETEIGNORE$
   /// Creates a copy of the string.
   import String  Copy();
-  /// Returns the index of the first occurrence of the needle in this string.
-  import int     IndexOf(const string needle);
+  /// Returns the index of the first occurrence of the needle in this string, after specified index. A count 0 will run until string end.
+  import int     IndexOf(const string needle, int index = 0, int count = 0, StringCompareStyle style = eCaseInsensitive);
   /// Returns a lower-cased version of this string.
   import String  LowerCase();
   /// Returns a new string, with the specified character changed.

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -552,6 +552,10 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
     return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].GetAsBool()))
 
+#define API_OBJCALL_INT_POBJ_PINT2_PBOOL(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 4); \
+    return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].IValue, params[2].IValue, params[3].GetAsBool()))
+
 #define API_OBJCALL_FLOAT(CLASS, METHOD) \
     ASSERT_SELF(METHOD); \
     return RuntimeScriptValue().SetFloat(METHOD((CLASS*)self))


### PR DESCRIPTION
fix #2487

- I don't remember how to deal with the previous script API being only 1 parameter in ags4 branch! (Should I also link to  `String::IndexOf^1` and then have both be able to set through ifdefs in the header? Or is this not needed in ags4 ? the defaults will keep them working but rebuild is still needed.
- I am not convinced that the final code is actually getting proper offset in unicode characters, even as is in the current branch, did we test this at some point?
- I stole bits of the substring function to make the substring that the IndexOf will apply to. I wasn't sure if I should error here too or just throw a warn and return -1.