### PR TITLE
Editor: fix Colors pane and ColorMapper to display RGB values matching the engine

### DIFF
--- a/Common/util/wgt2allg.h
+++ b/Common/util/wgt2allg.h
@@ -25,8 +25,7 @@ using namespace AGS; // FIXME later
 
 //=============================================================================
 
-// [IKM] 2012-09-13: this function is now defined in engine and editor separately
-extern void __my_setcolor(int *ctset, int newcol, int wantColDep);
+    extern void __my_setcolor(int *ctset, int newcol, int wantColDep);
     
     extern void wsetrgb(int coll, int r, int g, int b, RGB * pall);
     extern void wcolrotate(unsigned char start, unsigned char finish, int dir, RGB * pall);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -152,6 +152,7 @@ namespace AGS.Editor
         private Tasks _tasks = new Tasks();
         private IEngineCommunication _engineComms = new NamedPipesEngineCommunication();
         private DebugController _debugger;
+        private ColorMapper _colorMapper;
 		private bool _applicationStarted = false;
         private FileSystemWatcher _fileWatcher = null;
         private FileStream _lockFile = null;
@@ -275,6 +276,11 @@ namespace AGS.Editor
             get { return _debugger; }
         }
 
+        public ColorMapper ColorMapper
+        {
+            get { return _colorMapper; }
+        }
+
 		public bool ApplicationStarted
 		{
             get { return _applicationStarted; }
@@ -295,6 +301,9 @@ namespace AGS.Editor
                 // this is an optional folder that might have user data in
                 // the parent folder, so don't try too hard to force this
             }
+
+            _colorMapper = new ColorMapper(this);
+            AGSColor.ColorMapper = _colorMapper;
 
             _game = new Game();
             _debugger = new DebugController(_engineComms);

--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -40,7 +40,6 @@ namespace AGS.Editor
             _guiController.OnEditorShutdown += new GUIController.EditorShutdownHandler(GUIController_OnEditorShutdown);
             _guiController.Initialize(_agsEditor);
             _agsEditor.DoEditorInitialization();
-            AGSColor.ColorMapper = new ColorMapper(_agsEditor);
             CreateComponents();
         }
 

--- a/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
@@ -36,6 +36,9 @@ namespace AGS.Editor
             this.lblPaletteIntro = new System.Windows.Forms.Label();
             this.colourFinderPage = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.lblBlueFinal = new System.Windows.Forms.Label();
+            this.lblGreenFinal = new System.Windows.Forms.Label();
+            this.lblRedFinal = new System.Windows.Forms.Label();
             this.btnColorDialog = new System.Windows.Forms.Button();
             this.lblFixedColorsWarning = new System.Windows.Forms.Label();
             this.blockOfColour = new AGS.Editor.BufferedPanel();
@@ -138,6 +141,9 @@ namespace AGS.Editor
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.lblBlueFinal);
+            this.groupBox1.Controls.Add(this.lblGreenFinal);
+            this.groupBox1.Controls.Add(this.lblRedFinal);
             this.groupBox1.Controls.Add(this.btnColorDialog);
             this.groupBox1.Controls.Add(this.lblFixedColorsWarning);
             this.groupBox1.Controls.Add(this.blockOfColour);
@@ -159,6 +165,33 @@ namespace AGS.Editor
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Colour Finder";
+            // 
+            // lblBlueFinal
+            // 
+            this.lblBlueFinal.AutoSize = true;
+            this.lblBlueFinal.Location = new System.Drawing.Point(315, 192);
+            this.lblBlueFinal.Name = "lblBlueFinal";
+            this.lblBlueFinal.Size = new System.Drawing.Size(21, 13);
+            this.lblBlueFinal.TabIndex = 17;
+            this.lblBlueFinal.Text = "(0)";
+            // 
+            // lblGreenFinal
+            // 
+            this.lblGreenFinal.AutoSize = true;
+            this.lblGreenFinal.Location = new System.Drawing.Point(315, 153);
+            this.lblGreenFinal.Name = "lblGreenFinal";
+            this.lblGreenFinal.Size = new System.Drawing.Size(21, 13);
+            this.lblGreenFinal.TabIndex = 16;
+            this.lblGreenFinal.Text = "(0)";
+            // 
+            // lblRedFinal
+            // 
+            this.lblRedFinal.AutoSize = true;
+            this.lblRedFinal.Location = new System.Drawing.Point(315, 115);
+            this.lblRedFinal.Name = "lblRedFinal";
+            this.lblRedFinal.Size = new System.Drawing.Size(21, 13);
+            this.lblRedFinal.TabIndex = 15;
+            this.lblRedFinal.Text = "(0)";
             // 
             // btnColorDialog
             // 
@@ -358,6 +391,8 @@ namespace AGS.Editor
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label lblFixedColorsWarning;
 		private System.Windows.Forms.Button btnColorDialog;
-
+        private System.Windows.Forms.Label lblBlueFinal;
+        private System.Windows.Forms.Label lblGreenFinal;
+        private System.Windows.Forms.Label lblRedFinal;
     }
 }

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -72,19 +72,19 @@ namespace AGS.Editor
 
         private void trackBarRed_Scroll(object sender, EventArgs e)
         {
-            lblRedVal.Text = trackBarRed.Value.ToString();
+            ColourSlidersUpdated();
             UpdateNumberFromScrollBars();
         }
 
         private void trackBarGreen_Scroll(object sender, EventArgs e)
         {
-            lblGreenVal.Text = trackBarGreen.Value.ToString();
+            ColourSlidersUpdated();
             UpdateNumberFromScrollBars();
         }
 
         private void trackBarBlue_Scroll(object sender, EventArgs e)
         {
-            lblBlueVal.Text = trackBarBlue.Value.ToString();
+            ColourSlidersUpdated();
             UpdateNumberFromScrollBars();
         }
 
@@ -108,13 +108,22 @@ namespace AGS.Editor
             }
         }
 
-		private void ColourSlidersUpdated()
-		{
-			lblRedVal.Text = trackBarRed.Value.ToString();
-			lblGreenVal.Text = trackBarGreen.Value.ToString();
-			lblBlueVal.Text = trackBarBlue.Value.ToString();
-			blockOfColour.Invalidate();
-		}
+        private void ColourSlidersUpdated()
+        {
+            lblRedVal.Text = trackBarRed.Value.ToString();
+            lblGreenVal.Text = trackBarGreen.Value.ToString();
+            lblBlueVal.Text = trackBarBlue.Value.ToString();
+            // Ensure that we also display an honest clamped RGB values;
+            // we'd rather have users see an exact RGB which will be used in game,
+            // than to display a desired RGB that is going to be "secretly" clamped at runtime.
+            Color rgb = Color.FromArgb(trackBarRed.Value, trackBarGreen.Value, trackBarBlue.Value);
+            rgb = AGSEditor.Instance.ColorMapper.AgsColourNumberToColorDirect(
+                AGSEditor.Instance.ColorMapper.ColorToAgsColourNumberDirect(rgb));
+            lblRedFinal.Text = string.Format($"({rgb.R})");
+            lblGreenFinal.Text = string.Format($"({rgb.G})");
+            lblBlueFinal.Text = string.Format($"({rgb.B})");
+            blockOfColour.Invalidate();
+        }
 
         private void UpdateNumberFromScrollBars()
         {

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -99,9 +99,10 @@ namespace AGS.Editor
                     newVal = 0;
                 }
 
-                trackBarRed.Value = (newVal >> 11) * 8;
-                trackBarGreen.Value = ((newVal >> 5) & 0x003f) * 4;
-                trackBarBlue.Value = (newVal & 0x001f) * 8;
+                Color newColor = AGSEditor.Instance.ColorMapper.AgsColourNumberToColorDirect(newVal);
+                trackBarRed.Value = newColor.R;
+                trackBarGreen.Value = newColor.G;
+                trackBarBlue.Value = newColor.B;
 				lblFixedColorsWarning.Visible = ((newVal >= 1) && (newVal <= 31));
 				ColourSlidersUpdated();
             }
@@ -118,8 +119,8 @@ namespace AGS.Editor
         private void UpdateNumberFromScrollBars()
         {
             _noUpdates = true;
-			int greenValue = trackBarGreen.Value / 4;
-            int newValue = (trackBarBlue.Value / 8) + (greenValue << 5) + ((trackBarRed.Value / 8) << 11);
+            var newColor = Color.FromArgb(trackBarRed.Value, trackBarGreen.Value, trackBarBlue.Value);
+            int newValue = AGSEditor.Instance.ColorMapper.ColorToAgsColourNumberDirect(newColor);
             txtColourNumber.Text = newValue.ToString();
             _noUpdates = false;
             lblFixedColorsWarning.Visible = ((newValue >= 1) && (newValue <= 31));

--- a/Editor/AGS.Editor/Panes/PaletteEditor.resx
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/Utils/ColorMapper.cs
+++ b/Editor/AGS.Editor/Utils/ColorMapper.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor
             _editor = editor;
         }
 
+        #region IColorMapper
+
         public int MapRgbColorToAgsColourNumber(Color rgbColor)
         {
             int green = rgbColor.G;
@@ -51,9 +53,30 @@ namespace AGS.Editor
             return Color.FromArgb(red, green, blue);
         }
 
+        #endregion
+
+        /// <summary>
+        /// Converts RGB Color to a AGS color number directly, without use of palette or "special" entries.
+        /// </summary>
+        public int ColorToAgsColourNumberDirect(Color color)
+        {
+            return (color.B / 8) + ((color.G / 4) << 5) + ((color.R / 8) << 11);
+        }
+
+        /// <summary>
+        /// Converts AGS color number to RGB Color directly, without use of palette or "special" entries.
+        /// </summary>
+        public Color AgsColourNumberToColorDirect(int agsColorNumber)
+        {
+            return Color.FromArgb(
+                (agsColorNumber >> 11) * 8,
+                ((agsColorNumber >> 5) & 0x3f) * 4,
+                (agsColorNumber & 0x1f) * 8);
+        }
+
         private int FindNearestColourInGamePalette(Color rgbColor)
         {
-            int nearestDistance = 999999;
+            int nearestDistance = int.MaxValue;
             int nearestIndex = 0;
 
             foreach (PaletteEntry entry in _editor.CurrentGame.Palette)

--- a/Editor/AGS.Editor/Utils/ColorMapper.cs
+++ b/Editor/AGS.Editor/Utils/ColorMapper.cs
@@ -15,6 +15,35 @@ namespace AGS.Editor
             _editor = editor;
         }
 
+        /// <summary>
+        /// Lookup table for scaling 5 bit colors up to 8 bits,
+        /// copied from Allegro 4 library in order to match Editor and Engine.
+        /// </summary>
+        private readonly static int[] RGBScale5 = new int[32]
+        {
+           0,   8,   16,  24,  33,  41,  49,  57,
+           66,  74,  82,  90,  99,  107, 115, 123,
+           132, 140, 148, 156, 165, 173, 181, 189,
+           198, 206, 214, 222, 231, 239, 247, 255
+        };
+
+
+        /// <summary>
+        /// Lookup table for scaling 6 bit colors up to 8 bits,
+        /// copied from Allegro 4 library in order to match Editor and Engine.
+        /// </summary>
+        private readonly static int[] RGBScale6 = new int[64]
+        {
+           0,   4,   8,   12,  16,  20,  24,  28,
+           32,  36,  40,  44,  48,  52,  56,  60,
+           65,  69,  73,  77,  81,  85,  89,  93,
+           97,  101, 105, 109, 113, 117, 121, 125,
+           130, 134, 138, 142, 146, 150, 154, 158,
+           162, 166, 170, 174, 178, 182, 186, 190,
+           195, 199, 203, 207, 211, 215, 219, 223,
+           227, 231, 235, 239, 243, 247, 251, 255
+        };
+
         #region IColorMapper
 
         public int MapRgbColorToAgsColourNumber(Color rgbColor)
@@ -31,14 +60,11 @@ namespace AGS.Editor
                 return FindNearestColourInGamePalette(rgbColor);
             }
 
-            return (rgbColor.B / 8) + ((green / 4) << 5) + ((rgbColor.R / 8) << 11);
+            return ColorToAgsColourNumberDirect(rgbColor);
         }
 
         public Color MapAgsColourNumberToRgbColor(int agsColorNumber)
         {
-            int red = ((agsColorNumber >> 11) * 8) & 255;
-            int green = ((agsColorNumber >> 5) * 4) & 255;
-            int blue = ((agsColorNumber) * 8) & 255;
             if (((agsColorNumber > 0) && (agsColorNumber < 32)) ||
                 (_editor.CurrentGame.Settings.ColorDepth == GameColorDepth.Palette))
             {
@@ -50,7 +76,8 @@ namespace AGS.Editor
                 // Special Color Number that translates to one of the EGA colours
                 return _editor.CurrentGame.Palette[agsColorNumber].Colour;
             }
-            return Color.FromArgb(red, green, blue);
+
+            return AgsColourNumberToColorDirect(agsColorNumber);
         }
 
         #endregion
@@ -60,7 +87,7 @@ namespace AGS.Editor
         /// </summary>
         public int ColorToAgsColourNumberDirect(Color color)
         {
-            return (color.B / 8) + ((color.G / 4) << 5) + ((color.R / 8) << 11);
+            return (color.B >> 3) + ((color.G >> 2) << 5) + ((color.R >> 3) << 11);
         }
 
         /// <summary>
@@ -69,9 +96,9 @@ namespace AGS.Editor
         public Color AgsColourNumberToColorDirect(int agsColorNumber)
         {
             return Color.FromArgb(
-                (agsColorNumber >> 11) * 8,
-                ((agsColorNumber >> 5) & 0x3f) * 4,
-                (agsColorNumber & 0x1f) * 8);
+                RGBScale5[(agsColorNumber >> 11) & 0x1f],
+                RGBScale6[(agsColorNumber >> 5) & 0x3f],
+                RGBScale5[agsColorNumber & 0x1f]);
         }
 
         private int FindNearestColourInGamePalette(Color rgbColor)


### PR DESCRIPTION
Fixes #2352

This fix is **purely for user interface** in the editor, they do not change anything in how colors are stored, nor how they are represented in the engine.

1. Fix ColorMapper color defining algorithm to strictly match the internal engine's algorithm. The engine uses Allegro 4 for this, where actual RGB values are found using lookup tables. This seems to result in better distribution, for example it supports pure 255,255,255, while the common conversion algorithm is restricted by 252,252,252 (iirc).
2. On Color Finder pane display actual RGB values that will be used by the engine. This is to honestly notify user that AGS clamps RGBs to less precise 16-bit format.
