### PR TITLE
New compiler: Fix bugs uncovered by stricter 'compiledscript' code

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -303,7 +303,10 @@ void AGS::BackwardJumpDest::Set(CodeLoc cl)
 
 void AGS::BackwardJumpDest::WriteJump(CodeCell jump_op, size_t cur_line)
 {
-    if (SCMD_LINENUM != _scrip.code[_dest] &&
+    // In degenerate cases such as empty 'while (1)' loops,
+    // _no_ code has been generated at '_dest' yet.
+    // So in particular, there isn't a 'LINENUM' statement at '_dest'.
+    if ((_dest >= _scrip.Codesize_i32() || SCMD_LINENUM != _scrip.code[_dest]) &&
         _scrip.LastEmittedLineno != _lastEmittedSrcLineno)
     {
         _scrip.WriteLineno(cur_line);

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2346,12 +2346,13 @@ TEST_F(Compile0, Ternary01) {
 TEST_F(Compile0, Ternary02) {
 
     // Values of ternary must have compatible vartypes
+    // Note: the 'break;' is wrong. The compiler should stop before it.
 
     char const *inpl = "\
         int main()                      \n\
         {                               \n\
             return 2 < 1 ? 1 : 2.0;     \n\
-                    break;              \n\
+            break;                      \n\
         }                               \n\
         ";
   


### PR DESCRIPTION
Fixes #2417

Parser code for ternaries could sometimes patch code cells that had once existed but then were ripped out of the codebase.

In 'while(true)' loops with bodies that didn't contain code, the parser tried to look at the first byte beyond the end of the codebase.