### PR TITLE
Compiler: port preprocessor updates from C# to Cpp

### DIFF
--- a/Compiler/preproc/preprocessor.h
+++ b/Compiler/preproc/preprocessor.h
@@ -22,6 +22,7 @@ namespace AGS {
 namespace Preprocessor {
 
     enum class ErrorCode {
+        None = 0,
         MacroNameMissing = 1,
         MacroDoesNotExist,
         MacroAlreadyExists,
@@ -32,7 +33,13 @@ namespace Preprocessor {
         IfWithoutEndIf,
         ElseIfWithoutIf,
         InvalidVersionNumber,
-        UnterminatedString
+        UnterminatedString,
+        InvalidCharacter
+    };
+
+    struct Error {
+        ErrorCode Type = ErrorCode::None;
+        String Message = nullptr;
     };
 
     class Preprocessor {
@@ -43,14 +50,15 @@ namespace Preprocessor {
         String _scriptName;
         Version _applicationVersion;
         std::stack<bool> _conditionalStatements;
+        std::vector<Error> _errors;
 
-        static void LogError(ErrorCode error, const String &message = nullptr);
+        void LogError(ErrorCode error, const String &message = nullptr);
 
         void ProcessConditionalDirective(String &directive, String &line);
 
         bool DeletingCurrentLine();
 
-        static String GetNextWord(String &text, bool trimText = true, bool includeDots = false);
+        String GetNextWord(String &text, bool trimText = true, bool includeDots = false);
 
         String RemoveComments(String text);
 
@@ -59,6 +67,8 @@ namespace Preprocessor {
         String PreProcessLine(const String& lineToProcess);
 
     public:
+        static const Error NoError;
+        Error GetLastError() const;
         void SetAppVersion(const String& version);
         void MergeMacros(MacroTable &macros);
         void DefineMacro(const String &name, const String &value);

--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -127,7 +127,9 @@ inline bool IsWhitespaceNoLineBreak(int c)
 // Tells if this character may be a part of a script symbol
 inline bool IsScriptWordChar(int c)
 {
-    return std::isalnum(c) || c == '_';
+    // the behavior of std::isalnum is undefined if the argument's value
+    // is neither representable as unsigned char nor equal to EOF
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
 }
 
 // Returns a escaped character corresponding to the given character;

--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -125,11 +125,12 @@ inline bool IsWhitespaceNoLineBreak(int c)
 }
 
 // Tells if this character may be a part of a script symbol
-inline bool IsScriptWordChar(int c)
+inline bool IsScriptWordChar(char c)
 {
-    // the behavior of std::isalnum is undefined if the argument's value
-    // is neither representable as unsigned char nor equal to EOF
-    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+    return ((c >= 'A') && (c <= 'Z')) ||
+           ((c >= 'a') && (c <= 'z')) ||
+           ((c >= '0') && (c <= '9')) ||
+           (c == '_');
 }
 
 // Returns a escaped character corresponding to the given character;


### PR DESCRIPTION
This is essentially https://github.com/adventuregamestudio/ags/commit/cc465235b5a20b2a5a377aa4140ee3cbbd6d66d8 (https://github.com/adventuregamestudio/ags/pull/2482) and https://github.com/adventuregamestudio/ags/commit/69704a20c7bb70e34609d6ec78d3549b2a2e8a9f (small part of https://github.com/adventuregamestudio/ags/pull/2180)

- remove undefined behavior from IsScriptWordChar function
- port detection of non-latin characters in the preprocessor
- port escaping of the script name by the preprocessor
- minor readjustment on the error logging to ensure easier error testing this was needed to ease comparison when the error string contained non-latin characters.

**NOTE:** I am modifying the IsScriptWordChar function which is used by the script compiler. It had an undefined behavior - the comment text is from cppreference website. It looks like it's still working but previous isalnum was returning true for non-latin characters, I don't think this breaks anything because in the script compiler this is used only once and we pass a `char` type variable instead of an int. I actually think this function should take a `char` as parameter since both existing uses are only passing a char.