### PR TITLE
New compiler: Only imply `*` in import object declarations when a compiler flag is unset

### DIFF
--- a/Common/script/cc_common.h
+++ b/Common/script/cc_common.h
@@ -33,7 +33,8 @@
 #define SCOPT_RTTI          0x0200   // generate and export RTTI
 #define SCOPT_RTTIOPS       0x0400   // enable syntax & opcodes that require RTTI to work
 #define SCOPT_SCRIPT_TOC    0x0800   // generate and export ScriptTOC
-#define SCOPT_HIGHEST       SCOPT_SCRIPT_TOC
+#define SCOPT_NOAUTOPTRIMPORT 0x1000 // object pointers in imports must be declared explicitly
+#define SCOPT_HIGHEST       SCOPT_NOAUTOPTRIMPORT
 
 extern void ccSetOption(int, int);
 extern int ccGetOption(int);

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -37,6 +37,7 @@ int cc_compile(std::string const &inpl, AGS::ccCompiledScript &scrip)
         (0 != ccGetOption(SCOPT_NOIMPORTOVERRIDE)) * SCOPT_NOIMPORTOVERRIDE |
         (0 != ccGetOption(SCOPT_OLDSTRINGS)) * SCOPT_OLDSTRINGS |
         (0 != ccGetOption(SCOPT_RTTIOPS)) * SCOPT_RTTIOPS |
+        (0 != ccGetOption(SCOPT_NOAUTOPTRIMPORT)) * SCOPT_NOAUTOPTRIMPORT |
         false;
 
     int const error_code = cc_compile(inpl, options, scrip, mh);


### PR DESCRIPTION
In legacy AGS, the engine autogenerates code such as `import Object object[20];` where `object` is meant to be an array of `Object` and not an array of `Object *`. 
I'm told ( **but didn't check this myself** ) that this is no longer true in recent AGS 4.0. This PR makes the compiler cope with this situation. 

Introduce the compiler flag `SCOPT_NOAUTOPTRIMPORT` which is `false` by default. Normally, whenever AGS code declares an object variable then always imply that it is pointered. However, in import declarations of non-autopointered varables only do so when the flag `SCOPT_NOAUTOPTRIMPORT` is `false` (which is the default).

In the legacy AGS situation, the flag  `SCOPT_NOAUTOPTRIMPORT` can be set to `true` so that the compiler generates the correct (legacy) code. This might become interesting, e.g., if the compiler is backported to AGS 3 versions.