### PR TITLE
Engine: implement "accessibility" config for speech and text skip

### DIFF
--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -95,25 +95,47 @@ namespace StrUtil
 
 
     // Parses enum value by name, using provided C-string array,
-    // where strings are compared as case-insensitive; returns def_val if failed;
+    // where strings are compared as case-insensitive; returns def_val if failed
     template<typename T, std::size_t SIZE>
-    T ParseEnum(const String &option, const CstrArr<SIZE>& arr, const T def_val = static_cast<T>(-1))
+    T ParseEnum(const String &option, const CstrArr<SIZE> &arr, const T &def_val)
     {
         for (auto it = arr.cbegin(); it < arr.cend(); ++it)
             if ((*it && *it[0] != 0) && (option.CompareNoCase(*it) == 0))
                 return static_cast<T>(it - arr.begin());
         return def_val;
     }
+    // Parses enum value by name, using provided C-string array and a base value (e.g. 0, -1, +1, etc),
+    // where strings are compared as case-insensitive; returns def_val if failed
+    template<typename T, std::size_t SIZE>
+    T ParseEnumWithBase(const String &option, const CstrArr<SIZE> &arr, const T &base_val, const T &def_val)
+    {
+        for (auto it = arr.cbegin(); it < arr.cend(); ++it)
+            if ((*it && *it[0] != 0) && (option.CompareNoCase(*it) == 0))
+                return static_cast<T>(it - arr.begin() + base_val);
+        return def_val;
+    }
     // Parses enum value either as a number, or searching withing the C-string array,
     // where strings are compared as case-insensitive; returns def_val if failed to do both
     template<typename T, std::size_t SIZE>
-    T ParseEnumAllowNum(const String &option, const CstrArr<SIZE>& arr, const T def_val = static_cast<T>(-1))
+    T ParseEnumAllowNum(const String &option, const CstrArr<SIZE> &arr, const T &def_val)
     {
         int num = StrUtil::StringToInt(option, -1);
         if (num >= 0) return static_cast<T>(num);
         for (auto it = arr.cbegin(); it < arr.cend(); ++it)
             if ((*it && *it[0] != 0) && (option.CompareNoCase(*it) == 0))
                 return static_cast<T>(it - arr.begin());
+        return def_val;
+    }
+    // Parses enum value by name, using provided map of correspondence between
+    // C-strings and enum constants, where strings are compared as case-insensitive;
+    // returns def_val if failed
+    template<typename T, std::size_t SIZE>
+    T ParseEnumOptions(const String &option, const std::array<std::pair<const char*, T>, SIZE> &arr,
+        const T &def_val)
+    {
+        for (auto it = arr.cbegin(); it < arr.cend(); ++it)
+            if ((it->first && it->first[0] != 0) && (option.CompareNoCase(it->first) == 0))
+                return static_cast<T>(it->second);
         return def_val;
     }
 

--- a/Engine/ac/dynobj/scriptgame.cpp
+++ b/Engine/ac/dynobj/scriptgame.cpp
@@ -14,6 +14,7 @@
 #include "ac/dynobj/scriptgame.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/game.h"
+#include "ac/gamesetup.h"
 #include "ac/gamestate.h"
 #include "ac/gui.h"
 #include "debug/debug_log.h"
@@ -157,7 +158,10 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 68:  play.speech_textwindow_gui = val; break;
     case 69:  play.follow_change_room_timer = val; break;
     case 70:  play.totalscore = val; break;
-    case 71:  play.skip_display = val; break;
+    case 71:
+        if (usetup.access_textskip == kSkipSpeechNone)
+            play.skip_display = static_cast<SkipSpeechStyle>(val);
+        break;
     case 72:  play.no_multiloop_repeat = val; break;
     case 73:  play.roomscript_finished = val; break;
     case 74:  play.used_inv_on = val; break;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -15,6 +15,7 @@
 #define __AC_GAMESETUP_H
 
 #include "ac/game_version.h"
+#include "ac/speech.h"
 #include "ac/sys_events.h"
 #include "main/graphics_mode.h"
 #include "util/string.h"
@@ -120,6 +121,12 @@ struct GameSetup
     // is not implemented (or does not work correctly).
     int   key_save_game = 0;
     int   key_restore_game = 0;
+
+    // Accessibility settings and overrides;
+    // these are meant to make playing the game easier, by modifying certain
+    // game properties which are non-critical for the game progression.
+    SkipSpeechStyle access_speechskip = kSkipSpeechNone; // speech skip style
+    SkipSpeechStyle access_textskip = kSkipSpeechNone; // display box skip style
 
     GameSetup();
 };

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -473,7 +473,7 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
     speech_textwindow_gui = in->ReadInt32();
     follow_change_room_timer = in->ReadInt32();
     totalscore = in->ReadInt32();
-    skip_display = in->ReadInt32();
+    skip_display = static_cast<SkipSpeechStyle>(in->ReadInt32());
     no_multiloop_repeat = in->ReadInt32();
     roomscript_finished = in->ReadInt32();
     used_inv_on = in->ReadInt32();

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -118,7 +118,7 @@ struct GamePlayState
     int  speech_textwindow_gui = 0;      // textwindow used for sierra-style speech
     int  follow_change_room_timer = 0;   // delay before moving following characters into new room
     int  totalscore = 0;        // maximum possible score
-    int  skip_display = 0;      // how the user can skip normal Display windows
+    SkipSpeechStyle skip_display = kSkipSpeechKeyMouse; // how the user can skip normal Display windows
     int  no_multiloop_repeat = 0; // for backwards compatibility
     int  roomscript_finished = 0; // on_call finished in room
     int  used_inv_on = 0;       // inv item they clicked on
@@ -193,6 +193,7 @@ struct GamePlayState
     short wait_counter = 0;
     char  wait_skipped_by = 0; // tells how last blocking wait was skipped [not serialized]
     int   wait_skipped_by_data = 0; // extended data telling how last blocking wait was skipped [not serialized]
+    SkipSpeechStyle skip_timed_display = kSkipSpeechKeyMouseTime; // how the timed room messages may be skipped (see MSG_TIMELIMIT) [not serialized]
     short mboundx1 = 0;
     short mboundx2 = 0;
     short mboundy1 = 0;
@@ -211,7 +212,7 @@ struct GamePlayState
     int   entered_edge = 0;
     bool  voice_avail = false; // whether voice-over is available
     SpeechMode speech_mode = kSpeech_TextOnly; // speech mode (text, voice, or both)
-    int   speech_skip_style = 0;
+    int   speech_skip_style = 0; // stores SKIP_* flags
     int   script_timers[MAX_TIMERS]{};
     int   sound_volume = 0;
     int   speech_volume = 0;

--- a/Engine/ac/global_display.cpp
+++ b/Engine/ac/global_display.cpp
@@ -18,6 +18,7 @@
 #include "ac/display.h"
 #include "ac/draw.h"
 #include "ac/game.h"
+#include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/global_character.h"
@@ -122,13 +123,13 @@ void DisplayMessageImpl(int msnum, int aschar, int ypos) {
         }
         else {
             // time out automatically if they have set that
-            int oldGameSkipDisp = play.skip_display;
+            const SkipSpeechStyle old_skip_display = play.skip_display;
             if (thisroom.MessageInfos[msnum].Flags & MSG_TIMELIMIT)
-                play.skip_display = 0;
+                play.skip_display = play.skip_timed_display;
 
             DisplayAtY(ypos, msgbufr);
 
-            play.skip_display = oldGameSkipDisp;
+            play.skip_display = old_skip_display;
         }
         if (thisroom.MessageInfos[msnum].Flags & MSG_DISPLAYNEXT) {
             msnum++;
@@ -204,7 +205,8 @@ void SetSkipSpeech (SkipSpeechStyle newval) {
         quit("!SetSkipSpeech: invalid skip mode specified");
 
     debug_script_log("SkipSpeech style set to %d", newval);
-    play.speech_skip_style = user_to_internal_skip_speech((SkipSpeechStyle)newval);
+    if (usetup.access_speechskip == kSkipSpeechNone)
+        play.speech_skip_style = user_to_internal_skip_speech((SkipSpeechStyle)newval);
 }
 
 SkipSpeechStyle GetSkipSpeech()

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -27,8 +27,13 @@ enum SkipSpeechStyle
     kSkipSpeechKey          =  5,
     kSkipSpeechMouse        =  6,
 
+    // Aliases for the most useful styles (used in accessibility options)
+    kSkipSpeech_AnyInput    = kSkipSpeechKeyMouse,
+    kSkipSpeech_AnyInputOrTime = kSkipSpeechKeyMouseTime,
+
     kSkipSpeechFirst        = kSkipSpeechNone,
-    kSkipSpeechLast         = kSkipSpeechMouse
+    kSkipSpeechLast         = kSkipSpeechMouse,
+    kNumSpeechSkipOptions   = kSkipSpeechLast - kSkipSpeechFirst
 };
 
 enum SpeechMode

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -588,7 +588,24 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     if (create_global_script())
         return new GameInitError(kGameInitErr_ScriptLinkFailed, cc_get_error().ErrorString);
 
+    // Apply accessibility options, must be done last, because some
+    // may override startup game settings.
+    ApplyAccessibilityOptions();
+
     return HGameInitError::None();
+}
+
+void ApplyAccessibilityOptions()
+{
+    if (usetup.access_speechskip != kSkipSpeechNone)
+    {
+        play.speech_skip_style = user_to_internal_skip_speech(usetup.access_speechskip);
+    }
+    if (usetup.access_textskip != kSkipSpeechNone)
+    {
+        play.skip_display = usetup.access_textskip;
+        play.skip_timed_display = usetup.access_textskip;
+    }
 }
 
 } // namespace Engine

--- a/Engine/game/game_init.h
+++ b/Engine/game/game_init.h
@@ -49,7 +49,9 @@ typedef TypedCodeError<GameInitErrorType, GetGameInitErrorText> GameInitError;
 typedef ErrorHandle<GameInitError> HGameInitError;
 
 // Sets up game state for play using preloaded data
-HGameInitError  InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver);
+HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver);
+// Applies accessibility options, some of them may override game settings
+void ApplyAccessibilityOptions();
 
 } // namespace Engine
 } // namespace AGS

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -666,6 +666,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
 
     set_game_speed(r_data.FPS);
 
+    // Apply accessibility options, must be done last, because some
+    // may override restored game settings
+    ApplyAccessibilityOptions();
+
     return HSaveError::None();
 }
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -389,6 +389,14 @@ void apply_config(const ConfigTree &cfg)
         usetup.override_upscale = CfgReadBoolInt(cfg, "override", "upscale", usetup.override_upscale);
         usetup.key_save_game = CfgReadInt(cfg, "override", "save_game_key", 0);
         usetup.key_restore_game = CfgReadInt(cfg, "override", "restore_game_key", 0);
+
+        // Accessibility settings
+        std::array<std::pair<const char*, SkipSpeechStyle>, 4> skip_speech_arr{
+                { { "none", kSkipSpeechNone }, { "input", kSkipSpeech_AnyInput }, { "any", kSkipSpeech_AnyInputOrTime }, { "time", kSkipSpeechTime } } };
+        usetup.access_speechskip = StrUtil::ParseEnumOptions<SkipSpeechStyle>(
+            CfgReadString(cfg, "access", "speechskip"), skip_speech_arr, kSkipSpeechNone);
+        usetup.access_textskip = StrUtil::ParseEnumOptions<SkipSpeechStyle>(
+            CfgReadString(cfg, "access", "textskip"), skip_speech_arr, kSkipSpeechNone);
     }
 
     // Apply logging configuration

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -57,6 +57,7 @@
 #include "device/mousew32.h"
 #include "font/agsfontrenderer.h"
 #include "font/fonts.h"
+#include "game/game_init.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxdriverfactory.h"
 #include "gfx/ddb.h"
@@ -766,7 +767,7 @@ void engine_init_game_settings()
     play.swap_portrait_lastchar = -1;
     play.swap_portrait_lastlastchar = -1;
     play.in_conversation = 0;
-    play.skip_display = 3;
+    play.skip_display = kSkipSpeechKeyMouse;
     play.no_multiloop_repeat = 0;
     play.in_cutscene = 0;
     play.fast_forward = 0;
@@ -859,6 +860,10 @@ void engine_init_game_settings()
     usetup.RenderAtScreenRes = 
         (game.options[OPT_RENDERATSCREENRES] == kRenderAtScreenRes_UserDefined && usetup.RenderAtScreenRes) ||
          game.options[OPT_RENDERATSCREENRES] == kRenderAtScreenRes_Enabled;
+
+    // FIXME: this should be done once in InitGameState, but the code for default game settings
+    // is spread across 2 or more functions; keep this extra call here until this nonsense is fixed.
+    ApplyAccessibilityOptions();
 }
 
 void engine_setup_scsystem_auxiliary()


### PR DESCRIPTION
Per a *very old* users request.

This allows players to override game's speech skip style to their preference if the game does not provide such option.

Adds two config options under "[access]" group:
```
[access]
speechskip = <none, input, any, time>
textskip = <none, input, any, time>
```

Both may take following values:
* "none", or empty string (default) - this actually means that the option is not used
* "input", meaning any player input
* "any", meaning any player input, or time
* "time", meaning time only

These options override in-game settings for skipping speech and displayed messages respectively.

The override is done:
- when the game is loaded
- when the save is restored (because these options may be saved)
- when these options are changed by a script, these overriding settings may prevent assignment of a new value.

Note that reading a Speech.SkipStyle property in script will actually return a true overridden value. This is done in case game script uses this property as a reference when implementing custom speech, for example.