### PR TITLE
Compiler.Tests: make sure that specific flags are reset to default

### DIFF
--- a/Common/script/cc_common.cpp
+++ b/Common/script/cc_common.cpp
@@ -22,6 +22,10 @@ int ccCompOptions = 0;
 int currentline = 0;
 const char *ccCurScriptName = "";
 
+void ccResetOptions(int optbit)
+{
+    ccCompOptions = optbit;
+}
 
 void ccSetOption(int optbit, int onoroff)
 {

--- a/Common/script/cc_common.h
+++ b/Common/script/cc_common.h
@@ -36,8 +36,9 @@
 #define SCOPT_NOAUTOPTRIMPORT 0x1000 // object pointers in imports must be declared explicitly
 #define SCOPT_HIGHEST       SCOPT_NOAUTOPTRIMPORT
 
-extern void ccSetOption(int, int);
-extern int ccGetOption(int);
+extern void ccResetOptions(int optbit);
+extern void ccSetOption(int optbit, int on);
+extern int ccGetOption(int optbit);
 
 // error reporting
 

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -84,7 +84,7 @@ protected:
     {
         // Initializations, will be done at the start of each test
         // Note, the parser doesn't react to SCOPT_LINENUMBERS, that's on ccCompiledScript
-        ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
+        ccResetOptions(0);
         clear_error();
     }
 };

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -38,7 +38,7 @@ protected:
     {
         // Initializations, will be done at the start of each test
         // Note, the parser doesn't react to SCOPT_LINENUMBERS, that's on ccCompiledScript
-        ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
+        ccResetOptions(0);
         clear_error();
     }
 };
@@ -690,6 +690,9 @@ TEST_F(Bytecode1, AccessStructAsPointer02) {
     
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
+    //
+    // LEGACY MODE: Assume that builtin managed objects are NOT autopointered
+    // TODO: make an alternative bytecode test for the default mode
 
     char const *inpl = "\
         builtin managed struct Object { };              \n\
@@ -708,6 +711,7 @@ TEST_F(Bytecode1, AccessStructAsPointer02) {
         }                                               \n\
     ";
 
+    ccSetOption(SCOPT_NOAUTOPTRIMPORT, true);
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
@@ -758,6 +762,9 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
     
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
+    //
+    // LEGACY MODE: Assume that builtin managed objects are NOT autopointered
+    // TODO: make an alternative bytecode test for the default mode
 
     char const *inpl = "\
         builtin managed struct Object {                 \n\
@@ -777,6 +784,7 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
         }                                               \n\
     ";
 
+    ccSetOption(SCOPT_NOAUTOPTRIMPORT, true);
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -77,7 +77,7 @@ protected:
     Compile0()
     {
         // Initializations, will be done at the start of each test
-        ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
+        ccResetOptions(0);
         ccSetOption(SCOPT_LINENUMBERS, true);
         clear_error();
     }

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -35,7 +35,7 @@ protected:
     Compile1()
     {
         // Initializations, will be done at the start of each test
-        ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
+        ccResetOptions(0);
         ccSetOption(SCOPT_LINENUMBERS, true);
         clear_error();
     }


### PR DESCRIPTION
Fix #2518

Backwards compatible flags must be reset to defaults whenever a new test runs. This is done in a test initialization method.
Each test that requires a backwards mode should set them explicitly.