### PR TITLE
Script API: support eNullFont, a pseudo font ID which draws nothing

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -121,4 +121,7 @@
 // Animates once and stops, resetting to the very first frame
 #define ANIM_ONCERESET         2
 
+// An identifier of a "null font", a pseudo font used when you don't want a text to be drawn
+#define FONT_NULL (-1)
+
 #endif // __AC_DEFINES_H

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -871,24 +871,15 @@ namespace AGS.Editor
         private void AppendFontsToHeader(StringBuilder sb, IList<AGS.Types.Font> fonts)
         {
             sb.AppendLine("enum FontType {");
-            bool firstFont = true;
+            sb.Append("  eNullFont = -1");
             foreach (AGS.Types.Font font in fonts)
             {
                 string fontName = font.ScriptID;
                 if (fontName.Length > 0)
                 {
-                    if (!firstFont)
-                    {
-                        sb.AppendLine(",");
-                    }
+                    sb.AppendLine(",");
                     sb.Append("  " + fontName + " = " + font.ID);
-                    firstFont = false;
                 }
-            }
-            if (firstFont)
-            {
-                // no cursors, make sure the enum has something in it
-                sb.Append("eDummyFont__ = 99  // $AUTOCOMPLETEIGNORE$ ");
             }
             sb.AppendLine();
             sb.AppendLine("};");

--- a/Editor/AGS.Types/PropertyGridExtras/FontTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/FontTypeConverter.cs
@@ -32,6 +32,7 @@ namespace AGS.Types
             }
 
             _possibleValues.Clear();
+            _possibleValues.Add(-1, "Null Font");
             foreach (Font font in _Fonts)
             {
                 _possibleValues.Add(font.ID, font.ScriptID);

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -109,8 +109,7 @@ void Button_SetText(GUIButton *butt, const char *newtx) {
 }
 
 void Button_SetFont(GUIButton *butt, int newFont) {
-    if ((newFont < 0) || (newFont >= game.numfonts))
-        quit("!Button.Font: invalid font number.");
+    newFont = ValidateFontNumber("Button.Font", newFont);
 
     if (butt->Font != newFont) {
         butt->Font = newFont;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -837,14 +837,12 @@ void GetMessageText (int msg, char *buffer) {
 }
 
 void SetSpeechFont (int fontnum) {
-    if ((fontnum < 0) || (fontnum >= game.numfonts))
-        quit("!SetSpeechFont: invalid font number.");
+    fontnum = ValidateFontNumber("SetSpeechFont", fontnum);
     play.speech_font = fontnum;
 }
 
 void SetNormalFont (int fontnum) {
-    if ((fontnum < 0) || (fontnum >= game.numfonts))
-        quit("!SetNormalFont: invalid font number.");
+    fontnum = ValidateFontNumber("SetNormalFont", fontnum);
     play.normal_font = fontnum;
 }
 

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -155,16 +155,14 @@ void CentreGUI (int ifn) {
 
 int GetTextWidth(const char *text, int fontnum) {
   VALIDATE_STRING(text);
-  if ((fontnum < 0) || (fontnum >= game.numfonts))
-    quit("!GetTextWidth: invalid font number.");
+  fontnum = ValidateFontNumber("GetTextWidth", fontnum);
 
   return game_to_data_coord(get_text_width_outlined(text, fontnum));
 }
 
 int GetTextHeight(const char *text, int fontnum, int width) {
   VALIDATE_STRING(text);
-  if ((fontnum < 0) || (fontnum >= game.numfonts))
-    quit("!GetTextHeight: invalid font number.");
+  fontnum = ValidateFontNumber("GetTextHeight", fontnum);
 
   const char *draw_text = skip_voiceover_token(text);
   if (break_up_text_into_lines(draw_text, Lines, data_to_game_coord(width), fontnum) == 0)
@@ -174,15 +172,13 @@ int GetTextHeight(const char *text, int fontnum, int width) {
 
 int GetFontHeight(int fontnum)
 {
-  if ((fontnum < 0) || (fontnum >= game.numfonts))
-    quit("!GetFontHeight: invalid font number.");
+  fontnum = ValidateFontNumber("GetFontHeight", fontnum);
   return game_to_data_coord(get_font_height_outlined(fontnum));
 }
 
 int GetFontLineSpacing(int fontnum)
 {
-  if ((fontnum < 0) || (fontnum >= game.numfonts))
-    quit("!GetFontLineSpacing: invalid font number.");
+  fontnum = ValidateFontNumber("GetFontLineSpacing", fontnum);
   return game_to_data_coord(get_font_linespacing(fontnum));
 }
 

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -79,8 +79,7 @@ int Label_GetFont(GUILabel *labl) {
 }
 
 void Label_SetFont(GUILabel *guil, int fontnum) {
-    if ((fontnum < 0) || (fontnum >= game.numfonts))
-        quit("!SetLabelFont: invalid font number.");
+    fontnum = ValidateFontNumber("Label.Font", fontnum);
 
     if (fontnum != guil->Font) {
         guil->Font = fontnum;

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -179,9 +179,7 @@ int ListBox_GetFont(GUIListBox *listbox) {
 }
 
 void ListBox_SetFont(GUIListBox *listbox, int newfont) {
-
-  if ((newfont < 0) || (newfont >= game.numfonts))
-    quit("!ListBox.Font: invalid font number.");
+  newfont = ValidateFontNumber("ListBox.Font", newfont);
 
   if (newfont != listbox->Font) {
     listbox->SetFont(newfont);

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -32,6 +32,18 @@ using namespace AGS::Common;
 extern GameSetupStruct game;
 extern int longestline;
 
+// Tests if a font number is valid, if not then prints a warning and returns a substitution
+int ValidateFontNumber(const char *apiname, int font_num)
+{
+    if (((font_num < 0) || (font_num >= game.numfonts)) && (font_num != FONT_NULL))
+    {
+        debug_script_warn("%s: invalid font number %d, valid range is %d-%d.", font_num, 0, game.numfonts);
+        return FONT_NULL;
+    }
+    return font_num;
+}
+
+
 const char *CreateNewScriptString(const char *text)
 {
     return static_cast<const char*>(ScriptString::Create(text).Obj);

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -30,6 +30,9 @@ inline void VALIDATE_STRING(const char *strin)
         quit("!String argument was null: make sure you pass a valid string as a buffer.");
 }
 
+// Tests if a font number is valid, if not then prints a warning and returns a substitution
+int ValidateFontNumber(const char *apiname, int font_num);
+
 const char *CreateNewScriptString(const char *text);
 inline const char *CreateNewScriptString(const AGS::Common::String &text)
     { return CreateNewScriptString(text.GetCStr()); }

--- a/Engine/ac/textbox.cpp
+++ b/Engine/ac/textbox.cpp
@@ -56,8 +56,7 @@ int TextBox_GetFont(GUITextBox *guit) {
 }
 
 void TextBox_SetFont(GUITextBox *guit, int fontnum) {
-    if ((fontnum < 0) || (fontnum >= game.numfonts))
-        quit("!SetTextBoxFont: invalid font number.");
+    fontnum = ValidateFontNumber("TextBox.Font", fontnum);
 
     if (guit->Font != fontnum) {
         guit->Font = fontnum;


### PR DESCRIPTION
This is a bit of a exotic feature, it's meant to be used in a situation when you want to have an object with a valid text property, but does not really have that text drawn. One of the use cases is a button which text is used to form a sentence on a action label (MI-style), but you like to have a button image only and not the text.
Maybe there are others, like invisible speech, for instance, or else.

In script this adds `eNullFont` constant, as a part of `eFontType` enum.
Adds "Null Font" in a font selection for properties.

Codewise this is a tiny change, and does not seem to bring much with itself. Our font system already reacts safely on a "invalid" font number, reports 0 width, height, no outline, and not drawing anything with it when requested.
Works for GUI controls, and DrawingSurface.DrawString function.


NOTE: It's important to mention that this is different from "transparent" text, because the "no font" has no measurements, or rather all of them are 0. So anything that relies on the text's *render size* will not get any meaningful calculations.