### PR TITLE
New compiler: Fix bug in ternaries; revamp checks for spurious symbols after expressions

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -579,37 +579,31 @@ private:
     bool ParseExpression_CompileTime(Symbol op_sym, EvaluationResult const &eres_lhs, EvaluationResult const &eres_rhs, EvaluationResult &eres);
 
     // Parse the term given in 'expression'. The lowest-binding operator is unary 'new'
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     void ParseExpression_New(SrcList &expression, EvaluationResult &eres);
 
-    // Parse the term given in 'expression'. The lowest-binding operator is unary '-'
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
-    void ParseExpression_PrefixMinus(SrcList &expression, EvaluationResult &eres);
+    // Apply '-' to the expression 'eres'
+    void ParseExpression_PrefixMinus(EvaluationResult &eres);
 
-    // Parse the term given in 'expression'. The lowest-binding operator is unary '+'
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
-    void ParseExpression_PrefixPlus(SrcList &expression, EvaluationResult &eres);
+    // Apply '+' to the expression 'eres'
+    void ParseExpression_PrefixPlus(EvaluationResult &eres);
 
-    // Parse the term given in 'expression'. The lowest-binding operator is a boolean or bitwise negation
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
-    void ParseExpression_PrefixNegate(Symbol operation, SrcList &expression, EvaluationResult &eres);
+    // Apply boolean or bitwise negation to the expression 'eres'
+    void ParseExpression_PrefixNegate(Symbol operation, EvaluationResult &eres);
 
-    // Parse the term given in 'expression'. The lowest-binding operator is '++' or '--'.
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parse the term given in 'expression'.
+    // The lowest-binding operator is a prefix '++' or '--' that is _not_ included in the expression
+    // Parsing must use up 'expression' completely; trailing symbols cause a UserError
     void ParseExpression_PrefixCrement(Symbol op_sym, SrcList &expression, EvaluationResult &eres);
     // Parse the term given in 'expression'. The lowest-binding operator is '++' or '--'.
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     void ParseExpression_PostfixCrement(Symbol op_sym, SrcList &expression, EvaluationResult &eres);
 
-    // Parse literal int with the lowest possible value
-    // This will arrive at the parser as '-' '2147483648'
-    void ParseExpression_LongMin(EvaluationResult &eres);
-
-    // If consecutive parentheses surround the expression, strip them.
+    // If 'expression' starts with '(', then strip all fully enclosing pairs of parentheses
     void StripOutermostParens(SrcList &expression);
 
     // Parse the term given in 'expression'. The lowest-binding operator is a unary operator
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     void ParseExpression_Prefix(SrcList &expression, EvaluationResult &eres);
 
     // Parse the term given in 'expression'. The lowest-binding operator is a unary operator
@@ -622,23 +616,23 @@ private:
         SrcList &term2, EvaluationResult &eres_term2, bool result_used);
 
     // Parse the term given in 'expression'. Expression is a ternary 'a ? b : c'
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     // If result_used == false then the calling function doesn't use the term result for calculating
     // This happens when a term is called for side effect only, e.g. in the statement 'i ? --foo : ++foo;'
-    void ParseExpression_Ternary(size_t tern_idx, SrcList &expression, EvaluationResult &eres, bool result_used);
+    void ParseExpression_Ternary(size_t tern_idx, SrcList &expression, bool result_used, EvaluationResult &eres);
 
     // Parse the term given in 'expression'. The lowest-binding operator a binary operator.
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; trailing symbols cause a UserError
     void ParseExpression_Binary(size_t op_idx, SrcList &expression, EvaluationResult &eres);
 
     // Parse the term given in 'expression'. Expression begins with '('
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     // If result_used == false then the calling function doesn't use the term result for calculating
     // This happens when a term is called for side effect only, e.g. in the statement '(--foo);'
     void ParseExpression_InParens(SrcList &expression, EvaluationResult &eres, bool result_used);
 
     // Parse the term given in 'expression'. Expression does not contain operators
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
+    // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.
     // If result_used == false then the calling function doesn't use the term result for calculating
     // This happens when a term is called for side effect only, e.g. in the statement '--foo;'
     void ParseExpression_NoOps(SrcList &expression, EvaluationResult &eres, bool result_used);
@@ -646,9 +640,8 @@ private:
     // Check whether spurious symbols exist after a subterm is processed
     void ParseExpression_CheckUsedUp(AGS::SrcList &expression);
 
-    // Parse the term given in 'expression'.
-    // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
-    // If result_used == false then the calling function doesn't use the term result for calculating
+    // Parse the expression. If there are trailing symbols after the expression, throw UserError.
+    // If 'result_used' is 'false' then the calling function doesn't use the term result for calculating
     // This happens when a term is called for side effect only, e.g. in the statement '--foo;'
     void ParseExpression_Term(SrcList &expression, EvaluationResult &eres, bool result_used = true);
 

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2416,28 +2416,22 @@ TEST_F(Compile0, Ternary06) {
 
     // ternary operations with nested bracketed expressions in them
 
-    // FIXME: in the following script input some parts are removed temporarily
-    // to let full build run on CI. Enable them back after ternary parsing is fixed.
     char const *inpl = "\
-        void main()                                            \n\
-        {                                                      \n\
-            int a = 10;                                        \n\
-            int b0 = (a < 5 ? 1 : 2);                          \n\
-            int b1 = (a < 5) ? 1 : 2;                          \n\
-            int b2 = (a + 1) < 5 ? 1 : 2;                      \n\
-            int b3 = (a + (a + 1)) < 5 ? 1 : 2;                \n\
-                                                               \n\
-            int c1 = a < 5 ? (a + 1) : a;                      \n\
-                                                               \n\
-            int d1 = a < 5 ? a : (a + 1);                      \n\
-            int d2 = a < 5 ? a : (a + (a + 1));                \n\
-        }                                                      \n\
+		void main()                                            \n\
+		{                                                      \n\
+			int a = 10;                                        \n\
+			int b0 = (a < 5 ? 1 : 2);                          \n\
+			int b1 = (a < 5) ? 1 : 2;                          \n\
+			int b2 = (a + 1) < 5 ? 1 : 2;                      \n\
+			int b3 = (a + (a + 1)) < 5 ? 1 : 2;                \n\
+			int b4 = (a + (a + 1)) < (5 - a) ? 1 : 2;          \n\
+			int b5 = (a + (a + 1)) < (5 - (5 - a)) ? 1 : 2;    \n\
+			int c1 = a < 5 ? (a + 1) : a;                      \n\
+			int c2 = a < 5 ? (a + (a + 1)) : a;                \n\
+			int d1 = a < 5 ? a : (a + 1);                      \n\
+			int d2 = a < 5 ? a : (a + (a + 1));                \n\
+		}                                                      \n\
         ";
-    /*
-            int b4 = (a + (a + 1)) < (5 - a) ? 1 : 2;          \n\
-            int b5 = (a + (a + 1)) < (5 - (5 - a)) ? 1 : 2;    \n\
-            int c2 = a < 5 ? (a + (a + 1)) : a;                \n\
-    */
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());


### PR DESCRIPTION
Fixes #2069

Some ternaries weren't parsed correctly. Root cause was: When processing a ternary, the parser splits it into its components and hands off the components to be parsed in their turn. At this point, the bad code tried to make sure – in an incorrect way – that there weren't any symbols trailing one of the components. But this very check was superfluous in the first place.

Background: When the parser arrives at an expression in the source code, it isolates the whole expression and then processes exactly it, by splitting it apart and processing the respective parts. From that point onwards, it is the responsibility of each function that receives a (sub-) expression as a parameter to check that there aren't any symbols trailing after it, e.g., flag something like  `(5 + 6) %` as an error where `%` is a trailing symbol.  The _caller_ of such a function must trust that the called function does the necessary tests: It must not try to repeat these tests (separation of concerns principle).

Clarify in header file comments which functions check for trailing symbols in their `expression` parameter.

Rewrite and reorder the ‘trailing symbol’ checks so that the functions strictly only check what they are responsible for.

Fix a bug in the code that strips the outermost parentheses in an expression.

Enforce that all functions that take an expression as a parameter, don't alter that parameter.

Fix a bug in three places where a function had referenced `_src` instead of its parameter `expression`. 

Eliminate the `expression` parameter in three functions that don't actually need it.

Reinstate a googletest that had been partially commented out for unrelated reasons.

Relocate `AGS::Parser::StripOutermostParens()` in code.

