### PR TITLE
Support running interaction callbacks in any script module

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -16,7 +16,6 @@
 #include "ac/oldgamesetupstruct.h"
 #include "ac/wordsdictionary.h"
 #include "ac/dynobj/scriptaudioclip.h"
-#include "game/interactions.h"
 #include "util/string_utils.h"
 
 using namespace AGS::Common;
@@ -174,18 +173,18 @@ void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersi
         charScripts.resize(numcharacters);
         invScripts.resize(numinvitems);
         for (size_t i = 0; i < (size_t)numcharacters; ++i)
-            charScripts[i].reset(InteractionScripts::CreateFromStream(in));
+            charScripts[i] = InteractionEvents::CreateFromStream(in);
         // NOTE: new inventory items' events are loaded starting from 1 for some reason
         for (size_t i = 1; i < (size_t)numinvitems; ++i)
-            invScripts[i].reset(InteractionScripts::CreateFromStream(in));
+            invScripts[i] = InteractionEvents::CreateFromStream(in);
     }
     else // 2.x
     {
         intrChar.resize(numcharacters);
         for (size_t i = 0; i < (size_t)numcharacters; ++i)
-            intrChar[i].reset(Interaction::CreateFromStream(in));
+            intrChar[i] = Interaction::CreateFromStream(in);
         for (size_t i = 0; i < (size_t)numinvitems; ++i)
-            intrInv[i].reset(Interaction::CreateFromStream(in));
+            intrInv[i] = Interaction::CreateFromStream(in);
 
         numIntrVars = in->ReadInt32();
         for (size_t i = 0; i < (size_t)numIntrVars; ++i)

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -173,10 +173,10 @@ void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersi
         charScripts.resize(numcharacters);
         invScripts.resize(numinvitems);
         for (size_t i = 0; i < (size_t)numcharacters; ++i)
-            charScripts[i] = InteractionEvents::CreateFromStream(in);
+            charScripts[i] = InteractionEvents::CreateFromStream_v361(in);
         // NOTE: new inventory items' events are loaded starting from 1 for some reason
         for (size_t i = 1; i < (size_t)numinvitems; ++i)
-            invScripts[i] = InteractionEvents::CreateFromStream(in);
+            invScripts[i] = InteractionEvents::CreateFromStream_v361(in);
     }
     else // 2.x
     {

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -29,18 +29,10 @@
 #include "game/interactions.h"
 #include "game/main_game_file.h" // TODO: constants to separate header or split out reading functions
 
-namespace AGS
-{
-    namespace Common
-    {
-        struct AssetLibInfo;
-        typedef std::shared_ptr<Interaction> PInteraction;
-        typedef std::shared_ptr<InteractionScripts> PInteractionScripts;
-    }
-}
 
-using AGS::Common::PInteraction;
-using AGS::Common::PInteractionScripts;
+using AGS::Common::UInteraction;
+using AGS::Common::UInteractionEvents;
+using AGS::Common::InteractionVariable;
 using AGS::Common::HGameFileError;
 
 
@@ -54,12 +46,12 @@ struct GameSetupStruct : public GameSetupStructBase
     InventoryItemInfo invinfo[MAX_INV]{};
     std::vector<MouseCursor> mcurs;
     // These are old-style interaction variables created by the Interaction editor
-    AGS::Common::InteractionVariable intrVars[MAX_INTERACTION_VARIABLES];
+    InteractionVariable intrVars[MAX_INTERACTION_VARIABLES];
     int numIntrVars = 0;
-    std::vector<PInteraction> intrChar;
-    PInteraction intrInv[MAX_INV];
-    std::vector<PInteractionScripts> charScripts;
-    std::vector<PInteractionScripts> invScripts;
+    std::vector<UInteraction> intrChar;
+    UInteraction intrInv[MAX_INV];
+    std::vector<UInteractionEvents> charScripts;
+    std::vector<UInteractionEvents> invScripts;
     // TODO: why we do not use this in the engine instead of
     // loaded_game_file_version?
     int               filever;  // just used by editor

--- a/Common/game/interactions.cpp
+++ b/Common/game/interactions.cpp
@@ -16,6 +16,7 @@
 #include <string.h>
 #include "ac/common.h" // quit
 #include "util/stream.h"
+#include "util/string_utils.h"
 
 namespace AGS
 {
@@ -28,24 +29,61 @@ namespace Common
 //
 //-----------------------------------------------------------------------------
 
-std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream(Stream *in)
+std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v361(Stream *in)
 {
     std::unique_ptr<InteractionEvents> inter(new InteractionEvents());
-    const size_t evt_count = in->ReadInt32();
-    for (size_t i = 0; i < evt_count; ++i)
-    {
-        String fn = String::FromStream(in);
-        inter->Events.push_back(fn);
-    }
+    inter->Read_v361(in);
     return inter;
 }
 
-void InteractionEvents::Write(Stream *out) const
+std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v362(Stream *in)
+{
+    std::unique_ptr<InteractionEvents> inter(new InteractionEvents());
+    inter->Read_v362(in);
+    return inter;
+}
+
+void InteractionEvents::Read_v361(Stream *in)
+{
+    const size_t evt_count = in->ReadInt32();
+    for (size_t i = 0; i < evt_count; ++i)
+    {
+        Events.push_back(String::FromStream(in));
+    }
+}
+
+HError InteractionEvents::Read_v362(Stream *in)
+{
+    InteractionEventsVersion ver = (InteractionEventsVersion)in->ReadInt32();
+    if (ver != kInterEvents_v362)
+        return new Error(String::FromFormat("InteractionEvents version not supported: %d", ver));
+
+    ScriptModule = StrUtil::ReadString(in);
+    const size_t evt_count = in->ReadInt32();
+    for (size_t i = 0; i < evt_count; ++i)
+    {
+        Events.push_back(StrUtil::ReadString(in));
+    }
+    return HError::None();
+}
+
+void InteractionEvents::Write_v361(Stream *out) const
 {
     out->WriteInt32(Events.size());
     for (const auto &fn : Events)
     {
         fn.Write(out);
+    }
+}
+
+void InteractionEvents::Write_v362(Stream *out) const
+{
+    out->WriteInt32(kInterEvents_v362);
+    StrUtil::WriteString(ScriptModule, out);
+    out->WriteInt32(Events.size());
+    for (const auto &fn : Events)
+    {
+        StrUtil::WriteString(fn, out);
     }
 }
 

--- a/Common/game/interactions.h
+++ b/Common/game/interactions.h
@@ -69,6 +69,8 @@ class Stream;
 // A indexed list of function links for all the supported events.
 struct InteractionEvents
 {
+    // An optional name of a script module to run functions in
+    String ScriptModule;
     std::vector<String> Events;
 
     static std::unique_ptr<InteractionEvents> CreateFromStream(Stream *in);

--- a/Common/game/interactions.h
+++ b/Common/game/interactions.h
@@ -49,6 +49,7 @@
 
 #include <memory>
 #include <vector>
+#include "util/error.h"
 #include "util/string.h"
 
 namespace AGS
@@ -66,6 +67,12 @@ class Stream;
 //
 //-----------------------------------------------------------------------------
 
+enum InteractionEventsVersion
+{
+    kInterEvents_Initial = 0,
+    kInterEvents_v362    = 3060200,
+};
+
 // A indexed list of function links for all the supported events.
 struct InteractionEvents
 {
@@ -73,8 +80,14 @@ struct InteractionEvents
     String ScriptModule;
     std::vector<String> Events;
 
-    static std::unique_ptr<InteractionEvents> CreateFromStream(Stream *in);
-    void Write(Stream *out) const;
+    // Read and create pre-3.6.2 version of the InteractionEvents
+    static std::unique_ptr<InteractionEvents> CreateFromStream_v361(Stream *in);
+    // Read and create 3.6.2+ version of the InteractionEvents
+    static std::unique_ptr<InteractionEvents> CreateFromStream_v362(Stream *in);
+    void Read_v361(Stream *in);
+    HError Read_v362(Stream *in);
+    void Write_v361(Stream *out) const;
+    void Write_v362(Stream *out) const;
 };
 
 typedef std::unique_ptr<InteractionEvents> UInteractionEvents;

--- a/Common/game/interactions.h
+++ b/Common/game/interactions.h
@@ -12,15 +12,24 @@
 //
 //=============================================================================
 //
-// Interaction structs.
+// Interaction structs: they define engine's reaction to player interaction
+// with various game objects.
+//
+// There are two kinds of interaction systems: the modern and legacy ones.
+// The new one, represented by InteractionEvents struct, is very simple:
+// it is defined as a indexed list of script function names, where index is a
+// internal index of a interaction type or event (object-specific),
+// and function name tells which function to run, either in a global script
+// or room script (again, object-specific).
 //
 //-----------------------------------------------------------------------------
 //
-// Most of the interaction types here were used before the script and have
-// very limited capabilities. They were removed from AGS completely in
-// generation 3.0. The code is left for backwards compatibility.
+// Legacy system was used prior the proper scripting was introduced in AGS.
+// This sytem was removed from AGS Editor completely in generation 3.0,
+// so it's here strictly for backwards compatibility.
 //
-//-----------------------------------------------------------------------------
+// Legacy system is represented by Interaction struct, and is defined by a
+// tree-like collection of events, conditions and actions.
 //
 /* THE WAY THIS WORKS:
 *
@@ -39,16 +48,45 @@
 #define __AGS_CN_GAME__INTEREACTIONS_H
 
 #include <memory>
-#include "util/string_types.h"
-
-#define MAX_ACTION_ARGS             5
-#define MAX_NEWINTERACTION_EVENTS   30
-#define MAX_COMMANDS_PER_LIST       40
+#include <vector>
+#include "util/string.h"
 
 namespace AGS
 {
 namespace Common
 {
+
+class Stream;
+
+//-----------------------------------------------------------------------------
+//
+// InteractionEvents (modern interaction system).
+// A indexed list of script functions for all the supported events.
+// Indexes are object-specific.
+//
+//-----------------------------------------------------------------------------
+
+// A indexed list of function links for all the supported events.
+struct InteractionEvents
+{
+    std::vector<String> Events;
+
+    static std::unique_ptr<InteractionEvents> CreateFromStream(Stream *in);
+    void Write(Stream *out) const;
+};
+
+typedef std::unique_ptr<InteractionEvents> UInteractionEvents;
+
+
+//-----------------------------------------------------------------------------
+//
+// Interactions (legacy interaction system).
+//
+//-----------------------------------------------------------------------------
+
+#define MAX_ACTION_ARGS             5
+#define MAX_NEWINTERACTION_EVENTS   30
+#define MAX_COMMANDS_PER_LIST       40
 
 enum InterValType : int8_t
 {
@@ -156,13 +194,11 @@ struct Interaction
     void Reset();
 
     // Game static data (de)serialization
-    static Interaction *CreateFromStream(Stream *in);
-    void                Write(Stream *out) const;
+    static std::unique_ptr<Interaction> CreateFromStream(Stream *in);
+    void Write(Stream *out) const;
 
     Interaction &operator =(const Interaction &inter);
 };
-
-typedef std::shared_ptr<Interaction> PInteraction;
 
 
 // Legacy pre-3.0 kind of global and local room variables
@@ -180,15 +216,7 @@ struct InteractionVariable
 };
 
 
-// A list of script function names for all supported events
-struct InteractionScripts
-{
-    StringV ScriptFuncNames;
-
-    static InteractionScripts *CreateFromStream(Stream *in);
-};
-
-typedef std::shared_ptr<InteractionScripts> PInteractionScripts;
+typedef std::unique_ptr<Interaction> UInteraction;
 
 } // namespace Common
 } // namespace AGS

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -887,6 +887,28 @@ HError GameDataExtReader::ReadBlock(Stream *in, int /*block_id*/, const String &
             clip.fileName = StrUtil::ReadString(in);
         }
     }
+    else if (ext_id.CompareNoCase("v362_interevents") == 0)
+    {
+        // Updated InteractionEvents format, which specifies script module
+        // for object interaction events
+        size_t num_chars = in->ReadInt32();
+        if (num_chars != _ents.Game.chars.size())
+            return new Error(String::FromFormat("Mismatching number of characters: read %zu expected %zu", num_chars, _ents.Game.chars.size()));
+        for (size_t i = 0; i < (size_t)_ents.Game.numcharacters; ++i)
+            _ents.Game.charScripts[i] = InteractionEvents::CreateFromStream_v362(in);
+        size_t num_invitems = in->ReadInt32();
+        if (num_invitems != _ents.Game.numinvitems)
+            return new Error(String::FromFormat("Mismatching number of inventory items: read %zu expected %zu", num_invitems, (size_t)_ents.Game.numinvitems));
+        for (size_t i = 0; i < (size_t)_ents.Game.numinvitems; ++i)
+            _ents.Game.invScripts[i] = InteractionEvents::CreateFromStream_v362(in);
+
+        // Script module specification for GUI events
+        size_t num_gui = in->ReadInt32();
+        if (num_gui != _ents.Game.numgui)
+            return new Error(String::FromFormat("Mismatching number of GUI: read %zu expected %zu", num_gui, (size_t)_ents.Game.numgui));
+        for (size_t i = 0; i < (size_t)_ents.Game.numgui; ++i)
+            _ents.Guis[i].ScriptModule = StrUtil::ReadString(in);
+    }
     else
     {
         return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -196,15 +196,16 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
     }
 
     // Event script links
+    // NOTE: we keep pre-3.6.2 interaction format for now, room interactions don't need module selection
     if (data_ver >= kRoomVersion_300a)
     {
-        room->EventHandlers = InteractionEvents::CreateFromStream(in);
+        room->EventHandlers = InteractionEvents::CreateFromStream_v361(in);
         for (size_t i = 0; i < room->HotspotCount; ++i)
-            room->Hotspots[i].EventHandlers = InteractionEvents::CreateFromStream(in);
+            room->Hotspots[i].EventHandlers = InteractionEvents::CreateFromStream_v361(in);
         for (auto &obj : room->Objects)
-            obj.EventHandlers = InteractionEvents::CreateFromStream(in);
+            obj.EventHandlers = InteractionEvents::CreateFromStream_v361(in);
         for (size_t i = 0; i < room->RegionCount; ++i)
-            room->Regions[i].EventHandlers = InteractionEvents::CreateFromStream(in);
+            room->Regions[i].EventHandlers = InteractionEvents::CreateFromStream_v361(in);
     }
 
     if (data_ver >= kRoomVersion_200_alpha)
@@ -737,13 +738,14 @@ void WriteMainBlock(const RoomStruct *room, Stream *out)
     out->WriteInt32(0); // legacy interaction vars
     out->WriteInt32(MAX_ROOM_REGIONS);
 
-    room->EventHandlers->Write(out);
+    // NOTE: we keep pre-3.6.2 interaction format for now, room interactions don't need module selection
+    room->EventHandlers->Write_v361(out);
     for (size_t i = 0; i < room->HotspotCount; ++i)
-        room->Hotspots[i].EventHandlers->Write(out);
+        room->Hotspots[i].EventHandlers->Write_v361(out);
     for (const auto &obj : room->Objects)
-        obj.EventHandlers->Write(out);
+        obj.EventHandlers->Write_v361(out);
     for (size_t i = 0; i < room->RegionCount; ++i)
-        room->Regions[i].EventHandlers->Write(out);
+        room->Regions[i].EventHandlers->Write_v361(out);
 
     for (const auto &obj : room->Objects)
         out->WriteInt32(obj.Baseline);

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -176,10 +176,10 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
     if (data_ver >= kRoomVersion_241 && data_ver < kRoomVersion_300a)
     {
         for (size_t i = 0; i < room->HotspotCount; ++i)
-            room->Hotspots[i].Interaction.reset(Interaction::CreateFromStream(in));
+            room->Hotspots[i].Interaction = Interaction::CreateFromStream(in);
         for (auto &obj : room->Objects)
-            obj.Interaction.reset(Interaction::CreateFromStream(in));
-        room->Interaction.reset(Interaction::CreateFromStream(in));
+            obj.Interaction = Interaction::CreateFromStream(in);
+        room->Interaction = Interaction::CreateFromStream(in);
     }
 
     if (data_ver >= kRoomVersion_255b)
@@ -191,20 +191,20 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
         if (data_ver < kRoomVersion_300a)
         {
             for (size_t i = 0; i < room->RegionCount; ++i)
-                room->Regions[i].Interaction.reset(Interaction::CreateFromStream(in));
+                room->Regions[i].Interaction = Interaction::CreateFromStream(in);
         }
     }
 
     // Event script links
     if (data_ver >= kRoomVersion_300a)
     {
-        room->EventHandlers.reset(InteractionScripts::CreateFromStream(in));
+        room->EventHandlers = InteractionEvents::CreateFromStream(in);
         for (size_t i = 0; i < room->HotspotCount; ++i)
-            room->Hotspots[i].EventHandlers.reset(InteractionScripts::CreateFromStream(in));
+            room->Hotspots[i].EventHandlers = InteractionEvents::CreateFromStream(in);
         for (auto &obj : room->Objects)
-            obj.EventHandlers.reset(InteractionScripts::CreateFromStream(in));
+            obj.EventHandlers = InteractionEvents::CreateFromStream(in);
         for (size_t i = 0; i < room->RegionCount; ++i)
-            room->Regions[i].EventHandlers.reset(InteractionScripts::CreateFromStream(in));
+            room->Regions[i].EventHandlers = InteractionEvents::CreateFromStream(in);
     }
 
     if (data_ver >= kRoomVersion_200_alpha)
@@ -703,13 +703,6 @@ HRoomFileError ExtractScriptText(String &script, std::unique_ptr<Stream> &&in, R
     return HRoomFileError::None();
 }
 
-void WriteInteractionScripts(const InteractionScripts *interactions, Stream *out)
-{
-    out->WriteInt32(interactions->ScriptFuncNames.size());
-    for (size_t i = 0; i < interactions->ScriptFuncNames.size(); ++i)
-        interactions->ScriptFuncNames[i].Write(out);
-}
-
 void WriteMainBlock(const RoomStruct *room, Stream *out)
 {
     out->WriteInt32(room->BackgroundBPP);
@@ -744,13 +737,13 @@ void WriteMainBlock(const RoomStruct *room, Stream *out)
     out->WriteInt32(0); // legacy interaction vars
     out->WriteInt32(MAX_ROOM_REGIONS);
 
-    WriteInteractionScripts(room->EventHandlers.get(), out);
+    room->EventHandlers->Write(out);
     for (size_t i = 0; i < room->HotspotCount; ++i)
-        WriteInteractionScripts(room->Hotspots[i].EventHandlers.get(), out);
+        room->Hotspots[i].EventHandlers->Write(out);
     for (const auto &obj : room->Objects)
-        WriteInteractionScripts(obj.EventHandlers.get(), out);
+        obj.EventHandlers->Write(out);
     for (size_t i = 0; i < room->RegionCount; ++i)
-        WriteInteractionScripts(room->Regions[i].EventHandlers.get(), out);
+        room->Regions[i].EventHandlers->Write(out);
 
     for (const auto &obj : room->Objects)
         out->WriteInt32(obj.Baseline);

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -42,6 +42,7 @@
 #include "game/interactions.h"
 #include "util/error.h"
 #include "util/geometry.h"
+#include "util/string_types.h"
 
 struct ccScript;
 struct SpriteInfo;
@@ -165,9 +166,9 @@ struct RoomHotspot
     // Custom properties
     StringIMap  Properties;
     // Old-style interactions
-    PInteraction Interaction;
+    UInteraction Interaction;
     // Event script links
-    PInteractionScripts EventHandlers;
+    UInteractionEvents EventHandlers;
 
     // Player will automatically walk here when interacting with hotspot
     Point       WalkTo;
@@ -189,9 +190,9 @@ struct RoomObjectInfo
     // Custom properties
     StringIMap      Properties;
     // Old-style interactions
-    PInteraction    Interaction;
+    UInteraction    Interaction;
     // Event script links
-    PInteractionScripts EventHandlers;
+    UInteractionEvents EventHandlers;
 
     RoomObjectInfo();
 };
@@ -206,9 +207,9 @@ struct RoomRegion
     // Custom properties
     StringIMap      Properties;
     // Old-style interactions
-    PInteraction    Interaction;
+    UInteraction    Interaction;
     // Event script links
-    PInteractionScripts EventHandlers;
+    UInteractionEvents EventHandlers;
 
     RoomRegion();
 };
@@ -364,9 +365,9 @@ public:
     StringIMap              Properties;
     // Old-style interactions
     std::vector<InteractionVariable> LocalVariables;
-    PInteraction            Interaction;
+    UInteraction            Interaction;
     // Event script links
-    PInteractionScripts     EventHandlers;
+    UInteractionEvents      EventHandlers;
     // Compiled room script
     PScript                 CompiledScript;
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -225,6 +225,8 @@ public:
     int32_t MouseDownCtrl;  // which control has the mouse button pressed on it
     Point   MouseWasAt;     // last mouse cursor position
 
+    String  ScriptModule;   // (optional) script module which contains callbacks
+                            // for this GUI and its controls
     String  OnClickHandler; // script function name
 
 private:

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -27,7 +27,6 @@ int currentline;
 // script file format signature
 const char scfilesig[5] = "SCOM";
 
-
 ccScript *ccScript::CreateFromStream(Stream *in)
 {
     ccScript *scri = new ccScript();
@@ -39,22 +38,42 @@ ccScript *ccScript::CreateFromStream(Stream *in)
     return scri;
 }
 
+ccScript *ccScript::CreateFromStream(const std::string &name, Common::Stream *in)
+{
+    ccScript *scri = new ccScript(name);
+    if (!scri->Read(in))
+    {
+        delete scri;
+        return nullptr;
+    }
+    return scri;
+}
+
+ccScript::ccScript(const std::string &name)
+{
+    scriptname = name;
+}
+
 ccScript::ccScript(const ccScript &src)
 {
+    *this = src;
+}
+
+ccScript &ccScript::operator =(const ccScript &src)
+{
+    scriptname = src.scriptname;
     globaldata = src.globaldata;
     code = src.code;
     strings = src.strings;
     fixuptypes = src.fixuptypes;
     fixups = src.fixups;
-
     imports = src.imports;
     exports = src.exports;
     export_addr = src.export_addr;
-
     sectionNames = src.sectionNames;
     sectionOffsets = src.sectionOffsets;
-
     instances = 0; // don't copy reference count, since it's a new object
+    return *this;
 }
 
 void ccScript::Write(Stream *out)
@@ -175,6 +194,15 @@ bool ccScript::Read(Stream *in)
         return false;
     }
     return true;
+}
+
+const char *ccScript::GetScriptName() const
+{
+    if (!scriptname.empty())
+        return scriptname.c_str();
+    if (sectionNames.size() > 0)
+        return sectionNames[0].c_str();
+    return "";
 }
 
 const char* ccScript::GetSectionName(int32_t offs) const

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -16,7 +16,6 @@
 // loaded and run by the engine. A single game may have multiple scripts.
 //
 //=============================================================================
-
 #ifndef __CC_SCRIPT_H
 #define __CC_SCRIPT_H
 
@@ -31,6 +30,7 @@ using namespace AGS; // FIXME later
 struct ccScript
 {
 public:
+    std::string scriptname;
     std::vector<char> globaldata;
     std::vector<int32_t> code;    // executable byte-code, 32-bit per op or arg
     std::vector<char> strings;
@@ -48,16 +48,22 @@ public:
     int instances = 0; // reference count for this script object
 
     static ccScript *CreateFromStream(Common::Stream *in);
+    static ccScript *CreateFromStream(const std::string &name, Common::Stream *in);
 
     ccScript() = default;
+    ccScript(const std::string &name);
     ccScript(const ccScript &src);
     virtual ~ccScript() = default; // there are few derived classes, so dtor should be virtual
+
+    ccScript &operator =(const ccScript&);
+
+    const char *GetScriptName() const;
+    const char *GetSectionName(int32_t offset) const;
 
     // write the script to disk (after compiling)
     void        Write(Common::Stream *out);
     // read back a script written with Write
     bool        Read(Common::Stream *in);
-    const char* GetSectionName(int32_t offset) const;
 };
 
 typedef std::shared_ptr<ccScript> PScript;

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1319,8 +1319,11 @@ namespace AGS.Editor.Components
 
         private void GUIController_OnGetScript(string fileName, ref Script script)
         {
-            if ((fileName == Script.CURRENT_ROOM_SCRIPT_FILE_NAME) &&
-                (_loadedRoom != null))
+            if (_loadedRoom == null)
+                return;
+
+            if ((fileName == Script.CURRENT_ROOM_SCRIPT_FILE_NAME) ||
+                (fileName == _loadedRoom.ScriptFileName))
             {
                 ContentDocument document;
                 if (_roomScriptEditors.TryGetValue(_loadedRoom.Number, out document))

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -103,6 +103,7 @@ namespace AGS.Editor.Components
                 {
                     ScriptAndHeader chosenItem = _agsEditor.CurrentGame.RootScriptFolder.GetScriptAndHeaderByName(_rightClickedScript, true);
                     DeleteSingleItem(chosenItem);
+                    ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
                 }
             }
             else if (controlID == MENU_COMMAND_IMPORT)
@@ -138,6 +139,7 @@ namespace AGS.Editor.Components
             {
                 var scripts = AddNewScript("NewScript", "// new module header\r\n", "// new module script\r\n");
                 AddSingleItem(scripts);
+                ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
                 _guiController.ProjectTree.BeginLabelEdit(this, ITEM_COMMAND_PREFIX + scripts.Script.NameForLabelEdit);
             }
 			else if (controlID == COMMAND_OPEN_GLOBAL_HEADER)
@@ -501,6 +503,7 @@ namespace AGS.Editor.Components
             if (!string.IsNullOrEmpty(lastAddedScriptNodeID))
             {
                 RePopulateTreeView(lastAddedScriptNodeID);
+                ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
             }
 
             if (errors.Count > 0)
@@ -520,6 +523,7 @@ namespace AGS.Editor.Components
             newScripts[1].SaveToDisk();
             ScriptAndHeader scripts = new ScriptAndHeader(newScripts[0], newScripts[1]);
             AddSingleItem(scripts);
+            ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
             _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
             foreach (Script script in newScripts)
                 AutoComplete.ConstructCache(script, _agsEditor.GetImportedScriptHeaders(script));
@@ -739,6 +743,7 @@ namespace AGS.Editor.Components
             _editors.Clear();
 
             RePopulateTreeView(null);
+            ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
         }
 
         public override void GameSettingsChanged()
@@ -845,7 +850,7 @@ namespace AGS.Editor.Components
             {
                 _agsEditor.RenameFileOnDisk(oldScriptName, renamedScript.FileName);
 				_agsEditor.RenameFileOnDisk(associatedScript.FileName, newNameForAssociatedScript);
-				_agsEditor.CurrentGame.FilesAddedOrRemoved = true;
+                _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
                 associatedScript.FileName = newNameForAssociatedScript;
             }
 
@@ -860,6 +865,7 @@ namespace AGS.Editor.Components
             }
 
             RePopulateTreeView(GetNodeID(renamedScript));
+            ScriptListTypeConverter.SetScriptList(Factory.AGSEditor.CurrentGame.ScriptsAndHeaders);
         }
 
         protected override ProjectTreeItem CreateTreeItemForItem(ScriptAndHeader item)

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -788,19 +788,20 @@ namespace AGS.Editor
 
         static void SerializeInteractionScripts(Interactions interactions, BinaryWriter writer)
         {
+            writer.Write((int)3060200); // kInterEvents_v362 version
+            FilePutString(interactions.ScriptModule, writer);
             writer.Write(interactions.ScriptFunctionNames.Length);
             foreach (string funcName in interactions.ScriptFunctionNames)
             {
-                if (funcName == null)
-                {
-                    writer.Write((byte)0);
-                }
-                else
-                {
-                    WriteString(funcName, funcName.Length, writer);
-                    writer.Write((byte)0);
-                }
+                FilePutString(funcName, writer);
             }
+        }
+
+        static void SerializeEmptyInteractionScripts(BinaryWriter writer)
+        {
+            writer.Write((int)3060200); // kInterEvents_v362 version
+            writer.Write((int)0); // empty ScriptModule string
+            writer.Write((int)0); // zero list length
         }
 
         // Encrypts an ANSI string
@@ -1481,13 +1482,15 @@ namespace AGS.Editor
                 writer.Write(flags);
                 writer.Write(new byte[3]); // 3 bytes padding
             }
+            // Pre-3.6.2 InteractionEvents: write zero-sized dummy lists here,
+            // proper events will be written in the "v362_eventscmod" extension
             for (int i = 0; i < game.Characters.Count; ++i)
             {
-                SerializeInteractionScripts(game.Characters[i].Interactions, writer);
+                writer.Write((int)0);
             }
-            for (int i = 1; i <= game.InventoryItems.Count; ++i)
+            for (int i = 1; i <= game.InventoryItems.Count; ++i) // NOTE: we write inv interactions from 1th here
             {
-                SerializeInteractionScripts(game.InventoryItems[i - 1].Interactions, writer);
+                writer.Write((int)0);
             }
             writer.Write(game.TextParser.Words.Count);
             for (int i = 0; i < game.TextParser.Words.Count; ++i)
@@ -1750,6 +1753,7 @@ namespace AGS.Editor
             WriteExtension("v360_fonts", WriteExt_360Fonts, writer, game, errors);
             WriteExtension("v360_cursors", WriteExt_360Cursors, writer, game, errors);
             WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, game, errors);
+            WriteExtension("v362_interevents", WriteExt_362InteractionEvents, writer, game, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1821,6 +1825,30 @@ namespace AGS.Editor
             {
                 FilePutString(game.AudioClips[i].ScriptName, writer);
                 FilePutString(game.AudioClips[i].CacheFileNameWithoutPath, writer);
+            }
+        }
+
+        // >= 3.6.1: object script names and names of unrestricted length
+        // this saves only those properties that were restricted in length previously
+        private static void WriteExt_362InteractionEvents(BinaryWriter writer, Game game, CompileMessages errors)
+        {
+            writer.Write(game.Characters.Count);
+            for (int i = 0; i < game.Characters.Count; ++i)
+            {
+                SerializeInteractionScripts(game.Characters[i].Interactions, writer);
+            }
+            writer.Write((int)game.InventoryItems.Count + 1); // +1 for a dummy item at id 0
+            // inventory slot 0 is unused, so write a dummy interactions struct
+            SerializeEmptyInteractionScripts(writer);
+            for (int i = 0; i < game.InventoryItems.Count; ++i)
+            {
+                SerializeInteractionScripts(game.InventoryItems[i].Interactions, writer);
+            }
+
+            writer.Write(game.GUIs.Count);
+            foreach (GUI gui in game.GUIs)
+            {
+                FilePutString(gui.ScriptModule, writer);
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1405,18 +1405,12 @@ namespace AGS.Editor
             prefsEditor.Dispose();
         }
 
-        private void ScriptFunctionUIEditor_CreateScriptFunction(bool isGlobalScript, string functionName, string parameters)
+        private void ScriptFunctionUIEditor_CreateScriptFunction(string scriptModule, string functionName, string parameters)
         {
-            string scriptToRetrieve = Script.GLOBAL_SCRIPT_FILE_NAME;
-            if (!isGlobalScript)
-            {
-                scriptToRetrieve = Script.CURRENT_ROOM_SCRIPT_FILE_NAME;
-            }
-
             if (OnGetScript != null)
             {
                 Script script = null;
-                OnGetScript(scriptToRetrieve, ref script);
+                OnGetScript(scriptModule, ref script);
                 if (script != null)
                 {
                     if (_agsEditor.AttemptToGetWriteAccess(script.FileName))
@@ -1429,15 +1423,14 @@ namespace AGS.Editor
             }
         }
 
-        private void ScriptFunctionUIEditor_OpenScriptEditor(bool isGlobalScript, string functionName)
+        private void ScriptFunctionUIEditor_OpenScriptEditor(string scriptModule, string functionName)
         {
             if (OnZoomToFile != null)
             {
                 // We need to start a timer, because we are within the
                 // property grid processing at the moment
-                string scriptName = (isGlobalScript) ? Script.GLOBAL_SCRIPT_FILE_NAME : Script.CURRENT_ROOM_SCRIPT_FILE_NAME;
                 string searchForText = "function " + functionName + "(";
-                TickOnceTimer.CreateAndStart(100, new EventHandler((sender, e) => ZoomFile_Tick(scriptName, searchForText)));
+                TickOnceTimer.CreateAndStart(100, new EventHandler((sender, e) => ZoomFile_Tick(scriptModule, searchForText)));
             }
         }
 

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -1325,7 +1325,7 @@ namespace AGS.Editor
 			object[] paramsAttribute = property.GetCustomAttributes(typeof(ScriptFunctionParametersAttribute), true);
 			if (paramsAttribute.Length > 0)
 			{
-				property.SetValue(objectToCheck, ScriptFunctionUIEditor.CreateOrOpenScriptFunction(eventHandler, itemName, property.Name, (ScriptFunctionParametersAttribute)paramsAttribute[0], true, 0), null);
+				property.SetValue(objectToCheck, ScriptFunctionUIEditor.CreateOrOpenScriptFunction(eventHandler, itemName, property.Name, (ScriptFunctionParametersAttribute)paramsAttribute[0], Script.GLOBAL_SCRIPT_FILE_NAME), null);
 			}
 		}
 

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -1130,6 +1130,7 @@ namespace AGS.Editor
 
             newControl.Name = Factory.AGSEditor.GetFirstAvailableScriptName(newControl.ControlType);
             newControl.ZOrder = _gui.Controls.Count;
+            newControl.Parent = _gui;
             newControl.ID = _gui.Controls.Count;
             _gui.Controls.Add(newControl);
             _selectedControl = newControl;

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -1293,12 +1293,12 @@ namespace AGS.Editor
 
             foreach (PropertyInfo property in objectToCheck.GetType().GetProperties())
             {
-                if (property.GetCustomAttributes(typeof(AGSEventPropertyAttribute), true).Length > 0)
+                if (property.GetCustomAttributes(typeof(AGSDefaultEventPropertyAttribute), true).Length > 0)
                 {
                     string eventHandler = (string)property.GetValue(objectToCheck, null);
 					if (eventHandler.Length > 0)
 					{
-						Factory.GUIController.ZoomToFile(Script.GLOBAL_SCRIPT_FILE_NAME, eventHandler);
+						Factory.GUIController.ZoomToFile(_gui.ScriptModule, eventHandler);
 					}
 					else 
 					{
@@ -1326,7 +1326,8 @@ namespace AGS.Editor
 			object[] paramsAttribute = property.GetCustomAttributes(typeof(ScriptFunctionParametersAttribute), true);
 			if (paramsAttribute.Length > 0)
 			{
-				property.SetValue(objectToCheck, ScriptFunctionUIEditor.CreateOrOpenScriptFunction(eventHandler, itemName, property.Name, (ScriptFunctionParametersAttribute)paramsAttribute[0], Script.GLOBAL_SCRIPT_FILE_NAME), null);
+				property.SetValue(objectToCheck, ScriptFunctionUIEditor.CreateOrOpenScriptFunction(
+                    eventHandler, itemName, property.Name, (ScriptFunctionParametersAttribute)paramsAttribute[0], _gui.ScriptModule), null);
 			}
 		}
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3646,6 +3646,8 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
     }
     catch (...) {}
 
+    String ^roomScriptName = String::Format("room{0}.asc", room->Number);
+
     room->GameID = rs.GameID;
     room->BottomEdgeY = rs.Edges.Bottom;
     room->LeftEdgeX = rs.Edges.Left;
@@ -3709,6 +3711,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		{
 			CopyInteractions(obj->Interactions, rs.Objects[i].EventHandlers.get());
 		}
+        obj->Interactions->ScriptModule = roomScriptName;
 
 		room->Objects->Add(obj);
 	}
@@ -3732,6 +3735,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		{
 			CopyInteractions(hotspot->Interactions, rs.Hotspots[i].EventHandlers.get());
 		}
+        hotspot->Interactions->ScriptModule = roomScriptName;
 	}
 
 	for (size_t i = 0; i < MAX_WALK_AREAS; ++i) 
@@ -3789,6 +3793,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		{
 			CopyInteractions(area->Interactions, rs.Regions[i].EventHandlers.get());
 		}
+        area->Interactions->ScriptModule = roomScriptName;
 	}
 
 	ConvertCustomProperties(room->Properties, &rs.Properties);
@@ -3801,6 +3806,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 	{
 		CopyInteractions(room->Interactions, rs.EventHandlers.get());
 	}
+    room->Interactions->ScriptModule = roomScriptName;
 }
 
 AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3598,6 +3598,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
             newControl->Clickable = curObj->IsClickable();
             newControl->Enabled = curObj->IsEnabled();
             newControl->Visible = curObj->IsVisible();
+            newControl->Parent = newGui;
 			newControl->ID = j;
 			newControl->Name = TextHelper::ConvertASCII(curObj->Name);
 			newGui->Controls->Add(newControl);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -68,10 +68,10 @@ using AGS::Common::GUIListBox;
 using AGS::Common::GUISlider;
 using AGS::Common::GUITextBox;
 using AGS::Common::RoomStruct;
-using AGS::Common::PInteractionScripts;
 using AGS::Common::Interaction;
 using AGS::Common::InteractionCommand;
 using AGS::Common::InteractionCommandList;
+using AGS::Common::InteractionEvents;
 typedef AGS::Common::String AGSString;
 namespace AGSDirectory = AGS::Common::Directory;
 namespace AGSFile = AGS::Common::File;
@@ -3105,14 +3105,14 @@ void ConvertInteractionCommandList(System::Text::StringBuilder^ sb, InteractionC
 	}
 }
 
-void CopyInteractions(AGS::Types::Interactions ^destination, AGS::Common::InteractionScripts *source)
+void CopyInteractions(AGS::Types::Interactions ^destination, const AGS::Common::InteractionEvents *source)
 {
-    size_t evt_count = std::min(source->ScriptFuncNames.size(), (size_t)destination->ScriptFunctionNames->Length);
+    destination->ScriptModule = TextHelper::ConvertASCII(source->ScriptModule);
+    size_t evt_count = std::min(source->Events.size(), (size_t)destination->ScriptFunctionNames->Length);
     // TODO: add a warning? if warning list would be passed in here
-
 	for (size_t i = 0; i < evt_count; i++) 
 	{
-		destination->ScriptFunctionNames[i] = TextHelper::ConvertASCII(source->ScriptFuncNames[i]);
+		destination->ScriptFunctionNames[i] = TextHelper::ConvertASCII(source->Events[i]);
 	}
 }
 
@@ -3989,14 +3989,15 @@ void save_default_crm_file(Room ^room)
     save_room_file(rs, roomFileName);
 }
 
-PInteractionScripts convert_interaction_scripts(Interactions ^interactions)
+std::unique_ptr<InteractionEvents> convert_interaction_scripts(Interactions ^interactions)
 {
-    AGS::Common::InteractionScripts *native_scripts = new AGS::Common::InteractionScripts();
+    std::unique_ptr<InteractionEvents> native_inter(new InteractionEvents());
+    native_inter->ScriptModule = TextHelper::ConvertASCII(interactions->ScriptModule);
 	for each (String^ funcName in interactions->ScriptFunctionNames)
 	{
-        native_scripts->ScriptFuncNames.push_back(TextHelper::ConvertASCII(funcName));
+        native_inter->Events.push_back(TextHelper::ConvertASCII(funcName));
 	}
-    return PInteractionScripts(native_scripts);
+    return native_inter;
 }
 
 void convert_room_interactions_to_native(Room ^room, RoomStruct &rs)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -219,10 +219,12 @@
     <Compile Include="PropertyGridExtras\ColorUIEditor.cs" />
     <Compile Include="PropertyGridExtras\CustomPropertiesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
+    <Compile Include="PropertyGridExtras\InteractionEventPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />
     <Compile Include="PropertyGridExtras\ReadOnlyConverter .cs" />
     <Compile Include="PropertyGridExtras\RoomMaskResolutionTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\RoomMessagesUIEditor.cs" />
+    <Compile Include="PropertyGridExtras\ScriptListTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\SpriteFileNameEditor.cs" />
     <Compile Include="PropertyGridExtras\SpriteSelectUIEditor.cs" />
     <Compile Include="PropertyGridExtras\TextEncodingTypeConverter.cs" />

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -50,7 +50,8 @@ namespace AGS.Types
 
         static Character()
         {
-            _interactionSchema = new InteractionSchema(new string[] {"$$01 character",
+            _interactionSchema = new InteractionSchema(Script.GLOBAL_SCRIPT_FILE_NAME, false,
+                new string[] {"$$01 character",
                 "$$02 character","$$03 character","Use inventory on character",
                 "Any click on character", "$$05 character","$$08 character", 
                 "$$09 character"}, 

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -23,6 +23,7 @@ namespace AGS.Types
         protected int _bgcol;
         protected int _bgimage;
         protected List<GUIControl> _controls = new List<GUIControl>();
+        private string _scriptModule = Script.GLOBAL_SCRIPT_FILE_NAME;
 
         /// <summary>
         /// Width of the GUI, as displayed in the Editor.
@@ -101,6 +102,17 @@ namespace AGS.Types
             }
         }
 
+        [Description("Script module which contains this GUI's event functions")]
+        [Category("(Basic)")]
+        [Browsable(false)]
+        [AGSEventsTabProperty()]
+        [TypeConverter(typeof(ScriptListTypeConverter))]
+        public string ScriptModule
+        {
+            get { return _scriptModule; }
+            set { _scriptModule = value; }
+        }
+
         [Browsable(false)]
         public string WindowTitle
         {
@@ -172,38 +184,41 @@ namespace AGS.Types
 
             foreach (XmlNode node in SerializeUtils.GetChildNodes(rootGuiNode, "Controls"))
             {
+                GUIControl control = null;
                 if (node.Name == "GUIButton")
                 {
-                    _controls.Add(new GUIButton(node));
+                    control = new GUIButton(node);
                 }
                 else if (node.Name == "GUIInventory")
                 {
-                    _controls.Add(new GUIInventory(node));
+                    control = new GUIInventory(node);
                 }
                 else if (node.Name == "GUILabel")
                 {
-                    _controls.Add(new GUILabel(node));
+                    control = new GUILabel(node);
                 }
                 else if (node.Name == "GUIListBox")
                 {
-                    _controls.Add(new GUIListBox(node));
+                    control = new GUIListBox(node);
                 }
                 else if (node.Name == "GUISlider")
                 {
-                    _controls.Add(new GUISlider(node));
+                    control = new GUISlider(node);
                 }
                 else if (node.Name == "GUITextBox")
                 {
-                    _controls.Add(new GUITextBox(node));
+                    control = new GUITextBox(node);
                 }
                 else if (node.Name == "GUITextWindowEdge")
                 {
-                    _controls.Add(new GUITextWindowEdge(node));
+                    control = new GUITextWindowEdge(node);
                 }
                 else
                 {
                     throw new InvalidDataException("Unknown control type: " + node.Name);
                 }
+                control.Parent = this;
+                _controls.Add(control);
             }
         }
 

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -45,7 +45,7 @@ namespace AGS.Types
         [Description("Script function to run when the button is clicked")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventsTabProperty(), AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty(), AGSDefaultEventProperty()]
         [ScriptFunctionParameters("GUIControl *control, MouseButton button")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnClick

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -45,7 +45,7 @@ namespace AGS.Types
         [Description("Script function to run when the button is clicked")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty()]
         [ScriptFunctionParameters("GUIControl *control, MouseButton button")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnClick

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -42,9 +42,19 @@ namespace AGS.Types
         private bool _visible = true;
         private bool _translated = true;
 
-        [AGSNoSerialize]
+        [NonSerialized]
+        private GUI _parent;
+        [NonSerialized]
         private GUIControlGroup _memberOf;
-        
+
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public GUI Parent
+        {
+            get { return _parent; }
+            set { _parent = value; }
+        }
+
         [Browsable(false)]
         [AGSNoSerialize]
         public GUIControlGroup MemberOf

--- a/Editor/AGS.Types/GUIListBox.cs
+++ b/Editor/AGS.Types/GUIListBox.cs
@@ -44,7 +44,7 @@ namespace AGS.Types
         [Description("Script function to run when the selection is changed")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventsTabProperty(), AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty(), AGSDefaultEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnSelectionChanged

--- a/Editor/AGS.Types/GUIListBox.cs
+++ b/Editor/AGS.Types/GUIListBox.cs
@@ -44,7 +44,7 @@ namespace AGS.Types
         [Description("Script function to run when the selection is changed")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnSelectionChanged

--- a/Editor/AGS.Types/GUISlider.cs
+++ b/Editor/AGS.Types/GUISlider.cs
@@ -39,7 +39,7 @@ namespace AGS.Types
         [Description("Script function to run when the slider is moved")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventsTabProperty(), AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty(), AGSDefaultEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnChange

--- a/Editor/AGS.Types/GUISlider.cs
+++ b/Editor/AGS.Types/GUISlider.cs
@@ -39,7 +39,7 @@ namespace AGS.Types
         [Description("Script function to run when the slider is moved")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnChange

--- a/Editor/AGS.Types/GUITextBox.cs
+++ b/Editor/AGS.Types/GUITextBox.cs
@@ -38,7 +38,7 @@ namespace AGS.Types
         [Description("Script function to run when return is pressed in the text box")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnActivate

--- a/Editor/AGS.Types/GUITextBox.cs
+++ b/Editor/AGS.Types/GUITextBox.cs
@@ -38,7 +38,7 @@ namespace AGS.Types
         [Description("Script function to run when return is pressed in the text box")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventsTabProperty(), AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty(), AGSDefaultEventProperty()]
         [ScriptFunctionParameters("GUIControl *control")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnActivate

--- a/Editor/AGS.Types/InteractionSchema.cs
+++ b/Editor/AGS.Types/InteractionSchema.cs
@@ -6,24 +6,42 @@ namespace AGS.Types
 {
     public class InteractionSchema
     {
+        private string _defaultScriptModule = string.Empty;
+        private bool _scriptModuleFixed = false;
         private string[] _eventNames;
         private string[] _functionSuffixes;
         private string[] _functionParameterLists;
 
-        public InteractionSchema(string[] eventNames, string[] functionSuffixes, string functionParameterList)
+        public InteractionSchema(string defaultScriptModule, bool scriptModuleFixed,
+            string[] eventNames, string[] functionSuffixes, string functionParameterList)
         {
             _eventNames = eventNames;
             _functionSuffixes = functionSuffixes;
             _functionParameterLists = new string[eventNames.Length];
             for (int i = 0; i < eventNames.Length; ++i)
                 _functionParameterLists[i] = functionParameterList;
+            _defaultScriptModule = defaultScriptModule;
+            _scriptModuleFixed = scriptModuleFixed;
         }
 
-        public InteractionSchema(string[] eventNames, string[] functionSuffixes, string[] functionParameterLists)
+        public InteractionSchema(string defaultScriptModule, bool scriptModuleFixed,
+            string[] eventNames, string[] functionSuffixes, string[] functionParameterLists)
         {
             _eventNames = eventNames;
             _functionSuffixes = functionSuffixes;
             _functionParameterLists = functionParameterLists;
+            _defaultScriptModule = defaultScriptModule;
+            _scriptModuleFixed = scriptModuleFixed;
+        }
+
+        public string DefaultScriptModule
+        {
+            get { return _defaultScriptModule; }
+        }
+
+        public bool ScriptModuleFixed
+        {
+            get { return _scriptModuleFixed; }
         }
 
         public string[] EventNames

--- a/Editor/AGS.Types/Interactions.cs
+++ b/Editor/AGS.Types/Interactions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
@@ -8,12 +9,14 @@ namespace AGS.Types
     public class Interactions
     {
         private InteractionSchema _schema;
+        private string _scriptModule = string.Empty;
         private string[] _scriptFunctionNames;
         private string[] _importedScripts;
 
         public Interactions(InteractionSchema schema)
         {
             _schema = schema;
+            _scriptModule = schema.DefaultScriptModule;
             _scriptFunctionNames = new string[schema.EventNames.Length];
             _importedScripts = new string[schema.EventNames.Length];
             Reset();
@@ -52,6 +55,20 @@ namespace AGS.Types
             }
         }
 
+        public InteractionSchema Schema
+        {
+            get { return _schema; }
+        }
+
+        //[Category("(Basic)")]
+        //[DefaultValue(Script.GLOBAL_SCRIPT_FILE_NAME)]
+        //[TypeConverter(typeof(ScriptListTypeConverter))]
+        public string ScriptModule
+        {
+            get { return _scriptModule; }
+            set { _scriptModule = value; }
+        }
+
         public string[] ScriptFunctionNames
         {
             get { return _scriptFunctionNames; }
@@ -82,6 +99,13 @@ namespace AGS.Types
             Reset();
             foreach (XmlNode child in SerializeUtils.GetChildNodes(node, "Interactions"))
             {
+                if (child.Name != "Event")
+                {
+                    if (child.Name == "ScriptModule")
+                        ScriptModule = child.InnerText;
+                    continue;
+                } 
+
                 int index = SerializeUtils.GetAttributeInt(child, "Index");
                 _scriptFunctionNames[index] = child.InnerText;
                 if (_scriptFunctionNames[index] == string.Empty)
@@ -94,6 +118,7 @@ namespace AGS.Types
         public void ToXml(XmlTextWriter writer)
         {
             writer.WriteStartElement("Interactions");
+            writer.WriteElementString("ScriptModule", ScriptModule);
             for (int i = 0; i < _scriptFunctionNames.Length; i++)
             {
                 writer.WriteStartElement("Event");

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -25,7 +25,8 @@ namespace AGS.Types
 
         static InventoryItem()
         {
-            _interactionSchema = new InteractionSchema(new string[] { "$$01 inventory item", 
+            _interactionSchema = new InteractionSchema(Script.GLOBAL_SCRIPT_FILE_NAME, false,
+                new string[] { "$$01 inventory item", 
                 "$$02 inventory item", "$$03 inventory item", "Use inventory on this item", 
                 "Other click on inventory item" },
                 new string[] { "Look", "Interact", "Talk", "UseInv", "OtherClick" },

--- a/Editor/AGS.Types/NormalGUI.cs
+++ b/Editor/AGS.Types/NormalGUI.cs
@@ -56,7 +56,7 @@ namespace AGS.Types
         [Description("Script function to run when the GUI is clicked")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty()]
         [ScriptFunctionParameters("GUI *theGui, MouseButton button")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnClick

--- a/Editor/AGS.Types/NormalGUI.cs
+++ b/Editor/AGS.Types/NormalGUI.cs
@@ -56,7 +56,7 @@ namespace AGS.Types
         [Description("Script function to run when the GUI is clicked")]
         [Category("Events")]
         [Browsable(false)]
-        [AGSEventsTabProperty(), AGSEventProperty()]
+        [AGSEventsTabProperty(), AGSEventProperty(), AGSDefaultEventProperty()]
         [ScriptFunctionParameters("GUI *theGui, MouseButton button")]
         [EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OnClick

--- a/Editor/AGS.Types/PropertyGridExtras/AGSEventPropertyAttribute.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AGSEventPropertyAttribute.cs
@@ -29,4 +29,13 @@ namespace AGS.Types
         {
         }
     }
+
+    /// <summary>
+    /// AGSDefaultEventProperty marks a event property that is assigned
+    /// when the GUI or control is double-clicked in the GUI Editor.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AGSDefaultEventPropertyAttribute : AGSEventPropertyAttribute
+    {
+    }
 }

--- a/Editor/AGS.Types/PropertyGridExtras/AGSEventPropertyAttribute.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AGSEventPropertyAttribute.cs
@@ -4,7 +4,26 @@ using System.Text;
 
 namespace AGS.Types
 {
-    public class AGSEventPropertyAttribute : Attribute
+    /// <summary>
+    /// AGSEventsTabProperty attribute marks a property that belong
+    /// to the Events tab on the Property Grid pane.
+    /// This attribute is meant for generic properties, not necessarily
+    /// a object's event.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AGSEventsTabPropertyAttribute : Attribute
+    {
+        public AGSEventsTabPropertyAttribute()
+        {
+        }
+    }
+
+    /// <summary>
+    /// AGSEventProperty attribute marks a property that defines
+    /// object's event, possible to attach a script function to.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AGSEventPropertyAttribute : AGSEventsTabPropertyAttribute
     {
         public AGSEventPropertyAttribute()
         {

--- a/Editor/AGS.Types/PropertyGridExtras/InteractionEventPropertyDescriptor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/InteractionEventPropertyDescriptor.cs
@@ -1,30 +1,36 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace AGS.Types
 {
     /// <summary>
-    /// InteractionPropertyDescriptor defines a real property from
-    /// Interactions type, wrapped and depicted as being a property of
-    /// another type instead, such as e.g. Character type.
-    /// This allows to have this pseudo-property displayed on that type's
-    /// Events properties tab.
+    /// InteractionEventPropertyDescriptor defines a programmatically generated property
+    /// associated with a certain Interactions event element.
+    /// This descriptor "tricks" its user (such as PropertyGrid) in thinking that the
+    /// property belongs to another type. This type must be passed to class constructor as "component".
+    /// This allows to have this event pseudo-property displayed for a type like e.g. Character,
+    /// while values are read and written not in Character type directly, but in its
+    /// child Interactions member.
     /// </summary>
-    public class InteractionPropertyDescriptor : PropertyDescriptor
+    public class InteractionEventPropertyDescriptor : PropertyDescriptor
     {
         private Type _componentType;
-        private bool _isReadonly;
+        private int _eventIndex;
 
-        public InteractionPropertyDescriptor(object component, string propertyName, Attribute[] attributes, bool isReadOnly)
-            : base(propertyName, attributes)
+        public InteractionEventPropertyDescriptor(object component, int eventIndex, string eventName, string displayName,
+                string parameterList)
+            :
+            base(eventName, new Attribute[]{new DisplayNameAttribute(displayName), 
+                new EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor)),
+                new CategoryAttribute("Events"),
+                new DefaultValueAttribute(string.Empty),
+                new ScriptFunctionParametersAttribute(parameterList)})
         {
             _componentType = component.GetType();
-            _isReadonly = isReadOnly;
+            _eventIndex = eventIndex;
         }
 
         public override bool CanResetValue(object component)
@@ -41,13 +47,12 @@ namespace AGS.Types
         {
             PropertyInfo interactionsProperty = component.GetType().GetProperty("Interactions");
             Interactions interactions = (Interactions)interactionsProperty.GetValue(component, null);
-            var valueProperty = typeof(Interactions).GetProperty(Name);
-            return valueProperty.GetValue(interactions);
+            return interactions.ScriptFunctionNames[_eventIndex];
         }
 
         public override bool IsReadOnly
         {
-            get { return _isReadonly; }
+            get { return false; }
         }
 
         public override Type PropertyType
@@ -62,13 +67,9 @@ namespace AGS.Types
 
         public override void SetValue(object component, object value)
         {
-            if (_isReadonly)
-                return;
-
             PropertyInfo interactionsProperty = component.GetType().GetProperty("Interactions");
             Interactions interactions = (Interactions)interactionsProperty.GetValue(component, null);
-            var valueProperty = typeof(Interactions).GetProperty(Name);
-            valueProperty.SetValue(interactions, value);
+            interactions.ScriptFunctionNames[_eventIndex] = value.ToString();
         }
 
         public override bool ShouldSerializeValue(object component)
@@ -76,4 +77,5 @@ namespace AGS.Types
             return false;
         }
     }
+
 }

--- a/Editor/AGS.Types/PropertyGridExtras/PropertyTabEvents.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/PropertyTabEvents.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms.Design;
@@ -43,7 +44,7 @@ namespace AGS.Types
 
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attrs)
         {
-            return TypeDescriptor.GetProperties(component, new Attribute[]{new AGSEventPropertyAttribute()});
+            return TypeDescriptor.GetProperties(component, new Attribute[] { new AGSEventsTabPropertyAttribute() });
         }
 
     }

--- a/Editor/AGS.Types/PropertyGridExtras/PropertyTabInteractions.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/PropertyTabInteractions.cs
@@ -52,6 +52,25 @@ namespace AGS.Types
             if (interactionsProperty != null)
             {
                 Interactions interactions = (Interactions)interactionsProperty.GetValue(component, null);
+                if (interactions.Schema.ScriptModuleFixed)
+                {
+                    propList.Add(new InteractionPropertyDescriptor(component, "ScriptModule",
+                        new Attribute[] {
+                            new CategoryAttribute("(Basic)"),
+                            new DefaultValueAttribute(interactions.Schema.DefaultScriptModule),
+                            new ReadOnlyAttribute(true)
+                        }, true));
+                }
+                else
+                {
+                    propList.Add(new InteractionPropertyDescriptor(component, "ScriptModule",
+                        new Attribute[] {
+                            new CategoryAttribute("(Basic)"),
+                            new DefaultValueAttribute(interactions.Schema.DefaultScriptModule),
+                            new TypeConverterAttribute(typeof(ScriptListTypeConverter))
+                        }, false));
+                }
+                
                 for (int i = 0; i < interactions.FunctionSuffixes.Length; i++)
                 {
                     string eventName = interactions.DisplayNames[i];
@@ -62,7 +81,7 @@ namespace AGS.Types
 					if (eventName.IndexOf("$$") < 0)
 					{
 						// Only add the event if the cursor mode exists
-						propList.Add(new InteractionPropertyDescriptor(component, i,
+						propList.Add(new InteractionEventPropertyDescriptor(component, i,
                             interactions.FunctionSuffixes[i], eventName, interactions.FunctionParameterLists[i]));
 					}
                 }

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
@@ -32,10 +32,14 @@ namespace AGS.Types
             if (context.Instance is GUI)
             {
                 itemName = ((GUI)context.Instance).Name;
+                scriptModule = ((GUI)context.Instance).ScriptModule;
             }
             else if (context.Instance is GUIControl)
             {
                 itemName = ((GUIControl)context.Instance).Name;
+                GUI gui = ((GUIControl)context.Instance).Parent;
+                if (gui != null)
+                    scriptModule = gui.ScriptModule;
             }
             else if (context.Instance is InventoryItem)
             {

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
@@ -11,9 +11,9 @@ namespace AGS.Types
 {
     public class ScriptFunctionUIEditor : UITypeEditor
     {
-        public delegate void OpenScriptEditorHandler(bool isGlobalScript, string functionName);
+        public delegate void OpenScriptEditorHandler(string scriptModule, string functionName);
         public static OpenScriptEditorHandler OpenScriptEditor;
-        public delegate void CreateScriptFunctionHandler(bool isGlobalScript, string functionName, string parameters);
+        public delegate void CreateScriptFunctionHandler(string scriptModule, string functionName, string parameters);
         public static CreateScriptFunctionHandler CreateScriptFunction;
 
         public ScriptFunctionUIEditor()
@@ -27,52 +27,60 @@ namespace AGS.Types
 
         public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            bool isGlobalScript = false;
-			int maxLength = 50; // TODO: why even 50?
             string itemName = string.Empty;
+            string scriptModule = Script.GLOBAL_SCRIPT_FILE_NAME;
             if (context.Instance is GUI)
             {
                 itemName = ((GUI)context.Instance).Name;
-                isGlobalScript = true;
             }
             else if (context.Instance is GUIControl)
             {
                 itemName = ((GUIControl)context.Instance).Name;
-                isGlobalScript = true;
             }
             else if (context.Instance is InventoryItem)
             {
                 itemName = ((InventoryItem)context.Instance).Name;
-                isGlobalScript = true;
+                scriptModule = ((InventoryItem)context.Instance).Interactions.ScriptModule;
             }
             else if (context.Instance is Character)
             {
                 itemName = ((Character)context.Instance).ScriptName;
-                isGlobalScript = true;
+                scriptModule = ((Character)context.Instance).Interactions.ScriptModule;
             }
             else if (context.Instance is Room)
             {
                 itemName = "room";
+                scriptModule = ((Room)context.Instance).Interactions.ScriptModule;
             }
             else if (context.Instance is RoomHotspot)
             {
                 itemName = ((RoomHotspot)context.Instance).Name;
+                scriptModule = ((RoomHotspot)context.Instance).Interactions.ScriptModule;
             }
             else if (context.Instance is RoomObject)
             {
                 itemName = ((RoomObject)context.Instance).Name;
+                scriptModule = ((RoomObject)context.Instance).Interactions.ScriptModule;
             }
             else if (context.Instance is RoomRegion)
             {
                 itemName = "region" + ((RoomRegion)context.Instance).ID;
+                scriptModule = ((RoomRegion)context.Instance).Interactions.ScriptModule;
+            }
+            else
+            {
+                throw new AGSEditorException($"Invalid object type for editing: {context.Instance.GetType().Name}");
             }
 
-			ScriptFunctionParametersAttribute parametersAttribute = ((ScriptFunctionParametersAttribute)context.PropertyDescriptor.Attributes[typeof(ScriptFunctionParametersAttribute)]);
+            if (!scriptModule.EndsWith(".asc"))
+                scriptModule = scriptModule + ".asc";
 
-			return CreateOrOpenScriptFunction((string)value, itemName, context.PropertyDescriptor.Name, parametersAttribute, isGlobalScript, maxLength);
+            ScriptFunctionParametersAttribute parametersAttribute = ((ScriptFunctionParametersAttribute)context.PropertyDescriptor.Attributes[typeof(ScriptFunctionParametersAttribute)]);
+
+			return CreateOrOpenScriptFunction((string)value, itemName, context.PropertyDescriptor.Name, parametersAttribute, scriptModule);
         }
 
-		public static string CreateOrOpenScriptFunction(string stringValue, string itemName, string functionSuffix, ScriptFunctionParametersAttribute parametersAttribute, bool isGlobalScript, int maxLength)
+		public static string CreateOrOpenScriptFunction(string stringValue, string itemName, string functionSuffix, ScriptFunctionParametersAttribute parametersAttribute, string scriptModule)
 		{
 			if (string.IsNullOrEmpty(stringValue))
 			{
@@ -84,20 +92,15 @@ namespace AGS.Types
 
 				stringValue = itemName + "_" + functionSuffix;
 
-				if (maxLength > 0 && stringValue.Length > maxLength)
-				{
-					stringValue = stringValue.Substring(0, maxLength);
-				}
-
 				if (CreateScriptFunction != null)
 				{
 					string parameters = parametersAttribute.Parameters;
-					CreateScriptFunction(isGlobalScript, stringValue, parameters);
+					CreateScriptFunction(scriptModule, stringValue, parameters);
 				}
 			}
 			if (OpenScriptEditor != null)
 			{
-				OpenScriptEditor(isGlobalScript, stringValue);
+				OpenScriptEditor(scriptModule, stringValue);
 			}
 			return stringValue;
 		}

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptListTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptListTypeConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AGS.Types
+{
+    public class ScriptListTypeConverter : BaseListSelectTypeConverter<string, string>
+    {
+        private static Dictionary<string, string> _possibleValues = new Dictionary<string, string>();
+        private static ScriptsAndHeaders _scripts = null;
+
+        protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _possibleValues;
+        }
+
+        public static void SetScriptList(ScriptsAndHeaders scripts)
+        {
+            // Keep a refernce to the list so it can be updated whenever we need to
+            _scripts = scripts;
+            RefreshScriptList();
+        }
+
+        public static void RefreshScriptList()
+        {
+            if (_scripts == null)
+            {
+                throw new InvalidOperationException("Static collection has not been set");
+            }
+
+            _possibleValues.Clear();
+            foreach (ScriptAndHeader script in _scripts.OrderBy(s => s.Name))
+            {
+                _possibleValues.Add(script.Script.FileName, script.Script.FileName);
+            }
+        }
+    }
+}

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -58,7 +58,9 @@ namespace AGS.Types
 
         static Room()
         {
-            _interactionSchema = new InteractionSchema(new string[] {
+            _interactionSchema = new InteractionSchema(
+                string.Empty, true,
+                new string[] {
                 "Walks off left edge",
                 "Walks off right edge",
                 "Walks off bottom edge",

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -24,7 +24,8 @@ namespace AGS.Types
 
         static RoomHotspot()
         {
-            _interactionSchema = new InteractionSchema(new string[] {"Stands on hotspot",
+            _interactionSchema = new InteractionSchema(string.Empty, true,
+                new string[] {"Stands on hotspot",
                 "$$01 hotspot","$$02 hotspot","Use inventory on hotspot",
                 "$$03 hotspot", "Any click on hotspot","Mouse moves over hotspot", 
                 "$$05 hotspot", "$$08 hotspot", "$$09 hotspot"},

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -31,7 +31,8 @@ namespace AGS.Types
 
         static RoomObject()
         {
-            _interactionSchema = new InteractionSchema(new string[] {"$$01 object",
+            _interactionSchema = new InteractionSchema(string.Empty, true,
+                new string[] {"$$01 object",
                 "$$02 object", "$$03 object",  "Use inventory on object", 
                 "Any click on object", 
                 "$$05 object", "$$08 object", "$$09 object"},

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -24,7 +24,8 @@ namespace AGS.Types
 
         static RoomRegion()
         {
-            _interactionSchema = new InteractionSchema(new string[] {
+            _interactionSchema = new InteractionSchema(string.Empty, true,
+                new string[] {
                 "While standing on region",
                 "Walks onto region", 
                 "Walks off region"},

--- a/Editor/AGS.Types/TextWindowGUI.cs
+++ b/Editor/AGS.Types/TextWindowGUI.cs
@@ -68,6 +68,8 @@ namespace AGS.Types
             _controls.Add(new GUITextWindowEdge(90, 40, 5));
             _controls.Add(new GUITextWindowEdge(40, 0, 6));
             _controls.Add(new GUITextWindowEdge(40, 90, 7));
+            foreach (var control in _controls)
+                control.Parent = this;
         }
         
         public TextWindowGUI(XmlNode rootGuiNode) : base(rootGuiNode)

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -167,8 +167,8 @@ void process_event(const AGSEvent *evp)
     else if (evp->Type == kAGSEvent_Interaction)
     {
         const auto &inter = evp->Data.Inter;
-        Interaction*evpt=nullptr;
-        PInteractionScripts scriptPtr = nullptr;
+        Interaction *obj_inter = nullptr;
+        InteractionEvents *obj_events = nullptr;
         ObjectEvent obj_evt;
 
         switch (inter.IntEvType)
@@ -177,9 +177,9 @@ void process_event(const AGSEvent *evp)
         {
             const int hotspot_id = inter.ObjID;
             if (thisroom.Hotspots[hotspot_id].EventHandlers != nullptr)
-                scriptPtr = thisroom.Hotspots[hotspot_id].EventHandlers;
+                obj_events = thisroom.Hotspots[hotspot_id].EventHandlers.get();
             else
-                evpt=&croom->intrHotspot[hotspot_id];
+                obj_inter = &croom->intrHotspot[hotspot_id];
 
             obj_evt = ObjectEvent(kScTypeRoom, "hotspot%d", hotspot_id,
                 RuntimeScriptValue().SetScriptObject(&scrHotspot[hotspot_id], &ccDynamicHotspot));
@@ -189,9 +189,9 @@ void process_event(const AGSEvent *evp)
         case kIntEventType_Room:
         {
             if (thisroom.EventHandlers != nullptr)
-                scriptPtr = thisroom.EventHandlers;
+                obj_events = thisroom.EventHandlers.get();
             else
-                evpt=&croom->intrRoom;
+                obj_inter = &croom->intrRoom;
 
             obj_evt = ObjectEvent(kScTypeRoom, "room");
             if (inter.ObjEvent == kRoomEvent_BeforeFadein) {
@@ -209,14 +209,14 @@ void process_event(const AGSEvent *evp)
             break;
         }
 
-        assert(scriptPtr || evpt);
-        if (scriptPtr != nullptr)
+        assert(obj_inter || obj_events);
+        if (obj_events)
         {
-            run_interaction_script(obj_evt, scriptPtr.get(), inter.ObjEvent);
+            run_interaction_script(obj_evt, obj_events, inter.ObjEvent);
         }
         else
         {
-            run_interaction_event(obj_evt, evpt, inter.ObjEvent);
+            run_interaction_event(obj_evt, obj_inter, inter.ObjEvent);
         }
 
         if ((inter.IntEvType == kIntEventType_Room) && (inter.ObjEvent == kRoomEvent_BeforeFadein))

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -439,7 +439,7 @@ void process_interface_click(int ifce, int btn, int mbut) {
         // click on GUI background
         RuntimeScriptValue params[]{ RuntimeScriptValue().SetScriptObject(&scrGui[ifce], &ccDynamicGUI),
             RuntimeScriptValue().SetInt32(mbut) };
-        QueueScriptFunction(kScTypeGame, guis[ifce].OnClickHandler.GetCStr(), 2, params);
+        QueueScriptFunction(kScTypeGame, ScriptFunctionRef(guis[ifce].ScriptModule, guis[ifce].OnClickHandler), 2, params);
         return;
     }
 
@@ -463,19 +463,21 @@ void process_interface_click(int ifce, int btn, int mbut) {
         // otherwise, run interface_click
         if ((theObj->GetEventCount() > 0) &&
             (!theObj->EventHandlers[0].IsEmpty()) &&
-            DoesScriptFunctionExistInModules(theObj->EventHandlers[0])) {
-                // control-specific event handler
-                if (theObj->GetEventArgs(0).FindChar(',') != String::NoIndex)
-                {
-                    RuntimeScriptValue params[]{ RuntimeScriptValue().SetScriptObject(theObj, &ccDynamicGUIObject),
-                        RuntimeScriptValue().SetInt32(mbut) };
-                    QueueScriptFunction(kScTypeGame, theObj->EventHandlers[0].GetCStr(), 2, params);
-                }
-                else
-                {
-                    RuntimeScriptValue params[]{ RuntimeScriptValue().SetScriptObject(theObj, &ccDynamicGUIObject) };
-                    QueueScriptFunction(kScTypeGame, theObj->EventHandlers[0].GetCStr(), 1, params);
-                }
+            DoesScriptFunctionExistInModules(theObj->EventHandlers[0]))
+        {
+            // control-specific event handler
+            const ScriptFunctionRef fn_ref(guis[ifce].ScriptModule, theObj->EventHandlers[0]);
+            if (theObj->GetEventArgs(0).FindChar(',') != String::NoIndex)
+            {
+                RuntimeScriptValue params[]{ RuntimeScriptValue().SetScriptObject(theObj, &ccDynamicGUIObject),
+                    RuntimeScriptValue().SetInt32(mbut) };
+                QueueScriptFunction(kScTypeGame, fn_ref, 2, params);
+            }
+            else
+            {
+                RuntimeScriptValue params[]{ RuntimeScriptValue().SetScriptObject(theObj, &ccDynamicGUIObject) };
+                QueueScriptFunction(kScTypeGame, fn_ref, 1, params);
+            }
         }
         else
         {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -463,7 +463,7 @@ void process_interface_click(int ifce, int btn, int mbut) {
         // otherwise, run interface_click
         if ((theObj->GetEventCount() > 0) &&
             (!theObj->EventHandlers[0].IsEmpty()) &&
-            DoesScriptFunctionExist(gameinst.get(), theObj->EventHandlers[0])) {
+            DoesScriptFunctionExistInModules(theObj->EventHandlers[0])) {
                 // control-specific event handler
                 if (theObj->GetEventArgs(0).FindChar(',') != String::NoIndex)
                 {

--- a/Engine/script/executingscript.cpp
+++ b/Engine/script/executingscript.cpp
@@ -57,11 +57,16 @@ void ExecutingScript::QueueAction(PostScriptAction &&act)
     PostScriptActions.push_back(std::move(act_pos));
 }
 
-void ExecutingScript::RunAnother(ScriptType sctype, const String &fnname, size_t param_count, const RuntimeScriptValue *params)
+void ExecutingScript::RunAnother(ScriptType sctype, const String &fn_name, size_t param_count, const RuntimeScriptValue *params)
+{
+    RunAnother(sctype, ScriptFunctionRef(fn_name), param_count, params);
+}
+
+void ExecutingScript::RunAnother(ScriptType sctype, const ScriptFunctionRef &fn_ref, size_t param_count, const RuntimeScriptValue *params)
 {
     QueuedScript script;
     script.ScType = sctype;
-    script.FnName = fnname;
+    script.Function = fn_ref;
     script.ParamCount = param_count;
     for (size_t p = 0; p < MAX_SCRIPT_EVT_PARAMS && p < param_count; ++p)
         script.Params[p] = params[p];

--- a/Engine/script/executingscript.h
+++ b/Engine/script/executingscript.h
@@ -27,6 +27,7 @@
 // A general script type, used to search for or run a function.
 // NOTE: "game" type may mean either "global script" or any script module,
 // depending on other circumstances.
+// TODO: get rid of this later, remains of old event function logic
 enum ScriptType
 {
     kScTypeNone,
@@ -34,10 +35,27 @@ enum ScriptType
     kScTypeRoom     // room script
 };
 
+// ScriptFunctionRef - represents a *unresolved* reference to the script function.
+// This means that it has only script and function names, but not the actual
+// pointer to a loaded bytecode.
+struct ScriptFunctionRef
+{
+    AGS::Common::String ModuleName;
+    AGS::Common::String FuncName;
+ 
+    ScriptFunctionRef() = default;
+    ScriptFunctionRef(const AGS::Common::String &fn_name)
+        : FuncName(fn_name) {}
+    ScriptFunctionRef(const AGS::Common::String &module_name, const AGS::Common::String &fn_name)
+        : ModuleName(module_name), FuncName(fn_name) {}
+    bool IsEmpty() const { return FuncName.IsEmpty(); }
+    operator bool() const { return FuncName.IsEmpty(); }
+};
+
 struct QueuedScript
 {
-    Common::String     FnName;
     ScriptType         ScType = kScTypeNone;
+    ScriptFunctionRef  Function;
     size_t             ParamCount = 0u;
     RuntimeScriptValue Params[MAX_SCRIPT_EVT_PARAMS];
 
@@ -89,7 +107,10 @@ struct ExecutingScript
 
     ExecutingScript() = default;
     void QueueAction(PostScriptAction &&act);
-    void RunAnother(ScriptType scinst, const Common::String &fnname, size_t param_count, const RuntimeScriptValue *params);
+    void RunAnother(ScriptType scinst, const AGS::Common::String &fn_name,
+        size_t param_count, const RuntimeScriptValue *params);
+    void RunAnother(ScriptType scinst, const ScriptFunctionRef &fn_ref,
+        size_t param_count, const RuntimeScriptValue *params);
 };
 
 #endif // __AGS_EE_SCRIPT__EXECUTINGSCRIPT_H

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -199,7 +199,7 @@ int run_interaction_script(const ObjectEvent &obj_evt, const InteractionEvents *
 
     // Which script do we call: global script or room script?
     const ScriptType sc_type = obj_evt.ScType;
-    QueueScriptFunction(sc_type, nint->Events[evnt], obj_evt.ParamCount, obj_evt.Params);
+    QueueScriptFunction(sc_type, ScriptFunctionRef(nint->ScriptModule, nint->Events[evnt]), obj_evt.ParamCount, obj_evt.Params);
 
     // if the room changed within the action
     if (room_was != play.room_changes)
@@ -312,12 +312,17 @@ bool DoesScriptFunctionExistInModules(const String &fn_name)
 
 void QueueScriptFunction(ScriptType sc_type, const String &fn_name, size_t param_count, const RuntimeScriptValue *params)
 {
+    QueueScriptFunction(sc_type, ScriptFunctionRef(fn_name), param_count, params);
+}
+
+void QueueScriptFunction(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count, const RuntimeScriptValue *params)
+{
     if (inside_script)
         // queue the script for the run after current script is finished
-        curscript->RunAnother(sc_type, fn_name, param_count, params);
+        curscript->RunAnother(sc_type, fn_ref, param_count, params);
     else
         // if no script is currently running, run the requested script right away
-        RunScriptFunctionAuto(sc_type, fn_name, param_count, params);
+        RunScriptFunctionAuto(sc_type, fn_ref, param_count, params);
 }
 
 static bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc)
@@ -493,6 +498,24 @@ static void RunSingleEvent(const String &tsname, size_t param_count, const Runti
     RunEventInModules(tsname, param_count, params, true);
 }
 
+// Run a single event callback in the specified script module;
+// if the name is not provided, then tries to run it in global script.
+static void RunEventInModule(const ScriptFunctionRef &fn_ref, size_t param_count, const RuntimeScriptValue *params)
+{
+    if (!fn_ref.ModuleName.IsEmpty())
+    {
+        for (size_t i = 0; i < numScriptModules; ++i)
+        {
+            if (fn_ref.ModuleName.Compare(moduleInst[i]->instanceof->GetScriptName()) == 0)
+            {
+                RunScriptFunction(moduleInst[i].get(), fn_ref.FuncName, param_count, params);
+                return;
+            }
+        }
+    }
+    RunScriptFunction(gameinst.get(), fn_ref.FuncName, param_count, params);
+}
+
 // Run claimable event in all script modules, *including* room;
 // break if event was claimed by any of the run callbacks.
 // CHECKME: should not this also break on room change / save restore, like RunUnclaimableEvent?
@@ -507,17 +530,18 @@ static void RunClaimableEvent(const String &tsname, size_t param_count, const Ru
     RunScriptFunction(gameinst.get(), tsname, param_count, params);
 }
 
-void RunScriptFunctionAuto(ScriptType sc_type, const String &tsname, size_t param_count, const RuntimeScriptValue *params)
+void RunScriptFunctionAuto(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count, const RuntimeScriptValue *params)
 {
     // If told to use a room instance, then run only there
     if (sc_type == kScTypeRoom)
     {
-        RunScriptFunctionInRoom(tsname, param_count, params);
+        RunScriptFunctionInRoom(fn_ref.FuncName, param_count, params);
         return;
     }
     // Rep-exec is only run in script modules, but not room script
     // (because room script has its own callback, attached to event slot)
-    if (strcmp(tsname.GetCStr(), REP_EXEC_NAME) == 0)
+    const String &fn_name = fn_ref.FuncName;
+    if (strcmp(fn_name.GetCStr(), REP_EXEC_NAME) == 0)
     {
         RunUnclaimableEvent(REP_EXEC_NAME);
         return;
@@ -525,15 +549,15 @@ void RunScriptFunctionAuto(ScriptType sc_type, const String &tsname, size_t para
     // Claimable event is run in all the script modules and room script,
     // before running in the globalscript instance
     // FIXME: make this condition a callback parameter?
-    if ((strcmp(tsname.GetCStr(), ScriptEventCb[kTS_KeyPress].FnName) == 0) || (strcmp(tsname.GetCStr(), ScriptEventCb[kTS_MouseClick].FnName) == 0) ||
-        (strcmp(tsname.GetCStr(), ScriptEventCb[kTS_TextInput].FnName) == 0) || (strcmp(tsname.GetCStr(), "on_event") == 0))
+    if ((strcmp(fn_name.GetCStr(), ScriptEventCb[kTS_KeyPress].FnName) == 0) || (strcmp(fn_name.GetCStr(), ScriptEventCb[kTS_MouseClick].FnName) == 0) ||
+        (strcmp(fn_name.GetCStr(), ScriptEventCb[kTS_TextInput].FnName) == 0) || (strcmp(fn_name.GetCStr(), "on_event") == 0))
     {
-        RunClaimableEvent(tsname, param_count, params);
+        RunClaimableEvent(fn_name, param_count, params);
         return;
     }
 
-    // Else run first found event in script modules (except room)
-    return RunSingleEvent(tsname, param_count, params);
+    // Else run this event in script modules (except room) according to the function ref
+    return RunEventInModule(fn_ref, param_count, params);
 }
 
 void AllocScriptModules()
@@ -714,7 +738,7 @@ void post_script_cleanup() {
 
     for (const auto &script : copyof.ScFnQueue) {
         old_room_number = displayed_room;
-        RunScriptFunctionAuto(script.ScType, script.FnName.GetCStr(), script.ParamCount, script.Params);
+        RunScriptFunctionAuto(script.ScType, script.Function, script.ParamCount, script.Params);
         if (script.ScType == kScTypeRoom && script.ParamCount == 1)
         {
             // some bogus hack for "on_call" event handler

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -174,15 +174,15 @@ int run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evn
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
 // (eg. a room change occured)
-int run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny) {
-
-    if (evnt < 0 || static_cast<size_t>(evnt) >= nint->ScriptFuncNames.size() ||
-            nint->ScriptFuncNames[evnt].IsEmpty()) {
+int run_interaction_script(const ObjectEvent &obj_evt, const InteractionEvents *nint, int evnt, int chkAny)
+{
+    if (evnt < 0 || static_cast<size_t>(evnt) >= nint->Events.size() ||
+            nint->Events[evnt].IsEmpty()) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
         if (chkAny < 0) ;
-        else if (!nint->ScriptFuncNames[chkAny].IsEmpty())
+        else if (!nint->Events[chkAny].IsEmpty())
             return 0;
 
         // Otherwise, run unhandled_event
@@ -199,7 +199,7 @@ int run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint,
 
     // Which script do we call: global script or room script?
     const ScriptType sc_type = obj_evt.ScType;
-    QueueScriptFunction(sc_type, nint->ScriptFuncNames[evnt].GetCStr(), obj_evt.ParamCount, obj_evt.Params);
+    QueueScriptFunction(sc_type, nint->Events[evnt], obj_evt.ParamCount, obj_evt.Params);
 
     // if the room changed within the action
     if (room_was != play.room_changes)

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -25,7 +25,7 @@
 using AGS::Common::String;
 using AGS::Common::Interaction;
 using AGS::Common::InteractionCommandList;
-using AGS::Common::InteractionScripts;
+using AGS::Common::InteractionEvents;
 using AGS::Common::InteractionVariable;
 
 #define LATE_REP_EXEC_ALWAYS_NAME "late_repeatedly_execute_always"
@@ -109,7 +109,7 @@ int     run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int
 // Runs the ObjectEvent using a script callback of 'evnt' index,
 // or alternatively of 'chkAny' index, if previous does not exist
 // Returns 0 normally, or -1 telling of a game state change (eg. a room change occured).
-int     run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny = -1);
+int     run_interaction_script(const ObjectEvent &obj_evt, const InteractionEvents *nint, int evnt, int chkAny = -1);
 int     run_interaction_commandlist(const ObjectEvent &obj_evt, InteractionCommandList *nicl, int *timesrun, int*cmdsrun);
 void    run_unhandled_event(const ObjectEvent &obj_evt, int evnt);
 

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -129,8 +129,14 @@ ccInstance *GetScriptInstanceByType(ScriptType sc_type);
 bool    DoesScriptFunctionExist(ccInstance *sci, const String &fn_name);
 // Tests if a function exists in any of the regular script module, *except* room script
 bool    DoesScriptFunctionExistInModules(const String &fn_name);
-// Queues a script function to be run either called by the engine or from another script
+// Queues a script function to be run either called by the engine or from another script;
+// the function is identified by its name, and will be run in time, by RunScriptFunctionAuto().
 void    QueueScriptFunction(ScriptType sc_type, const String &fn_name, size_t param_count = 0,
+    const RuntimeScriptValue *params = nullptr);
+// Queues a script function to be run either called by the engine or from another script;
+// the function is identified by its name and script module, and will be run in time,
+// by RunScriptFunctionAuto().
+void    QueueScriptFunction(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count = 0,
     const RuntimeScriptValue *params = nullptr);
 // Try to run a script function on a given script instance
 RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t param_count = 0,
@@ -144,7 +150,7 @@ void    RunScriptFunctionInRoom(const String &tsname, size_t param_count = 0,
     const RuntimeScriptValue *params = nullptr);
 // Try to run a script function, guessing the behavior by its name and script instance type;
 // depending on the type may run a claimable callback chain
-void   RunScriptFunctionAuto(ScriptType sc_type, const String &fn_name, size_t param_count = 0,
+void   RunScriptFunctionAuto(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count = 0,
     const RuntimeScriptValue *params = nullptr);
 
 // Preallocates script module instances


### PR DESCRIPTION
Fix #485

When running a global object's interaction function, the engine will search in all modules in their order, until it finds a matching function. Only the first found callback is run, the others (if any exist) are skipped.

There's still a question of how to handle this in the Editor.
I can try to make Editor jump to the correct place when user presses "..." button in events table with existing function.
But all the new functions will be still generated in GlobalScript. I cannot see any easy way to reconfigure this.

EDIT:
Hmm, here's what I may try:
1. Add a new field to the types, related to events, which caches the script file where event functions are located. Since nothing prevents user from moving these around, I suppose this may store the location of a first filled event. After all, this is not a restriction, but is for a convenience. This field will not be saved to game, and not used at runtime.
2. When adding for a new event, Editor will insert a function in the script, referenced by this script name cache field. If that script does not exist, then it will recache the name based on which events exists, searching for them in all scripts, or using global script if there's none.
3. When opening a connected event function for editing, Editor will first try to zoom into this cached script name. If that script does not exist, or function not found, it then will recache and search further, as explained above.
