### PR TITLE
GUI Buttons can wrap & pad text, GUI Labels full alignment

### DIFF
--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -136,6 +136,7 @@ public:
         if (_pool.size() == _count) _pool.resize(_count + 1);
         _pool[_count++].SetString(cstr);
     }
+    inline const std::vector<AGS::Common::String> &GetVector() const { return _pool; }
 
     // Auxiliary line processing buffers
     std::string LineBuf[2];

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -909,6 +909,20 @@ HError GameDataExtReader::ReadBlock(Stream *in, int /*block_id*/, const String &
         for (size_t i = 0; i < (size_t)_ents.Game.numgui; ++i)
             _ents.Guis[i].ScriptModule = StrUtil::ReadString(in);
     }
+    else if (ext_id.CompareNoCase("v362_guictrls") == 0)
+    {
+        size_t num_guibut = in->ReadInt32();
+        if (num_guibut != _ents.GuiControls.Buttons.size())
+            return new Error(String::FromFormat("Mismatching number of GUI buttons: read %zu expected %zu", num_guibut, _ents.GuiControls.Buttons.size()));
+        for (GUIButton &but : _ents.GuiControls.Buttons)
+        {
+            // button padding
+            but.TextPaddingHor = in->ReadInt32();
+            but.TextPaddingVer = in->ReadInt32();
+            in->ReadInt32(); // reserve 2 ints
+            in->ReadInt32();
+        }
+    }
     else
     {
         return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -60,6 +60,8 @@ GUIButton::GUIButton()
     Font = 0;
     TextColor = 0;
     TextAlignment = kAlignTopCenter;
+    TextPaddingHor = DefaultHorPadding;
+    TextPaddingVer = DefaultVerPadding;
     ClickAction[kGUIClickLeft] = kGUIAction_RunScript;
     ClickAction[kGUIClickRight] = kGUIAction_RunScript;
     ClickData[kGUIClickLeft] = 0;
@@ -162,11 +164,10 @@ Rect GUIButton::CalcGraphicRect(bool clipped)
     if (!IsImageButton() || ((_placeholder == kButtonPlace_None) && !_unnamed))
     {
         PrepareTextToDraw();
-        Rect frame = RectWH(0 + 2, 0 + 2, _width - 4, _height - 4);
+        Rect frame = RectWH(TextPaddingHor, TextPaddingVer, _width - TextPaddingHor * 2, _height - TextPaddingVer * 2);
         if (IsPushed && IsMouseOver)
         {
-            frame.Left++;
-            frame.Top++;
+            frame = frame.MoveBy(frame, 1, 1);
         }
 
         Rect text_rc = IsWrapText() ?
@@ -414,7 +415,6 @@ void GUIButton::ReadFromFile(Stream *in, GuiVersion gui_version)
 void GUIButton::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
 {
     GUIObject::ReadFromSavegame(in, svg_ver);
-    // Properties
     _image = in->ReadInt32();
     _mouseOverImage = in->ReadInt32();
     _pushedImage = in->ReadInt32();
@@ -423,8 +423,16 @@ void GUIButton::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
     SetText(StrUtil::ReadString(in));
     if (svg_ver >= kGuiSvgVersion_350)
         TextAlignment = (FrameAlignment)in->ReadInt32();
-    // Dynamic state
+    // CHECKME: possibly this may be avoided, and currentimage updated according
+    // to the button state after load
     _currentImage = in->ReadInt32();
+    if (svg_ver >= kGuiSvgVersion_36202)
+    {
+        TextPaddingHor = in->ReadInt32();
+        TextPaddingVer = in->ReadInt32();
+        in->ReadInt32(); // reserve 2 ints
+        in->ReadInt32();
+    }
 
     // Update current state after reading
     IsPushed = false;
@@ -433,7 +441,6 @@ void GUIButton::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
 
 void GUIButton::WriteToSavegame(Stream *out) const
 {
-    // Properties
     GUIObject::WriteToSavegame(out);
     out->WriteInt32(_image);
     out->WriteInt32(_mouseOverImage);
@@ -442,8 +449,11 @@ void GUIButton::WriteToSavegame(Stream *out) const
     out->WriteInt32(TextColor);
     StrUtil::WriteString(GetText(), out);
     out->WriteInt32(TextAlignment);
-    // Dynamic state
     out->WriteInt32(_currentImage);
+    out->WriteInt32(TextPaddingHor);
+    out->WriteInt32(TextPaddingVer);
+    out->WriteInt32(0); // reserve 2 ints
+    out->WriteInt32(0);
 }
 
 void GUIButton::DrawImageButton(Bitmap *ds, int x, int y, bool draw_disabled)
@@ -505,12 +515,11 @@ void GUIButton::DrawText(Bitmap *ds, int x, int y, bool draw_disabled)
     // but that will require to update all gui controls when translation is changed in game
     PrepareTextToDraw();
 
-    Rect frame = RectWH(x + 2, y + 2, _width - 4, _height - 4);
+    Rect frame = RectWH(x + TextPaddingHor, y + TextPaddingVer, _width - TextPaddingHor * 2, _height - TextPaddingVer * 2);
     if (IsPushed && IsMouseOver)
     {
         // move the Text a bit while pushed
-        frame.Left++;
-        frame.Top++;
+        frame = frame.MoveBy(frame, 1, 1);
     }
     color_t text_color = ds->GetCompatibleColor(TextColor);
     if (draw_disabled)

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -168,7 +168,7 @@ Rect GUIButton::CalcGraphicRect(bool clipped)
             frame.Left++;
             frame.Top++;
         }
-        rc = SumRects(rc, GUI::CalcTextGraphicalRect(_textToDraw.GetCStr(), Font, frame, TextAlignment));
+        rc = SumRects(rc, GUI::CalcTextGraphicalRect(_textToDraw, Font, frame, TextAlignment));
     }
     return rc;
 }
@@ -502,7 +502,7 @@ void GUIButton::DrawText(Bitmap *ds, int x, int y, bool draw_disabled)
     color_t text_color = ds->GetCompatibleColor(TextColor);
     if (draw_disabled)
         text_color = ds->GetCompatibleColor(8);
-    GUI::DrawTextAligned(ds, _textToDraw.GetCStr(), Font, text_color, frame, TextAlignment);
+    GUI::DrawTextAligned(ds, _textToDraw, Font, text_color, frame, TextAlignment);
 }
 
 void GUIButton::DrawTextButton(Bitmap *ds, int x, int y, bool draw_disabled)

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -66,6 +66,10 @@ enum GUIButtonPlaceholder
 class GUIButton : public GUIObject
 {
 public:
+    // Default text padding
+    static const int DefaultHorPadding = 2;
+    static const int DefaultVerPadding = 2;
+
     GUIButton();
 
     bool HasAlphaChannel() const override;
@@ -107,10 +111,12 @@ public:
     int32_t     Font;
     color_t     TextColor;
     FrameAlignment TextAlignment;
+    int32_t     TextPaddingHor;
+    int32_t     TextPaddingVer;
     // Click actions for left and right mouse buttons
     // NOTE: only left click is currently in use
     GUIClickAction ClickAction[kNumGUIClicks];
-    int32_t        ClickData[kNumGUIClicks];
+    int32_t     ClickData[kNumGUIClicks];
 
     bool        IsPushed;
     bool        IsMouseOver;

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -88,6 +88,7 @@ public:
     void SetPushedImage(int32_t image);
     void SetImages(int32_t normal, int32_t over, int32_t pushed);
     void SetText(const String &text);
+    void SetWrapText(bool on);
 
     // Events
     bool OnMouseDown() override;

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -139,6 +139,7 @@ enum GUIControlFlags
     kGUICtrl_Clip       = 0x0020, // only button
     kGUICtrl_Clickable  = 0x0040,
     kGUICtrl_Translated = 0x0080, // 3.3.0.1132
+    kGUICtrl_WrapText   = 0x0100, // 3.6.2
     kGUICtrl_Deleted    = 0x8000, // unused (probably remains from the old editor?)
 
     kGUICtrl_DefFlags   = kGUICtrl_Enabled | kGUICtrl_Visible | kGUICtrl_Clickable |

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -193,7 +193,8 @@ enum GuiSvgVersion
     kGuiSvgVersion_36020,
     kGuiSvgVersion_36023,
     kGuiSvgVersion_36025,
-    kGuiSvgVersion_36200    = 3060200 // re-added control refs
+    kGuiSvgVersion_36200    = 3060200, // re-added control refs
+    kGuiSvgVersion_36202    = 3060202
 };
 
 // Style of GUI drawing in disabled state

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -30,7 +30,7 @@ GUILabel::GUILabel()
 {
     Font = 0;
     TextColor = 0;
-    TextAlignment = kHAlignLeft;
+    TextAlignment = kAlignTopLeft;
 
     _scEventCount = 0;
 }
@@ -125,9 +125,9 @@ void GUILabel::ReadFromFile(Stream *in, GuiVersion gui_version)
     Font = in->ReadInt32();
     TextColor = in->ReadInt32();
     if (gui_version < kGuiVersion_350)
-        TextAlignment = ConvertLegacyGUIAlignment((LegacyGUIAlignment)in->ReadInt32());
+        TextAlignment = (FrameAlignment)ConvertLegacyGUIAlignment((LegacyGUIAlignment)in->ReadInt32());
     else
-        TextAlignment = (HorAlignment)in->ReadInt32();
+        TextAlignment = (FrameAlignment)in->ReadInt32();
 
     if (TextColor == 0)
         TextColor = 16;
@@ -142,7 +142,7 @@ void GUILabel::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
     TextColor = in->ReadInt32();
     Text = StrUtil::ReadString(in);
     if (svg_ver >= kGuiSvgVersion_350)
-        TextAlignment = (HorAlignment)in->ReadInt32();
+        TextAlignment = (FrameAlignment)in->ReadInt32();
 
     _textMacro = GUI::FindLabelMacros(Text);
 }

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -74,7 +74,7 @@ Rect GUILabel::CalcGraphicRect(bool clipped)
         i < Lines.Count() && (!limit_by_label_frame || at_y <= _height);
         ++i, at_y += linespacing)
     {
-        Line lpos = GUI::CalcTextPositionHor(Lines[i].GetCStr(), Font, 0, 0 + _width - 1, at_y,
+        Line lpos = GUI::CalcTextPositionHor(Lines[i], Font, 0, 0 + _width - 1, at_y,
             (FrameAlignment)TextAlignment);
         max_line.X2 = std::max(max_line.X2, lpos.X2);
     }
@@ -105,7 +105,7 @@ void GUILabel::Draw(Bitmap *ds, int x, int y)
         i < Lines.Count() && (!limit_by_label_frame || at_y <= y + _height);
         ++i, at_y += linespacing)
     {
-        GUI::DrawTextAlignedHor(ds, Lines[i].GetCStr(), Font, text_color, x, x + _width - 1, at_y,
+        GUI::DrawTextAlignedHor(ds, Lines[i], Font, text_color, x, x + _width - 1, at_y,
             (FrameAlignment)TextAlignment);
     }
 }

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -68,21 +68,9 @@ Rect GUILabel::CalcGraphicRect(bool clipped)
         get_font_linespacing(Font);
     // < 2.72 labels did not limit vertical size of text
     const bool limit_by_label_frame = loaded_game_file_version >= kGameVersion_272;
-    int at_y = 0;
-    Line max_line;
-    for (size_t i = 0;
-        i < Lines.Count() && (!limit_by_label_frame || at_y <= _height);
-        ++i, at_y += linespacing)
-    {
-        Line lpos = GUI::CalcTextPositionHor(Lines[i], Font, 0, 0 + _width - 1, at_y,
-            (FrameAlignment)TextAlignment);
-        max_line.X2 = std::max(max_line.X2, lpos.X2);
-    }
-    // Include font fixes for the first and last text line,
-    // in case graphical height is different, and there's a VerticalOffset
-    Line vextent = GUI::CalcFontGraphicalVExtent(Font);
-    Rect text_rc = RectWH(0, vextent.Y1, max_line.X2 - max_line.X1 + 1,
-        at_y - linespacing + (vextent.Y2 - vextent.Y1));
+
+    Rect text_rc = GUI::CalcTextGraphicalRect(Lines.GetVector(), Lines.Count(), Font, linespacing,
+        RectWH(0, 0, _width, _height), (FrameAlignment)TextAlignment, limit_by_label_frame);
     return SumRects(rc, text_rc);
 }
 
@@ -100,14 +88,8 @@ void GUILabel::Draw(Bitmap *ds, int x, int y)
         get_font_linespacing(Font);
     // < 2.72 labels did not limit vertical size of text
     const bool limit_by_label_frame = loaded_game_file_version >= kGameVersion_272;
-    int at_y = y;
-    for (size_t i = 0;
-        i < Lines.Count() && (!limit_by_label_frame || at_y <= y + _height);
-        ++i, at_y += linespacing)
-    {
-        GUI::DrawTextAlignedHor(ds, Lines[i], Font, text_color, x, x + _width - 1, at_y,
-            (FrameAlignment)TextAlignment);
-    }
+    GUI::DrawTextLinesAligned(ds, Lines.GetVector(), Lines.Count(), Font, linespacing, text_color,
+        RectWH(x, y, _width, _height), (FrameAlignment)TextAlignment, limit_by_label_frame);
 }
 
 void GUILabel::SetText(const String &text)

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -50,7 +50,7 @@ public:
     String  Text;
     int32_t Font;
     color_t TextColor;
-    HorAlignment TextAlignment;
+    FrameAlignment TextAlignment;
 
 private:
     // Transforms the Text property to a drawn text, applies translation,

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -104,7 +104,7 @@ Rect GUIListBox::CalcGraphicRect(bool clipped)
         int at_y = pixel_size + item * RowHeight;
         int item_index = item + TopItem;
         PrepareTextToDraw(Items[item_index]);
-        Line lpos = GUI::CalcTextPositionHor(_textToDraw.GetCStr(), Font, 1 + pixel_size, right_hand_edge, at_y + 1,
+        Line lpos = GUI::CalcTextPositionHor(_textToDraw, Font, 1 + pixel_size, right_hand_edge, at_y + 1,
             (FrameAlignment)TextAlignment);
         max_line.X2 = std::max(max_line.X2, lpos.X2);
     }
@@ -209,7 +209,7 @@ void GUIListBox::Draw(Bitmap *ds, int x, int y)
         int item_index = item + TopItem;
         PrepareTextToDraw(Items[item_index]);
 
-        GUI::DrawTextAlignedHor(ds, _textToDraw.GetCStr(), Font, text_color, x + 1 + pixel_size, right_hand_edge, at_y + 1,
+        GUI::DrawTextAlignedHor(ds, _textToDraw, Font, text_color, x + 1 + pixel_size, right_hand_edge, at_y + 1,
             (FrameAlignment)TextAlignment);
     }
     ds->SetClip(old_clip);

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -765,14 +765,14 @@ Line CalcFontGraphicalVExtent(int font)
     return Line(0, top, 0, bottom);
 }
 
-Point CalcTextPosition(const char *text, int font, const Rect &frame, FrameAlignment align, Rect *gr_rect)
+Point CalcTextPosition(const String &text, int font, const Rect &frame, FrameAlignment align, Rect *gr_rect)
 {
     // When aligning we use the formal font's height, which in practice may not be
     // its real graphical height (this is because of historical AGS's font behavior)
     int use_height = (loaded_game_file_version < kGameVersion_360_21) ?
         get_font_height(font) + ((align & kMAlignVCenter) ? 1 : 0) :
         get_font_height_outlined(font);
-    Rect rc = AlignInRect(frame, RectWH(0, 0, get_text_width_outlined(text, font), use_height), align);
+    Rect rc = AlignInRect(frame, RectWH(0, 0, get_text_width_outlined(text.GetCStr(), font), use_height), align);
     if (gr_rect)
     {
         Line vextent = CalcFontGraphicalVExtent(font);
@@ -781,22 +781,22 @@ Point CalcTextPosition(const char *text, int font, const Rect &frame, FrameAlign
     return rc.GetLT();
 }
 
-Line CalcTextPositionHor(const char *text, int font, int x1, int x2, int y, FrameAlignment align)
+Line CalcTextPositionHor(const String &text, int font, int x1, int x2, int y, FrameAlignment align)
 {
-    int w = get_text_width_outlined(text, font);
+    int w = get_text_width_outlined(text.GetCStr(), font);
     int x = AlignInHRange(x1, x2, 0, w, align);
     return Line(x, y, x + w - 1, y);
 }
 
-Rect CalcTextGraphicalRect(const char *text, int font, const Point &at)
+Rect CalcTextGraphicalRect(const String &text, int font, const Point &at)
 {
     // Calc only width, and let CalcFontGraphicalVExtent() calc height
-    int w = get_text_width_outlined(text, font);
+    int w = get_text_width_outlined(text.GetCStr(), font);
     Line vextent = CalcFontGraphicalVExtent(font);
     return RectWH(at.X, at.Y + vextent.Y1, w, vextent.Y2 - vextent.Y1);
 }
 
-Rect CalcTextGraphicalRect(const char *text, int font, const Rect &frame, FrameAlignment align)
+Rect CalcTextGraphicalRect(const String &text, int font, const Rect &frame, FrameAlignment align)
 {
     Rect gr_rect;
     CalcTextPosition(text, font, frame, align, &gr_rect);
@@ -815,16 +815,16 @@ void DrawDisabledEffect(Bitmap *ds, const Rect &rc)
     }
 }
 
-void DrawTextAligned(Bitmap *ds, const char *text, int font, color_t text_color, const Rect &frame, FrameAlignment align)
+void DrawTextAligned(Bitmap *ds, const String &text, int font, color_t text_color, const Rect &frame, FrameAlignment align)
 {
     Point pos = CalcTextPosition(text, font, frame, align);
-    wouttext_outline(ds, pos.X, pos.Y, font, text_color, text);
+    wouttext_outline(ds, pos.X, pos.Y, font, text_color, text.GetCStr());
 }
 
-void DrawTextAlignedHor(Bitmap *ds, const char *text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align)
+void DrawTextAlignedHor(Bitmap *ds, const String &text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align)
 {
     Line line = CalcTextPositionHor(text, font, x1, x2, y, align);
-    wouttext_outline(ds, line.X1, y, font, text_color, text);
+    wouttext_outline(ds, line.X1, y, font, text_color, text.GetCStr());
 }
 
 GUILabelMacro FindLabelMacros(const String &text)

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -298,16 +298,16 @@ namespace GUI
     String ApplyTextDirection(const String &text);
     // Calculates the text's draw position, given the alignment
     // optionally returns the real graphical rect that the text would occupy
-    Point CalcTextPosition(const char *text, int font, const Rect &frame, FrameAlignment align, Rect *gr_rect = nullptr);
+    Point CalcTextPosition(const String &text, int font, const Rect &frame, FrameAlignment align, Rect *gr_rect = nullptr);
     // Calculates the text's draw position and horizontal extent,
     // using strictly horizontal alignment
-    Line CalcTextPositionHor(const char *text, int font, int x1, int x2, int y, FrameAlignment align);
+    Line CalcTextPositionHor(const String &text, int font, int x1, int x2, int y, FrameAlignment align);
     // Calculates the graphical rect that the text would occupy
     // if drawn at the given coordinates
-    Rect CalcTextGraphicalRect(const char *text, int font, const Point &at);
+    Rect CalcTextGraphicalRect(const String &text, int font, const Point &at);
     // Calculates the graphical rect that the text would occupy
     // if drawn aligned to the given frame
-    Rect CalcTextGraphicalRect(const char *text, int font, const Rect &frame, FrameAlignment align);
+    Rect CalcTextGraphicalRect(const String &text, int font, const Rect &frame, FrameAlignment align);
     // Calculates a vertical graphical extent for a given font,
     // which is a top and bottom offsets in zero-based coordinates.
     // NOTE: this applies font size fixups.
@@ -315,9 +315,9 @@ namespace GUI
     // Draw standart "shading" effect over rectangle
     void DrawDisabledEffect(Bitmap *ds, const Rect &rc);
     // Draw text aligned inside rectangle
-    void DrawTextAligned(Bitmap *ds, const char *text, int font, color_t text_color, const Rect &frame, FrameAlignment align);
+    void DrawTextAligned(Bitmap *ds, const String &text, int font, color_t text_color, const Rect &frame, FrameAlignment align);
     // Draw text aligned horizontally inside given bounds
-    void DrawTextAlignedHor(Bitmap *ds, const char *text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align);
+    void DrawTextAlignedHor(Bitmap *ds, const String &text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align);
 
     // Parses the string and returns combination of label macro flags
     GUILabelMacro FindLabelMacros(const String &text);
@@ -326,7 +326,7 @@ namespace GUI
     String TransformTextForDrawing(const String &text, bool translate, bool apply_direction);
     // Wraps given text to make it fit into width, stores it in the lines;
     // apply_direction param tells whether text direction setting should be applied
-    size_t SplitLinesForDrawing(const char *text, bool apply_direction, SplitLines &lines, int font, int width, size_t max_lines = -1);
+    size_t SplitLinesForDrawing(const String &text, bool apply_direction, SplitLines &lines, int font, int width, size_t max_lines = -1);
 
     // Reads all GUIs and their controls.
     HError ReadGUI(std::vector<GUIMain> &guis, GUIRefCollection &guiobjs, Stream *in);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -308,6 +308,10 @@ namespace GUI
     // Calculates the graphical rect that the text would occupy
     // if drawn aligned to the given frame
     Rect CalcTextGraphicalRect(const String &text, int font, const Rect &frame, FrameAlignment align);
+    // Calculates the graphical rect that the multiline text would occupy
+    // if drawn aligned to the given frame
+    Rect CalcTextGraphicalRect(const std::vector<String> &text, size_t item_count, int font, int linespace, 
+        const Rect &frame, FrameAlignment align, bool limit_by_frame = true);
     // Calculates a vertical graphical extent for a given font,
     // which is a top and bottom offsets in zero-based coordinates.
     // NOTE: this applies font size fixups.
@@ -318,6 +322,11 @@ namespace GUI
     void DrawTextAligned(Bitmap *ds, const String &text, int font, color_t text_color, const Rect &frame, FrameAlignment align);
     // Draw text aligned horizontally inside given bounds
     void DrawTextAlignedHor(Bitmap *ds, const String &text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align);
+    // Draw wrapped text aligned inside rectangle:
+    // a block of text is aligned vertically, while each line is aligned horizontally.
+    void DrawTextLinesAligned(Bitmap *ds, const std::vector<String> &text, size_t item_count,
+        int font, int linespace, color_t text_color, const Rect &frame, FrameAlignment align,
+        bool limit_by_frame = true);
 
     // Parses the string and returns combination of label macro flags
     GUILabelMacro FindLabelMacros(const String &text);

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -51,6 +51,7 @@ public:
     bool            IsEnabled() const { return (Flags & kGUICtrl_Enabled) != 0; }
     bool            IsTranslated() const { return (Flags & kGUICtrl_Translated) != 0; }
     bool            IsVisible() const { return (Flags & kGUICtrl_Visible) != 0; }
+    bool            IsWrapText() const { return (Flags & kGUICtrl_WrapText) != 0; }
     // overridable routine to determine whether the mouse is over the control
     virtual bool    IsOverControl(int x, int y, int leeway) const;
     Size            GetSize() const { return Size(_width, _height); }

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -55,7 +55,7 @@ Rect GUITextBox::CalcGraphicRect(bool clipped)
     // TODO: need to find a way to cache text position, or there'll be some repetition
     Rect rc = RectWH(0, 0, _width, _height);
     Point text_at(1 + get_fixed_pixel_size(1), 1 + get_fixed_pixel_size(1));
-    Rect text_rc = GUI::CalcTextGraphicalRect(Text.GetCStr(), Font, text_at);
+    Rect text_rc = GUI::CalcTextGraphicalRect(Text, Font, text_at);
     if (GUI::IsGUIEnabled(this))
     {
         // add a cursor

--- a/Common/util/geometry.cpp
+++ b/Common/util/geometry.cpp
@@ -63,22 +63,22 @@ Size ProportionalStretch(const Size &dest, const Size &item)
     return ProportionalStretch(dest.Width, dest.Height, item.Width, item.Height);
 }
 
-int AlignInHRange(int x1, int x2, int off_x, int width, FrameAlignment align)
+int AlignInHRange(int frame_x1, int frame_x2, int item_offx, int item_width, FrameAlignment align)
 {
     if (align & kMAlignRight)
-        return off_x + x2 - width;
+        return item_offx + frame_x2 - item_width;
     else if (align & kMAlignHCenter)
-        return off_x + x1 + ((x2 - x1 + 1) >> 1) - (width >> 1);
-    return off_x + x1; // kAlignLeft is default
+        return item_offx + frame_x1 + ((frame_x2 - frame_x1 + 1) >> 1) - (item_width >> 1);
+    return item_offx + frame_x1; // kAlignLeft is default
 }
 
-int AlignInVRange(int y1, int y2, int off_y, int height, FrameAlignment align)
+int AlignInVRange(int frame_y1, int frame_y2, int item_offy, int item_height, FrameAlignment align)
 {
     if (align & kMAlignBottom)
-        return off_y + y2 - height;
+        return item_offy + frame_y2 - item_height;
     else if (align & kMAlignVCenter)
-        return off_y + y1 + ((y2 - y1 + 1) >> 1) - (height >> 1);
-    return off_y + y1; // kAlignTop is default
+        return item_offy + frame_y1 + ((frame_y2 - frame_y1 + 1) >> 1) - (item_height >> 1);
+    return item_offy + frame_y1; // kAlignTop is default
 }
 
 Rect AlignInRect(const Rect &frame, const Rect &item, FrameAlignment align)

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -451,8 +451,11 @@ bool IsRectInsideRect(const Rect &place, const Rect &item);
 // Calculates a distance between two axis-aligned rectangles, returns 0 if they intersect
 float DistanceBetween(const Rect &r1, const Rect &r2);
 
-int AlignInHRange(int x1, int x2, int off_x, int width, FrameAlignment align);
-int AlignInVRange(int y1, int y2, int off_y, int height, FrameAlignment align);
+// Align an item of certain width in the given horizontal frame; returns item's X position
+int AlignInHRange(int frame_x1, int frame_x2, int item_offx, int item_width, FrameAlignment align);
+// Align an item of certain height in the given vertical frame; returns item's Y position
+int AlignInVRange(int frame_y1, int frame_y2, int item_offy, int item_height, FrameAlignment align);
+// Align an item in the given frame, returns item's position as rectangle
 Rect AlignInRect(const Rect &frame, const Rect &item, FrameAlignment align);
 
 Size ProportionalStretch(int dest_w, int dest_h, int item_w, int item_h);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -107,8 +107,9 @@ namespace AGS.Editor
          * 3.6.2          - Character.TurnWhenFacing, Settings.UseOldVoiceClipNaming,
          *                  ScriptModules for interaction/event lists,
          *                  GlobalVariable may be of array type.
+         * 3.6.2.2        - Button.WrapText
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060200;
+        public const int    LATEST_XML_VERSION_INDEX = 3060202;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1059,6 +1059,16 @@ namespace AGS.Editor
                     }
                 }
 
+                public bool WrapText
+                {
+                    get
+                    {
+                        GUIButton button = (GUIButton)this;
+                        if (button != null) return button.WrapText;
+                        return false;
+                    }
+                }
+
                 public string OnClick
                 {
                     get
@@ -1122,7 +1132,8 @@ namespace AGS.Editor
                 foreach (GUIButtonOrTextWindowEdge ctrl in GUIButtonsAndTextWindowEdges)
                 {
                     int flags;
-                    flags = (ctrl.ClipImage ? NativeConstants.GUIF_CLIP : 0);
+                    flags = (ctrl.ClipImage ? NativeConstants.GUIF_CLIP : 0) |
+                            (ctrl.WrapText ? NativeConstants.GUIF_WRAPTEXT : 0);
                     WriteGUIControl(ctrl, flags, new string[] { ctrl.OnClick });
                     writer.Write(ctrl.Image); // pic
                     writer.Write(ctrl.MouseoverImage); // overpic

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1067,6 +1067,26 @@ namespace AGS.Editor
                     }
                 }
 
+                public int TextPaddingHorizontal
+                {
+                    get
+                    {
+                        GUIButton button = (GUIButton)this;
+                        if (button != null) return button.TextPaddingHorizontal;
+                        return 0;
+                    }
+                }
+
+                public int TextPaddingVertical
+                {
+                    get
+                    {
+                        GUIButton button = (GUIButton)this;
+                        if (button != null) return button.TextPaddingVertical;
+                        return 0;
+                    }
+                }
+
                 public bool WrapText
                 {
                     get
@@ -1788,6 +1808,7 @@ namespace AGS.Editor
             WriteExtension("v360_cursors", WriteExt_360Cursors, writer, gameEnts, errors);
             WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, gameEnts, errors);
             WriteExtension("v362_interevents", WriteExt_362InteractionEvents, writer, gameEnts, errors);
+            WriteExtension("v362_guictrls", WriteExt_362GUIControls, writer, gameEnts, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1887,6 +1908,18 @@ namespace AGS.Editor
             foreach (GUI gui in game.GUIs)
             {
                 FilePutString(gui.ScriptModule, writer);
+            }
+        }
+
+        private static void WriteExt_362GUIControls(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
+        {
+            writer.Write(ents.GUIControls.GUIButtons.Count);
+            foreach (var button in ents.GUIControls.GUIButtons)
+            {
+                writer.Write(button.TextPaddingHorizontal);
+                writer.Write(button.TextPaddingVertical);
+                writer.Write((int)0);
+                writer.Write((int)0);
             }
         }
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1890,6 +1890,14 @@ builtin managed struct Button extends GUIControl {
   /// Gets/sets text alignment inside the button.
   import attribute Alignment TextAlignment;
 #endif
+#ifdef SCRIPT_API_v362
+  /// Gets/sets whether the button will wrap its text.
+  import attribute bool WrapText;
+  /// Gets/sets amount of padding, restricting the text from left and right
+  import attribute int TextPaddingHorizontal;
+  /// Gets/sets amount of padding, restricting the text from top and bottom
+  import attribute int TextPaddingVertical;
+#endif
 };
 
 builtin managed struct Slider extends GUIControl {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1839,7 +1839,7 @@ builtin managed struct Label extends GUIControl {
   import attribute int  TextColor;
 #ifdef SCRIPT_API_v350
   /// Gets/sets label's text alignment.
-  import attribute HorizontalAlignment TextAlignment;
+  import attribute Alignment TextAlignment;
 #endif
 };
 

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -56,6 +56,7 @@ namespace AGS.Editor
         public static readonly int GUIF_VISIBLE = (int)Factory.NativeProxy.GetNativeConstant("GUIF_VISIBLE");
         public static readonly int GUIF_CLIP = (int)Factory.NativeProxy.GetNativeConstant("GUIF_CLIP");
         public static readonly int GUIF_TRANSLATED = (int)Factory.NativeProxy.GetNativeConstant("GUIF_TRANSLATED");
+        public static readonly int GUIF_WRAPTEXT = (int)Factory.NativeProxy.GetNativeConstant("GUIF_WRAPTEXT");
         public static readonly int GLF_SHOWBORDER = (int)Factory.NativeProxy.GetNativeConstant("GLF_SHOWBORDER");
         public static readonly int GLF_SHOWARROWS = (int)Factory.NativeProxy.GetNativeConstant("GLF_SHOWARROWS");
         public static readonly int GUI_POPUP_MODAL = (int)Factory.NativeProxy.GetNativeConstant("GUI_POPUP_MODAL");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -805,6 +805,7 @@ namespace AGS
             if (name->Equals("GUIF_VISIBLE")) return (int)Common::kGUICtrl_Visible;
             if (name->Equals("GUIF_CLIP")) return (int)Common::kGUICtrl_Clip;
             if (name->Equals("GUIF_TRANSLATED")) return (int)Common::kGUICtrl_Translated;
+            if (name->Equals("GUIF_WRAPTEXT")) return (int)Common::kGUICtrl_WrapText;
             if (name->Equals("GLF_SHOWBORDER")) return (int)Common::kListBox_ShowBorder;
             if (name->Equals("GLF_SHOWARROWS")) return (int)Common::kListBox_ShowArrows;
             if (name->Equals("GUI_POPUP_MODAL")) return (int)Common::kGUIPopupModal;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2730,6 +2730,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
           nbut.SetMouseOverImage(button->MouseoverImage);
           nbut.SetPushedImage(button->PushedImage);
           nbut.TextAlignment = (::FrameAlignment)button->TextAlignment;
+          nbut.SetWrapText(button->WrapText);
           nbut.ClickAction[Common::kGUIClickLeft] = (Common::GUIClickAction)button->ClickAction;
           nbut.ClickData[Common::kGUIClickLeft] = button->NewModeNumber;
           nbut.SetClipImage(button->ClipImage);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2730,6 +2730,8 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
           nbut.SetMouseOverImage(button->MouseoverImage);
           nbut.SetPushedImage(button->PushedImage);
           nbut.TextAlignment = (::FrameAlignment)button->TextAlignment;
+          nbut.TextPaddingHor = button->TextPaddingHorizontal;
+          nbut.TextPaddingVer = button->TextPaddingVertical;
           nbut.SetWrapText(button->WrapText);
           nbut.ClickAction[Common::kGUIClickLeft] = (Common::GUIClickAction)button->ClickAction;
           nbut.ClickData[Common::kGUIClickLeft] = button->NewModeNumber;
@@ -3542,6 +3544,9 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 					newButton->MouseoverImage = copyFrom->GetMouseOverImage();
 					newButton->PushedImage = copyFrom->GetPushedImage();
 					newButton->TextAlignment = (AGS::Types::FrameAlignment)copyFrom->TextAlignment;
+                    newButton->TextPaddingHorizontal = copyFrom->TextPaddingHor;
+                    newButton->TextPaddingVertical = copyFrom->TextPaddingVer;
+                    newButton->WrapText = copyFrom->IsWrapText();
                     newButton->ClickAction = (GUIClickAction)copyFrom->ClickAction[Common::kGUIClickLeft];
 					newButton->NewModeNumber = copyFrom->ClickData[Common::kGUIClickLeft];
                     newButton->ClipImage = copyFrom->IsClippingImage();

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2747,7 +2747,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
           Common::GUILabel nlabel;
           nlabel.TextColor = label->TextColor;
           nlabel.Font = label->Font;
-          nlabel.TextAlignment = (::HorAlignment)label->TextAlignment;
+          nlabel.TextAlignment = (::FrameAlignment)label->TextAlignment;
           Common::String text = tcv->ConvertTextProperty(label->Text);
           nlabel.SetText(text);
           guilabels.push_back(nlabel);
@@ -3562,7 +3562,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 				newControl = newLabel;
 				newLabel->TextColor = copyFrom->TextColor;
 				newLabel->Font = copyFrom->Font;
-				newLabel->TextAlignment = (AGS::Types::HorizontalAlignment)copyFrom->TextAlignment;
+				newLabel->TextAlignment = (AGS::Types::FrameAlignment)copyFrom->TextAlignment;
 				newLabel->Text = tcv->Convert(copyFrom->GetText());
 				break;
 				}

--- a/Editor/AGS.Types/Enums/FrameAlignment.cs
+++ b/Editor/AGS.Types/Enums/FrameAlignment.cs
@@ -9,6 +9,10 @@ namespace AGS.Types
     [DeserializeConvertValue("Left", "TopLeft")]
     [DeserializeConvertValue("Right", "TopRight")]
     [DeserializeConvertValue("TopMiddle", "TopCenter")]
+    /* convert from HorizontalAlignment */
+    [DeserializeConvertValue("Left", "TopLeft")]
+    [DeserializeConvertValue("Center", "TopCenter")]
+    [DeserializeConvertValue("Right", "TopRight")]
     [Flags]
     public enum FrameAlignment
     {

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -38,6 +38,8 @@ namespace AGS.Types
         private int _textColor;
         private FrameAlignment _textAlign;
         private bool _wrapText;
+        private int _paddingHor = 2;
+        private int _paddingVer = 2;
         private bool _clipImage;
         private GUIClickAction _clickAction;
         private int _newModeNumber;
@@ -93,6 +95,24 @@ namespace AGS.Types
         {
             get { return _wrapText; }
             set { _wrapText = value; }
+        }
+
+        [Description("The amount of padding, in pixels, restricting the text's alignment from left and right")]
+        [Category("Appearance")]
+        [DefaultValue(2)]
+        public int TextPaddingHorizontal
+        {
+            get { return _paddingHor; }
+            set { _paddingHor = value; }
+        }
+
+        [Description("The amount of padding, in pixels, restricting the text's alignment from top and bottom")]
+        [Category("Appearance")]
+        [DefaultValue(2)]
+        public int TextPaddingVertical
+        {
+            get { return _paddingVer; }
+            set { _paddingVer = value; }
         }
 
         [Description("AGS Colour Number of the button text")]

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -37,6 +37,7 @@ namespace AGS.Types
         private int _font;
         private int _textColor;
         private FrameAlignment _textAlign;
+        private bool _wrapText;
         private bool _clipImage;
         private GUIClickAction _clickAction;
         private int _newModeNumber;
@@ -84,6 +85,14 @@ namespace AGS.Types
         {
             get { return _textAlign; }
             set { _textAlign = value; }
+        }
+
+        [Description("Whether button will wrap text when it exceeds button's width or has new line characters")]
+        [Category("Appearance")]
+        public bool WrapText
+        {
+            get { return _wrapText; }
+            set { _wrapText = value; }
         }
 
         [Description("AGS Colour Number of the button text")]

--- a/Editor/AGS.Types/GUILabel.cs
+++ b/Editor/AGS.Types/GUILabel.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
             : base(x, y, width, height)
         {
             _text = "New Label";
-            _textAlign = HorizontalAlignment.Left;
+            _textAlign = FrameAlignment.TopLeft;
         }
 
         public GUILabel(XmlNode node) : base(node)
@@ -31,11 +31,11 @@ namespace AGS.Types
         private string _text;
         private int _font;
         private int _textColor;
-        private HorizontalAlignment _textAlign;
+        private FrameAlignment _textAlign;
 
         [Description("Position on the label where the text is displayed")]
         [Category("Appearance")]
-        public HorizontalAlignment TextAlignment
+        public FrameAlignment TextAlignment
         {
             get { return _textAlign; }
             set { _textAlign = value; }

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -91,9 +91,9 @@ String GUI::TransformTextForDrawing(const String &text, bool /*translate*/, bool
     return text;
 }
 
-size_t GUI::SplitLinesForDrawing(const char *text, bool /*apply_direction*/, SplitLines &lines, int font, int width, size_t max_lines)
+size_t GUI::SplitLinesForDrawing(const String &text, bool /*apply_direction*/, SplitLines &lines, int font, int width, size_t max_lines)
 {
-    return split_lines(text, lines, width, font, max_lines);
+    return split_lines(text.GetCStr(), lines, width, font, max_lines);
 }
 
 void GUIObject::MarkChanged()
@@ -119,7 +119,7 @@ void GUIObject::MarkStateChanged(bool, bool)
 int GUILabel::PrepareTextToDraw()
 {
     _textToDraw = Text;
-    return GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), false, Lines, Font, _width);
+    return GUI::SplitLinesForDrawing(_textToDraw, false, Lines, Font, _width);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -146,7 +146,15 @@ void GUIInvWindow::Draw(Bitmap *ds, int x, int y)
 
 void GUIButton::PrepareTextToDraw()
 {
-    _textToDraw = _text;
+    if (IsWrapText())
+    {
+        _textToDraw = _text;
+        GUI::SplitLinesForDrawing(_text, false, Lines, Font, _width);
+    }
+    else
+    {
+        _textToDraw = _text;
+    }
 }
 
 } // namespace Common

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -149,7 +149,7 @@ void GUIButton::PrepareTextToDraw()
     if (IsWrapText())
     {
         _textToDraw = _text;
-        GUI::SplitLinesForDrawing(_text, false, Lines, Font, _width);
+        GUI::SplitLinesForDrawing(_text, false, Lines, Font, _width - TextPaddingHor * 2);
     }
     else
     {

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -308,6 +308,48 @@ void Button_SetTextAlignment(GUIButton *butt, int align)
     }
 }
 
+bool Button_GetWrapText(GUIButton *butt)
+{
+    return butt->IsWrapText();
+}
+
+void Button_SetWrapText(GUIButton *butt, bool wrap)
+{
+    if (butt->IsWrapText() != wrap)
+    {
+        butt->SetWrapText(wrap);
+        butt->MarkChanged();
+    }
+}
+
+int Button_GetTextPaddingHorizontal(GUIButton *butt)
+{
+    return butt->TextPaddingHor;
+}
+
+void Button_SetTextPaddingHorizontal(GUIButton *butt, int pad)
+{
+    if (butt->TextPaddingHor != pad)
+    {
+        butt->TextPaddingHor = pad;
+        butt->MarkChanged();
+    }
+}
+
+int Button_GetTextPaddingVertical(GUIButton *butt)
+{
+    return butt->TextPaddingVer;
+}
+
+void Button_SetTextPaddingVertical(GUIButton *butt, int pad)
+{
+    if (butt->TextPaddingVer != pad)
+    {
+        butt->TextPaddingVer = pad;
+        butt->MarkChanged();
+    }
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -451,6 +493,36 @@ RuntimeScriptValue Sc_Button_SetTextAlignment(void *self, const RuntimeScriptVal
     API_OBJCALL_VOID_PINT(GUIButton, Button_SetTextAlignment);
 }
 
+RuntimeScriptValue Sc_Button_GetWrapText(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(GUIButton, Button_GetWrapText);
+}
+
+RuntimeScriptValue Sc_Button_SetWrapText(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PBOOL(GUIButton, Button_SetWrapText);
+}
+
+RuntimeScriptValue Sc_Button_GetTextPaddingHorizontal(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetTextPaddingHorizontal);
+}
+
+RuntimeScriptValue Sc_Button_SetTextPaddingHorizontal(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(GUIButton, Button_SetTextPaddingHorizontal);
+}
+
+RuntimeScriptValue Sc_Button_GetTextPaddingVertical(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetTextPaddingVertical);
+}
+
+RuntimeScriptValue Sc_Button_SetTextPaddingVertical(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(GUIButton, Button_SetTextPaddingVertical);
+}
+
 RuntimeScriptValue Sc_Button_GetAnimFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(GUIButton, Button_GetAnimFrame);
@@ -477,6 +549,12 @@ void RegisterButtonAPI()
         { "Button::SetText^1",            API_FN_PAIR(Button_SetText) },
         { "Button::get_TextAlignment",    API_FN_PAIR(Button_GetTextAlignment) },
         { "Button::set_TextAlignment",    API_FN_PAIR(Button_SetTextAlignment) },
+        { "Button::get_TextPaddingHorizontal", API_FN_PAIR(Button_GetTextPaddingHorizontal) },
+        { "Button::set_TextPaddingHorizontal", API_FN_PAIR(Button_SetTextPaddingHorizontal) },
+        { "Button::get_TextPaddingVertical", API_FN_PAIR(Button_GetTextPaddingVertical) },
+        { "Button::set_TextPaddingVertical", API_FN_PAIR(Button_SetTextPaddingVertical) },
+        { "Button::get_WrapText",         API_FN_PAIR(Button_GetWrapText) },
+        { "Button::set_WrapText",         API_FN_PAIR(Button_SetWrapText) },
         { "Button::get_Animating",        API_FN_PAIR(Button_IsAnimating) },
         { "Button::get_ClipImage",        API_FN_PAIR(Button_GetClipImage) },
         { "Button::set_ClipImage",        API_FN_PAIR(Button_SetClipImage) },

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -351,7 +351,7 @@ void DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy,
 
     for (size_t i = 0; i < Lines.Count(); i++)
     {
-        GUI::DrawTextAlignedHor(ds, Lines[i].GetCStr(), font, text_color,
+        GUI::DrawTextAlignedHor(ds, Lines[i], font, text_color,
             xx, xx + wid - 1, yy + linespacing*i, (FrameAlignment)alignment);
     }
 

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -45,17 +45,17 @@ int Label_GetTextAlignment(GUILabel *labl)
 {
     return (loaded_game_file_version >= kGameVersion_350) ?
         labl->TextAlignment :
-        GetLegacyGUIAlignment(labl->TextAlignment);
+        GetLegacyGUIAlignment((HorAlignment)labl->TextAlignment);
 }
 
 void Label_SetTextAlignment(GUILabel *labl, int align)
 {
     // NOTE: some custom engines supported Label.TextAlignment
     // before 3.5.0 got this added officially
-    HorAlignment use_align =
+    FrameAlignment use_align =
         (loaded_game_file_version >= kGameVersion_350) ?
-        (HorAlignment)align :
-        ConvertLegacyGUIAlignment((LegacyGUIAlignment)align);
+        (FrameAlignment)align :
+        (FrameAlignment)ConvertLegacyGUIAlignment((LegacyGUIAlignment)align);
     if (labl->TextAlignment != use_align)
     {
         labl->TextAlignment = use_align;

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1282,7 +1282,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "GUI",
-        kGuiSvgVersion_36200,
+        kGuiSvgVersion_36202,
         kGuiSvgVersion_Initial,
         WriteGUI,
         ReadGUI

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -190,7 +190,7 @@ void GUIButton::PrepareTextToDraw()
     if (IsWrapText())
     {
         _textToDraw = _text;
-        GUI::SplitLinesForDrawing(_text, (Flags & kGUICtrl_Translated) != 0, Lines, Font, _width);
+        GUI::SplitLinesForDrawing(_text, (Flags & kGUICtrl_Translated) != 0, Lines, Font, _width - TextPaddingHor * 2);
     }
     else
     {

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -187,8 +187,16 @@ void GUIListBox::PrepareTextToDraw(const String &text)
 
 void GUIButton::PrepareTextToDraw()
 {
-    _textToDraw = GUI::TransformTextForDrawing(_text, (Flags & kGUICtrl_Translated) != 0,
-        (loaded_game_file_version >= kGameVersion_361));
+    if (IsWrapText())
+    {
+        _textToDraw = _text;
+        GUI::SplitLinesForDrawing(_text, (Flags & kGUICtrl_Translated) != 0, Lines, Font, _width);
+    }
+    else
+    {
+        _textToDraw = GUI::TransformTextForDrawing(_text, (Flags & kGUICtrl_Translated) != 0,
+            (loaded_game_file_version >= kGameVersion_361));
+    }
 }
 
 } // namespace Common

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -106,10 +106,10 @@ String GUI::TransformTextForDrawing(const String &text, bool translate, bool app
     return res_text;
 }
 
-size_t GUI::SplitLinesForDrawing(const char *text, bool is_translated, SplitLines &lines, int font, int width, size_t max_lines)
+size_t GUI::SplitLinesForDrawing(const String &text, bool is_translated, SplitLines &lines, int font, int width, size_t max_lines)
 {
     // Use the engine's word wrap tool, to have RTL writing and other features
-    const char *draw_text = skip_voiceover_token(text);
+    const char *draw_text = skip_voiceover_token(text.GetCStr());
     return break_up_text_into_lines(draw_text, is_translated, lines, width, font);
 }
 
@@ -149,7 +149,7 @@ int GUILabel::PrepareTextToDraw()
 {
     const bool is_translated = (Flags & kGUICtrl_Translated) != 0;
     replace_macro_tokens(is_translated ? get_translation(Text.GetCStr()) : Text.GetCStr(), _textToDraw);
-    return GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), is_translated, Lines, Font, _width);
+    return GUI::SplitLinesForDrawing(_textToDraw, is_translated, Lines, Font, _width);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)
@@ -164,7 +164,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_colo
         reverse = game.options[OPT_RIGHTLEFTWRITE] != 0;
     }
 
-    Line tpos = GUI::CalcTextPositionHor(_textToDraw.GetCStr(), Font,
+    Line tpos = GUI::CalcTextPositionHor(_textToDraw, Font,
         x + 1 + get_fixed_pixel_size(1), x + _width - 1, y + 1 + get_fixed_pixel_size(1),
         reverse ? kAlignTopRight : kAlignTopLeft);
     wouttext_outline(ds, tpos.X1, tpos.Y1, Font, text_color, _textToDraw.GetCStr());


### PR DESCRIPTION
Resolves #1876
Resolves #2546

1. Added a GUIControl flag kGUICtrl_WrapText that may be applied to any text-based control, in theory.
GUIButton supports this flag, and in case it is set:
 - splits text into lines;
 - aligns the text block vertically using vertical part of text alignment;
 - aligns each text line horizontally using horizontal part of text alignment;

Wrapping and drawing code is mostly shared with the GUILabel class (picked out as a separate commit).

Added WrapText property to a Button in the Editor.

2. Added TextHorizontalPadding and TextVerticalPadding properties to GUIButton. These specify left-right and top-bottom space between button's frame and aligned text.

Button placeholder text supposedly should not be affected by this.
This has to be tested more.

3. GUILabels support full Alignment (both horizontal and vertical).

Possible TODOs:
* Add new properties to script API.
