### PR TITLE
Common: Fix lzwexpand on strict-alignment platforms

### DIFF
--- a/Common/util/lzw.cpp
+++ b/Common/util/lzw.cpp
@@ -18,6 +18,7 @@
 #include "util/lzw.h"
 #include <stdlib.h>
 #include "util/bbop.h"
+#include "util/memory.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
@@ -213,7 +214,7 @@ bool lzwexpand(const uint8_t *src, size_t src_sz, uint8_t *dst, size_t dst_sz)
           break;
 
         short jshort = 0;
-        jshort = BBOp::Int16FromLE(*(reinterpret_cast<const int16_t*>(src_ptr)));
+        jshort = Memory::ReadInt16LE(src_ptr);
         src_ptr += sizeof(int16_t);
         j = jshort;
 


### PR DESCRIPTION
Hi!

I'm upstreaming this after ScummVM's [Trac#15179](https://bugs.scummvm.org/ticket/15179) and related scummvm/scummvm#6185 PR of mine.

The following commit fixes Maniac Mansion Deluxe on mips64el (OpenBSD/loongson, more precisely) where a fatal SIGBUS was triggered because of an unaligned load in `lzwexpand()`.

`memcpy()` is guaranteed to be safe, for this.

The unaligned load was also reported by UBSan (see the Trac ticket above for logs, if necessary).

(This may need to be cherry-picked for your ags4 branch as well.)