### PR TITLE
Script API: more DateTime factory methods

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2266,6 +2266,10 @@ builtin struct Maths {
 builtin managed struct DateTime {
   /// Gets the current date and time on the player's system.
   readonly import static attribute DateTime* Now;   // $AUTOCOMPLETESTATICONLY$
+  /// Creates DateTime object from the provided date and time; returns invalid object if year is below 1970 or above 2038, or any other value is invalid
+  import static DateTime* CreateFromDate(int year, int month, int day, int hour = 0, int minute = 0, int second = 0);   // $AUTOCOMPLETESTATICONLY$
+  /// Creates DateTime object from the provided raw time value (in seconds); returns invalid object if rawTime is negative
+  import static DateTime* CreateFromRawTime(int rawTime);   // $AUTOCOMPLETESTATICONLY$
   /// Gets the Year component of the date.
   readonly import attribute int Year;
   /// Gets the Month (1-12) component of the date.

--- a/Engine/ac/datetime.cpp
+++ b/Engine/ac/datetime.cpp
@@ -16,46 +16,40 @@
 #include "ac/dynobj/dynobj_manager.h"
 #include "platform/base/agsplatformdriver.h"
 
-ScriptDateTime* DateTime_Now_Core() {
-    ScriptDateTime *sdt = new ScriptDateTime();
-
-    platform->GetSystemTime(sdt);
-
-    return sdt;
-}
 
 ScriptDateTime* DateTime_Now() {
-    ScriptDateTime *sdt = DateTime_Now_Core();
+    ScriptDateTime *sdt = new ScriptDateTime(ScriptDateTime::SystemClock::now());
     ccRegisterManagedObject(sdt, sdt);
     return sdt;
 }
 
+
 int DateTime_GetYear(ScriptDateTime *sdt) {
-    return sdt->year;
+    return sdt->Year();
 }
 
 int DateTime_GetMonth(ScriptDateTime *sdt) {
-    return sdt->month;
+    return sdt->Month();
 }
 
 int DateTime_GetDayOfMonth(ScriptDateTime *sdt) {
-    return sdt->day;
+    return sdt->Day();
 }
 
 int DateTime_GetHour(ScriptDateTime *sdt) {
-    return sdt->hour;
+    return sdt->Hour();
 }
 
 int DateTime_GetMinute(ScriptDateTime *sdt) {
-    return sdt->minute;
+    return sdt->Minute();
 }
 
 int DateTime_GetSecond(ScriptDateTime *sdt) {
-    return sdt->second;
+    return sdt->Second();
 }
 
 int DateTime_GetRawTime(ScriptDateTime *sdt) {
-    return sdt->rawUnixTime;
+    return sdt->RawTime();
 }
 
 //=============================================================================

--- a/Engine/ac/datetime.cpp
+++ b/Engine/ac/datetime.cpp
@@ -11,9 +11,9 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#include <time.h>
 #include "ac/datetime.h"
 #include "ac/dynobj/dynobj_manager.h"
+#include "debug/debug_log.h"
 #include "platform/base/agsplatformdriver.h"
 
 
@@ -23,6 +23,38 @@ ScriptDateTime* DateTime_Now() {
     return sdt;
 }
 
+ScriptDateTime* DateTime_CreateFromDate(int year, int month, int day, int hour, int minute, int second) {
+    // NOTE: implementation cannot handle years before 1970,
+    // and since DateTime.RawTime is int32, years from 2038 and above cause overflow.
+    ScriptDateTime *sdt;
+    if (year < 1970 || year >= 2038 || month < 1 || month > 12 || day < 1 || day > 31 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59)
+    {
+        debug_script_warn("DateTime.CreateFromDate: requested date or time is not in a supported range: %dy,%dm,%dd %dh:%dm:%ds",
+            year, month, day, hour, minute, second);
+        sdt = new ScriptDateTime();
+    }
+    else
+    {
+        sdt = new ScriptDateTime(year, month, day, hour, minute, second);
+    }
+    ccRegisterManagedObject(sdt, sdt);
+    return sdt;
+}
+
+ScriptDateTime* DateTime_CreateFromRawTime(int raw_time) {
+    ScriptDateTime *sdt;
+    if (raw_time < 0)
+    {
+        debug_script_warn("DateTime.CreateFromRawTime: raw time is not in a supported range: %d", raw_time);
+        sdt = new ScriptDateTime();
+    }
+    else
+    {
+        sdt = new ScriptDateTime(raw_time);
+    }
+    ccRegisterManagedObject(sdt, sdt);
+    return sdt;
+}
 
 int DateTime_GetYear(ScriptDateTime *sdt) {
     return sdt->Year();
@@ -66,6 +98,16 @@ int DateTime_GetRawTime(ScriptDateTime *sdt) {
 RuntimeScriptValue Sc_DateTime_Now(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO(ScriptDateTime, DateTime_Now);
+}
+
+RuntimeScriptValue Sc_DateTime_CreateFromRawTime(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PINT(ScriptDateTime, DateTime_CreateFromRawTime);
+}
+
+RuntimeScriptValue Sc_DateTime_CreateFromDate(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PINT6(ScriptDateTime, DateTime_CreateFromDate);
 }
 
 // int (ScriptDateTime *sdt)
@@ -114,6 +156,8 @@ void RegisterDateTimeAPI()
 {
     ScFnRegister datetime_api[] = {
         { "DateTime::get_Now",        API_FN_PAIR(DateTime_Now) },
+        { "DateTime::CreateFromDate", API_FN_PAIR(DateTime_CreateFromDate) },
+        { "DateTime::CreateFromRawTime", API_FN_PAIR(DateTime_CreateFromRawTime) },
 
         { "DateTime::get_DayOfMonth", API_FN_PAIR(DateTime_GetDayOfMonth) },
         { "DateTime::get_Hour",       API_FN_PAIR(DateTime_GetHour) },

--- a/Engine/ac/datetime.h
+++ b/Engine/ac/datetime.h
@@ -20,7 +20,6 @@
 
 #include "ac/dynobj/scriptdatetime.h"
 
-ScriptDateTime* DateTime_Now_Core();
 ScriptDateTime* DateTime_Now();
 int             DateTime_GetYear(ScriptDateTime *sdt);
 int             DateTime_GetMonth(ScriptDateTime *sdt);

--- a/Engine/ac/dynobj/scriptdatetime.cpp
+++ b/Engine/ac/dynobj/scriptdatetime.cpp
@@ -14,6 +14,7 @@
 #include "ac/dynobj/scriptdatetime.h"
 #include <ctime>
 #include "ac/dynobj/dynobj_manager.h"
+#include "debug/debug_log.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
@@ -40,14 +41,41 @@ ScriptDateTime::ScriptDateTime(const ClockTimePoint &time)
     SetTime(time);
 }
 
+ScriptDateTime::ScriptDateTime(int raw_time)
+{
+    SetTime(ClockTimePoint(std::chrono::seconds(raw_time)));
+}
+
+ScriptDateTime::ScriptDateTime(int year, int month, int day, int hour, int minute, int second)
+{
+    // NOTE: we do not init our calendar fields here directly, and instead
+    // go through SetTime, in case the combination of input values does not
+    // represent a true date, in which case it may be auto corrected when
+    // constructing a time point.
+    std::tm tm = { /* .tm_sec  = */ second,
+                   /* .tm_min  = */ minute,
+                   /* .tm_hour = */ hour,
+                   /* .tm_mday = */ day,
+                   /* .tm_mon  = */ month - 1,
+                   /* .tm_year = */ year - 1900,
+                };
+    tm.tm_isdst = -1; // use DST value from local time zone
+    SetTime(std::chrono::system_clock::from_time_t(std::mktime(&tm)));
+}
+
 void ScriptDateTime::SetTime(const ClockTimePoint &time)
 {
     // NOTE: subject to year 2038 problem due to shoving seconds since epoch into an int32
-    _rawtime = static_cast<int32_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
-
     std::time_t ttime = SystemClock::to_time_t(time);
     std::tm *newtime = std::localtime(&ttime);
+    const auto rawtime = std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count();
+    if (newtime == nullptr || rawtime < 0 || rawtime > INT32_MAX)
+    {
+        debug_script_warn("DateTime: failed to initialize, bad input or date is in unsupported range");
+        return;
+    }
+
+    _rawtime = static_cast<int32_t>(rawtime);
     _hour = newtime->tm_hour;
     _minute = newtime->tm_min;
     _second = newtime->tm_sec;

--- a/Engine/ac/dynobj/scriptdatetime.cpp
+++ b/Engine/ac/dynobj/scriptdatetime.cpp
@@ -12,33 +12,48 @@
 //
 //=============================================================================
 #include "ac/dynobj/scriptdatetime.h"
+#include <ctime>
 #include "ac/dynobj/dynobj_manager.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
 
-int ScriptDateTime::Dispose(void* /*address*/, bool /*force*/) {
+int ScriptDateTime::Dispose(void* /*address*/, bool /*force*/)
+{
     // always dispose a DateTime
     delete this;
     return 1;
 }
 
-const char *ScriptDateTime::GetType() {
+const char *ScriptDateTime::GetType()
+{
     return "DateTime";
 }
 
-void ScriptDateTime::SetFromStdTime(time_t time)
+ScriptDateTime::ScriptDateTime(const time_t &time)
 {
-    // NOTE: subject to year 2038 problem due to shoving time_t in an integer
-    rawUnixTime = static_cast<int>(time);
+    SetTime(SystemClock::from_time_t(time));
+}
 
-    struct tm *newtime = localtime(&time);
-    hour = newtime->tm_hour;
-    minute = newtime->tm_min;
-    second = newtime->tm_sec;
-    day = newtime->tm_mday;
-    month = newtime->tm_mon + 1;
-    year = newtime->tm_year + 1900;
+ScriptDateTime::ScriptDateTime(const ClockTimePoint &time)
+{
+    SetTime(time);
+}
+
+void ScriptDateTime::SetTime(const ClockTimePoint &time)
+{
+    // NOTE: subject to year 2038 problem due to shoving seconds since epoch into an int32
+    _rawtime = static_cast<int32_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
+
+    std::time_t ttime = SystemClock::to_time_t(time);
+    std::tm *newtime = std::localtime(&ttime);
+    _hour = newtime->tm_hour;
+    _minute = newtime->tm_min;
+    _second = newtime->tm_sec;
+    _day = newtime->tm_mday;
+    _month = newtime->tm_mon + 1;
+    _year = newtime->tm_year + 1900;
 }
 
 size_t ScriptDateTime::CalcSerializeSize(const void* /*address*/)
@@ -46,29 +61,25 @@ size_t ScriptDateTime::CalcSerializeSize(const void* /*address*/)
     return sizeof(int32_t) * 7;
 }
 
-void ScriptDateTime::Serialize(const void* /*address*/, Stream *out) {
-    out->WriteInt32(year);
-    out->WriteInt32(month);
-    out->WriteInt32(day);
-    out->WriteInt32(hour);
-    out->WriteInt32(minute);
-    out->WriteInt32(second);
-    out->WriteInt32(rawUnixTime);
+void ScriptDateTime::Serialize(const void* /*address*/, Stream *out)
+{
+    out->WriteInt32(_year);
+    out->WriteInt32(_month);
+    out->WriteInt32(_day);
+    out->WriteInt32(_hour);
+    out->WriteInt32(_minute);
+    out->WriteInt32(_second);
+    out->WriteInt32(_rawtime);
 }
 
-void ScriptDateTime::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
-    year = in->ReadInt32();
-    month = in->ReadInt32();
-    day = in->ReadInt32();
-    hour = in->ReadInt32();
-    minute = in->ReadInt32();
-    second = in->ReadInt32();
-    rawUnixTime = in->ReadInt32();
+void ScriptDateTime::Unserialize(int index, Stream *in, size_t /*data_sz*/)
+{
+    _year = in->ReadInt32();
+    _month = in->ReadInt32();
+    _day = in->ReadInt32();
+    _hour = in->ReadInt32();
+    _minute = in->ReadInt32();
+    _second = in->ReadInt32();
+    _rawtime = in->ReadInt32();
     ccRegisterUnserializedObject(index, this, this);
-}
-
-ScriptDateTime::ScriptDateTime() {
-    year = month = day = 0;
-    hour = minute = second = 0;
-    rawUnixTime = 0;
 }

--- a/Engine/ac/dynobj/scriptdatetime.h
+++ b/Engine/ac/dynobj/scriptdatetime.h
@@ -12,29 +12,47 @@
 //
 //=============================================================================
 //
-//
+// ScriptDateTime is a script object that contains date/time definition.
 //
 //=============================================================================
 #ifndef __AGS_EE_DYNOBJ__SCRIPTDATETIME_H
 #define __AGS_EE_DYNOBJ__SCRIPTDATETIME_H
 
-#include <time.h>
+#include <chrono>
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
-struct ScriptDateTime final : AGSCCDynamicObject {
-    int year, month, day;
-    int hour, minute, second;
-    int rawUnixTime;
+struct ScriptDateTime final : AGSCCDynamicObject
+{
+public:
+    typedef std::chrono::system_clock SystemClock;
+    typedef std::chrono::time_point<SystemClock> ClockTimePoint;
+
+    // Constructs DateTime initialized with zero time
+    ScriptDateTime() = default;
+    // Constructs DateTime initialized using C time_t
+    ScriptDateTime(const time_t &time);
+    // Constructs DateTime initialized using chrono::time_point
+    ScriptDateTime(const ClockTimePoint &time);
 
     int Dispose(void *address, bool force) override;
     const char *GetType() override;
     void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
 
-    void SetFromStdTime(time_t time);
+    inline int RawTime() const { return _rawtime; }
+    inline int Year() const { return _year; }
+    inline int Month() const { return _month; }
+    inline int Day() const { return _day; }
+    inline int Hour() const { return _hour; }
+    inline int Minute() const { return _minute; }
+    inline int Second() const { return _second; }
 
-    ScriptDateTime();
+private:
+    int _year = 0, _month = 0, _day = 0;
+    int _hour = 0, _minute = 0, _second = 0;
+    int _rawtime = 0;
 
-protected:
+    void SetTime(const ClockTimePoint &time);
+
     // Calculate and return required space for serialization, in bytes
     size_t CalcSerializeSize(const void *address) override;
     // Write object data into the provided stream

--- a/Engine/ac/dynobj/scriptdatetime.h
+++ b/Engine/ac/dynobj/scriptdatetime.h
@@ -33,6 +33,10 @@ public:
     ScriptDateTime(const time_t &time);
     // Constructs DateTime initialized using chrono::time_point
     ScriptDateTime(const ClockTimePoint &time);
+    // Constructs DateTime initialized with raw time (unix time)
+    ScriptDateTime(int raw_time);
+    // Constructs DateTime initialized with all the date/time components
+    ScriptDateTime(int year, int month, int day, int hour, int minute, int second);
 
     int Dispose(void *address, bool force) override;
     const char *GetType() override;
@@ -49,7 +53,7 @@ public:
 private:
     int _year = 0, _month = 0, _day = 0;
     int _hour = 0, _minute = 0, _second = 0;
-    int _rawtime = 0;
+    int _rawtime = -1;
 
     void SetTime(const ClockTimePoint &time);
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -70,8 +70,7 @@ ScriptDateTime* File_GetFileTime(const char *fnmm) {
     ft = File::GetFileTime(rp.FullPath);
   }
 
-  ScriptDateTime *sdt = new ScriptDateTime();
-  sdt->SetFromStdTime(ft);
+  ScriptDateTime *sdt = new ScriptDateTime(ft);
   ccRegisterManagedObject(sdt, sdt);
   return sdt;
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -420,8 +420,7 @@ const char* Game_GetSaveSlotDescription(int slnum) {
 ScriptDateTime* Game_GetSaveSlotTime(int slnum)
 {
     time_t ft = File::GetFileTime(get_save_game_path(slnum));
-    ScriptDateTime *sdt = new ScriptDateTime();
-    sdt->SetFromStdTime(ft);
+    ScriptDateTime *sdt = new ScriptDateTime(ft);
     ccRegisterManagedObject(sdt, sdt);
     return sdt;
 }

--- a/Engine/ac/global_datetime.cpp
+++ b/Engine/ac/global_datetime.cpp
@@ -18,18 +18,16 @@
 #include "ac/common.h"
 
 int sc_GetTime(int whatti) {
-    ScriptDateTime *sdt = DateTime_Now_Core();
+    ScriptDateTime sdt(ScriptDateTime::SystemClock::now());
     int returnVal = 0;
 
-    if (whatti == 1) returnVal = sdt->hour;
-    else if (whatti == 2) returnVal = sdt->minute;
-    else if (whatti == 3) returnVal = sdt->second;
-    else if (whatti == 4) returnVal = sdt->day;
-    else if (whatti == 5) returnVal = sdt->month;
-    else if (whatti == 6) returnVal = sdt->year;
+    if (whatti == 1) returnVal = sdt.Hour();
+    else if (whatti == 2) returnVal = sdt.Minute();
+    else if (whatti == 3) returnVal = sdt.Second();
+    else if (whatti == 4) returnVal = sdt.Day();
+    else if (whatti == 5) returnVal = sdt.Month();
+    else if (whatti == 6) returnVal = sdt.Year();
     else quit("!GetTime: invalid parameter passed");
-
-    delete sdt;
 
     return returnVal;
 }

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -78,12 +78,6 @@ const char *AGSPlatformDriver::GetDiskWriteAccessTroubleshootingText()
     return "Make sure you have write permissions, and also check the disk's free space.";
 }
 
-void AGSPlatformDriver::GetSystemTime(ScriptDateTime *sdt)
-{
-    time_t t = time(nullptr);
-    sdt->SetFromStdTime(t);
-}
-
 void AGSPlatformDriver::DisplayAlert(const char *text, ...)
 {
     char displbuf[2048];

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -104,7 +104,6 @@ public:
     virtual uint64_t GetDiskFreeSpaceMB(const Common::String &path) = 0;
     virtual const char* GetBackendFailUserHint();
     virtual eScriptSystemOSID GetSystemOSID() = 0;
-    virtual void GetSystemTime(ScriptDateTime*);
     virtual SetupReturnValue RunSetup(const Common::ConfigTree &cfg_in, Common::ConfigTree &cfg_out);
     // Formats message and writes to standard platform's output;
     // Always adds trailing '\n' after formatted string

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -352,6 +352,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue); \
     return RuntimeScriptValue().SetScriptObject(ret_obj, ret_obj)
 
+#define API_SCALL_OBJAUTO_PINT6(RET_CLASS, FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 6); \
+    RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue); \
+    return RuntimeScriptValue().SetScriptObject(ret_obj, ret_obj)
+
 #define API_SCALL_OBJAUTO_PINT2_PBOOL(RET_CLASS, FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 3); \
     RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].GetAsBool()); \


### PR DESCRIPTION
Implements factory methods that create DateTime from full date/time, and from "rawtime".
Creating from normal date/time values may be useful to compare another DateTime object with certain "base point".
All of these may be useful to create DateTime back from previously saved values, either calendar values or rawtime.

```
/// Creates DateTime object from the provided calendar and, optionally, time components
static DateTime* DateTime.CreateFromDate(int year, int month, int day, int hour = 0, int minute = 0, int second = 0); 
/// Creates DateTime object from the provided raw time value (in seconds)
static DateTime* DateTime.CreateFromRawTime(int rawTime);
```