### PR TITLE
Script API: implement File.ReadBytes, WriteBytes

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1347,6 +1347,10 @@ builtin managed struct File {
   import float  ReadRawFloat();
   /// Writes a raw 32-bit float to the file.
   import void   WriteRawFloat(float value);
+  /// Reads up to "count" number of bytes and stores them in a provided dynamic array, starting with certain index. Returns actual number of read bytes.
+  import int    ReadBytes(char bytes[], int index, int count);
+  /// Writes up to "count" number of bytes from the provided dynamic array, starting with certain index. Returns actual number of written bytes.
+  import int    WriteBytes(char bytes[], int index, int count);
 #endif // SCRIPT_API_v362
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -29,9 +29,12 @@ public:
     struct Header
     {
         // May contain ARRAY_MANAGED_TYPE_FLAG
-        uint32_t ElemCount = 0u;
+        uint32_t ElemCount = 0u; // number of elements, up to INT32_MAX !
         // TODO: refactor and store "elem size" instead
-        uint32_t TotalSize = 0u;
+        uint32_t TotalSize = 0u; // total size in bytes
+
+        inline bool IsManagedType() const { return (ElemCount & ARRAY_MANAGED_TYPE_FLAG) != 0; }
+        inline uint32_t GetElemCount() const { return ElemCount & ~ARRAY_MANAGED_TYPE_FLAG; }
     };
 
     CCDynamicArray() = default;

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -525,6 +525,10 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
     return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].IValue))
 
+#define API_OBJCALL_INT_POBJ_PINT2(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 3); \
+    return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].IValue, params[2].IValue))
+
 #define API_OBJCALL_INT_POBJ_PBOOL(CLASS, METHOD, P1CLASS) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
     return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].GetAsBool()))


### PR DESCRIPTION
I wonder if this may be useful?

Adds File.ReadBytes and FileWriteBytes that accept a dynamic `char[]` array and index,count positions:

```
/// Reads up to "count" number of bytes and stores them in a provided dynamic array, starting with index. Returns actual number of read bytes.
int File.ReadBytes(char bytes[], int index, int count);
/// Writes up to "count" number of bytes from the provided dynamic array, starting with index. Returns actual number of written bytes.
int File.WriteBytes(char bytes[], int index, int count);
```

The use case is writing and reading long sequences of byte values, instead of using ReadRawChar/WriteRawChar in a loop.

Simple test example:
```
  char bytes[] = new char[100];
  for (int i = 0; i < 100; i++)
    bytes[i] = i;
  int wrote_bytes = f.WriteBytes(bytes, 40, 20);
  System.Log(eLogDebug, "wrote_bytes = %d", wrote_bytes);

  char bytes2[] = new char[100];
  int read_bytes = f.ReadBytes(bytes2, 0, 20);
  System.Log(eLogDebug, "read_bytes = %d, %s", read_bytes, bytes2);
  // Note that %s works here because char[] array is implicitly cast as `const char*`
  // and byte values are printable characters in this example
```