### PR TITLE
AGS 4: remake DynamicArray.Length pseudo-property getter as a object member function

### DIFF
--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -125,7 +125,9 @@
 #define FIXUP_DATADATA    5     // globaldata[fixup] += &globaldata[0]
 #define FIXUP_STACK       6     // code[fixup] += &stack[0]
 
-
+#define BUILTIN_SYMBOL_PREFIX        "__Builtin_"
+// Built-in pseudo property DynamicArray.Length
+#define BUILTIN_DYNAMIC_ARRAY_LENGTH "__Builtin_DynamicArray::get_Length"
 
 // Script file signature
 extern const char scfilesig[5];

--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -99,6 +99,19 @@ int ccCompiledScript::add_new_import(const char*namm)
     return imports.size() - 1;
 }
 
+int ccCompiledScript::find_or_add_import(const char *namm)
+{
+    for (size_t i = 0; i < imports.size(); i++)
+    {
+        if (strcmp(imports[i].c_str(), namm) == 0)
+        {
+            return i;
+        }
+    }
+    
+    return add_new_import(namm);
+}
+
 int ccCompiledScript::remove_any_import (const char*namm, SymbolDef *oldSym) {
     // Remove any import with the specified name
     int sidx = sym.find(namm);

--- a/Compiler/script/cc_compiledscript.h
+++ b/Compiler/script/cc_compiledscript.h
@@ -39,6 +39,7 @@ struct ccCompiledScript: public ccScript {
     void fixup_previous(char);
     int  add_new_function(const char*, int *idx);
     int  add_new_import(const char*);
+    int  find_or_add_import(const char*);
     int  add_new_export(const char*, int, int32_t, int);
     void write_code(int32_t);
     void set_line_number(int nlum) { next_line=nlum; }

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -252,6 +252,12 @@ int symbolTable::add_ex(const char*nta,int typo,char sizee) {
     symbolTree.addEntry(nta, p_value);
     return p_value;
 }
+int symbolTable::find_or_add(const char *name) {
+    int index = find(name);
+    if (index >= 0)
+        return index;
+    return add(name);
+}
 int symbolTable::add_operator(const char *nta, int priority, int vcpucmd) {
     int nss = add_ex(nta, SYM_OPERATOR, priority);
 	if (nss >= 0) {

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -30,7 +30,7 @@ struct SymbolTableEntry
     int16_t stype = 0;
     int32_t flags = 0;
     int16_t vartype = 0;
-    int soffs = 0;
+    int soffs = 0; // or property getter/setter import indexes, packed as two int16 
     int32_t ssize = 0; // or return type size for function
     int16_t sscope = 0; // or num arguments for function
     // symbol's life scope, in bytecode pos
@@ -78,6 +78,7 @@ struct symbolTable {
     int  find(const char*);  // returns ID of symbol, or -1
     int  add_ex(const char*,int,char);  // adds new symbol of type and size
     int  add(const char*);   // adds new symbol, returns -1 if already exists
+    int  find_or_add(const char*);
 
     // TODO: why is there "friendly name" and "name", and what's the difference?
     std::string get_friendly_name(int idx);  // inclue ptr

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -35,6 +35,8 @@ void ccGetExtensions(std::vector<std::string> &exts)
 
     // Managed ptr in managed structs
     exts.push_back("NESTEDPOINTERS");
+    // DynamicArray.Length pseudo-property
+    exts.push_back("DYNARRAY_LENGTH");
     return;
 }
 

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -34,6 +34,8 @@ void ccGetExtensions2(std::vector<std::string> &exts)
     exts.push_back("AGS4");
     // Managed ptr in managed structs
     exts.push_back("NESTEDPOINTERS");
+    // DynamicArray.Length pseudo-property
+    exts.push_back("DYNARRAY_LENGTH");
 }
 
 // Convert VartypeFlags to RTTI::TypeFlags

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -396,6 +396,10 @@ private:
     // Buffer for ccCurScriptName
     std::string _scriptNameBuffer;
 
+    // Various builtin symbols
+    static const std::string _builtinSymbolPrefix;
+    static const std::string _builtinDynArrayLength;
+
     // Augment the message with a "See ..." indication
     // 'declared' is the point in _src where the thing is declared
     std::string const ReferenceMsgLoc(std::string const &msg, size_t declared);
@@ -564,7 +568,7 @@ private:
 
     // Generate the function call for the function that returns the number of elements
     // of a dynarray.
-    void AccessData_GenerateDynarrayLengthFuncCall(EvaluationResult &eres);
+    void AccessData_GenerateDynarrayLengthAttrib(EvaluationResult &eres);
 
     // We are processing a function call.
     // Get the parameters of the call and push them onto the stack.
@@ -813,6 +817,9 @@ private:
     void ParseStruct_Attribute_DeclareFunc(TypeQualifierSet tqs, Symbol strct, Symbol qualified_name, Symbol unqualified_name, bool is_setter, bool is_indexed, Vartype vartype);
 
     void ParseStruct_Attribute2SymbolTable(TypeQualifierSet tqs, Vartype const vartype, Symbol const name_of_struct, Symbol const unqualified_attribute, bool const is_indexed);
+
+    void ParseStruct_MasterAttribute2SymbolTable(TypeQualifierSet tqs, Vartype const vartype, Symbol const name_of_struct, Symbol const unqualified_attribute, bool const is_indexed,
+        Symbol getter_func = kKW_NoSymbol, Symbol setter_func = kKW_NoSymbol);
 
     // We're in a struct declaration. Parse an attribute declaration.
     void ParseStruct_Attribute(TypeQualifierSet tqs, Symbol stname);

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -3142,15 +3142,15 @@ TEST_F(Bytecode1, DynarrayLength1_NoRTTI) {
 
     // WriteOutput("DynarrayLength1_NoRtti", scrip);
 
-    size_t const codesize = 38;
+    size_t const codesize = 40;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,    6,    3,    // 7
        5,   72,    3,    4,            1,    6,    2,    0,    // 15
       47,    3,   36,    9,            6,    2,    0,   48,    // 23
-       2,   52,   34,    2,           39,    1,    6,    3,    // 31
-       0,   33,    3,   35,            1,    5,  -999
+       2,   52,   29,    6,           45,    2,    39,   0,    // 31
+       6,    3,    0,   33,            3,    30,   6,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3158,7 +3158,7 @@ TEST_F(Bytecode1, DynarrayLength1_NoRTTI) {
     EXPECT_EQ(numfixups, scrip.fixups.size());
 
     int32_t fixups[] = {
-      15,   22,   32,  -999
+      15,   22,   34,  -999
     };
     char fixuptypes[] = {
       1,   1,   4,  '\0'
@@ -3167,7 +3167,7 @@ TEST_F(Bytecode1, DynarrayLength1_NoRTTI) {
 
     int const numimports = 1;
     std::string imports[] = {
-    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    BUILTIN_DYNAMIC_ARRAY_LENGTH,             "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
@@ -3200,15 +3200,15 @@ TEST_F(Bytecode1, DynarrayLength1_RTTI) {
     EXPECT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("DynarrayLength1_Rtti", scrip);
-    size_t const codesize = 38;
+    size_t const codesize = 40;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,    6,    3,    // 7
        5,   75,    3,   91,            4,    6,    2,    0,    // 15
       47,    3,   36,    9,            6,    2,    0,   48,    // 23
-       2,   52,   34,    2,           39,    1,    6,    3,    // 31
-       0,   33,    3,   35,            1,    5,  -999
+       2,   52,   29,    6,           45,    2,   39,    0,    // 31
+       6,    3,    0,   33,            3,   30,    6,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3216,7 +3216,7 @@ TEST_F(Bytecode1, DynarrayLength1_RTTI) {
     EXPECT_EQ(numfixups, scrip.fixups.size());
 
     int32_t fixups[] = {
-      15,   22,   32,  -999
+      15,   22,   34,  -999
     };
     char fixuptypes[] = {
       1,   1,   4,  '\0'
@@ -3225,7 +3225,7 @@ TEST_F(Bytecode1, DynarrayLength1_RTTI) {
 
     int const numimports = 1;
     std::string imports[] = {
-    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    BUILTIN_DYNAMIC_ARRAY_LENGTH,             "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
@@ -3252,17 +3252,17 @@ TEST_F(Bytecode1, DynarrayLength2_NoRTTI) {
 
     // WriteOutput("DynarrayLength2_NoRtti", scrip);
 
-    size_t const codesize = 52;
+    size_t const codesize = 54;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
       36,    2,   38,    0,           36,    3,    6,    3,    // 7
        7,   72,    3,    4,            0,   51,    0,   47,    // 15
        3,    1,    1,    4,           36,    4,   51,    4,    // 23
-      48,    2,   52,   34,            2,   39,    1,    6,    // 31
-       3,    0,   33,    3,           35,    1,   29,    3,    // 39
-      36,    5,   51,    8,           49,    2,    1,    8,    // 47
-       6,    3,    0,    5,          -999
+      48,    2,   52,   29,            6,   45,    2,   39,    // 31
+       0,    6,    3,    0,           33,    3,   30,    6,    // 39
+       29,   3,   36,    5,           51,    8,   49,    2,    // 47
+       1,    8,    6,    3,            0,    5,   -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3270,7 +3270,7 @@ TEST_F(Bytecode1, DynarrayLength2_NoRTTI) {
     EXPECT_EQ(numfixups, scrip.fixups.size());
 
     int32_t fixups[] = {
-      33,  -999
+      35,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -3279,7 +3279,7 @@ TEST_F(Bytecode1, DynarrayLength2_NoRTTI) {
 
     int const numimports = 1;
     std::string imports[] = {
-    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    BUILTIN_DYNAMIC_ARRAY_LENGTH,             "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
@@ -3307,17 +3307,17 @@ TEST_F(Bytecode1, DynarrayLength2_RTTI) {
     EXPECT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("DynarrayLength2_Rtti", scrip);
-    size_t const codesize = 52;
+    size_t const codesize = 54;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
       36,    2,   38,    0,           36,    3,    6,    3,    // 7
        7,   75,    3,    3,            4,   51,    0,   47,    // 15
        3,    1,    1,    4,           36,    4,   51,    4,    // 23
-      48,    2,   52,   34,            2,   39,    1,    6,    // 31
-       3,    0,   33,    3,           35,    1,   29,    3,    // 39
-      36,    5,   51,    8,           49,    2,    1,    8,    // 47
-       6,    3,    0,    5,          -999
+      48,    2,   52,   29,            6,   45,    2,   39,    // 31
+       0,    6,    3,    0,           33,    3,   30,    6,    // 39
+       29,   3,   36,    5,           51,    8,   49,    2,    // 47
+       1,    8,    6,    3,            0,    5,   -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3325,7 +3325,7 @@ TEST_F(Bytecode1, DynarrayLength2_RTTI) {
     EXPECT_EQ(numfixups, scrip.fixups.size());
 
     int32_t fixups[] = {
-      33,  -999
+      35,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -3334,7 +3334,7 @@ TEST_F(Bytecode1, DynarrayLength2_RTTI) {
 
     int const numimports = 1;
     std::string imports[] = {
-    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    BUILTIN_DYNAMIC_ARRAY_LENGTH,             "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -252,13 +252,20 @@ int32_t DynamicArray_Length(void *untyped_dynarray)
     return hdr.ElemCount;
 }
 
-RuntimeScriptValue Sc_DynamicArray_Length(const RuntimeScriptValue *params, int32_t param_count)
+// Deprecated variant of DynamicArray.Length, which emulates a static function;
+// was replaced in script compilers around Editor v4.0.0.11, but is kept for backwards compat.
+RuntimeScriptValue Sc_DynamicArray_Static_Length(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_INT_POBJ(DynamicArray_Length, void);
 }
 
-void RegisterDynamicArrayAPI()
+RuntimeScriptValue Sc_DynamicArray_Length(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    ccAddExternalStaticFunction("__Builtin_DynamicArrayLength^1", Sc_DynamicArray_Length);
+    API_OBJCALL_INT(void, DynamicArray_Length);
 }
 
+void RegisterDynamicArrayAPI()
+{
+    ccAddExternalStaticFunction("__Builtin_DynamicArrayLength^1", Sc_DynamicArray_Static_Length);
+    ccAddExternalObjectFunction("__Builtin_DynamicArray::get_Length", Sc_DynamicArray_Length);
+}


### PR DESCRIPTION
@fernewelten , I would very much like to know your opinion on this.

I've been revisiting Array.Length pseudo property recently, and it hit me that it's implemented as a static function. Somehow I did not pay attention to this back when it was done (by #1256). I noticed that my proposal in [this comment](https://github.com/adventuregamestudio/ags/issues/637#issuecomment-778922004) mentions "function name accepting 1 argument", so maybe this is what caused it, or maybe there were other considerations too.

But thinking about this now, this does not seem convenient, as such interpretation breaks parsing rules: you have `object.property` syntax, but it's been treated as if it were `function(arg)`. The new compiler has to have a separate case for this, where it has to generate a function call in a separate "outside of system" way.

I am not completely sure, but I suspect that this may cause trouble would we have more pseudo-properties like that, or would a compiler's parser be structured differently, making it more complicated to inject special handling like that.

My proposal is to modify this by treating the property's getter as a object's member function, just like properties (attributes) are normally treated in AGS.

What I did was this:
Instead of generating a call to a pseudo-static-function, the parser generates an actual readonly attribute "T[]::Length", where "T[]" is a dynamic array type.
The getter is substituted by a generated function called `"__Builtin_DynamicArray::get_Length"`. The same symbol is used for each such generated attribute. This is where it goes slightly away from your system, as the function does not have a reference to the struct it belongs to, as it cannot belong to multiple structs. But this does not cause any trouble at the moment.
I *suppose* that for the perfect simulation we could have a hidden built-in parent class for arrays, and attach this attribute there. But I did not go that far.

Note that *no* special *function call* is generated after this, instead I just let parser to continue its work and deal with the attribute usage in a normal way. This seems to be a more natural way of handling this.

In regards to backwards compatibility. This feature did not introduce any new opcodes, thankfully, it was only a function name. All it relies on is an actual function linked by the engine. I kept old static function registration within the engine for the time being, in case it is used to run old compiled script.

---

As an extra change, this PR contains support for Array.Length added to the old compiler. I was doing this as an experiment, when I stumbled on the issue above.

Added new extension name to compilers, called "DYNARRAY_LENGTH", this may be used to test if compiler supports .Length pseudo property.