### PR TITLE
Engine: use safe strcpy function instead of snprintf where truncation expected

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -639,16 +639,19 @@ void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
     }
 
     // Fixup character script names for 2.x (EGO -> cEgo)
+    // In 2.x versions the "scriptname" field in game data contained a name
+    // limited by 14 chars (although serialized in 20 bytes). After reading,
+    // it was exported as "cScriptname..." for the script.
     if (data_ver <= kGameVersion_272)
     {
-        char namelwr[LEGACY_MAX_SCRIPT_NAME_LEN];
+        char namelwr[LEGACY_MAX_SCRIPT_NAME_LEN - 1];
         for (int i = 0; i < numcharacters; i++)
         {
             if (chars[i].scrname[0] == 0)
                 continue;
-            memcpy(namelwr, chars[i].scrname, LEGACY_MAX_SCRIPT_NAME_LEN);
+            ags_strncpy_s(namelwr, sizeof(namelwr), chars[i].scrname, LEGACY_MAX_SCRIPT_NAME_LEN - 2);
             ags_strlwr(namelwr + 1); // lowercase starting with the second char
-            snprintf(chars[i].scrname, LEGACY_MAX_SCRIPT_NAME_LEN, "c%s", namelwr);
+            snprintf(chars[i].scrname, sizeof(chars[i].scrname), "c%s", namelwr);
             chars2[i].scrname_new = chars[i].scrname;
         }
     }

--- a/Common/util/string_compat.h
+++ b/Common/util/string_compat.h
@@ -26,6 +26,7 @@ int ags_stricmp(const char *, const char *);
 int ags_strnicmp(const char *, const char *, size_t);
 char *ags_strdup(const char *s);
 char *ags_strstr(const char *haystack, const char *needle);
+int ags_strncpy_s(char *dest, size_t dest_sz, const char *src, size_t count);
 
 #ifdef __cplusplus
 }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -580,7 +580,7 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
     screen_tint = in->ReadInt32();
     num_parsed_words = in->ReadInt32();
     in->ReadArrayOfInt16( parsed_words, MAX_PARSED_WORDS);
-    in->Read( bad_parsed_word, 100);
+    bad_parsed_word.ReadCount(in, 100); // CHECKME: does it have to be serialized?
     raw_color = in->ReadInt32();
     in->ReadArrayOfInt16( filenumbers, LEGACY_MAXSAVEGAMES);
     mouse_cursor_hidden = in->ReadInt32();
@@ -770,7 +770,7 @@ void GamePlayState::WriteForSavegame(Stream *out) const
     out->WriteInt32( screen_tint);
     out->WriteInt32( num_parsed_words);
     out->WriteArrayOfInt16( parsed_words, MAX_PARSED_WORDS);
-    out->Write( bad_parsed_word, 100);
+    bad_parsed_word.WriteCount(out, 100); // CHECKME: does it have to be serialized?
     out->WriteInt32( raw_color);
     out->WriteArrayOfInt16( filenumbers, LEGACY_MAXSAVEGAMES);
     out->WriteInt32( mouse_cursor_hidden);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -227,7 +227,7 @@ struct GamePlayState
     int   screen_tint = 0;
     int   num_parsed_words = 0;
     short parsed_words[MAX_PARSED_WORDS]{};
-    char  bad_parsed_word[100]{};
+    Common::String bad_parsed_word;
     int   raw_color = 0;
     int   raw_modified[MAX_ROOM_BGFRAMES]{};
     Common::PBitmap raw_drawing_surface;

--- a/Engine/ac/global_parser.cpp
+++ b/Engine/ac/global_parser.cpp
@@ -19,8 +19,8 @@
 
 int SaidUnknownWord (char*buffer) {
     VALIDATE_STRING(buffer);
-    snprintf(buffer, MAX_MAXSTRLEN, "%s", play.bad_parsed_word);
-    if (play.bad_parsed_word[0] == 0)
+    snprintf(buffer, MAX_MAXSTRLEN, "%s", play.bad_parsed_word.GetCStr());
+    if (play.bad_parsed_word.IsEmpty())
         return 0;
     return 1;
 }

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -34,7 +34,7 @@ int Parser_FindWordID(const char *wordToFind)
 }
 
 const char* Parser_SaidUnknownWord() {
-    if (play.bad_parsed_word[0] == 0)
+    if (play.bad_parsed_word.IsEmpty())
         return nullptr;
     return CreateNewScriptString(play.bad_parsed_word);
 }
@@ -138,7 +138,7 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
 
     numwords[0] = 0;
     if (compareto == nullptr)
-        play.bad_parsed_word[0] = 0;
+        play.bad_parsed_word.Empty();
 
     String uniform_text = src_text;
     uniform_text.MakeLower();
@@ -277,8 +277,8 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
                     return 0;
                 // if it's an unknown word, store it for use in messages like
                 // "you can't use the word 'xxx' in this game"
-                if ((word < 0) && (play.bad_parsed_word[0] == 0))
-                    snprintf(play.bad_parsed_word, 100, "%s", thisword);
+                if ((word < 0) && (play.bad_parsed_word.IsEmpty()))
+                    play.bad_parsed_word = thisword;
             }
 
             if (do_word_now) {

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -28,6 +28,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/sys_main.h"
 #include "main/engine.h"
+#include "util/string_compat.h"
 #include "util/string_utils.h"
 #include "util/utf8.h"
 
@@ -64,7 +65,7 @@ KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event, bool old_keyhandle)
                 ki.CompatKey = ki.Key;
             }
         }
-        snprintf(ki.Text, KeyInput::UTF8_ARR_SIZE, "%s", event.text.text);
+        ags_strncpy_s(ki.Text, KeyInput::UTF8_ARR_SIZE, event.text.text, KeyInput::UTF8_ARR_SIZE - 1);
         Utf8::GetChar(event.text.text, sizeof(SDL_TextInputEvent::text), &ki.UChar);
         return ki;
     case SDL_KEYDOWN:

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -762,7 +762,7 @@ void engine_init_game_settings()
     play.speech_font = 1;
     play.speech_text_shadow = 16;
     play.screen_tint = -1;
-    play.bad_parsed_word[0] = 0;
+    play.bad_parsed_word.Empty();
     play.swap_portrait_side = 0;
     play.swap_portrait_lastchar = -1;
     play.swap_portrait_lastlastchar = -1;


### PR DESCRIPTION
Fix #2567

This replaces uses of `snprintf` in the code where truncation of the source string is *intended*.
Added a "ags_strncpy_s", using "strncpy_s" from the C11 extension as a reference (see https://en.cppreference.com/w/c/string/byte/strncpy)