### PR TITLE
Editor: fix pressing alt doesn't select File in menu

### DIFF
--- a/Editor/AGS.Editor/GUI/frmMain.Designer.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.Designer.cs
@@ -78,6 +78,7 @@ namespace AGS.Editor
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmMain_FormClosing);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.frmMain_KeyDown);
             this.IsMdiContainer = true;
+            this.MainMenuStrip = this.mainMenu;
             this.Controls.Add(this.mainContainer);
             this.Controls.Add(this.toolStrip);
             this.Controls.Add(this.mainMenu);


### PR DESCRIPTION
fix #2566 

From [the MSDN docs on the property](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.form.mainmenustrip?view=netframework-4.6&devlangs=csharp&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(System.Windows.Forms.Form.MainMenuStrip)%3Bk(TargetFrameworkMoniker-.NETFramework%2CVersion%253Dv4.6)%3Bk(DevLang-csharp)%26rd%3Dtrue), it appears it was just something it was not set by accident.