### PR TITLE
Editor: fix exception when saving at close

### DIFF
--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -159,7 +159,7 @@ namespace AGS.Editor.Preferences
             ApplyLimit(RecentGames, MAX_RECENT_GAMES);
             afterListChangedDebouncer.Debounce(() =>
             {
-                AfterRecentGamesChanged.Invoke(sender);
+                AfterRecentGamesChanged?.Invoke(sender);
             });
         }
 


### PR DESCRIPTION
AfterRecentGamesChanged has it's event removed (the update of the Open Recent menu), when the Editor is closed, but later Settings_LimitRecentGames events triggers. This prevents an exception at null in this specific case.

I think this is one of those things I should commit directly on master but I was a bit unsure if it was something wrong on my side since this wasn't reported yet and I thought it would be something common to see.