### PR TITLE
Editor: multiline text editing in labels and buttons

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -210,6 +210,12 @@
     <Compile Include="GUI\LogPanel.Designer.cs">
       <DependentUpon>LogPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\MultilineStringEditorDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\MultilineStringEditorDialog.Designer.cs">
+      <DependentUpon>MultilineStringEditorDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\NumberEntryWithInfoDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -441,6 +447,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\LogPanel.resx">
       <DependentUpon>LogPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\MultilineStringEditorDialog.resx">
+      <DependentUpon>MultilineStringEditorDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\NumberEntryWithInfoDialog.resx">
       <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1465,9 +1465,9 @@ namespace AGS.Editor
             return CustomResolutionDialog.Show(currentSize);
         }
 
-        private String ShowMultilineStringDialog(String text)
+        private String ShowMultilineStringDialog(string title, String text)
         {
-            return MultilineStringEditorDialog.ShowEditor(text ?? string.Empty);
+            return MultilineStringEditorDialog.ShowEditor(title, text ?? string.Empty);
         }
 
         private Color? ShowColorDialog(Color? color)

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -891,6 +891,7 @@ namespace AGS.Editor
                 RoomMessagesUIEditor.ShowRoomMessagesEditor = new RoomMessagesUIEditor.RoomMessagesEditorType(ShowRoomMessageEditorFromPropertyGrid);
                 CustomResolutionUIEditor.CustomResolutionSetGUI = new CustomResolutionUIEditor.CustomResolutionGUIType(ShowCustomResolutionChooserFromPropertyGrid);
                 ColorUIEditor.ColorGUI = new ColorUIEditor.ColorGUIType(ShowColorDialog);
+                MultiLineStringUIEditor.MultilineStringGUI = new MultiLineStringUIEditor.MultilineStringGUIType(ShowMultilineStringDialog);
                 AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = new AudioClipSourceFileUIEditor.AudioClipSourceFileGUIType(ShowAudioClipSourceFileChooserFromPropertyGrid);
             }
         }
@@ -1462,6 +1463,11 @@ namespace AGS.Editor
         private Size ShowCustomResolutionChooserFromPropertyGrid(Size currentSize)
         {
             return CustomResolutionDialog.Show(currentSize);
+        }
+
+        private String ShowMultilineStringDialog(String text)
+        {
+            return MultilineStringEditorDialog.ShowEditor(text ?? string.Empty);
         }
 
         private Color? ShowColorDialog(Color? color)

--- a/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.Designer.cs
@@ -1,0 +1,161 @@
+﻿namespace AGS.Editor
+{
+    partial class MultilineStringEditorDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.tableLayoutDialog = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutBottom = new System.Windows.Forms.TableLayoutPanel();
+            this.btnOk = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.labelStatus = new System.Windows.Forms.Label();
+            this.tableLayoutDialog.SuspendLayout();
+            this.tableLayoutBottom.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // textBox1
+            // 
+            this.textBox1.AcceptsReturn = true;
+            this.textBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox1.Location = new System.Drawing.Point(3, 3);
+            this.textBox1.Multiline = true;
+            this.textBox1.Name = "textBox1";
+            this.textBox1.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.textBox1.Size = new System.Drawing.Size(580, 239);
+            this.textBox1.TabIndex = 0;
+            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            this.textBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox1_KeyDown);
+            // 
+            // tableLayoutDialog
+            // 
+            this.tableLayoutDialog.AutoSize = true;
+            this.tableLayoutDialog.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutDialog.ColumnCount = 1;
+            this.tableLayoutDialog.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutDialog.Controls.Add(this.textBox1, 0, 0);
+            this.tableLayoutDialog.Controls.Add(this.tableLayoutBottom, 0, 1);
+            this.tableLayoutDialog.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutDialog.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.tableLayoutDialog.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutDialog.MinimumSize = new System.Drawing.Size(300, 200);
+            this.tableLayoutDialog.Name = "tableLayoutDialog";
+            this.tableLayoutDialog.RowCount = 2;
+            this.tableLayoutDialog.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutDialog.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
+            this.tableLayoutDialog.Size = new System.Drawing.Size(586, 300);
+            this.tableLayoutDialog.TabIndex = 1;
+            // 
+            // tableLayoutBottom
+            // 
+            this.tableLayoutBottom.ColumnCount = 3;
+            this.tableLayoutBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 137F));
+            this.tableLayoutBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 137F));
+            this.tableLayoutBottom.Controls.Add(this.btnOk, 1, 0);
+            this.tableLayoutBottom.Controls.Add(this.btnCancel, 2, 0);
+            this.tableLayoutBottom.Controls.Add(this.labelStatus, 0, 0);
+            this.tableLayoutBottom.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutBottom.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.tableLayoutBottom.Location = new System.Drawing.Point(3, 248);
+            this.tableLayoutBottom.MinimumSize = new System.Drawing.Size(200, 49);
+            this.tableLayoutBottom.Name = "tableLayoutBottom";
+            this.tableLayoutBottom.RowCount = 1;
+            this.tableLayoutBottom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutBottom.Size = new System.Drawing.Size(580, 49);
+            this.tableLayoutBottom.TabIndex = 1;
+            // 
+            // btnOk
+            // 
+            this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOk.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnOk.Location = new System.Drawing.Point(314, 8);
+            this.btnOk.Margin = new System.Windows.Forms.Padding(8);
+            this.btnOk.Name = "btnOk";
+            this.btnOk.Size = new System.Drawing.Size(121, 33);
+            this.btnOk.TabIndex = 0;
+            this.btnOk.Text = "OK";
+            this.btnOk.UseVisualStyleBackColor = true;
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnCancel.Location = new System.Drawing.Point(451, 8);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(8);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(121, 33);
+            this.btnCancel.TabIndex = 1;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // labelStatus
+            // 
+            this.labelStatus.AutoSize = true;
+            this.labelStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelStatus.Location = new System.Drawing.Point(3, 0);
+            this.labelStatus.Name = "labelStatus";
+            this.labelStatus.Size = new System.Drawing.Size(300, 49);
+            this.labelStatus.TabIndex = 2;
+            this.labelStatus.Text = "label1";
+            this.labelStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // MultilineStringEditorDialog
+            // 
+            this.AcceptButton = this.btnOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(586, 300);
+            this.Controls.Add(this.tableLayoutDialog);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(300, 200);
+            this.Name = "MultilineStringEditorDialog";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Edit text...";
+            this.Load += new System.EventHandler(this.MultilineStringEditorDialog_Load);
+            this.tableLayoutDialog.ResumeLayout(false);
+            this.tableLayoutDialog.PerformLayout();
+            this.tableLayoutBottom.ResumeLayout(false);
+            this.tableLayoutBottom.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutDialog;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutBottom;
+        private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Label labelStatus;
+    }
+}

--- a/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.cs
+++ b/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.cs
@@ -8,17 +8,18 @@ namespace AGS.Editor
     {
         private static System.Drawing.Font _font = null;
 
-        private MultilineStringEditorDialog(String text)
+        private MultilineStringEditorDialog(string title, String text)
         {
             InitializeComponent();
             AdjustFont(); // make text slightly bigger
             MultilineString = text;
+            Text = title;
             UpdateTextStatus();
         }
 
-        public static String ShowEditor(String text)
+        public static String ShowEditor(string title, String text)
         {
-            MultilineStringEditorDialog dialog = new MultilineStringEditorDialog(text);
+            MultilineStringEditorDialog dialog = new MultilineStringEditorDialog(title, text);
             bool ok = dialog.ShowDialog() == DialogResult.OK;
             String result = dialog.MultilineString;
             dialog.Dispose();

--- a/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.cs
+++ b/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.cs
@@ -1,0 +1,106 @@
+﻿using AGS.Types;
+using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public partial class MultilineStringEditorDialog : Form
+    {
+        private static System.Drawing.Font _font = null;
+
+        private MultilineStringEditorDialog(String text)
+        {
+            InitializeComponent();
+            AdjustFont(); // make text slightly bigger
+            MultilineString = text;
+            UpdateTextStatus();
+        }
+
+        public static String ShowEditor(String text)
+        {
+            MultilineStringEditorDialog dialog = new MultilineStringEditorDialog(text);
+            bool ok = dialog.ShowDialog() == DialogResult.OK;
+            String result = dialog.MultilineString;
+            dialog.Dispose();
+            return ok ? result : null;
+        }
+
+        public String MultilineString
+        {
+            set { textBox1.Text = UnescapeToTextbox(value); }
+            get { return EscapeToProperty(textBox1.Text); }
+        }
+
+        // textbox in winforms uses CR+LF for newlines
+        private String UnescapeToTextbox(String text)
+        {
+            return text.Replace("\\r", "\r").Replace("\\n", "\n").Replace("\r\n", "\n").Replace("\n","\r\n");
+        }
+
+        // we need to convert from CR+LF to "\n" for AGS, but account for a "\n" that was copy-pasted somehow
+        private String EscapeToProperty(String text)
+        {
+            return text.Replace("\r\n", "\n").Replace("\n", "\\n");
+        }
+
+        private void UpdateTextStatus()
+        {
+            int charCount = textBox1.Text.Length;
+            int lineCount = textBox1.Lines.Length;
+            string charText = charCount == 1 ? "character" : "characters";
+            string lineText = lineCount == 1 ? "line" : "lines";
+            labelStatus.Text = $"{charCount} {charText}, {lineCount} {lineText}";
+        }
+
+        private void AdjustFont()
+        {
+            if (_font == null)
+                _font = textBox1.Font;
+            textBox1.Font = new System.Drawing.Font(_font.Name, _font.SizeInPoints * 1.2f);
+        }
+
+        private void textBox1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && (Control.ModifierKeys == Keys.Control || Control.ModifierKeys == Keys.Shift))
+            {
+                e.Handled = true;
+                this.DialogResult = DialogResult.OK; // either ctrl + return or shift + return confirms the dialog
+                this.Close();
+            }
+        }
+
+        private void textBox1_TextChanged(object sender, EventArgs e)
+        {
+            UpdateTextStatus();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                var config = GUIController.Instance.WindowConfig;
+                ConfigUtils.WriteFormPosition(config, "MultilineStringEditorDialog", this);
+            }
+        }
+
+        private void MultilineStringEditorDialog_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+                var config = GUIController.Instance.WindowConfig;
+                ConfigUtils.ReadFormPosition(config, "MultilineStringEditorDialog", this);
+            }
+        }
+
+        private void LoadColorTheme(ColorTheme t)
+        {
+            t.SetColor("global/background", c => BackColor = c);
+            t.SetColor("global/foreground", c => ForeColor = c);
+            t.SetColor("global/foreground", c => labelStatus.ForeColor = c);
+            t.ButtonHelper(btnOk, "global/button");
+            t.ButtonHelper(btnCancel, "global/button");
+            t.TextBoxHelper(textBox1, "global/text-box");
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.resx
+++ b/Editor/AGS.Editor/GUI/MultilineStringEditorDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -225,6 +225,7 @@
     <Compile Include="PropertyGridExtras\FontSizeUIEditor.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\InteractionEventPropertyDescriptor.cs" />
+    <Compile Include="PropertyGridExtras\MultilineStringUIEditor.cs" />
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />
     <Compile Include="PropertyGridExtras\ReadOnlyConverter .cs" />
     <Compile Include="PropertyGridExtras\RoomMaskResolutionTypeConverter.cs" />

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -197,6 +197,7 @@ namespace AGS.Types
 
         [Description("The text displayed on the button")]
         [Category("Appearance")]
+        [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string Text
         {
             get { return _text; }

--- a/Editor/AGS.Types/GUILabel.cs
+++ b/Editor/AGS.Types/GUILabel.cs
@@ -96,6 +96,7 @@ namespace AGS.Types
 
         [Description("The text displayed on the label")]
         [Category("Appearance")]
+        [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string Text
         {
             get { return _text; }

--- a/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Design;
+
+namespace AGS.Types
+{
+    public class MultiLineStringUIEditor : UITypeEditor
+    {
+        public delegate String MultilineStringGUIType(String text);
+        public static MultilineStringGUIType MultilineStringGUI;
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.Modal;
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            String text = (String)value;
+            if (MultilineStringGUI != null)
+            {
+                text = MultilineStringGUI(text);
+            }
+            return text ?? value; // must return strictly original value if no change
+        }
+    }
+}

--- a/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
@@ -7,7 +7,7 @@ namespace AGS.Types
 {
     public class MultiLineStringUIEditor : UITypeEditor
     {
-        public delegate String MultilineStringGUIType(String text);
+        public delegate String MultilineStringGUIType(String title, String text);
         public static MultilineStringGUIType MultilineStringGUI;
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
@@ -17,11 +17,25 @@ namespace AGS.Types
 
         public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            String text = (String)value;
-            if (MultilineStringGUI != null)
+            if (MultilineStringGUI == null)
+                return value;
+
+            String text = value as String;
+            string title = "Edit text...";
+
+            GUIControl ctrl = context.Instance as GUIControl;
+            if (ctrl != null)
             {
-                text = MultilineStringGUI(text);
+                title = "Edit " + ctrl.Name + " text...";
             }
+
+            GUIControl[] ctrls = context.Instance as GUIControl[];
+            if (ctrls != null)
+            {
+                title = "Edit " + ctrls.Length.ToString() + " controls text...";
+            }
+
+            text = MultilineStringGUI(title, text);
             return text ?? value; // must return strictly original value if no change
         }
     }


### PR DESCRIPTION
This is just an idea for a multiline text editor for property grids

<img width="641" alt="image" src="https://github.com/user-attachments/assets/fa1502f2-2934-432e-a418-42df911f8ea6">


https://github.com/user-attachments/assets/abffa5c1-3169-4992-aa7b-9fa8d2202592



When editing properly tagged strings, they will show a three dots and then hitting it they show this custom modal dialog that allow multiline editing.

[I had this idea after this forum post](https://www.adventuregamestudio.co.uk/forums/beginners-technical-questions/how-to-create-a-large-gui-that-would-hold-a-lot-of-text/msg636666904/?boardseen#new)

In a far future of ags perhaps it has an option to have a folder of txt files and you can assign one to a label or whatever, but I don't know the ui for this.