### PR TITLE
Editor: new game wizard project name changes filename

### DIFF
--- a/Editor/AGS.Editor/GUI/StartNewGameWizardPage2.Designer.cs
+++ b/Editor/AGS.Editor/GUI/StartNewGameWizardPage2.Designer.cs
@@ -92,6 +92,7 @@ namespace AGS.Editor
             this.txtFriendlyName.Size = new System.Drawing.Size(286, 21);
             this.txtFriendlyName.TabIndex = 0;
             this.txtFriendlyName.Text = "New game";
+            this.txtFriendlyName.TextChanged += new System.EventHandler(this.txtFriendlyName_TextChanged);
             // 
             // label2
             // 
@@ -113,6 +114,7 @@ namespace AGS.Editor
             this.txtFileName.Size = new System.Drawing.Size(286, 21);
             this.txtFileName.TabIndex = 1;
             this.txtFileName.TextChanged += new System.EventHandler(this.txtFileName_TextChanged);
+            this.txtFileName.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtFileName_KeyPress);
             // 
             // label1
             // 

--- a/Editor/AGS.Editor/GUI/StartNewGameWizardPage2.cs
+++ b/Editor/AGS.Editor/GUI/StartNewGameWizardPage2.cs
@@ -13,6 +13,9 @@ namespace AGS.Editor
 {
     public partial class StartNewGameWizardPage2 : WizardPage
     {
+        private bool _typedInFileName = false;
+        private readonly Debouncer _afterFileNameClearDebouncer = new Debouncer(150);
+
         public StartNewGameWizardPage2(string baseDirectory)
         {
             InitializeComponent();
@@ -123,6 +126,13 @@ namespace AGS.Editor
             else
             {
                 lblFilePath.Text = string.Empty;
+                _afterFileNameClearDebouncer.Debounce(() =>
+                {
+                    if (txtFileName.Text.Length == 0)
+                    {
+                        _typedInFileName = false;
+                    }
+                });
             }
         }
 
@@ -134,6 +144,18 @@ namespace AGS.Editor
         private void btnCreateInBrowse_Click(object sender, EventArgs e)
         {
             txtCreateInFolder.Text = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Please select the folder that you wish to create your new project in.", txtCreateInFolder.Text);
+        }
+
+        private void txtFriendlyName_TextChanged(object sender, EventArgs e)
+        {
+            if (_typedInFileName)
+                return;
+            txtFileName.Text = Utilities.ConvertToNiceFilename(txtFriendlyName.Text);
+        }
+
+        private void txtFileName_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            _typedInFileName = true;
         }
     }
 }

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Reflection;
+using System.Globalization;
+using System.Text;
 
 namespace AGS.Editor
 {
@@ -738,6 +740,33 @@ namespace AGS.Editor
             {
                 prop.SetValue(clone, prop.GetValue(source_obj));
             }
+        }
+
+        /// <summary>
+        /// A function to convert a name that possible has spaces to a nice file name.
+        /// </summary>
+        public static string ConvertToNiceFilename(string input)
+        {
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            string filteredInput = new string(input.Where(c => !invalidChars.Contains(c) && c <= 127).ToArray());
+
+            string[] words = filteredInput
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            StringBuilder txt = new StringBuilder();
+            for (int i = 0; i < words.Length; i++)
+            {
+                if (words[i].Length > 0)
+                {
+                    txt.Append(words[i]);
+                    if (i < words.Length - 1)
+                    {
+                        txt.Append('-');
+                    }
+                }
+            }
+
+            return txt.ToString().Replace("'", "").Trim();
         }
     }
 }


### PR DESCRIPTION
In the Start New Game wizard, if you type the project name, it will now automatically fill the filename too. If you then type a different filename there it will stop automatically following what is typed in project name. If you then delete what is in the filename AND later types in the project name it goes back to automatically tracking the project name. Here is a video to make it easier to understand

https://github.com/user-attachments/assets/bef088c8-4b7a-48fe-bdd3-4b4b5f249a4c

This is something I have wanted after creating a gazillion of ags projects for testing things, because I always have to type things twice.

I can see people may have different opinions on how the filename from project name rules should be but I gave a good default that feels sensible for me. I don't think it has to work for everyone, people can still type manually like it always been if they have a specific taste.
