### PR TITLE
Editor: adds version in Welcome Screen

### DIFF
--- a/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
@@ -43,23 +43,23 @@ namespace AGS.Editor
             this.btnExit = new System.Windows.Forms.Button();
             this.panelLogo = new System.Windows.Forms.Panel();
             this.lblLogo = new System.Windows.Forms.Label();
+            this.tableLayoutPanelAll = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanelBottom = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanelCenter = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1.SuspendLayout();
             this.panelLogo.SuspendLayout();
+            this.tableLayoutPanelAll.SuspendLayout();
+            this.tableLayoutPanelBottom.SuspendLayout();
+            this.tableLayoutPanelCenter.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.lstRecentGames);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.radRecent);
-            this.groupBox1.Controls.Add(this.radLoadGame);
-            this.groupBox1.Controls.Add(this.radNewGame);
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Location = new System.Drawing.Point(11, 74);
+            this.groupBox1.Controls.Add(this.tableLayoutPanelCenter);
+            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox1.Location = new System.Drawing.Point(3, 75);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(498, 293);
+            this.groupBox1.Size = new System.Drawing.Size(513, 283);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Welcome";
@@ -67,9 +67,11 @@ namespace AGS.Editor
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(35, 168);
+            this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label4.Location = new System.Drawing.Point(36, 147);
+            this.label4.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(296, 13);
+            this.label4.Size = new System.Drawing.Size(451, 13);
             this.label4.TabIndex = 7;
             this.label4.Text = "Continue making a game that you were recently working on:";
             // 
@@ -78,13 +80,15 @@ namespace AGS.Editor
             this.lstRecentGames.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader2});
+            this.lstRecentGames.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lstRecentGames.FullRowSelect = true;
             this.lstRecentGames.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.lstRecentGames.HideSelection = false;
-            this.lstRecentGames.Location = new System.Drawing.Point(38, 190);
+            this.lstRecentGames.Location = new System.Drawing.Point(20, 167);
+            this.lstRecentGames.Margin = new System.Windows.Forms.Padding(20, 3, 20, 6);
             this.lstRecentGames.MultiSelect = false;
             this.lstRecentGames.Name = "lstRecentGames";
-            this.lstRecentGames.Size = new System.Drawing.Size(422, 92);
+            this.lstRecentGames.Size = new System.Drawing.Size(467, 90);
             this.lstRecentGames.TabIndex = 6;
             this.lstRecentGames.UseCompatibleStateImageBehavior = false;
             this.lstRecentGames.View = System.Windows.Forms.View.Details;
@@ -101,28 +105,34 @@ namespace AGS.Editor
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(35, 120);
+            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label3.Location = new System.Drawing.Point(36, 102);
+            this.label3.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(138, 13);
+            this.label3.Size = new System.Drawing.Size(451, 13);
             this.label3.TabIndex = 5;
             this.label3.Text = "Load one you made earlier!";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(35, 72);
+            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label2.Location = new System.Drawing.Point(36, 57);
+            this.label2.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(335, 13);
+            this.label2.Size = new System.Drawing.Size(451, 13);
             this.label2.TabIndex = 4;
             this.label2.Text = "Start making a new game, from scratch. Turn your ideas into reality!";
             // 
             // radRecent
             // 
             this.radRecent.AutoSize = true;
+            this.radRecent.Dock = System.Windows.Forms.DockStyle.Fill;
             this.radRecent.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-            this.radRecent.Location = new System.Drawing.Point(19, 148);
+            this.radRecent.Location = new System.Drawing.Point(20, 124);
+            this.radRecent.Margin = new System.Windows.Forms.Padding(20, 5, 20, 3);
             this.radRecent.Name = "radRecent";
-            this.radRecent.Size = new System.Drawing.Size(209, 17);
+            this.radRecent.Size = new System.Drawing.Size(467, 17);
             this.radRecent.TabIndex = 3;
             this.radRecent.TabStop = true;
             this.radRecent.Text = "Continue a recently edited game";
@@ -132,10 +142,12 @@ namespace AGS.Editor
             // radLoadGame
             // 
             this.radLoadGame.AutoSize = true;
+            this.radLoadGame.Dock = System.Windows.Forms.DockStyle.Fill;
             this.radLoadGame.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-            this.radLoadGame.Location = new System.Drawing.Point(19, 100);
+            this.radLoadGame.Location = new System.Drawing.Point(20, 79);
+            this.radLoadGame.Margin = new System.Windows.Forms.Padding(20, 5, 20, 3);
             this.radLoadGame.Name = "radLoadGame";
-            this.radLoadGame.Size = new System.Drawing.Size(175, 17);
+            this.radLoadGame.Size = new System.Drawing.Size(467, 17);
             this.radLoadGame.TabIndex = 2;
             this.radLoadGame.TabStop = true;
             this.radLoadGame.Text = "Continue an existing game";
@@ -144,10 +156,12 @@ namespace AGS.Editor
             // radNewGame
             // 
             this.radNewGame.AutoSize = true;
+            this.radNewGame.Dock = System.Windows.Forms.DockStyle.Fill;
             this.radNewGame.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-            this.radNewGame.Location = new System.Drawing.Point(19, 52);
+            this.radNewGame.Location = new System.Drawing.Point(20, 34);
+            this.radNewGame.Margin = new System.Windows.Forms.Padding(20, 5, 20, 3);
             this.radNewGame.Name = "radNewGame";
-            this.radNewGame.Size = new System.Drawing.Size(125, 17);
+            this.radNewGame.Size = new System.Drawing.Size(467, 17);
             this.radNewGame.TabIndex = 1;
             this.radNewGame.TabStop = true;
             this.radNewGame.Text = "Start a new game";
@@ -156,15 +170,17 @@ namespace AGS.Editor
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(16, 27);
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(20, 4);
+            this.label1.Margin = new System.Windows.Forms.Padding(20, 4, 20, 4);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(215, 13);
+            this.label1.Size = new System.Drawing.Size(467, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Welcome to AGS! What do you want to do?";
             // 
             // btnContinue
             // 
-            this.btnContinue.Location = new System.Drawing.Point(313, 373);
+            this.btnContinue.Location = new System.Drawing.Point(313, 3);
             this.btnContinue.Name = "btnContinue";
             this.btnContinue.Size = new System.Drawing.Size(94, 28);
             this.btnContinue.TabIndex = 2;
@@ -175,7 +191,7 @@ namespace AGS.Editor
             // btnExit
             // 
             this.btnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnExit.Location = new System.Drawing.Point(412, 373);
+            this.btnExit.Location = new System.Drawing.Point(413, 3);
             this.btnExit.Name = "btnExit";
             this.btnExit.Size = new System.Drawing.Size(97, 28);
             this.btnExit.TabIndex = 3;
@@ -186,11 +202,12 @@ namespace AGS.Editor
             // 
             this.panelLogo.BackColor = System.Drawing.Color.RoyalBlue;
             this.panelLogo.Controls.Add(this.lblLogo);
-            this.panelLogo.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelLogo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelLogo.ForeColor = System.Drawing.Color.White;
             this.panelLogo.Location = new System.Drawing.Point(0, 0);
+            this.panelLogo.Margin = new System.Windows.Forms.Padding(0);
             this.panelLogo.Name = "panelLogo";
-            this.panelLogo.Size = new System.Drawing.Size(519, 68);
+            this.panelLogo.Size = new System.Drawing.Size(519, 72);
             this.panelLogo.TabIndex = 4;
             // 
             // lblLogo
@@ -203,6 +220,68 @@ namespace AGS.Editor
             this.lblLogo.TabIndex = 0;
             this.lblLogo.Text = "Adventure Game Studio";
             // 
+            // tableLayoutPanelAll
+            // 
+            this.tableLayoutPanelAll.ColumnCount = 1;
+            this.tableLayoutPanelAll.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelAll.Controls.Add(this.tableLayoutPanelBottom, 0, 2);
+            this.tableLayoutPanelAll.Controls.Add(this.groupBox1, 0, 1);
+            this.tableLayoutPanelAll.Controls.Add(this.panelLogo, 0, 0);
+            this.tableLayoutPanelAll.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelAll.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelAll.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanelAll.Name = "tableLayoutPanelAll";
+            this.tableLayoutPanelAll.RowCount = 3;
+            this.tableLayoutPanelAll.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 72F));
+            this.tableLayoutPanelAll.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelAll.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 49F));
+            this.tableLayoutPanelAll.Size = new System.Drawing.Size(519, 410);
+            this.tableLayoutPanelAll.TabIndex = 5;
+            // 
+            // tableLayoutPanelBottom
+            // 
+            this.tableLayoutPanelBottom.ColumnCount = 3;
+            this.tableLayoutPanelBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelBottom.Controls.Add(this.btnExit, 2, 0);
+            this.tableLayoutPanelBottom.Controls.Add(this.btnContinue, 1, 0);
+            this.tableLayoutPanelBottom.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelBottom.Location = new System.Drawing.Point(3, 364);
+            this.tableLayoutPanelBottom.Name = "tableLayoutPanelBottom";
+            this.tableLayoutPanelBottom.RowCount = 1;
+            this.tableLayoutPanelBottom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelBottom.Size = new System.Drawing.Size(513, 43);
+            this.tableLayoutPanelBottom.TabIndex = 0;
+            // 
+            // tableLayoutPanelCenter
+            // 
+            this.tableLayoutPanelCenter.ColumnCount = 1;
+            this.tableLayoutPanelCenter.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelCenter.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanelCenter.Controls.Add(this.lstRecentGames, 0, 8);
+            this.tableLayoutPanelCenter.Controls.Add(this.label4, 0, 7);
+            this.tableLayoutPanelCenter.Controls.Add(this.label2, 0, 3);
+            this.tableLayoutPanelCenter.Controls.Add(this.radRecent, 0, 6);
+            this.tableLayoutPanelCenter.Controls.Add(this.radLoadGame, 0, 4);
+            this.tableLayoutPanelCenter.Controls.Add(this.label3, 0, 5);
+            this.tableLayoutPanelCenter.Controls.Add(this.radNewGame, 0, 2);
+            this.tableLayoutPanelCenter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelCenter.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanelCenter.Name = "tableLayoutPanelCenter";
+            this.tableLayoutPanelCenter.RowCount = 9;
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelCenter.Size = new System.Drawing.Size(507, 263);
+            this.tableLayoutPanelCenter.TabIndex = 8;
+            // 
             // WelcomeScreen
             // 
             this.AcceptButton = this.btnContinue;
@@ -210,10 +289,7 @@ namespace AGS.Editor
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnExit;
             this.ClientSize = new System.Drawing.Size(519, 410);
-            this.Controls.Add(this.panelLogo);
-            this.Controls.Add(this.btnExit);
-            this.Controls.Add(this.btnContinue);
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.tableLayoutPanelAll);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
@@ -222,9 +298,12 @@ namespace AGS.Editor
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Welcome to AGS!";
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.panelLogo.ResumeLayout(false);
             this.panelLogo.PerformLayout();
+            this.tableLayoutPanelAll.ResumeLayout(false);
+            this.tableLayoutPanelBottom.ResumeLayout(false);
+            this.tableLayoutPanelCenter.ResumeLayout(false);
+            this.tableLayoutPanelCenter.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -245,5 +324,8 @@ namespace AGS.Editor
         private System.Windows.Forms.ColumnHeader columnHeader2;
         private System.Windows.Forms.Panel panelLogo;
         private System.Windows.Forms.Label lblLogo;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelAll;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelBottom;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelCenter;
     }
 }

--- a/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
@@ -29,29 +29,31 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.label4 = new System.Windows.Forms.Label();
+            this.tableLayoutPanelCenter = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
             this.lstRecentGames = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.radRecent = new System.Windows.Forms.RadioButton();
             this.radLoadGame = new System.Windows.Forms.RadioButton();
+            this.label3 = new System.Windows.Forms.Label();
             this.radNewGame = new System.Windows.Forms.RadioButton();
-            this.label1 = new System.Windows.Forms.Label();
             this.btnContinue = new System.Windows.Forms.Button();
             this.btnExit = new System.Windows.Forms.Button();
             this.panelLogo = new System.Windows.Forms.Panel();
+            this.labelVersion = new System.Windows.Forms.Label();
             this.lblLogo = new System.Windows.Forms.Label();
             this.tableLayoutPanelAll = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanelBottom = new System.Windows.Forms.TableLayoutPanel();
-            this.tableLayoutPanelCenter = new System.Windows.Forms.TableLayoutPanel();
-            this.labelVersion = new System.Windows.Forms.Label();
+            this.tableLayoutRightAlignVersion = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1.SuspendLayout();
+            this.tableLayoutPanelCenter.SuspendLayout();
             this.panelLogo.SuspendLayout();
             this.tableLayoutPanelAll.SuspendLayout();
             this.tableLayoutPanelBottom.SuspendLayout();
-            this.tableLayoutPanelCenter.SuspendLayout();
+            this.tableLayoutRightAlignVersion.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -65,16 +67,44 @@ namespace AGS.Editor
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Welcome";
             // 
-            // label4
+            // tableLayoutPanelCenter
             // 
-            this.label4.AutoSize = true;
-            this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label4.Location = new System.Drawing.Point(36, 147);
-            this.label4.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(451, 13);
-            this.label4.TabIndex = 7;
-            this.label4.Text = "Continue making a game that you were recently working on:";
+            this.tableLayoutPanelCenter.ColumnCount = 1;
+            this.tableLayoutPanelCenter.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelCenter.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanelCenter.Controls.Add(this.lstRecentGames, 0, 8);
+            this.tableLayoutPanelCenter.Controls.Add(this.label4, 0, 7);
+            this.tableLayoutPanelCenter.Controls.Add(this.label2, 0, 3);
+            this.tableLayoutPanelCenter.Controls.Add(this.radRecent, 0, 6);
+            this.tableLayoutPanelCenter.Controls.Add(this.radLoadGame, 0, 4);
+            this.tableLayoutPanelCenter.Controls.Add(this.label3, 0, 5);
+            this.tableLayoutPanelCenter.Controls.Add(this.radNewGame, 0, 2);
+            this.tableLayoutPanelCenter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelCenter.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanelCenter.Name = "tableLayoutPanelCenter";
+            this.tableLayoutPanelCenter.RowCount = 9;
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelCenter.Size = new System.Drawing.Size(507, 263);
+            this.tableLayoutPanelCenter.TabIndex = 8;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(20, 4);
+            this.label1.Margin = new System.Windows.Forms.Padding(20, 4, 20, 4);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(467, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Welcome to AGS! What do you want to do?";
             // 
             // lstRecentGames
             // 
@@ -103,16 +133,16 @@ namespace AGS.Editor
             // 
             this.columnHeader2.Width = 600;
             // 
-            // label3
+            // label4
             // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(36, 102);
-            this.label3.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(451, 13);
-            this.label3.TabIndex = 5;
-            this.label3.Text = "Load one you made earlier!";
+            this.label4.AutoSize = true;
+            this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label4.Location = new System.Drawing.Point(36, 147);
+            this.label4.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(451, 13);
+            this.label4.TabIndex = 7;
+            this.label4.Text = "Continue making a game that you were recently working on:";
             // 
             // label2
             // 
@@ -154,6 +184,17 @@ namespace AGS.Editor
             this.radLoadGame.Text = "Continue an existing game";
             this.radLoadGame.UseVisualStyleBackColor = true;
             // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label3.Location = new System.Drawing.Point(36, 102);
+            this.label3.Margin = new System.Windows.Forms.Padding(36, 3, 20, 4);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(451, 13);
+            this.label3.TabIndex = 5;
+            this.label3.Text = "Load one you made earlier!";
+            // 
             // radNewGame
             // 
             this.radNewGame.AutoSize = true;
@@ -167,17 +208,6 @@ namespace AGS.Editor
             this.radNewGame.TabStop = true;
             this.radNewGame.Text = "Start a new game";
             this.radNewGame.UseVisualStyleBackColor = true;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(20, 4);
-            this.label1.Margin = new System.Windows.Forms.Padding(20, 4, 20, 4);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(467, 13);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Welcome to AGS! What do you want to do?";
             // 
             // btnContinue
             // 
@@ -202,7 +232,7 @@ namespace AGS.Editor
             // panelLogo
             // 
             this.panelLogo.BackColor = System.Drawing.Color.RoyalBlue;
-            this.panelLogo.Controls.Add(this.labelVersion);
+            this.panelLogo.Controls.Add(this.tableLayoutRightAlignVersion);
             this.panelLogo.Controls.Add(this.lblLogo);
             this.panelLogo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelLogo.ForeColor = System.Drawing.Color.White;
@@ -211,6 +241,20 @@ namespace AGS.Editor
             this.panelLogo.Name = "panelLogo";
             this.panelLogo.Size = new System.Drawing.Size(519, 72);
             this.panelLogo.TabIndex = 4;
+            // 
+            // labelVersion
+            // 
+            this.labelVersion.AutoSize = true;
+            this.labelVersion.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelVersion.ForeColor = System.Drawing.Color.LightSteelBlue;
+            this.labelVersion.Location = new System.Drawing.Point(326, 0);
+            this.labelVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelVersion.Name = "labelVersion";
+            this.labelVersion.Padding = new System.Windows.Forms.Padding(4);
+            this.labelVersion.Size = new System.Drawing.Size(189, 21);
+            this.labelVersion.TabIndex = 2;
+            this.labelVersion.Text = "Build X.X.X.X BB-bit, MMMMMM YYYY";
+            this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblLogo
             // 
@@ -256,47 +300,20 @@ namespace AGS.Editor
             this.tableLayoutPanelBottom.Size = new System.Drawing.Size(513, 43);
             this.tableLayoutPanelBottom.TabIndex = 0;
             // 
-            // tableLayoutPanelCenter
+            // tableLayoutRightAlignVersion
             // 
-            this.tableLayoutPanelCenter.ColumnCount = 1;
-            this.tableLayoutPanelCenter.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanelCenter.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanelCenter.Controls.Add(this.lstRecentGames, 0, 8);
-            this.tableLayoutPanelCenter.Controls.Add(this.label4, 0, 7);
-            this.tableLayoutPanelCenter.Controls.Add(this.label2, 0, 3);
-            this.tableLayoutPanelCenter.Controls.Add(this.radRecent, 0, 6);
-            this.tableLayoutPanelCenter.Controls.Add(this.radLoadGame, 0, 4);
-            this.tableLayoutPanelCenter.Controls.Add(this.label3, 0, 5);
-            this.tableLayoutPanelCenter.Controls.Add(this.radNewGame, 0, 2);
-            this.tableLayoutPanelCenter.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanelCenter.Location = new System.Drawing.Point(3, 17);
-            this.tableLayoutPanelCenter.Name = "tableLayoutPanelCenter";
-            this.tableLayoutPanelCenter.RowCount = 9;
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelCenter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanelCenter.Size = new System.Drawing.Size(507, 263);
-            this.tableLayoutPanelCenter.TabIndex = 8;
-            // 
-            // labelVersion
-            // 
-            this.labelVersion.AutoSize = true;
-            this.labelVersion.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.labelVersion.ForeColor = System.Drawing.Color.LightSteelBlue;
-            this.labelVersion.Location = new System.Drawing.Point(0, 51);
-            this.labelVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.labelVersion.Name = "labelVersion";
-            this.labelVersion.Padding = new System.Windows.Forms.Padding(4);
-            this.labelVersion.Size = new System.Drawing.Size(189, 21);
-            this.labelVersion.TabIndex = 2;
-            this.labelVersion.Text = "Build X.X.X.X BB-bit, MMMMMM YYYY";
-            this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.tableLayoutRightAlignVersion.AutoSize = true;
+            this.tableLayoutRightAlignVersion.ColumnCount = 2;
+            this.tableLayoutRightAlignVersion.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutRightAlignVersion.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutRightAlignVersion.Controls.Add(this.labelVersion, 1, 0);
+            this.tableLayoutRightAlignVersion.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.tableLayoutRightAlignVersion.Location = new System.Drawing.Point(0, 51);
+            this.tableLayoutRightAlignVersion.Name = "tableLayoutRightAlignVersion";
+            this.tableLayoutRightAlignVersion.RowCount = 1;
+            this.tableLayoutRightAlignVersion.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutRightAlignVersion.Size = new System.Drawing.Size(519, 21);
+            this.tableLayoutRightAlignVersion.TabIndex = 3;
             // 
             // WelcomeScreen
             // 
@@ -314,12 +331,14 @@ namespace AGS.Editor
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Welcome to AGS!";
             this.groupBox1.ResumeLayout(false);
+            this.tableLayoutPanelCenter.ResumeLayout(false);
+            this.tableLayoutPanelCenter.PerformLayout();
             this.panelLogo.ResumeLayout(false);
             this.panelLogo.PerformLayout();
             this.tableLayoutPanelAll.ResumeLayout(false);
             this.tableLayoutPanelBottom.ResumeLayout(false);
-            this.tableLayoutPanelCenter.ResumeLayout(false);
-            this.tableLayoutPanelCenter.PerformLayout();
+            this.tableLayoutRightAlignVersion.ResumeLayout(false);
+            this.tableLayoutRightAlignVersion.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -344,5 +363,6 @@ namespace AGS.Editor
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelBottom;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelCenter;
         private System.Windows.Forms.Label labelVersion;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutRightAlignVersion;
     }
 }

--- a/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.Designer.cs
@@ -46,6 +46,7 @@ namespace AGS.Editor
             this.tableLayoutPanelAll = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanelBottom = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanelCenter = new System.Windows.Forms.TableLayoutPanel();
+            this.labelVersion = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.panelLogo.SuspendLayout();
             this.tableLayoutPanelAll.SuspendLayout();
@@ -201,6 +202,7 @@ namespace AGS.Editor
             // panelLogo
             // 
             this.panelLogo.BackColor = System.Drawing.Color.RoyalBlue;
+            this.panelLogo.Controls.Add(this.labelVersion);
             this.panelLogo.Controls.Add(this.lblLogo);
             this.panelLogo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelLogo.ForeColor = System.Drawing.Color.White;
@@ -282,6 +284,20 @@ namespace AGS.Editor
             this.tableLayoutPanelCenter.Size = new System.Drawing.Size(507, 263);
             this.tableLayoutPanelCenter.TabIndex = 8;
             // 
+            // labelVersion
+            // 
+            this.labelVersion.AutoSize = true;
+            this.labelVersion.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.labelVersion.ForeColor = System.Drawing.Color.LightSteelBlue;
+            this.labelVersion.Location = new System.Drawing.Point(0, 51);
+            this.labelVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelVersion.Name = "labelVersion";
+            this.labelVersion.Padding = new System.Windows.Forms.Padding(4);
+            this.labelVersion.Size = new System.Drawing.Size(189, 21);
+            this.labelVersion.TabIndex = 2;
+            this.labelVersion.Text = "Build X.X.X.X BB-bit, MMMMMM YYYY";
+            this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // WelcomeScreen
             // 
             this.AcceptButton = this.btnContinue;
@@ -327,5 +343,6 @@ namespace AGS.Editor
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelAll;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelBottom;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelCenter;
+        private System.Windows.Forms.Label labelVersion;
     }
 }

--- a/Editor/AGS.Editor/GUI/WelcomeScreen.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.cs
@@ -17,6 +17,7 @@ namespace AGS.Editor
         public WelcomeScreen()
         {
             InitializeComponent();
+            labelVersion.Text = $"Build {AGS.Types.Version.AGS_EDITOR_VERSION} {AGS.Types.Version.AGS_EDITOR_TARGETNAME}, {AGS.Types.Version.AGS_EDITOR_DATE}";
 
             foreach (RecentGame game in Factory.AGSEditor.Settings.RecentGames)
             {


### PR DESCRIPTION
fix #2576 

adds a subtle version label to the Welcome Screen.

![image](https://github.com/user-attachments/assets/1ea3d669-fdff-4b9b-bba6-1f37a43be305)

this screen in 3.6.1 for reference

![image](https://github.com/user-attachments/assets/a64e038f-f509-407e-bfb1-63768a7de1a1)

<details>
<summary>I also redid this screen using layouts, in case we ever want to change it's size or for future scaling support.</summary>

![image](https://github.com/user-attachments/assets/69c0ceba-f296-4407-a30e-f024fb456aee)

</details>