### PR TITLE
New compiler: support constructors

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -736,6 +736,21 @@ AGS::Symbol AGS::SymbolTable::FindStructComponent(Symbol strct, Symbol const com
     return kKW_NoSymbol;
 }
 
+AGS::Symbol AGS::SymbolTable::FindConstructorOfTypeOrParent(Symbol strct) const
+{
+    if (!IsVartype(strct) || !entries.at(strct).VartypeD->Flags[VTF::kStruct])
+        return kKW_NoSymbol; // not a struct
+
+    // Check for the constructor in the current struct and in all its parents
+    while (strct)
+    {
+        if (entries.at(strct).VartypeD->Constructor != kKW_NoSymbol)
+            return entries.at(strct).VartypeD->Constructor;
+        strct = entries.at(strct).VartypeD->Parent;
+    }
+    return kKW_NoSymbol;
+}
+
 AGS::Vartype AGS::SymbolTable::GetFirstBaseVartype(AGS::Vartype vartype) const
 {
     // TODO: extra safety checks?

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -731,6 +731,7 @@ AGS::Symbol AGS::SymbolTable::FindStructComponent(Symbol strct, Symbol const com
         for (auto components_it = components.begin(); components_it != components.end(); components_it++)
             if (component == components_it->first)
                 return components_it->second;
+        strct = entries.at(strct).VartypeD->Parent;
     }
     return kKW_NoSymbol;
 }

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -294,6 +294,7 @@ struct SymbolTableEntry : public SymbolTableConstant
         // [0] describes the return type of the function
         std::vector<FuncParameterDesc> Parameters = {};
         CodeLoc Offset = 0;
+        bool IsConstructor = false;
         bool IsVariadic = false;
         bool NoLoopCheck = false;
     } *FunctionD = nullptr;
@@ -430,6 +431,7 @@ public:
     inline bool IsDelimeter(Symbol s) const { return nullptr != entries.at(s).DelimeterD; }
     inline void MakeEntryDelimeter(Symbol s) { if (!entries.at(s).DelimeterD) entries.at(s).DelimeterD = new SymbolTableEntry::DelimeterDesc; }
     inline bool IsFunction(Symbol s) const { return nullptr != entries.at(s).FunctionD; }
+    inline bool IsConstructor(Symbol s) const { return (nullptr != entries.at(s).FunctionD) && (entries.at(s).FunctionD->IsConstructor); }
     inline void MakeEntryFunction(Symbol s) { if (!entries.at(s).FunctionD) entries.at(s).FunctionD = new SymbolTableEntry::FunctionDesc; }
     inline bool IsLiteral(Symbol s) const { return nullptr != entries.at(s).LiteralD; }
     inline void MakeEntryLiteral(Symbol s) { if (!entries.at(s).LiteralD) entries.at(s).LiteralD = new SymbolTableEntry::LiteralDesc; }

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -475,11 +475,9 @@ public:
     // Fills compo_list with the symbols of all the strct components. Includes the ancestors' components
     void GetComponentsOfStruct(Symbol strct, std::vector<Symbol> &compo_list) const;
     // Find the description of a component.
-    // Return nullptr if not found. Otherwise, caller must 'delete' the result after being done with it
-    // Start search with the components of ancestor.
     Symbol FindStructComponent(Symbol strct, Symbol component, Symbol ancestor) const;
-    inline Symbol *FindStructComponent(Symbol strct, Symbol component) const { FindStructComponent(strct, component, strct); }
-
+    inline Symbol FindStructComponent(Symbol strct, Symbol component) const { return FindStructComponent(strct, component, strct); }
+    
     // Arrays and variables that are arrays
     // The "Array[...] of vartype" vartype
     Vartype VartypeWithArray(std::vector<size_t> const &dims, AGS::Vartype vartype);

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -337,6 +337,7 @@ struct SymbolTableEntry : public SymbolTableConstant
         AGS::Vartype BaseVartype = kKW_NoSymbol;
         std::vector<size_t> Dims = {}; // For classic arrays: Number of elements in each dimension of static array
         std::map<Symbol, Symbol> Components = {}; // Maps the unqualified component to the qualified component
+        Symbol Constructor = kKW_NoSymbol; // For structs: this vartype's constructor (also contained in Components)
         Symbol Parent = kKW_NoSymbol; // For structs: this vartype extends the Parent
         VartypeFlags Flags;
     } *VartypeD = nullptr;
@@ -479,6 +480,8 @@ public:
     // Find the description of a component.
     Symbol FindStructComponent(Symbol strct, Symbol component, Symbol ancestor) const;
     inline Symbol FindStructComponent(Symbol strct, Symbol component) const { return FindStructComponent(strct, component, strct); }
+    // Finds the first constructor declared either in this struct or in any of its parent types (going up the hierarchy)
+    Symbol FindConstructorOfTypeOrParent(Symbol strct) const;
 
     // Arrays and variables that are arrays
     // The "Array[...] of vartype" vartype

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -477,7 +477,7 @@ public:
     // Find the description of a component.
     Symbol FindStructComponent(Symbol strct, Symbol component, Symbol ancestor) const;
     inline Symbol FindStructComponent(Symbol strct, Symbol component) const { return FindStructComponent(strct, component, strct); }
-    
+
     // Arrays and variables that are arrays
     // The "Array[...] of vartype" vartype
     Vartype VartypeWithArray(std::vector<size_t> const &dims, AGS::Vartype vartype);

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3636,6 +3636,9 @@ void AGS::Parser::AccessData_SubsequentClause(VariableAccess access_type, bool a
         if (static_access && !_sym[qualified_component].FunctionD->TypeQualifiers[TQ::kStatic])
             UserError("Must specify a specific object for non-static function %s", _sym.GetName(qualified_component).c_str());
 
+        if (_sym.IsConstructor(qualified_component))
+            UserError("Calling struct's constructor '%s' directly is illegal", _sym.GetName(qualified_component).c_str());
+
         SkipNextSymbol(expression, unqualified_component); // Eat function symbol
         if (kKW_OpenParenthesis != expression.PeekNext())
         {

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1931,9 +1931,9 @@ void AGS::Parser::ParseExpression_New_CtorFuncCall(Symbol argument_vartype, SrcL
             return; // not a struct type
 
         Symbol const ctor_function =
-            _sym.FindStructComponent(argument_vartype, argument_vartype);
-        if (kKW_NoSymbol == ctor_function || !_sym.IsConstructor(ctor_function))
-            return; // no constructor declared
+            _sym.FindConstructorOfTypeOrParent(argument_vartype);
+        if (kKW_NoSymbol == ctor_function)
+            return; // no suitable constructor declared
 
         UserError(
             ReferenceMsgSym(
@@ -1950,9 +1950,9 @@ void AGS::Parser::ParseExpression_New_CtorFuncCall(Symbol argument_vartype, SrcL
             break; // not a struct
 
         Symbol const ctor_function =
-            _sym.FindStructComponent(argument_vartype, argument_vartype);
-        if (kKW_NoSymbol == ctor_function || !_sym.IsConstructor(ctor_function))
-            break; // no constructor declared
+            _sym.FindConstructorOfTypeOrParent(argument_vartype);
+        if (kKW_NoSymbol == ctor_function)
+            break; // no suitable constructor declared
 
         PushReg(SREG_AX);
         // Address of the new object is expected in MAR
@@ -5209,6 +5209,8 @@ void AGS::Parser::ParseStruct_VariableOrFunctionDefn(Symbol name_of_struct, Type
     else 
         ParseStruct_VariableDefn(tqs, vartype, name_of_struct, qualified_component);
 
+    if (_sym.IsConstructor(qualified_component))
+        _sym[name_of_struct].VartypeD->Constructor = qualified_component;
     _sym.SetDeclared(qualified_component, declaration_start);
  }
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1895,6 +1895,67 @@ void AGS::Parser::StripOutermostParens(SrcList &expression)
     }
 }
 
+void AGS::Parser::ParseExpression_New_InitFuncCall(Symbol argument_vartype, SrcList &expression)
+{
+    if (kKW_OpenParenthesis != expression.PeekNext())
+    {
+        Symbol const init_sym = _sym.Find("initialize");
+        if (kKW_NoSymbol == init_sym || !_sym.IsStructVartype(argument_vartype))
+            return; // nothing to do
+
+        Symbol const init_function =
+            _sym.FindStructComponent(argument_vartype, init_sym);
+        if (!_sym.IsFunction(init_function))
+            return;
+
+        UserError(
+            ReferenceMsgSym(
+                "Expected the parameter list for function '%s'",
+                init_function).c_str(),
+            _sym.GetName(init_function).c_str()
+        );
+    }
+
+    do // exactly 1 times
+    {
+        Symbol const init_sym = _sym.Find("initialize");
+        if (kKW_NoSymbol == init_sym || !_sym.IsStructVartype(argument_vartype))
+            break;
+        if (!_sym.IsStructVartype(argument_vartype))
+            break;
+        Symbol const init_function =
+            _sym.FindStructComponent(argument_vartype, init_sym);
+        if (kKW_NoSymbol == init_function)
+            break;
+        if (!_sym.IsFunction(init_function))
+            break;
+        Symbol const frv = _sym.FuncReturnVartype(init_function);
+        // 'int' is a special accomodation for functions that are declared with the
+        // 'function' keyword. This is why we check for exactly 'int' here;
+        // the compiler is not fine with any other integer vartypes
+        if (kKW_Void != frv && kKW_Int != frv)
+            UserError(
+                ReferenceMsgSym(
+                    "The return type of function '%s' must be 'void' but is '%s'",
+                    init_function).c_str(),
+                _sym.GetName(init_function).c_str(),
+                _sym.GetName(frv).c_str());
+
+        PushReg(SREG_AX);
+        // Address of the new object is expected in MAR
+        WriteCmd(SCMD_REGTOREG, SREG_AX, SREG_MAR);
+        _reg_track.SetRegister(SREG_MAR);
+        EvaluationResult eres_dummy;
+        AccessData_FunctionCall(init_function, expression, eres_dummy);
+        PopReg(SREG_AX);
+        return;
+    } while (false);
+
+    // Here when there isn't any init function: must have '()' following
+    SkipNextSymbol(expression, kKW_OpenParenthesis);
+    Expect(kKW_CloseParenthesis, expression.GetNext());
+}
+
 void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &eres)
 {
     expression.StartRead();
@@ -1950,14 +2011,6 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
         if (!is_managed)
             UserError("Expected '[' after the non-managed type '%s'", _sym.GetName(argument_vartype).c_str());
 
-        if (kKW_OpenParenthesis == expression.PeekNext())
-        {
-            Warning("'()' after 'new' isn't implemented, is currently ignored");
-            expression.GetNext();
-            expression.SkipToCloser();
-            SkipNextSymbol(_src, kKW_CloseParenthesis);
-        }
-
         // Only do this check for new, not for new[]. 
         if (0u == _sym.GetSize(argument_vartype))
             UserError(
@@ -1993,6 +2046,9 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
     }
 
     _reg_track.SetRegister(SREG_AX);
+
+    if (!with_bracket_expr)
+        ParseExpression_New_InitFuncCall(argument_vartype, expression);
 
     ParseExpression_CheckUsedUp(expression);
 
@@ -2599,7 +2655,12 @@ void AGS::Parser::AccessData_FunctionCall_ProvideDefaults(int func_args_count, s
     {
         Symbol const param_default = _sym[func_symbol].FunctionD->Parameters[arg_idx].Default;
         if (kKW_NoSymbol == param_default)
-            UserError("Function call parameter #%d isn't provided and doesn't have any default value", arg_idx);
+            UserError(
+                ReferenceMsgSym(
+                    "Function call parameter #%d for function '%s' isn't provided and doesn't have any default value",
+                    func_symbol).c_str(),
+                    arg_idx,
+                    _sym.GetName(func_symbol).c_str());
         if (!_sym.IsLiteral(param_default))
             InternalError("Parameter default symbol isn't literal");
 

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -83,7 +83,7 @@ public:
 
         // Get the label of a function, in order to insert it into the code,
         // this label will be replaced by its value later on
-        inline CodeCell Function2Label(Symbol func) { return func * _size + _kind; }
+        inline CodeCell Function2Label(Symbol func) const { return func * _size + _kind; }
 
         // Keep track of the location of a label that needs to be replaced later on
         inline void TrackLabelLoc(CodeLoc loc) { _scrip.Labels.push_back(loc); }
@@ -581,6 +581,9 @@ private:
     // Evaluate 'vloc_lhs op_sym vloc_rhs' at compile time, return the result in 'vloc'.
     // Return whether this is possible.
     bool ParseExpression_CompileTime(Symbol op_sym, EvaluationResult const &eres_lhs, EvaluationResult const &eres_rhs, EvaluationResult &eres);
+
+    // Process a parenthesised list following a 'new'
+    void ParseExpression_New_InitFuncCall(Symbol arg_vartype, SrcList &expression);
 
     // Parse the term given in 'expression'. The lowest-binding operator is unary 'new'
     // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -563,7 +563,7 @@ private:
     // Count parameters, check that all the parameters are non-empty; find closing paren
     void AccessData_FunctionCall_CountAndCheckParm(SrcList &parameters, Symbol name_of_func, size_t &index_of_close_paren, size_t &supplied_args_count);
 
-    // We are processing a function call. General the actual function call
+    // We are processing a function call. Generate the actual function call
     void AccessData_GenerateFunctionCall(Symbol name_of_func, size_t args_count, bool func_is_import);
 
     // Generate the function call for the function that returns the number of elements

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -583,7 +583,7 @@ private:
     bool ParseExpression_CompileTime(Symbol op_sym, EvaluationResult const &eres_lhs, EvaluationResult const &eres_rhs, EvaluationResult &eres);
 
     // Process a parenthesised list following a 'new'
-    void ParseExpression_New_InitFuncCall(Symbol arg_vartype, SrcList &expression);
+    void ParseExpression_New_CtorFuncCall(Symbol arg_vartype, SrcList &expression);
 
     // Parse the term given in 'expression'. The lowest-binding operator is unary 'new'
     // Parsing must use up 'expression' completely; if there are trailing symbols, throw 'UserError'.

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -3558,3 +3558,33 @@ TEST_F(Bytecode1, Linenum02)
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
+TEST_F(Bytecode1, ParensAfterNew) {
+
+    char const *inpl = "\
+        managed struct Ancester             \n\
+        {                                   \n\
+            import int initialize(float);   \n\
+            int Payload1;                   \n\
+        };                                  \n\
+                                            \n\
+        managed struct Struct               \n\
+            extends Ancester                \n\
+        {                                   \n\
+            int Payload2;                   \n\
+        };                                  \n\
+                                            \n\
+        int game_start()                    \n\
+        {                                   \n\
+            Struct s = new Struct(7.0);     \n\
+            return s.Payload2 + s.Payload1; \n\
+        }                                   \n\
+        ";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    EXPECT_EQ(0u, mh.WarningsCount());
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+
+    // WriteOutput("ParensAfterNew", scrip);
+}
+

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -3558,33 +3558,28 @@ TEST_F(Bytecode1, Linenum02)
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode1, ParensAfterNew) {
+TEST_F(Bytecode1, StructCtorCall) {
 
     char const *inpl = "\
-        managed struct Ancester             \n\
-        {                                   \n\
-            import int initialize(float);   \n\
-            int Payload1;                   \n\
-        };                                  \n\
-                                            \n\
         managed struct Struct               \n\
-            extends Ancester                \n\
         {                                   \n\
-            int Payload2;                   \n\
+            import void Struct(float f);    \n\
+            int Payload;                    \n\
         };                                  \n\
                                             \n\
         int game_start()                    \n\
         {                                   \n\
             Struct s = new Struct(7.0);     \n\
-            return s.Payload2 + s.Payload1; \n\
+            return s.Payload;               \n\
         }                                   \n\
         ";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
-    EXPECT_EQ(0u, mh.WarningsCount());
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
-    // WriteOutput("ParensAfterNew", scrip);
+    // WriteOutput("StructCtorCall", scrip);
+
+    // TODO: proper bytecode test!!
 }
 


### PR DESCRIPTION
CC @fernewelten 
This is a remake of #2529, with proposed changes, based on top of a single original commit.

Managed structs can have an constructor:

* Constructor is defined as a member function of a *managed* struct that has name *identical* to the struct's name.
* The constructor must return `void`. In #2529 I suggested it should be completely typeless, but I did not try that still, as I'm not fully certain whether this is necessary, and and have concerns that implementing it this way may require extra hacks to the parser.
* Can have any parameter list, just like a regular function.
* Cannot be `static`. Having `static` type constructors would technically require to run some sort of a autogenerated script prior to "game_start" callback, but that is far outside current feature.
* Cannot be `protected`. Supporting `protected` will only make sense if we support function overloading, and if there's a way to call one constructor from another.
* Cannot be declared as extender function.
* Structs inherit constructors of their parent(s), but declaring their own constructor will completely "hide" parental one(s).

Constructor is called automatically whenever there's a `new T` or `new T( <...> )` expression.
Old-style `new T` without parameter list is still supported, but only if there's no constructor in T and neither its parent.

Calling constructor function directly in script is *forbidden*.

```
managed struct Stx
{
    int Payload;
    import void Stx(int payload);
};

void Stx::Stx(int payload)
{
    Payload = payload;
}

managed struct Sty
{
    short Payload;
};

function game_start()
{
    Stx *st1 = new Stx(7); // ← okay
    Stx *st2 = new Stx(7.0); // ← syntax error, parameters don't match
    Stx *st3 = new Stx(); // ← syntax error, parameter expected but not found
    Stx *st4 = new Stx; // ← syntax error, parameter list missing

    Sty *st5 = new Sty(); // ← empty list is okay, nothing will be called
    Sty *st6 = new Sty; // ← okay
    Sty *st7 = new Sty(4); // ←syntax error, no constructor declared, so cannot pass parameters
}
```

**TODO:**
- ~Using constructors from parent classes when extended class instance is created, and in case extended class does not define their own constructor.~
- ~Fix compiler tests.~