### PR TITLE
New compiler: Named function arguments, classic char array arguments

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -387,8 +387,6 @@ AGS::SymbolTable::SymbolTable()
 
 bool AGS::SymbolTable::IsVTT(Symbol s, VartypeType vtt) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s))
         return false;
 
@@ -400,8 +398,6 @@ bool AGS::SymbolTable::IsVTT(Symbol s, VartypeType vtt) const
 
 bool AGS::SymbolTable::IsVTF(Symbol s, VartypeFlag flag) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s))
         return false;
 
@@ -470,8 +466,6 @@ bool AGS::SymbolTable::CanBePartOfAnExpression(Symbol s)
 
 bool AGS::SymbolTable::IsAnyIntegerVartype(Symbol s) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s) || !IsAtomicVartype(s))
         return false;
     if (kKW_NoSymbol == entries.at(s).VartypeD->BaseVartype)
@@ -490,10 +484,9 @@ size_t AGS::SymbolTable::GetSize(Symbol s) const
 
 bool AGS::SymbolTable::IsPrimitiveVartype(Symbol s) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s))
         return false;
+
     if (VTT::kConst == entries.at(s).VartypeD->Type)
         s = entries.at(s).VartypeD->BaseVartype;
     if (!IsPredefined(s))
@@ -505,8 +498,6 @@ bool AGS::SymbolTable::IsPrimitiveVartype(Symbol s) const
 
 size_t AGS::SymbolTable::ArrayElementsCount(Symbol s) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s))
         return 0u;
 
@@ -523,8 +514,6 @@ size_t AGS::SymbolTable::ArrayElementsCount(Symbol s) const
 
 bool AGS::SymbolTable::IsManagedVartype(Symbol s) const
 {
-    if (IsVariable(s))
-        s = entries.at(s).VariableD->Vartype;
     if (!IsVartype(s))
         return false;
     
@@ -770,9 +759,6 @@ AGS::ScopeType AGS::SymbolTable::GetScopeType(Symbol s) const
 
 bool AGS::SymbolTable::IsAnyStringVartype(Symbol s) const
 {
-    if (IsVariable(s))
-        s = entries[s].VariableD->Vartype;
-
     if (!IsVartype(s))
         return false;
 
@@ -786,18 +772,12 @@ bool AGS::SymbolTable::IsAnyStringVartype(Symbol s) const
 
 bool AGS::SymbolTable::IsOldstring(Symbol s) const
 {
-    if (!IsInBounds(s))
-        return false;
-
-    // Convert a var to its vartype
-    if (IsVariable(s))
-        s = entries[s].VariableD->Vartype;
-
     if (!IsVartype(s))
             return false;
 
     Vartype const s_without_const =
         VartypeWithout(VTT::kConst, s);
+
     // string and const string are oldstrings
     if (kKW_String == s_without_const)
         return true;

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -467,7 +467,7 @@ bool AGS::SymbolTable::CanBePartOfAnExpression(Symbol s)
         (IsDelimeter(s) && entries.at(s).DelimeterD->CanBePartOfAnExpression) ||
         IsFunction(s) ||
         IsLiteral(s) ||
-        (IsOperator(s) && entries.at(s).OperatorD->CanBePartOfAnExpression) ||
+        (IsOperator(s)) ||
         IsVariable(s) ||
         (s == kKW_OnePastLongMax);
 }

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -396,14 +396,22 @@ bool AGS::SymbolTable::IsVTT(Symbol s, VartypeType vtt) const
     return vtt == entries.at(s).VartypeD->Type;
 }
 
+AGS::Vartype AGS::SymbolTable::CoreVartype(Vartype s) const
+{
+    if (!IsVartype(s))
+        return false;
+
+    // Get to the innermost symbol
+    while (VTT::kAtomic != entries.at(s).VartypeD->Type)
+        s = entries.at(s).VartypeD->BaseVartype;
+    return s;
+}
+
 bool AGS::SymbolTable::IsVTF(Symbol s, VartypeFlag flag) const
 {
     if (!IsVartype(s))
         return false;
 
-    // Get to the innermost symbol; read that symbol's flags
-    while (VTT::kAtomic != entries.at(s).VartypeD->Type)
-        s = entries.at(s).VartypeD->BaseVartype;
     return entries.at(s).VartypeD->Flags[flag];
 }
 
@@ -529,7 +537,8 @@ std::string const AGS::SymbolTable::GetName(AGS::Symbol symbl) const
         return std::string("(end of input)");
     if (static_cast<size_t>(symbl) >= entries.size())
         return std::string("(invalid symbol)");
-    if (IsAutoptrVartype(symbl))
+    if (IsDynpointerVartype(symbl) &&
+        IsAutoptrVartype(VartypeWithout(VTT::kDynpointer, symbl)))
     {
         std::string name = entries[symbl].Name;
         int const pos_of_last_ch = name.length() - 1u;

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -227,6 +227,7 @@ struct FuncParameterDesc
     AGS::Vartype Vartype = kKW_NoSymbol;
     Symbol Name = kKW_NoSymbol;
     Symbol Default = kKW_NoSymbol;
+    size_t Declared;
 };
 
 struct SymbolTable;
@@ -293,6 +294,13 @@ struct SymbolTableEntry : public SymbolTableConstant
         TypeQualifierSet TypeQualifiers = {};
         // [0] describes the return type of the function
         std::vector<FuncParameterDesc> Parameters = {};
+        struct ParamNamingInconsistencyDesc
+        {
+            bool Exists = false; // true when param #'ParamIdx' is inconsistently named
+            size_t ParamIdx = 0u;
+            Symbol Name1 = kKW_NoSymbol, Name2 = kKW_NoSymbol;
+            size_t Declared1 = 0u, Declared2 = 0u;
+        } ParamNamingInconsistency;
         CodeLoc Offset = 0;
         bool IsConstructor = false;
         bool IsVariadic = false;

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -455,15 +455,18 @@ public:
     // so it can be part of an expression no matter what is determined here
     bool CanBePartOfAnExpression(Symbol s);
 
-    // Whether the operator is boolean. "Boolean" operators return an 'int' no matter what vartype their arguments
+    // Whether the operator is boolean.
+    // Boolean operators return an 'int' no matter what vartype their arguments are
     inline bool IsBooleanOperator(Symbol s) { return IsOperator(s) && entries.at(s).OperatorD->Boolean; }
 
     // Variables or vartypes
     // Size of a variable or vartype
     size_t GetSize(Symbol s) const;
+    // The core vartype of a possibly composite vartype
+    Vartype CoreVartype(Vartype s) const; 
 
     inline bool IsAtomicVartype(Symbol s) const { return IsVTT(s, VTT::kAtomic); }
-    inline bool IsBuiltinVartype(Symbol s) const { return IsVTF(s, VTF::kBuiltin); }
+    inline bool IsBuiltinVartype(Symbol s) const { return IsVTF(CoreVartype(s), VTF::kBuiltin); }
     // Don't confuse with IsConstant() == is a constant that signifies a literal
     inline bool IsConstVartype(Symbol s) const { return IsVTT(s, VTT::kConst); }
 
@@ -478,6 +481,7 @@ public:
     // Fills compo_list with the symbols of all the strct components. Includes the ancestors' components
     void GetComponentsOfStruct(Symbol strct, std::vector<Symbol> &compo_list) const;
     // Find the description of a component.
+    // Start search with the components of ancestor.
     Symbol FindStructComponent(Symbol strct, Symbol component, Symbol ancestor) const;
     inline Symbol FindStructComponent(Symbol strct, Symbol component) const { return FindStructComponent(strct, component, strct); }
     // Finds the first constructor declared either in this struct or in any of its parent types (going up the hierarchy)

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -444,7 +444,9 @@ public:
     inline void MakeEntryFunction(Symbol s) { if (!entries.at(s).FunctionD) entries.at(s).FunctionD = new SymbolTableEntry::FunctionDesc; }
     inline bool IsLiteral(Symbol s) const { return nullptr != entries.at(s).LiteralD; }
     inline void MakeEntryLiteral(Symbol s) { if (!entries.at(s).LiteralD) entries.at(s).LiteralD = new SymbolTableEntry::LiteralDesc; }
-    inline bool IsOperator(Symbol s) const { return nullptr != entries.at(s).OperatorD; }
+    // Operators and assignments have an 'OperatorD' pointer, to differentiate also check 'CanBePartOfAnExpression'
+    inline bool IsAssignment(Symbol s) const { return entries.at(s).OperatorD && !entries.at(s).OperatorD->CanBePartOfAnExpression; }
+    inline bool IsOperator(Symbol s) const { return entries.at(s).OperatorD && entries.at(s).OperatorD->CanBePartOfAnExpression; }
     inline void MakeEntryOperator(Symbol s) { if (!entries.at(s).OperatorD) entries.at(s).OperatorD = new SymbolTableEntry::OperatorDesc; }
     inline bool IsComponent(Symbol s) const { return nullptr != entries.at(s).ComponentD; }
     inline void MakeEntryComponent(Symbol s) { if (!entries.at(s).ComponentD) entries.at(s).ComponentD = new SymbolTableEntry::ComponentDesc; }

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -852,8 +852,7 @@ Symbol AGS::Parser::ParseParamlist_Param_DefaultValue(size_t idx, Vartype const 
         return kKW_NoSymbol; // No default value given
 
     // For giving specifics in error messages
-    std::string msg = "In parameter #<idx>: ";
-    msg.replace(msg.find("<idx>"), 5u, std::to_string(idx));
+    std::string msg = string_replace("In parameter #<idx>: ", "<idx>", std::to_string(idx));
 
     SkipNextSymbol(_src, kKW_Assign);
 
@@ -1290,17 +1289,17 @@ void AGS::Parser::ParseFuncdecl_CheckThatKnownInfoMatches(std::string const &fun
             continue;
 
         std::string errstr1 = "In this declaration, parameter #<1> <2>; ";
-        errstr1.replace(errstr1.find("<1>"), 3, std::to_string(param_idx));
+            string_replace (errstr1, "<1>", std::to_string(param_idx));
         if (kKW_NoSymbol == this_default)
-            errstr1.replace(errstr1.find("<2>"), 3, "doesn't have a default value");
+            string_replace(errstr1, "<2>", "doesn't have a default value");
         else
-            errstr1.replace(errstr1.find("<2>"), 3, "has the default " + _sym.GetName(this_default));
+            string_replace(errstr1, "<2>", "has the default " + _sym.GetName(this_default));
 
         std::string errstr2 = "in a declaration elsewhere, that parameter <2>";
         if (kKW_NoSymbol == known_default)
-            errstr2.replace(errstr2.find("<2>"), 3, "doesn't have a default value");
+            string_replace(errstr2, "<2>", "doesn't have a default value");
         else
-            errstr2.replace(errstr2.find("<2>"), 3, "has the default " + _sym.GetName(known_default));
+            string_replace(errstr2, "<2>", "has the default " + _sym.GetName(known_default));
         errstr1 += errstr2;
         UserError(ReferenceMsgLoc(errstr1, known_declared).c_str());
     }
@@ -1641,10 +1640,10 @@ CodeCell AGS::Parser::GetOpcode(Symbol const op_sym, Vartype vartype1, Vartype v
     CodeCell opcode = _sym[op_sym].OperatorD->IntOpcode;
 
     std::string msg = "Left-hand side of '<op>' term";
-    msg.replace(msg.find("<op>"), 4u, _sym.GetName(op_sym));
+    string_replace(msg, "<op>", _sym.GetName(op_sym));
     CheckVartypeMismatch(vartype1, kKW_Int, true, msg);
     msg = "Right-hand side of '<op>' term";
-    msg.replace(msg.find("<op>"), 4u, _sym.GetName(op_sym));
+    string_replace(msg, "<op>", _sym.GetName(op_sym));
     CheckVartypeMismatch(vartype2, kKW_Int, true, msg);
     return opcode;
 }
@@ -2118,7 +2117,7 @@ void AGS::Parser::ParseExpression_PrefixNegate(Symbol op_sym, EvaluationResult &
     bool const bitwise_negation = kKW_BitNeg == op_sym;
 
     std::string msg = "Argument of '<op>'";
-    msg.replace(msg.find("<op>"), 4u, _sym.GetName(op_sym));
+    string_replace(msg, "<op>", _sym.GetName(op_sym));
     CheckVartypeMismatch(eres.Vartype, kKW_Int, true, msg);
     
     if (eres.kTY_Literal == eres.Type)
@@ -2177,7 +2176,7 @@ void AGS::Parser::ParseExpression_PrefixCrement(Symbol op_sym, AGS::SrcList &exp
     ParseAssignment_ReadLHSForModification(inner, eres);
     
     std::string msg = "Argument of '<op>'";
-    msg.replace(msg.find("<op>"), 4u, _sym.GetName(op_sym).c_str());
+    string_replace(msg, "<op>", _sym.GetName(op_sym).c_str());
     CheckVartypeMismatch(eres.Vartype, kKW_Int, true, msg); 
     
     WriteCmd((kKW_Increment == op_sym) ? SCMD_ADD : SCMD_SUB, SREG_AX, 1);
@@ -2279,7 +2278,7 @@ void AGS::Parser::ParseExpression_PostfixCrement(Symbol const op_sym, SrcList &e
     ParseExpression_CheckUsedUp(inner);
     
     std::string msg = "Argument of '<op>'";
-    msg.replace(msg.find("<op>"), 4u, _sym.GetName(op_sym).c_str());
+    string_replace(msg, "<op>", _sym.GetName(op_sym).c_str());
     CheckVartypeMismatch(eres.Vartype, kKW_Int, true, msg);
     
     // Really do the assignment the long way so that all the checks and safeguards will run.
@@ -2712,10 +2711,10 @@ std::string const AGS::Parser::ReferenceMsgLoc(std::string const &msg, size_t de
         tpl = ". See the current line";
     size_t const loc1 = tpl.find("<1>");
     if (std::string::npos != loc1)
-        tpl.replace(tpl.find("<1>"), 3, section);
+        string_replace(tpl, "<1>", section);
     size_t const loc2 = tpl.find("<2>");
     if (std::string::npos != loc2)
-        tpl.replace(tpl.find("<2>"), 3, std::to_string(line));
+        string_replace(tpl, "<2>", std::to_string(line));
     return msg + tpl;
 }
 
@@ -2783,8 +2782,8 @@ void AGS::Parser::AccessData_FunctionCall_PushParams(SrcList &params, size_t clo
                 WriteCmd(SCMD_CHECKNULLREG, SREG_AX);
 
             std::string msg = "Parameter #<num> of call to function <func>";
-            msg.replace(msg.find("<num>"), 5u, std::to_string(param_count));
-            msg.replace(msg.find("<func>"), 6u, _sym.GetName(func_symbol));
+            string_replace(msg, "<num>", std::to_string(param_count));
+            string_replace(msg, "<func>", _sym.GetName(func_symbol));
             CheckVartypeMismatch(eres.Vartype, param_vartype, true, msg);
         }
 
@@ -5426,7 +5425,7 @@ void AGS::Parser::ParseEnum_AssignedValue(Symbol vname, CodeCell &value)
     SkipNextSymbol(_src, kKW_Assign);
 
     std::string msg = "In the assignment to <name>: ";
-    msg.replace(msg.find("<name>"), 6u, _sym.GetName(vname));
+    string_replace(msg, "<name>", _sym.GetName(vname));
     Symbol const lit = ParseConstantExpression(_src, msg);
     
     value = _sym[lit].LiteralD->Value;
@@ -6975,7 +6974,7 @@ void AGS::Parser::Parse()
     catch (std::exception const &e)
     {
         std::string msg = "Exception encountered at currentline = <line>: ";
-        msg.replace(msg.find("<line>"), 6u, std::to_string(currentline));
+        string_replace(msg, "<line>", std::to_string(currentline));
         msg.append(e.what());
 
         _msgHandler.AddMessage(

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -349,7 +349,7 @@ void AGS::Parser::MarMgr::SetStart(ScopeType type, size_t offset)
 
     _scType = type;
     _startOffs = offset;
-    _componentOffs = 0;
+    _componentOffs = 0u;
 }
 
 void AGS::Parser::MarMgr::UpdateMAR(size_t lineno, ccCompiledScript &scrip)
@@ -452,8 +452,8 @@ AGS::Parser::Parser(SrcList &src, FlagSet options, ccCompiledScript &scrip, Symb
     , _structRefs({})
 {
     _givm.clear();
-    _lastEmittedSectionId = 0;
-    _lastEmittedLineno = 0;
+    _lastEmittedSectionId = 0u;
+    _lastEmittedLineno = 0u;
 }
 
 void AGS::Parser::SetDynpointerInManagedVartype(Vartype &vartype)
@@ -464,7 +464,7 @@ void AGS::Parser::SetDynpointerInManagedVartype(Vartype &vartype)
 
 size_t AGS::Parser::StacksizeOfLocals(size_t from_level)
 {
-    size_t total_size = 0;
+    size_t total_size = 0u;
     for (size_t level = from_level; level <= _nest.TopLevel(); level++)
     {
         // We only skim through the old definitions to get their indexes in _sym.
@@ -492,7 +492,7 @@ bool AGS::Parser::ContainsReleasableDynpointers(Vartype vartype)
 
     SymbolList compo_list;
     _sym.GetComponentsOfStruct(vartype, compo_list);
-    for (size_t cl_idx = 0; cl_idx < compo_list.size(); cl_idx++)
+    for (size_t cl_idx = 0u; cl_idx < compo_list.size(); cl_idx++)
     {
         Symbol const &var = compo_list[cl_idx];
         if (!_sym.IsVariable(var))
@@ -798,7 +798,7 @@ void AGS::Parser::HandleEndOfSwitch()
 
     const size_t number_of_cases = _nest.Snippets().size();
     const size_t default_idx = _nest.SwitchDefaultIdx();
-    for (size_t cases_idx = 0; cases_idx < number_of_cases; ++cases_idx)
+    for (size_t cases_idx = 0u; cases_idx < number_of_cases; ++cases_idx)
     {
         if (cases_idx == default_idx)
             continue;
@@ -1112,7 +1112,7 @@ void AGS::Parser::ParseFuncdecl_Paramlist(Symbol funcsym, bool body_follows)
 
     TypeQualifierSet tqs = {};
 
-    size_t param_idx = 0;
+    size_t param_idx = 0u;
     while (!_src.ReachedEOF())
     {
         ParseQualifiers(tqs);
@@ -1126,7 +1126,7 @@ void AGS::Parser::ParseFuncdecl_Paramlist(Symbol funcsym, bool body_follows)
         }
         
         Symbol const leading_sym = _src.PeekNext();
-        if (param_idx == 0 && kKW_Void == leading_sym)
+        if (param_idx == 0u && kKW_Void == leading_sym)
         {
             SkipNextSymbol(_src, kKW_Void);
             return Expect(kKW_CloseParenthesis, _src.GetNext());
@@ -1491,7 +1491,7 @@ void AGS::Parser::ParseFuncdecl(TypeQualifierSet tqs, Vartype return_vartype, Sy
     {
         auto &func_parameters = _sym[name_of_func].FunctionD->Parameters;
         auto const &known_parameters = known_info->Parameters;
-        for (size_t parameters_idx = 0; parameters_idx < func_parameters.size(); ++parameters_idx)
+        for (size_t parameters_idx = 0u; parameters_idx < func_parameters.size(); ++parameters_idx)
             func_parameters[parameters_idx].Default = known_parameters[parameters_idx].Default;
     }
 
@@ -1500,7 +1500,7 @@ void AGS::Parser::ParseFuncdecl(TypeQualifierSet tqs, Vartype return_vartype, Sy
 
 int AGS::Parser::IndexOfLeastBondingOperator(SrcList &expression)
 {
-    size_t nesting_depth = 0;
+    size_t nesting_depth = 0u;
 
     int largest_prio_found = INT_MIN; // note: largest number == lowest priority
     bool largest_is_prefix = false;
@@ -6920,7 +6920,7 @@ void AGS::Parser::Parse_CheckFixupSanity()
 
 void AGS::Parser::Parse_ExportAllFunctions()
 {
-    for (size_t func_idx = 0; func_idx < _scrip.Functions.size(); func_idx++)
+    for (size_t func_idx = 0u; func_idx < _scrip.Functions.size(); func_idx++)
     {
         if (0 > _scrip.AddExport(
             _scrip.Functions[func_idx].Name,

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -245,7 +245,7 @@ AGS::Symbol AGS::Parser::MangleStructAndComponent(Symbol stname, Symbol componen
     return _sym.FindOrAdd(fullname_str);
 }
 
-void AGS::Parser::SkipNextSymbol(SrcList src, Symbol expected)
+void AGS::Parser::SkipNextSymbol(SrcList &src, Symbol expected)
 {
     Symbol act = _src.GetNext();
     if (act != expected)
@@ -984,9 +984,9 @@ void AGS::Parser::ParseVarname0(bool accept_member_access, Symbol &structname, S
     if (kKW_ScopeRes != _src.PeekNext())
         return;
 
-    SkipNextSymbol(_src, kKW_ScopeRes); // 
+    SkipNextSymbol(_src, kKW_ScopeRes);
     if (!accept_member_access)
-        UserError("May not use '::' here");
+        UserError("Mustn't use '::' here");
 
     structname = varname;
     Symbol const unqualified_component = _src.GetNext();
@@ -2361,7 +2361,7 @@ void AGS::Parser::ParseExpression_Ternary_Term2(EvaluationResult &eres_term1, bo
 void AGS::Parser::ParseExpression_Ternary(size_t const tern_idx, SrcList &expression, bool const result_used, EvaluationResult &eres)
 {
     // First term ends before the '?'
-    SrcList term1 = SrcList(expression, 0, tern_idx);
+    SrcList term1 = SrcList(expression, 0u, tern_idx);
 
     // Second term begins after the '?', we don't know how long it is yet
     SrcList after_term1 = SrcList(expression, tern_idx + 1u, expression.Length() - (tern_idx + 1u));

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2990,10 +2990,8 @@ void AGS::Parser::AccessData_PushFunctionCallParams(Symbol name_of_func, bool fu
 
 void AGS::Parser::AccessData_FunctionCall(Symbol name_of_func, SrcList &expression, EvaluationResult &eres)
 {
-    if (kKW_OpenParenthesis != expression[1u])
+    if (kKW_OpenParenthesis != expression[0u])
         UserError("Expected '('");
-
-    expression.EatFirstSymbol();
 
     auto const function_tqs = _sym[name_of_func].FunctionD->TypeQualifiers;
     bool const func_is_import = function_tqs[TQ::kImport];
@@ -3506,7 +3504,8 @@ void AGS::Parser::AccessData_FirstClause(VariableAccess access_type, SrcList &ex
             return;
         }
 
-        AccessData_FunctionCall(first_sym, expression, eres);
+        SrcList call_expr = SrcList(expression, 1u, expression.Length() - 1u);
+        AccessData_FunctionCall(first_sym, call_expr, eres);
         if (_sym.IsDynarrayVartype(eres.Vartype))
             AccessData_ProcessArrayIndexes(expression, eres);
         return;
@@ -3651,7 +3650,6 @@ void AGS::Parser::AccessData_SubsequentClause(VariableAccess access_type, bool a
             return;
         }
 
-        expression.BackUp();
         SrcList start_of_funccall = SrcList(expression, expression.GetCursor(), expression.Length());
         AccessData_FunctionCall(qualified_component, start_of_funccall, eres);
         if (_sym.IsDynarrayVartype(vartype))

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -852,7 +852,8 @@ Symbol AGS::Parser::ParseParamlist_Param_DefaultValue(size_t idx, Vartype const 
         return kKW_NoSymbol; // No default value given
 
     // For giving specifics in error messages
-    std::string msg = string_replace("In parameter #<idx>: ", "<idx>", std::to_string(idx));
+    std::string msg = "In parameter #<idx>: ";
+    msg = string_replace(msg, "<idx>", std::to_string(idx));
 
     SkipNextSymbol(_src, kKW_Assign);
 

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -414,7 +414,7 @@ private:
     Symbol MangleStructAndComponent(Symbol stname, Symbol component);
 
     // Skip over the next symbol in 'src' which _must_ be 'expected', or else an internal (!) error is given.
-    void SkipNextSymbol(SrcList src, Symbol sym);
+    void SkipNextSymbol(SrcList &src, Symbol sym);
     // If the symbol 'actual' isn't in the list 'expected', give an error.
     // 'custom_msg', if given, replaces the "Expected ..." part of the message
     void Expect(SymbolList const &expected, Symbol actual, std::string const &custom_msg = "");

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -505,7 +505,7 @@ private:
     void ParseParamlist_Param(Symbol name_of_func, bool body_follows, TypeQualifierSet tqs, Vartype param_vartype, size_t param_idx);
 
     // Process a function parameter list
-    void ParseFuncdecl_Paramlist(Symbol funcsym, bool body_follows);
+    void ParseFuncdecl_Parameters(Symbol funcsym, bool body_follows);
 
     void ParseFuncdecl_MasterData2Sym(TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_func, Symbol name_of_func, bool body_follows);
 
@@ -543,9 +543,9 @@ private:
     // Check whether there is a type mismatch; if so, give an error. 'msg' for specializing the error message
     void CheckVartypeMismatch(Vartype vartype_is, Vartype vartype_wants_to_be, bool orderMatters, std::string const &msg = "");
 
-    // 'current_vartype' must be the vartype of AX. If it is 'string' and
-    // wanted_vartype is 'String', then AX will be converted to 'String'.
-    // then convert AX into a String object and set its type accordingly
+    // 'current_vartype' must be the vartype of AX. 
+    // If it is 'string' and 'wanted_vartype' is 'String', 
+    // then convert AX into a 'String' object and set its type accordingly
     void ConvertAXStringToStringObject(Vartype wanted_vartype, Vartype &current_vartype);
 
     static int GetReadCommandForSize(int the_size);
@@ -556,20 +556,22 @@ private:
     void EvaluationResultToAx(EvaluationResult &eres);
 
     // We are processing a function call. Emit the actual function call
-    void AccessData_FunctionCall_EmitCall(Symbol name_of_func, size_t params_count, bool func_is_import);
+    void AccessData_FunctionCall_EmitCall(Symbol name_of_func, size_t args_count, bool func_is_import);
 
     // Generate Length attribute for the parsed dynarray type 
     // and add it to the symbol table
     void AccessData_GenerateDynarrayLengthAttrib(EvaluationResult &eres);
 
-    void AccessData_FunctionCall_Parameters_Named(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool const is_variadic, SrcList &params, std::vector<SrcList> &param_exprs);
-    void AccessData_FunctionCall_Parameters_Sequence(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool const is_variadic, SrcList &params, std::vector<SrcList> &param_exprs);
+    void AccessData_FunctionCall_Arguments_Named(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool is_variadic, SrcList &arguments, std::vector<SrcList> &arg_exprs);
+    void AccessData_FunctionCall_Arguments_Sequence(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool is_variadic, SrcList &arguments, std::vector<SrcList> &arg_exprs);
 
-    // Parse the parameters 'param_list' of a function call
-    void AccessData_FunctionCall_Parameters(Symbol name_of_func, bool func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool is_variadic, SrcList &param_list, size_t &params_count);
+    void AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bool func_is_import, size_t args_count, std::vector<SrcList> arg_exprs, bool named_args, std::vector<AGS::FuncParameterDesc> const &param_descs);
 
-    // Process a function call. 'param_list' doesn't encompass the surrounding '()'
-    void AccessData_FunctionCall(Symbol name_of_func, SrcList &param_list, EvaluationResult &eres);
+    // Parse the arguments 'args_list' of a function call
+    void AccessData_FunctionCall_Arguments(Symbol name_of_func, bool func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool is_variadic, SrcList &arguments, size_t &args_count);
+
+    // Process a function call. 'arguments' doesn't encompass the surrounding '()'
+    void AccessData_FunctionCall(Symbol name_of_func, SrcList &arguments, EvaluationResult &eres);
 
     // Evaluate 'vloc_lhs op_sym vloc_rhs' at compile time, return the result in 'vloc'.
     // Return whether this is possible.

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -495,7 +495,8 @@ private:
 
     // We're accepting a parameter list. We've accepted something like 'int'.
     // We accept a param name such as 'i' if present
-    Symbol ParseParamlist_Param_Name(bool body_follows);
+    // 'param_idx' ist the 1-based index of the parameter in the parameter list, for error messages
+    Symbol ParseParamlist_Param_Name(size_t param_idx);
 
     // Additional handling to ParseVardecl_Var2SymTable() that is special for parameters
     void ParseParamlist_Param_AsVar2Sym(Symbol param_name, TypeQualifierSet tqs, Vartype param_vartype, int param_idx);
@@ -506,10 +507,10 @@ private:
     // Process a function parameter list
     void ParseFuncdecl_Paramlist(Symbol funcsym, bool body_follows);
 
-    void ParseFuncdecl_MasterData2Sym(TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_function, Symbol name_of_function, bool body_follows);
+    void ParseFuncdecl_MasterData2Sym(TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_func, Symbol name_of_func, bool body_follows);
 
     // There was a forward declaration -- check that the real declaration matches it
-    void ParseFuncdecl_CheckThatKnownInfoMatches(std::string const &func_name, SymbolTableEntry::FunctionDesc const *this_entry, SymbolTableEntry::FunctionDesc const *known_info, size_t declared, bool body_follows);
+    void ParseFuncdecl_CheckAndAddKnownInfo(Symbol name_of_func, SymbolTableEntry::FunctionDesc *known_info, size_t known_declared, bool body_follows);
 
     // Enter the function in the 'imports[]' or 'functions[]' array of '_script'; get its index   
     void ParseFuncdecl_EnterAsImportOrFunc(Symbol name_of_func, bool body_follows, bool func_is_import, size_t params_count, CodeLoc &function_soffs);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -570,7 +570,7 @@ private:
     // Parse the arguments 'args_list' of a function call
     void AccessData_FunctionCall_Arguments(Symbol name_of_func, bool func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool is_variadic, SrcList &arguments, size_t &args_count);
 
-    // Process a function call. 'arguments' doesn't encompass the surrounding '()'
+    // Process a function call. 
     void AccessData_FunctionCall(Symbol name_of_func, SrcList &arguments, EvaluationResult &eres);
 
     // Evaluate 'vloc_lhs op_sym vloc_rhs' at compile time, return the result in 'vloc'.

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -422,6 +422,9 @@ private:
     // 'custom_msg', if given, replaces the "Expected " part of the message
     inline void Expect(Symbol expected, Symbol actual, std::string const &custom_msg = "")
         { Expect(SymbolList{ expected }, actual, custom_msg); }
+    // Replace 'what' by 'by' within 's'
+    inline std::string string_replace(std::string &s, std::string const &what, std::string const &by) const
+        { return s.replace(s.find(what), what.length(), by); }
 
     // Mark the symbol as "accessed" in the symbol table
     inline void MarkAcessed(Symbol symb) { _sym[symb].Accessed = true; }

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -283,13 +283,13 @@ TEST_F(Bytecode0, Float01) {
       57,    4,    3,    3,            4,    3,   29,    3,    // 95
       36,   13,   51,   24,            7,    3,   36,   12,    // 103
       30,    4,   57,    4,            3,    3,    4,    3,    // 111
-      36,   13,   29,    3,           51,   20,    7,    3,    // 119
+      29,    3,   36,   13,           51,   20,    7,    3,    // 119
       30,    4,   57,    4,            3,    3,    4,    3,    // 127
       29,    3,   51,   16,            7,    3,   30,    4,    // 135
       57,    4,    3,    3,            4,    3,   29,    3,    // 143
       36,   14,   51,   12,            7,    3,   36,   13,    // 151
       30,    4,   57,    4,            3,    3,    4,    3,    // 159
-      36,   14,   29,    3,           51,    8,    7,    3,    // 167
+      29,    3,   36,   14,           51,    8,    7,    3,    // 167
       30,    4,   57,    4,            3,    3,    4,    3,    // 175
        2,    1,   32,    5,           36,   15,    6,    3,    // 183
     1117388800,   51,   32,    8,            3,  -999
@@ -809,7 +809,7 @@ TEST_F(Bytecode0, FlowDoNCall) {
     std::string const &err_msg = mh.GetError().Message;
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
-    // WriteOutput("FlowDoNCall", scrip);
+  // WriteOutput("FlowDoNCall", scrip);
 
     size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.code.size());

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -45,13 +45,6 @@
 */
 
 
-// NOTE! If any "WriteOutput" lines in this file are uncommented, then the 
-//  #define below _must_ be changed to a local writable temp dir. 
-// (If you only want to run the tests to see if any tests fail, you do NOT 
-// need that dir and you do NOT need any local files whatsoever.)
-#define LOCAL_PATH "C:\\TEMP\\"
-
-
 /*    PROTOTYPE
 
 TEST_F(Bytecode0, P_r_o_t_o_t_y_p_e) {
@@ -4819,7 +4812,7 @@ TEST_F(Bytecode0, Func20) {
         }"; 
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string err_msg = mh.GetError().Message;
+    std::string const &err_msg = mh.GetError().Message;
 
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
@@ -4863,6 +4856,26 @@ TEST_F(Bytecode0, Func20) {
     'H',  'i',  '!',    0,          '\0'
     };
     CompareStrings(&scrip, stringssize, strings);
+}
+
+TEST_F(Bytecode0, Func21) {
+
+    // Call function via named parameters
+
+    char const *inpl = "\
+        int Foo(const string str, int inty, float fnum = 12.34)     \n\
+        {                                           \n\
+            return Foo(                             \n\
+                inty: 99,                           \n\
+                str: \"Hi!\");                      \n\
+        }";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+
+    // WriteOutput("Func20", scrip);
 }
 
 TEST_F(Bytecode0, Export) {

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -4806,6 +4806,65 @@ TEST_F(Bytecode0, Func19) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
+TEST_F(Bytecode0, Func20) {
+
+    // Call function via named parameters
+
+    char const *inpl = "\
+        int Foo(const string str, int inty, float fnum = 12.34)     \n\
+        {                                           \n\
+            return Foo(                             \n\
+                inty: 99,                           \n\
+                str: \"Hi!\");                      \n\
+        }"; 
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+
+    // WriteOutput("Func20", scrip);
+    size_t const codesize = 34;
+    EXPECT_EQ(codesize, scrip.code.size());
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    5,    6,    3,    // 7
+    1095069860,   29,    3,   36,            4,    6,    3,   99,    // 15
+      29,    3,   36,    5,            6,    3,    0,   29,    // 23
+       3,    6,    3,    0,           23,    3,    2,    1,    // 31
+      12,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 2;
+    EXPECT_EQ(numfixups, scrip.fixups.size());
+
+    int32_t fixups[] = {
+      22,   27,  -999
+    };
+    char fixuptypes[] = {
+      3,   2,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.exports.size());
+
+    size_t const stringssize = 4;
+    EXPECT_EQ(stringssize, scrip.strings.size());
+
+    char strings[] = {
+    'H',  'i',  '!',    0,          '\0'
+    };
+    CompareStrings(&scrip, stringssize, strings);
+}
+
 TEST_F(Bytecode0, Export) {
 
     char const *inpl = "\

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -195,22 +195,22 @@ TEST_F(Bytecode1, StringOldstyle03) {
 
     // WriteOutput("StringOldstyle03", scrip);
 
-    size_t const codesize = 88;
+    size_t const codesize = 90;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
       36,    6,   38,    0,           36,    7,    6,    3,    // 7
-       0,   51,    8,    3,            3,    5,    3,    2,    // 15
-       4,    6,    7,  199,            3,    4,    2,    7,    // 23
-       3,    3,    5,    2,            8,    3,   28,   25,    // 31
-       1,    4,    1,    1,            5,    1,    2,    7,    // 39
-       1,    3,    7,    3,           70,  -26,    1,    5,    // 47
-       1,    3,    5,    2,            6,    3,    0,    8,    // 55
-       3,   36,    8,    5,           36,   11,   38,   60,    // 63
-      36,   12,    6,    2,            4,    3,    2,    3,    // 71
-      29,    3,    6,    3,            0,   23,    3,    2,    // 79
-       1,    4,   36,   13,            6,    3,    0,    5,    // 87
-     -999
+       0,   51,    8,    7,            2,    3,    3,    5,    // 15
+       3,    2,    4,    6,            7,  199,    3,    4,    // 23
+       2,    7,    3,    3,            5,    2,    8,    3,    // 31
+      28,   25,    1,    4,            1,    1,    5,    1,    // 39
+       2,    7,    1,    3,            7,    3,   70,  -26,    // 47
+       1,    5,    1,    3,            5,    2,    6,    3,    // 55
+       0,    8,    3,   36,            8,    5,   36,   11,    // 63
+      38,   62,   36,   12,            6,    2,    4,    3,    // 71
+       2,    3,   29,    3,            6,    3,    0,   23,    // 79
+       3,    2,    1,    4,           36,   13,    6,    3,    // 87
+       0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -218,7 +218,7 @@ TEST_F(Bytecode1, StringOldstyle03) {
     EXPECT_EQ(numfixups, scrip.fixups.size());
 
     int32_t fixups[] = {
-       8,   68,   76,  -999
+       8,   70,   78,  -999
     };
     char fixuptypes[] = {
       3,   1,   2,  '\0'
@@ -267,7 +267,7 @@ TEST_F(Bytecode1, StringOldstyle04) {
 
     // WriteOutput("StringOldstyle04", scrip);
 
-    size_t const codesize = 94;
+    size_t const codesize = 96;
     EXPECT_EQ(codesize, scrip.code.size());
 
     int32_t code[] = {
@@ -282,7 +282,8 @@ TEST_F(Bytecode1, StringOldstyle04) {
        2,    6,    3,    0,            8,    3,    1,    1,    // 71
      200,   36,    6,    2,            1,  200,    6,    3,    // 79
        0,    5,   36,    8,           38,   82,   36,    9,    // 87
-      51,    8,    3,    2,            3,    5,  -999
+      51,    8,    7,    2,            3,    2,    3,    5,    // 95
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -623,6 +624,76 @@ TEST_F(Bytecode1, StringStandardOldstyle) {
     };
     CompareStrings(&scrip, stringssize, strings);
 }
+
+TEST_F(Bytecode1, CharArrayAsString01)
+{
+    // An array of characters can be passed to a 'string' parameter
+
+    char const *inpl = "\
+        int PayloadDummy;                       \n\
+        char GlobalC[10];                       \n\
+        int printme(string text)                \n\
+        {                                       \n\
+            Display(text);                      \n\
+        }                                       \n\
+                                                \n\
+        int game_start()                        \n\
+        {                                       \n\
+            printme(GlobalC);                   \n\
+            char LocalC[5];                     \n\
+            printme(LocalC);                    \n\
+        }                                       \n\
+                                                \n\
+        import void Display(const string, ...); \n\
+        ";
+
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+
+    // WriteOutput("CharArrayAsString01", scrip);
+    size_t const codesize = 87;
+    EXPECT_EQ(codesize, scrip.code.size());
+
+    int32_t code[] = {
+      36,    4,   38,    0,           36,    5,   51,    8,    // 7
+       7,    2,    3,    2,            3,   34,    3,   39,    // 15
+       1,    6,    3,    0,           33,    3,   35,    1,    // 23
+      36,    6,    6,    3,            0,    5,   36,    9,    // 31
+      38,   30,   36,   10,            6,    2,    4,    3,    // 39
+       2,    3,   29,    3,            6,    3,    0,   23,    // 47
+       3,    2,    1,    4,           36,   11,   51,    0,    // 55
+      63,    5,    1,    1,            5,   36,   12,   51,    // 63
+       5,    3,    2,    3,           29,    3,    6,    3,    // 71
+       0,   23,    3,    2,            1,    4,   36,   13,    // 79
+       2,    1,    5,    6,            3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 4;
+    EXPECT_EQ(numfixups, scrip.fixups.size());
+
+    int32_t fixups[] = {
+      19,   38,   46,   72,        -999
+    };
+    char fixuptypes[] = {
+      4,   1,   2,   2,     '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 1;
+    std::string imports[] = {
+    "Display^101",  "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.exports.size());
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.strings.size());
+}
+
 
 TEST_F(Bytecode1, AccessStructAsPointer01) {
 
@@ -3678,3 +3749,4 @@ TEST_F(Bytecode1, CharArrayDecay01)
     };
     CompareStrings(&scrip, stringssize, strings);
 }
+

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -3580,7 +3580,43 @@ TEST_F(Bytecode1, StructCtorCall) {
 
     // WriteOutput("StructCtorCall", scrip);
 
-    // TODO: proper bytecode test!!
+    size_t const codesize = 63;
+    EXPECT_EQ(codesize, scrip.code.size());
+
+    int32_t code[] = {
+      36,    8,   38,    0,           36,    9,   73,    3,    // 7
+       4,   29,    3,    3,            3,    2,   29,    2,    // 15
+       6,    3, 1088421888,   34,            3,   51,    4,    7,    // 23
+       2,   45,    2,   39,            1,    6,    3,    0,    // 31
+      33,    3,   35,    1,           30,    2,   30,    3,    // 39
+      51,    0,   47,    3,            1,    1,    4,   36,    // 47
+      10,   51,    4,   48,            2,   52,    7,    3,    // 55
+      51,    4,   49,    2,            1,    4,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 1;
+    EXPECT_EQ(numfixups, scrip.fixups.size());
+
+    int32_t fixups[] = {
+      31,  -999
+    };
+    char fixuptypes[] = {
+      4,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 1;
+    std::string imports[] = {
+    "Struct::Struct^1",            "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.exports.size());
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
 TEST_F(Bytecode1, CharArrayDecay01)
@@ -3598,7 +3634,7 @@ TEST_F(Bytecode1, CharArrayDecay01)
         ";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string err_msg = mh.GetError().Message;
+    std::string const &err_msg = mh.GetError().Message;
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("CharArrayDecay01", scrip);

--- a/Compiler/test2/cc_internallist_test.cpp
+++ b/Compiler/test2/cc_internallist_test.cpp
@@ -19,135 +19,134 @@
 // defined in script_common, modified by getnext
 extern int currentline;
 
-TEST(SrcList, GetNext) {
+// The vars defined here are provided in each test
+class SrcList : public ::testing::Test
+{
+protected:
     AGS::LineHandler lh = AGS::LineHandler();
+    size_t cursor = 0u;
+};
+
+TEST_F(SrcList, GetNext) {
     std::vector<AGS::Symbol> script = { 1, 2, 3, 4, 5, };
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
 
     EXPECT_EQ(1, src.GetNext());
     EXPECT_EQ(2, src.GetNext());
 
-    src.SetCursor(1);
+    src.SetCursor(1u);
     EXPECT_EQ(2, src.GetNext());
 
-    src.SetCursor(4);
+    src.SetCursor(4u);
     EXPECT_EQ(5, src.GetNext());
     EXPECT_EQ(AGS::SrcList::kEOF, src.GetNext());
 
-    src.SetCursor(4711);
+    src.SetCursor(4711u);
     EXPECT_EQ(AGS::SrcList::kEOF, src.GetNext());
     EXPECT_TRUE(src.ReachedEOF());
 }
 
-TEST(SrcList, PeekNext) {
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, PeekNext) {
     std::vector<AGS::Symbol> script = { 1, 2, 3, 4, 5, };
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
 
-    src.SetCursor(1);
+    src.SetCursor(1u);
     EXPECT_EQ(2, src.PeekNext());
     EXPECT_EQ(2, src.PeekNext());
 
-    src.SetCursor(5);
+    src.SetCursor(5u);
     EXPECT_EQ(AGS::SrcList::kEOF, src.PeekNext());
     EXPECT_TRUE(src.ReachedEOF());
 }
 
-TEST(SrcList, InRange) {
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, InRange) {
     std::vector<AGS::Symbol> script = { 1, 2, 3, 4, 5, };
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
 
-    EXPECT_TRUE(src.InRange(3));
-    EXPECT_FALSE(src.InRange(5));
+    EXPECT_TRUE(src.InRange(3u));
+    EXPECT_FALSE(src.InRange(5u));
 }
 
-TEST(SrcList, Brackets) {
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, Brackets) {
     std::vector<AGS::Symbol> script = { 1, 2, 3, 4, 5, };
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
 
-    EXPECT_EQ(1, src[0]);
-    EXPECT_EQ(4, src[3]);
+    EXPECT_EQ(1, src[0u]);
+    EXPECT_EQ(4, src[3u]);
 
-    EXPECT_EQ(AGS::SrcList::kEOF, src[12345]);
+    EXPECT_EQ(AGS::SrcList::kEOF, src[12345u]);
 }
 
-TEST(SrcList, AppendLineno) {
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, AppendLineno) {
     std::vector<AGS::Symbol> script;
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
     src.Append(1);
     src.Append(1);
-    src.NewLine(4711);
+    src.NewLine(4711u);
     src.Append(3);
-    src.NewLine(7);
-    src.NewLine(11); // overwrites the previous NewLine()
+    src.NewLine(7u);
+    src.NewLine(11u); // overwrites the previous 'NewLine()'
     src.Append(9);
 
-    EXPECT_EQ(1, src.GetLinenoAt(0));
-    EXPECT_EQ(1, src.GetLinenoAt(1));
-    EXPECT_EQ(4711, src.GetLinenoAt(2));
-    EXPECT_EQ(11, src.GetLinenoAt(5)); // last linenum is valid "forever"
-    EXPECT_EQ(1, src.GetLinenoAt(1));
-    src.SetCursor(4);
-    EXPECT_EQ(11, src.GetLineno());
+    EXPECT_EQ(1u, src.GetLinenoAt(0u));
+    EXPECT_EQ(1u, src.GetLinenoAt(1u));
+    EXPECT_EQ(4711u, src.GetLinenoAt(2u));
+    EXPECT_EQ(11u, src.GetLinenoAt(5u)); // last linenum is valid "forever"
+    EXPECT_EQ(1u, src.GetLinenoAt(1u));
+    src.SetCursor(4u);
+    EXPECT_EQ(11u, src.GetLineno());
 }
 
-TEST(SrcList, AppendSections) {
-    // A section change will only "stick" when it is followed by a NewLine();
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, AppendSections) {
+    // A section change will only "stick" when it is followed by a 'NewLine()'
     std::vector<AGS::Symbol> script;
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
-    src.NewLine(10);
+    src.NewLine(10u);
     src.Append(1);
     src.NewSection("Apple");
-    src.NewLine(10);
+    src.NewLine(10u);
     src.Append(1);
     src.Append(3);
     src.NewSection("Banana");
-    src.NewLine(10);
+    src.NewLine(10u);
     src.NewSection("Cherry");
-    src.NewLine(10);
+    src.NewLine(10u);
     src.Append(9);
 
-    EXPECT_EQ(10, src.GetLinenoAt(0));
-    EXPECT_EQ(10, src.GetLinenoAt(1));
-    EXPECT_EQ(10, src.GetLinenoAt(2)); // NewSection doesn't automatically reset the line counter
+    EXPECT_EQ(10u, src.GetLinenoAt(0u));
+    EXPECT_EQ(10u, src.GetLinenoAt(1u));
+    EXPECT_EQ(10u, src.GetLinenoAt(2u)); // NewSection doesn't automatically reset the line counter
     EXPECT_STREQ("Apple", src.SectionId2Section(src.GetSectionIdAt(2)).c_str());
     EXPECT_STREQ("Cherry", src.SectionId2Section(src.GetSectionIdAt(9)).c_str());
-    src.SetCursor(0);
+    src.SetCursor(0u);
     EXPECT_STREQ("", src.SectionId2Section(src.GetSectionId()).c_str());
 }
 
-TEST(SrcList, Reference0) {
-    AGS::LineHandler lh = AGS::LineHandler();
+TEST_F(SrcList, Reference0) {
     std::vector<AGS::Symbol> script;
-    size_t cursor = 0;
+    // Script 1  1   3  9
+    // Line   10 10  10 77
+    // Sect.     Ap  Ch
     AGS::SrcList src(script, lh, cursor);
-    src.NewLine(10);
+    src.NewLine(10u);
     src.Append(1);
     src.NewSection("Apple");
-    src.NewLine(10);
+    src.NewLine(10u);
     src.Append(1);
     src.Append(3);
     src.NewSection("Cherry");
-    src.NewLine(10);
-    src.NewLine(77);
+    src.NewLine(10u);
+    src.NewLine(77u);
     src.Append(9);
+
+    // Script  3  9
     AGS::SrcList part = AGS::SrcList(src, 2, 7);
-    EXPECT_EQ(3, part[0]);
-    EXPECT_EQ(9, part[1]);
-    EXPECT_EQ(AGS::SrcList::kEOF, part[2]);
-    EXPECT_TRUE(part.InRange(1));
-    EXPECT_FALSE(part.InRange(2));
-    src.SetCursor(0);
+    EXPECT_EQ(3, part[0u]);
+    EXPECT_EQ(9, part[1u]);
+    EXPECT_EQ(AGS::SrcList::kEOF, part[2u]);
+    EXPECT_TRUE(part.InRange(1u));
+    EXPECT_FALSE(part.InRange(2u));
+    src.SetCursor(0u); // ´'src' (!)
     EXPECT_EQ(AGS::SrcList::kEOF, part.GetNext());
     part.StartRead();
     EXPECT_EQ(3, part.GetNext());
@@ -156,25 +155,23 @@ TEST(SrcList, Reference0) {
     EXPECT_EQ(9, part.GetNext());
     EXPECT_EQ(AGS::SrcList::kEOF, part.GetNext());
     EXPECT_TRUE(part.ReachedEOF());
-    EXPECT_EQ(10, part.GetLinenoAt(0));
+    EXPECT_EQ(10u, part.GetLinenoAt(0u));
     EXPECT_STREQ("Apple", part.SectionId2Section(part.GetSectionIdAt(0)).c_str());
-    EXPECT_EQ(77, part.GetLinenoAt(1));
+    EXPECT_EQ(77u, part.GetLinenoAt(1u));
     EXPECT_STREQ("Cherry", part.SectionId2Section(part.GetSectionIdAt(1)).c_str());
 }
 
-TEST(SrcList, Reference1) {
+TEST_F(SrcList, Reference1) {
 
     // cpy is set up as an excerpt of src.
     // GetCursor() should give the cursor position relative to the respective SrcList.
     // Moving the cursor in one SrcList should move the cursor in the other, too.
 
-    AGS::LineHandler lh = AGS::LineHandler();
     std::vector<AGS::Symbol> script;
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
     for (AGS::Symbol i = 0; i < 10; i++)
         src.Append(i);
-    AGS::SrcList cpy(src, 3, 3);
+    AGS::SrcList cpy(src, 3u, 3u);
     cpy.StartRead();
     EXPECT_EQ(3, src.GetCursor());
     EXPECT_EQ(0, cpy.GetCursor());
@@ -189,25 +186,23 @@ TEST(SrcList, Reference1) {
     EXPECT_EQ(false, src.ReachedEOF());
 }
 
-TEST(SrcList, Reference2) {
+TEST_F(SrcList, Reference2) {
 
     // cpy is set up as an excerpt of src.
     // Line numbers for a symbol should be the same
     // no matter the way the symbol is referenced.
 
-    AGS::LineHandler lh = AGS::LineHandler();
     std::vector<AGS::Symbol> script;
-    size_t cursor = 0;
     AGS::SrcList src(script, lh, cursor);
-    src.NewLine(5);
+    src.NewLine(5u);
     for (AGS::Symbol i = 0; i < 5; i++)
         src.Append(i);
-    src.NewLine(10);
+    src.NewLine(10u);
     for (AGS::Symbol i = 5; i < 10; i++)
         src.Append(i);
     AGS::SrcList cpy(src, 3, 3);
-    EXPECT_EQ(5, src.GetLinenoAt(4));
-    EXPECT_EQ(5, cpy.GetLinenoAt(1));
-    EXPECT_EQ(10, src.GetLinenoAt(5));
-    EXPECT_EQ(10, cpy.GetLinenoAt(2));
+    EXPECT_EQ(5u, src.GetLinenoAt(4u));
+    EXPECT_EQ(5u, cpy.GetLinenoAt(1u));
+    EXPECT_EQ(10u, src.GetLinenoAt(5u));
+    EXPECT_EQ(10u, cpy.GetLinenoAt(2u));
 }

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -587,7 +587,7 @@ TEST_F(Compile1, StrangeParameterName) {
 
 TEST_F(Compile1, DoubleParameterName) {
 
-    // Can't use keyword as parameter name
+    // Can't use parameter name twice
 
     char const *inpl = "\
         void Func(int PI, float PI)             \n\


### PR DESCRIPTION
This PR makes it possible (again) to have classic character arrays as function arguments. 

As far as I can see, the only way that this feature can be used is with _variadic_ arguments in _variadic_ functions such as `Display(const string format, ...)`. When the compiler finds a classic array in a variadic argument, it simply pushes a pointer to the first byte and hopes that the receiving function will find a good use for it. 
As far as I know, the "old" compiler did the same. 

The compiler can't check variadic arguments, anyway, because it doesn't know what types to expect. When I realized that, I gave up all misgivings about implementing "decaying classic arrays" as variadic parameters.

```
char ch[100];
Display("%s", ch);
```

Note that it isn't possible in AGS to define an _explicit_ parameter that receives a classic array. However you go about it, you end up defining a parameter that receives a _dynamic_ array. So it currently isn't possible from the get-go to pass a "classic" array to an _explicit_ parameter. 

------

I've taken this as an opportunity to revise and streamline the function calling code in general. And as a result, the code now offers the possibility to use __named arguments__, in `C#` style. 

```
void Heal(this Character *, 
    int added_health, int added_strength, int added_mana = 0)
{ … }

int game_start()
{
    player.Heal(
        added_strength: 30, 
        added_health: 20);
    player.Heal(20, 30); // is equivalent to the code above
}
```

* The way that the functions are __defined and declared__ hasn't changed in any way.
* The "normal" way of calling functions can still be used, and it hasn't changed in any way. Cf. the example above.
* When you use named arguments, each argument has the form `parametername: expression`. The `parametername` determines which parameter gets which expression, respectively. The sequence in which the named arguments are given is immaterial. 
* Currently, there is a restriction: You can't mix the calling conventions. Within one function call, either _all_ the arguments must be named or _none_ of the arguments can be named. 
* This restriction means that you can't use named arguments when calling variadic functions that have variadic arguments (e.g., `Display()`, `String.Format()`, etc.) : Those variadic arguments don't have parameter names, so there is no way to pass them as named arguments.  
* However, functions with optional parameters are fine. When you call a function with optional parameters, your call can name all the arguments that you want to pass, in any sequence, and the compiler will fill in the defaults for all the other parameters. Cf. the example given above.