### PR TITLE
Script API: SendEvent() function, calling "on_event"

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -537,6 +537,37 @@ enum SortDirection
 };
 #endif // SCRIPT_API_v362
 
+enum EventType {
+  eEventLeaveRoom		= 1,
+  eEventEnterRoomBeforeFadein = 2,
+  // 3 is reserved by an obsolete "death" event
+  eEventGotScore		= 4,
+  eEventGUIMouseDown	= 5,
+  eEventGUIMouseUp		= 6,
+  eEventAddInventory	= 7,
+  eEventLoseInventory	= 8,
+  eEventRestoreGame		= 9,
+#ifdef SCRIPT_API_v36026
+  eEventEnterRoomAfterFadein = 10,
+#endif // SCRIPT_API_v36026
+#ifdef SCRIPT_API_v361
+  eEventLeaveRoomAfterFadeout = 11,
+  eEventGameSaved		= 12,
+#endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v362
+  eEventDialogStart		= 13,
+  eEventDialogStop		= 14,
+  eEventDialogRun		= 15,
+  eEventDialogOptionsOpen = 16,
+  eEventDialogOptionsClose = 17,
+  eEventSavesScanComplete = 18,
+#endif // SCRIPT_API_v362
+
+#ifdef SCRIPT_API_v362
+  eEventUserEvent		= 10000
+#endif // SCRIPT_API_v362
+};
+
 
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
@@ -890,6 +921,10 @@ import void DisableInterface();
 import void EnableInterface();
 /// Checks whether the player interface is currently enabled.
 import int  IsInterfaceEnabled();
+#ifdef SCRIPT_API_v362
+/// Triggers the standard "on_event" script callback, passing EventType and a number of optional parameters
+import void SendEvent(EventType, int data1=0, int data2=0, int data3=0, int data4=0);
+#endif
 
 struct Mouse {
   /// Changes the sprite for the specified mouse cursor.
@@ -1721,33 +1756,6 @@ import void ListBoxRemove (int gui, int object, int listIndex);
 
 import void SetFrameSound (int view, int loop, int frame, int sound);
 #endif // !STRICT
-
-enum EventType {
-  eEventLeaveRoom = 1,
-  eEventEnterRoomBeforeFadein = 2,
-  // 3 is reserved by an obsolete "death" event
-  eEventGotScore = 4,
-  eEventGUIMouseDown = 5,
-  eEventGUIMouseUp = 6,
-  eEventAddInventory = 7,
-  eEventLoseInventory = 8,
-  eEventRestoreGame = 9,
-#ifdef SCRIPT_API_v36026
-  eEventEnterRoomAfterFadein = 10,
-#endif // SCRIPT_API_v36026
-#ifdef SCRIPT_API_v361
-  eEventLeaveRoomAfterFadeout = 11,
-  eEventGameSaved = 12,
-#endif // SCRIPT_API_v361
-#ifdef SCRIPT_API_v362
-  eEventDialogStart = 13,
-  eEventDialogStop = 14,
-  eEventDialogRun = 15,
-  eEventDialogOptionsOpen = 16,
-  eEventDialogOptionsClose = 17,
-  eEventSavesScanComplete = 18
-#endif // SCRIPT_API_v362
-};
 
 #ifdef SCRIPT_API_v350
 enum GUIPopupStyle {

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -206,7 +206,7 @@ struct AGSEvent
 };
 
 void run_claimable_event(const AGS::Common::String &tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed);
-// runs the global script on_event function, passing up to 2 integer parameters
+// runs the global script on_event function, passing a number of integer parameters
 void run_on_event(AGSScriptEventType evtype, int data1 = 0, int data2 = 0, int data3 = 0, int data4 = 0);
 void run_room_event(int id);
 // event list functions

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -1533,6 +1533,13 @@ RuntimeScriptValue Sc_SeekMP3PosMillis(const RuntimeScriptValue *params, int32_t
     API_SCALL_VOID_PINT(SeekMP3PosMillis);
 }
 
+RuntimeScriptValue Sc_SendEvent(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_PARAM_COUNT(run_on_event, 5); \
+    run_on_event(static_cast<AGSScriptEventType>(params[0].IValue), params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue);
+    return RuntimeScriptValue(0);
+}
+
 // void (int iit)
 RuntimeScriptValue Sc_SetActiveInventory(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2586,6 +2593,7 @@ void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*
         { "SeekMIDIPosition",         API_FN_PAIR(SeekMIDIPosition) },
         { "SeekMODPattern",           API_FN_PAIR(SeekMODPattern) },
         { "SeekMP3PosMillis",         API_FN_PAIR(SeekMP3PosMillis) },
+        { "SendEvent",                Sc_SendEvent, run_on_event },
         { "SetActiveInventory",       API_FN_PAIR(SetActiveInventory) },
         { "SetAmbientTint",           API_FN_PAIR(SetAmbientTint) },
         { "SetAmbientLightLevel",     API_FN_PAIR(SetAmbientLightLevel) },


### PR DESCRIPTION
Adds a very simple function:

```
/// Calls the standard "on_event" function, passing EventType and a number of optional parameters
void SendEvent(EventType, int data1=0, int data2=0, int data3=0, int data4=0);
```

This lets to trigger "on_event" callback, passing any arbitrary event type and up to 4 integer parameters (currently).
Declared a `eEventUserEvent` constant inside EventType enum, assigned to a large number. This is meant as a starting index for user scripts to declare their custom events (i.e. eEventUserEvent + 1, eEventUserEvent + 2, and so forth).

As usual, `on_event` is not executed right away, but only after current script finishes running (as a post-script step).

On another hand, since "on_event" is called in every script module, in a regular order (room, then each script from top to bottom), this is also a way to pass commands to scripts that have no direct connection to the current script.

Note: this has no effect on the engine itself, only causes "on_event" to be called with these args. For instance, if you call `SendEvent(eEventRestoreGame)` - that won't actually restore a game. But will make other scripts that handle such event *think* that the game was restored. In other words, this may also be useful to simulate that something happened in the engine.