### PR TITLE
Adds Character.Following readonly property

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2938,6 +2938,8 @@ builtin managed struct Character {
   import function MoveStraight(int x, int y, BlockingStyle=eNoBlock);
   /// Gets/sets whether the character turns on the spot when ordered to face the new standing direction.
   import attribute bool TurnWhenFacing;
+  /// Gets the character this character is following
+  readonly import attribute Character* Following;
 #endif // SCRIPT_API_v362
 #ifdef STRICT
   /// The character's current X-position.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -528,6 +528,15 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
 
 }
 
+CharacterInfo* Character_GetFollowing(CharacterInfo* chaa)
+{
+    if (chaa->following ==-1)
+        return nullptr;
+
+    int charid = chaa->following;
+    return &game.chars[charid];
+}
+
 int Character_IsCollidingWithChar(CharacterInfo *char1, CharacterInfo *char2) {
     if (char2 == nullptr)
         quit("!AreCharactersColliding: invalid char2");
@@ -3169,6 +3178,12 @@ RuntimeScriptValue Sc_Character_FollowCharacter(void *self, const RuntimeScriptV
     API_OBJCALL_VOID_POBJ_PINT2(CharacterInfo, Character_FollowCharacter, CharacterInfo);
 }
 
+// CharacterInfo * | CharacterInfo *chaa
+RuntimeScriptValue Sc_Character_GetFollowing(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(CharacterInfo, CharacterInfo, ccDynamicCharacter, Character_GetFollowing);
+}
+
 // int (CharacterInfo *chaa, const char *property)
 RuntimeScriptValue Sc_Character_GetProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -4081,6 +4096,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
         { "Character::get_DestinationY",          API_FN_PAIR(Character_GetDestinationY) },
         { "Character::get_DiagonalLoops",         API_FN_PAIR(Character_GetDiagonalWalking) },
         { "Character::set_DiagonalLoops",         API_FN_PAIR(Character_SetDiagonalWalking) },
+        { "Character::get_Following",             API_FN_PAIR(Character_GetFollowing) },
         { "Character::get_Frame",                 API_FN_PAIR(Character_GetFrame) },
         { "Character::set_Frame",                 API_FN_PAIR(Character_SetFrame) },
         { "Character::get_ID",                    API_FN_PAIR(Character_GetID) },


### PR DESCRIPTION
In Future Flashback, I use the CustomFollow module I showed in the forums, I also have a similar thing in some other unreleased games. In Don't Give Up the Cat I have this line: https://github.com/ericoporto/dont-give-up-the-cat/blob/fc2810d9d580f6e1b51742489fa388fbd96cdbd0/dont-give-up-the-cat/room1.asc#L164

This PR is to be specific to this need. It's not a major need, I can live without it, as I have a workaround, but it feels useful.

The issue I am not sure though is what happened in #2296 , I don't know how to properly return a Character* here that won't fail equality comparisons, Should I return `&game.chars[charid]` directly or the dynamic memory handle? Is ags4 the only version that has a right answer for this?

