### PR TITLE
Engine: Fix memory leak in ccInstance::CreateEx when it fails

### DIFF
--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -234,6 +234,7 @@ ccInstance *ccInstance::CreateEx(PScript scri, const ccInstance *joined)
     ccInstance *cinst = new ccInstance();
     if (!cinst->_Create(scri, joined))
     {
+        delete cinst;
         return nullptr;
     }
     return cinst;


### PR DESCRIPTION
This is a regression from commit 1f6abf4. Before that commit it used a std::shared_ptr which means the pointer was automatically deleted.