### PR TITLE
Editor: can drag and drop folders in the Sprite Manager

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Entities\CharacterIDChangedEventArgs.cs" />
     <Compile Include="Entities\CharacterRoomChangedEventArgs.cs" />
     <Compile Include="Entities\CompilationStepArgs.cs" />
+    <Compile Include="Entities\TreeItemDragEventArgs.cs" />
     <Compile Include="Entities\ExistingScriptHeaderToAdd.cs" />
     <Compile Include="Entities\ExistingFileToAdd.cs" />
     <Compile Include="Config\IObjectConfig.cs" />
@@ -163,6 +164,8 @@
     <Compile Include="Entities\OutputCreationStepArgs.cs" />
     <Compile Include="Entities\ScriptModuleDef.cs" />
     <Compile Include="Entities\GenericMessagesArgs.cs" />
+    <Compile Include="Entities\TreeItemTryDragEventArgs.cs" />
+    <Compile Include="Enums\TargetDropZone.cs" />
     <Compile Include="GUI\AssignToView.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -253,6 +256,9 @@
       <DependentUpon>SpriteChooser.cs</DependentUpon>
     </Compile>
     <Compile Include="GUI\TreeViewExtensions.cs" />
+    <Compile Include="GUI\TreeViewWithDragDrop.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="GUI\ViewChooser.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/Entities/TreeItemDragEventArgs.cs
+++ b/Editor/AGS.Editor/Entities/TreeItemDragEventArgs.cs
@@ -5,12 +5,15 @@ namespace AGS.Editor
 {
     public class TreeItemDragEventArgs : DragEventArgs
     {
-        public TreeItemDragEventArgs(DragEventArgs dragArgs, TreeNode dragItem, TreeNode dropTarget, TargetDropZone dropZone)
+        public TreeItemDragEventArgs(DragEventArgs dragArgs, TreeNode dragItem, TreeNode dropTarget,
+                                     TargetDropZone dropZone, bool showLine, bool expandOnHover)
             : base(dragArgs.Data, dragArgs.KeyState, dragArgs.X, dragArgs.Y, dragArgs.AllowedEffect, dragArgs.Effect)
         {
             DragItem = dragItem;
             DropTarget = dropTarget;
             DropZone = dropZone;
+            ShowLine = showLine;
+            ExpandOnDragHover = expandOnHover;
         }
 
         public TreeNode DragItem { get; private set; }

--- a/Editor/AGS.Editor/Entities/TreeItemDragEventArgs.cs
+++ b/Editor/AGS.Editor/Entities/TreeItemDragEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public class TreeItemDragEventArgs : DragEventArgs
+    {
+        public TreeItemDragEventArgs(DragEventArgs dragArgs, TreeNode dragItem, TreeNode dropTarget, TargetDropZone dropZone)
+            : base(dragArgs.Data, dragArgs.KeyState, dragArgs.X, dragArgs.Y, dragArgs.AllowedEffect, dragArgs.Effect)
+        {
+            DragItem = dragItem;
+            DropTarget = dropTarget;
+            DropZone = dropZone;
+        }
+
+        public TreeNode DragItem { get; private set; }
+        public TreeNode DropTarget { get; private set; }
+        public TargetDropZone DropZone { get; private set; }
+        public bool ShowLine { get; set; }
+        public bool ExpandOnDragHover { get; set; }
+    }
+}

--- a/Editor/AGS.Editor/Entities/TreeItemTryDragEventArgs.cs
+++ b/Editor/AGS.Editor/Entities/TreeItemTryDragEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public class TreeItemTryDragEventArgs : ItemDragEventArgs
+    {
+        public TreeItemTryDragEventArgs(ItemDragEventArgs baseArgs)
+            : base(baseArgs.Button, baseArgs.Item)
+        {
+            AllowedEffect = DragDropEffects.None;
+        }
+
+        public DragDropEffects AllowedEffect { get; set; }
+    }
+}

--- a/Editor/AGS.Editor/Enums/TargetDropZone.cs
+++ b/Editor/AGS.Editor/Enums/TargetDropZone.cs
@@ -1,6 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
 
-namespace AGS.Types
+namespace AGS.Editor
 {
     public enum TargetDropZone
     {

--- a/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ProjectPanel));
-            this.projectTree = new System.Windows.Forms.TreeView();
+            this.projectTree = new AGS.Editor.TreeViewWithDragDrop();
             this.SuspendLayout();
             // 
             // projectTree
@@ -60,6 +60,6 @@
 
         #endregion
 
-        internal System.Windows.Forms.TreeView projectTree;
+        internal AGS.Editor.TreeViewWithDragDrop projectTree;
     }
 }

--- a/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
@@ -61,5 +61,20 @@ namespace AGS.Editor
                 }
             }
         }
+
+        /// <summary>
+        /// Tells whether the given node is a descendant of otherNode.
+        /// Returns positive also if both references refer to the same node.
+        /// </summary>
+        public static bool IsDescendantOf(this TreeNode node, TreeNode otherNode)
+        {
+            while (node != null)
+            {
+                if (node == otherNode)
+                    return true;
+                node = node.Parent;
+            }
+            return false;
+        }
     }
 }

--- a/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
@@ -5,6 +5,17 @@ using System.Windows.Forms;
 
 namespace AGS.Editor
 {
+    /// <summary>
+    /// TreeViewWithDragDrop is an extended type of TreeView that handles drag and drop
+    /// action for tree nodes. Supports dropping tree nodes on top of another tree node,
+    /// or before or after particular node.
+    /// It provides 3 new events that let customize its behavior:
+    ///    * ItemTryDrag - called when the user starts dragging a tree node, and lets
+    ///                    specify AllowedEffect (Move, Copy, etc), or cancel the action
+    ///                    by setting DragDropEffects.None.
+    ///    * ItemDragOver - called repeatedly while the tree node is being dragged around.
+    ///    * ItemDragDrop - called when the tree node is dropped.
+    /// </summary>
     public class TreeViewWithDragDrop : TreeView
     {
         public delegate void ItemTryDragEventHandler(object sender, TreeItemTryDragEventArgs e);
@@ -36,11 +47,18 @@ namespace AGS.Editor
             _lineInBetween.Hide();
         }
 
+        /// <summary>
+        /// Tells if the dragging cursor was hovering above another node long enough to expand it.
+        /// </summary>
         private bool HasANodeBeenHoveredEnoughForExpanding()
         {
             return DateTime.Now.Subtract(_timeOfDragDropHoverStart) >= TimeSpan.FromMilliseconds(DragWaitBeforeExpandNodeMs);
         }
 
+        /// <summary>
+        /// Reacts to dragging cursor hovering over another node: highlights that node,
+        /// and optionally expands it, if it's expandable.
+        /// </summary>
         private void HighlightNodeAndExpandIfNeeded(TreeNode treeNode, bool expandOnDragHover, TargetDropZone dropZone)
         {
             if (treeNode != _dropHoveredNode)
@@ -62,6 +80,9 @@ namespace AGS.Editor
             }
         }
 
+        /// <summary>
+        /// Clears highlight from the last highlighted tree node.
+        /// </summary>
         private void ClearHighlightNode()
         {
             if (_dropHoveredNode != null)
@@ -74,17 +95,27 @@ namespace AGS.Editor
             }
         }
 
+        /// <summary>
+        /// Displays the "in-between tree nodes" marker at the given coordinates.
+        /// </summary>
         private void ShowMiddleLine(int x, int y, int w, int h)
         {
             // it auto-hides so we don't have to handle the drop being cancelled which has to be done in projectItem!
             _lineInBetween.ShowAndHideAt(x, y, w, h);
         }
 
+        /// <summary>
+        /// Hide thes "in-between tree nodes" marker.
+        /// </summary>
         private void HideMiddleLine()
         {
             _lineInBetween.Hide();
         }
 
+        /// <summary>
+        /// Calculates the necessary width of a "in-between tree nodes" marker,
+        /// depending on a selected tree node.
+        /// </summary>
         private int GetLineInBetweenWidth(TreeNode treeNode)
         {
             int maxWdith = treeNode.Bounds.Width;
@@ -99,6 +130,9 @@ namespace AGS.Editor
             return Math.Max(maxWdith, this.Width / 3);
         }
 
+        /// <summary>
+        /// Gets the location type of a cursor relative to the tree node.
+        /// </summary>
         private TargetDropZone GetDropZoneImpl(int y, int h)
         {
             TargetDropZone dropZone = TargetDropZone.Middle;
@@ -123,6 +157,9 @@ namespace AGS.Editor
             return dropZone;
         }
 
+        /// <summary>
+        /// Gets the location type of a cursor relative to the tree node.
+        /// </summary>
         private TargetDropZone GetDropZone(TreeNode treeNode, Point locationInControl)
         {
             int node_h = treeNode.Bounds.Height;
@@ -131,12 +168,19 @@ namespace AGS.Editor
             return GetDropZoneImpl(cur_y - node_y, node_h);
         }
 
+        /// <summary>
+        /// Clears all visual drag highlights and markers.
+        /// </summary>
         private void ClearAllDragHighlights()
         {
             HideMiddleLine();
             ClearHighlightNode();
         }
 
+        /// <summary>
+        /// Completely resets the visual state of a drag'n'drop action,
+        /// including any graphical configuration prepared when the drag starts.
+        /// </summary>
         private void ResetDragDropState()
         {
             ClearAllDragHighlights();

--- a/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
@@ -260,8 +260,15 @@ namespace AGS.Editor
                 e.Effect = itemDrag.Effect;
                 showLine = itemDrag.ShowLine;
                 expandOnHover = itemDrag.ExpandOnDragHover;
+
+                // Safety check: dragging a tree node into the sub-nodes is forbidden
+                if (e.Effect != DragDropEffects.None && dropTarget.IsDescendantOf(dragItem))
+                {
+                    e.Effect = DragDropEffects.None;
+                }
             }
 
+            // Apply visual indication, depending on Effect and position
             if (e.Effect != DragDropEffects.None)
             {
                 int node_h = dropTarget.Bounds.Height;

--- a/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
@@ -1,0 +1,261 @@
+﻿using AGS.Types;
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public class TreeViewWithDragDrop : TreeView
+    {
+        public delegate void ItemTryDragEventHandler(object sender, TreeItemTryDragEventArgs e);
+        public event ItemTryDragEventHandler ItemTryDrag;
+        public delegate void ItemDragOverEventHandler(object sender, TreeItemDragEventArgs e);
+        public event ItemDragOverEventHandler ItemDragOver;
+        public delegate void ItemDragDropEventHandler(object sender, TreeItemDragEventArgs e);
+        public event ItemDragDropEventHandler ItemDragDrop;
+
+        // Time to wait while dragging cursor hovers over a node before expanding it
+        private const int DragWaitBeforeExpandNodeMs = 500;
+
+        private Color? _treeNodesBackgroundColor;
+        private TreeNode _dropHoveredNode;
+        private DateTime _timeOfDragDropHoverStart;
+        private LineInBetween _lineInBetween;
+
+        public TreeViewWithDragDrop()
+        {
+            _lineInBetween = new LineInBetween();
+            Controls.Add(_lineInBetween);
+            _lineInBetween.BringToFront();
+            _lineInBetween.Hide();
+        }
+
+        private bool HasANodeBeenHoveredEnoughForExpanding()
+        {
+            return DateTime.Now.Subtract(_timeOfDragDropHoverStart) >= TimeSpan.FromMilliseconds(DragWaitBeforeExpandNodeMs);
+        }
+
+        private void HighlightNodeAndExpandIfNeeded(TreeNode treeNode, bool expandOnDragHover, TargetDropZone dropZone)
+        {
+            if (_treeNodesBackgroundColor == null)
+            {
+                _treeNodesBackgroundColor = treeNode.BackColor;
+            }
+
+            if (treeNode != _dropHoveredNode)
+            {
+                treeNode.BackColor = Color.LightGray;
+                ClearHighlightNode();
+                _dropHoveredNode = treeNode;
+                _timeOfDragDropHoverStart = DateTime.Now;
+            }
+            else if (expandOnDragHover && HasANodeBeenHoveredEnoughForExpanding() && dropZone == TargetDropZone.Middle)
+            {
+                treeNode.Expand();
+            }
+        }
+
+        private void ClearHighlightNode()
+        {
+            if (_dropHoveredNode != null)
+            {
+                _dropHoveredNode.BackColor = _treeNodesBackgroundColor.Value;
+                _dropHoveredNode = null;
+            }
+        }
+
+        private void ShowMiddleLine(int x, int y, int w, int h)
+        {
+            // it auto-hides so we don't have to handle the drop being cancelled which has to be done in projectItem!
+            _lineInBetween.ShowAndHideAt(x, y, w, h);
+        }
+
+        private void HideMiddleLine()
+        {
+            _lineInBetween.Hide();
+        }
+
+        private int GetLineInBetweenWidth(TreeNode treeNode)
+        {
+            int maxWdith = treeNode.Bounds.Width;
+            if (treeNode.PrevNode != null)
+            {
+                maxWdith = Math.Max(maxWdith, treeNode.PrevNode.Bounds.Width);
+            }
+            if (treeNode.NextNode != null)
+            {
+                maxWdith = Math.Max(maxWdith, treeNode.NextNode.Bounds.Width);
+            }
+            return Math.Max(maxWdith, this.Width / 3);
+        }
+
+        private TargetDropZone GetDropZoneImpl(int y, int h)
+        {
+            TargetDropZone dropZone = TargetDropZone.Middle;
+
+            if (y <= h / 4)
+            {
+                dropZone = TargetDropZone.Top;
+            }
+            else if (y > h / 4 && y < 2 * h / 5)
+            {
+                dropZone = TargetDropZone.MiddleTop;
+            }
+            else if (y > 3 * h / 5 && y < 3 * h / 4)
+            {
+                dropZone = TargetDropZone.MiddleBottom;
+            }
+            else if (y >= 3 * h / 4)
+            {
+                dropZone = TargetDropZone.Bottom;
+            }
+
+            return dropZone;
+        }
+
+        private TargetDropZone GetDropZone(TreeNode treeNode, Point locationInControl)
+        {
+            int node_h = treeNode.Bounds.Height;
+            int node_y = treeNode.Bounds.Y;
+            int cur_y = locationInControl.Y;
+            return GetDropZoneImpl(cur_y - node_y, node_h);
+        }
+
+        protected override void OnQueryContinueDrag(QueryContinueDragEventArgs e)
+        {
+            if (e.EscapePressed)
+            {
+                e.Action = DragAction.Cancel;
+            }
+
+            if (e.Action != DragAction.Continue)
+            {
+                HideMiddleLine();
+            }
+        }
+
+        protected override void OnDragDrop(DragEventArgs e)
+        {
+            // If not dragging a tree item, then fallback to standard drag drop
+            if (!e.Data.GetDataPresent(typeof(TreeNode)))
+            {
+                base.OnDragDrop(e);
+                return;
+            }
+
+            TreeNode dragItem = (TreeNode)e.Data.GetData(typeof(TreeNode));
+            HideMiddleLine();
+            ClearHighlightNode();
+            Point locationInControl = PointToClient(new Point(e.X, e.Y));
+            TreeNode dropTarget = HitTest(locationInControl).Node;
+            TargetDropZone dropZone = GetDropZone(dropTarget, locationInControl);
+
+            OnItemDragDrop(new TreeItemDragEventArgs(e, dragItem, dropTarget, dropZone));
+        }
+
+        protected override void OnDragEnter(DragEventArgs e)
+        {
+            base.OnDragEnter(e);
+        }
+
+        protected override void OnDragLeave(EventArgs e)
+        {
+            base.OnDragLeave(e);
+        }
+
+        protected override void OnDragOver(DragEventArgs e)
+        {
+            // If not dragging a tree item, then fallback to standard drag drop
+            if (!e.Data.GetDataPresent(typeof(TreeNode)))
+            {
+                base.OnDragOver(e);
+                return;
+            }
+
+            TreeNode dragItem = (TreeNode)e.Data.GetData(typeof(TreeNode));
+            Point locationInControl = PointToClient(new Point(e.X, e.Y));
+            TreeNode dropTarget = HitTest(locationInControl).Node;
+            if (dropTarget == null)
+            {
+                e.Effect = DragDropEffects.None; // cancel
+                return;
+            }
+
+            TargetDropZone dropZone = GetDropZone(dropTarget, locationInControl);
+            TreeItemDragEventArgs itemDrag = new TreeItemDragEventArgs(e, dragItem, dropTarget, dropZone);
+            OnItemDragOver(itemDrag); // let user code respond to the drag state
+            e.Effect = itemDrag.Effect;
+
+            if (itemDrag.Effect != DragDropEffects.None)
+            {
+                int node_h = dropTarget.Bounds.Height;
+                int node_y = dropTarget.Bounds.Y;
+                int line_h = node_h / 5;
+                int width = GetLineInBetweenWidth(dropTarget);
+
+                if (dropZone == TargetDropZone.Top && itemDrag.ShowLine)
+                {
+                    ShowMiddleLine(dropTarget.Bounds.X, node_y - line_h / 2, width, line_h);
+                }
+                else if (dropZone == TargetDropZone.Bottom && itemDrag.ShowLine)
+                {
+                    ShowMiddleLine(dropTarget.Bounds.X, node_y + node_h - line_h / 2, width, line_h);
+                }
+                else
+                {
+                    HideMiddleLine();
+                }
+
+                HighlightNodeAndExpandIfNeeded(dropTarget, itemDrag.ExpandOnDragHover, dropZone);
+            }
+            else
+            {
+                HideMiddleLine();
+                ClearHighlightNode();
+            }
+
+            // auto-scroll the tree when move the mouse to top/bottom
+            if (locationInControl.Y < 30)
+            {
+                if (dropTarget.PrevVisibleNode != null)
+                {
+                    dropTarget.PrevVisibleNode.EnsureVisible();
+                }
+            }
+            else if (locationInControl.Y > Height - 30)
+            {
+                if (dropTarget.NextVisibleNode != null)
+                {
+                    dropTarget.NextVisibleNode.EnsureVisible();
+                }
+            }
+        }
+
+        protected override void OnItemDrag(ItemDragEventArgs e)
+        {
+            var tryDrag = new TreeItemTryDragEventArgs(e);
+            OnItemTryDrag(tryDrag);
+
+            if (tryDrag.AllowedEffect == DragDropEffects.None)
+                return;
+
+            DoDragDrop(e.Item, tryDrag.AllowedEffect);
+            base.OnItemDrag(e);
+        }
+
+        protected virtual void OnItemTryDrag(TreeItemTryDragEventArgs e)
+        {
+            ItemTryDrag?.Invoke(this, e);
+        }
+
+        protected virtual void OnItemDragOver(TreeItemDragEventArgs e)
+        {
+            ItemDragOver?.Invoke(this, e);
+        }
+
+        protected virtual void OnItemDragDrop(TreeItemDragEventArgs e)
+        {
+            ItemDragDrop?.Invoke(this, e);
+        }
+    }
+}

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -29,7 +29,7 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.splitWindow = new System.Windows.Forms.SplitContainer();
-            this.folderList = new System.Windows.Forms.TreeView();
+            this.folderList = new AGS.Editor.TreeViewWithDragDrop();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.panel1 = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
@@ -81,7 +81,6 @@ namespace AGS.Editor
             this.folderList.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.folderList_AfterSelect);
             this.folderList.DragDrop += new System.Windows.Forms.DragEventHandler(this.folderList_DragDrop);
             this.folderList.DragOver += new System.Windows.Forms.DragEventHandler(this.folderList_DragOver);
-            this.folderList.DragLeave += new System.EventHandler(this.folderList_DragLeave);
             this.folderList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.folderList_MouseUp);
             // 
             // splitContainer1
@@ -209,7 +208,7 @@ namespace AGS.Editor
         #endregion
 
         private System.Windows.Forms.SplitContainer splitWindow;
-        private System.Windows.Forms.TreeView folderList;
+        private AGS.Editor.TreeViewWithDragDrop folderList;
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.ListView spriteList;
         private System.Windows.Forms.Panel panel1;

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -1788,10 +1788,11 @@ namespace AGS.Editor
 
         private void FolderList_ItemDragOver(object sender, TreeItemDragEventArgs e)
         {
-            if ((e.DragItem != null) && (e.DragItem != _rootTreeNode) && (e.DropTarget != _rootTreeNode)
-                && (e.DragItem != e.DropTarget) && (e.DropTarget != null || e.ShowLine))
+            if ((e.DragItem != null) && (e.DragItem != _rootTreeNode) && (e.DropTarget != null)
+                && (!e.DropTarget.IsDescendantOf(e.DragItem)))
             {
                 e.Effect = DragDropEffects.Move;
+                e.ShowLine &= e.DropTarget != _rootTreeNode;
             }
             else
             {
@@ -1801,6 +1802,13 @@ namespace AGS.Editor
 
         private void FolderList_ItemDragDrop(object sender, TreeItemDragEventArgs e)
         {
+            if (e.DropTarget == null)
+                return; // can't drop into nowhere
+            if (e.DropTarget.IsDescendantOf(e.DragItem))
+                return; // can't drop into itself or its own descendants
+
+            TargetDropZone zone = (e.DropTarget != _rootTreeNode) ? e.DropZone : TargetDropZone.Middle;
+
             switch (e.DropZone)
             {
                 case TargetDropZone.Top:
@@ -1826,6 +1834,7 @@ namespace AGS.Editor
 
             folder.Remove();
             beforeFolder.Parent.Nodes.Insert(beforeFolder.Index, folder);
+            folderList.SelectedNode = folder;
         }
 
         private void MoveFolderAfterFolder(TreeNode folder, TreeNode afterFolder)
@@ -1839,10 +1848,14 @@ namespace AGS.Editor
 
             folder.Remove();
             afterFolder.Parent.Nodes.Insert(afterFolder.Index + 1, folder);
+            folderList.SelectedNode = folder;
         }
 
         private void MoveFolderToFolder(TreeNode folder, TreeNode intoFolder)
         {
+            if (folder.Parent == intoFolder)
+                return; // already there
+
             SpriteFolder movedSpriteFolder = _folders[folder.Name];
             SpriteFolder sourceParent = _folders[folder.Parent.Name];
             SpriteFolder destParent = _folders[intoFolder.Name];
@@ -1851,6 +1864,7 @@ namespace AGS.Editor
 
             folder.Remove();
             intoFolder.Nodes.Add(folder);
+            folderList.SelectedNode = folder;
         }
 
         #endregion // Folder Drag n Drop

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -68,6 +68,7 @@ namespace AGS.Editor
         private Dictionary<TreeNode, SpriteFolder> _nodeFolderMapping;
         private SpriteFolder _currentFolder;
         private SpriteFolder _rootFolder;
+        private TreeNode _rootTreeNode;
         private ImageList _spriteImages = new ImageList();
         private int _spriteNumberOnMenuActivation;
         private bool _showUseThisSpriteOption = false;
@@ -100,6 +101,9 @@ namespace AGS.Editor
             }
             folderList.ImageList = _spManagerIcons;
             folderList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.folderList_KeyDown);
+            folderList.ItemTryDrag += FolderList_ItemTryDrag;
+            folderList.ItemDragOver += FolderList_ItemDragOver;
+            folderList.ItemDragDrop += FolderList_ItemDragDrop;
             SetSpritePreviewMultiplier(2); // default value for sprite multiplier
         }
 
@@ -184,6 +188,8 @@ namespace AGS.Editor
                 DisplaySpritesForFolder(rootFolder);
                 folderList.Nodes[0].Expand();
             }
+
+            _rootTreeNode = folderList.Nodes[0];
         }
 
         private void AddNodeState(SpriteFolder folder, List<int> expanded)
@@ -1585,48 +1591,6 @@ namespace AGS.Editor
             }
         }
 
-        private void folderList_DragOver(object sender, DragEventArgs e)
-        {
-			TreeNode target;
-
-            if (e.Data.GetDataPresent(typeof(SpriteManagerDragDropData)))
-            {
-				target = GetMouseOverTreeNode(e.X, e.Y);
-				SetFolderListDropHighlight(target);
-				if (target != null)
-                {
-					target.Expand();
-                    e.Effect = DragDropEffects.Move;
-                }
-                else
-                {
-                    e.Effect = DragDropEffects.None;
-                }
-            }
-        }
-
-		private void SetFolderListDropHighlight(TreeNode target)
-		{
-			if (_dropHighlight != target)
-			{
-				if (_dropHighlight != null)
-				{
-					_dropHighlight.BackColor = Color.Empty;
-					_dropHighlight.ForeColor = Color.Empty;
-				}
-				if (target != null)
-				{
-					folderList.HideSelection = target == folderList.SelectedNode;
-					target.BackColor = SystemColors.Highlight;
-					target.ForeColor = SystemColors.HighlightText;
-				}
-				else
-					if (_dropHighlight == folderList.SelectedNode)
-						folderList.HideSelection = false;
-				_dropHighlight = target;
-			}
-		}
-
         private void RemoveSpritesFromFolder(SpriteFolder folder, List<Sprite> spritesToRemove)
         {
             foreach (Sprite draggedSprite in spritesToRemove)
@@ -1634,24 +1598,6 @@ namespace AGS.Editor
                 folder.Sprites.Remove(draggedSprite);
             }
         }
-
-        private void folderList_DragDrop(object sender, DragEventArgs e)
-        {
-            SpriteFolder draggedInto = GetMouseOverFolder(e.X, e.Y);
-            SpriteManagerDragDropData dragged = (SpriteManagerDragDropData)e.Data.GetData(typeof(SpriteManagerDragDropData));
-            RemoveSpritesFromFolder(_currentFolder, dragged.Sprites);
-            foreach (Sprite draggedSprite in dragged.Sprites)
-            {
-                draggedInto.Sprites.Add(draggedSprite);
-            }
-			SetFolderListDropHighlight(null);
-            RefreshSpriteDisplay();
-        }
-
-		private void folderList_DragLeave(object sender, EventArgs e)
-		{
-			SetFolderListDropHighlight(null);
-		}
 
 		private TreeNode GetMouseOverTreeNode(int screenX, int screenY)
         {
@@ -1801,6 +1747,113 @@ namespace AGS.Editor
         {
             splitContainer1.SplitterDistance = 2 * (button_importNew.Font.Height) + button_importNew.Margin.Top + button_importNew.Margin.Bottom - 4;
         }
+
+        #region Folder Drag n Drop
+
+        private void folderList_DragOver(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(typeof(SpriteManagerDragDropData)))
+            {
+                TreeNode target = GetMouseOverTreeNode(e.X, e.Y);
+                if (target != null)
+                {
+                    e.Effect = DragDropEffects.Move;
+                }
+                else
+                {
+                    e.Effect = DragDropEffects.None;
+                }
+            }
+        }
+
+        private void folderList_DragDrop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(typeof(SpriteManagerDragDropData)))
+            {
+                SpriteFolder draggedInto = GetMouseOverFolder(e.X, e.Y);
+                SpriteManagerDragDropData dragged = (SpriteManagerDragDropData)e.Data.GetData(typeof(SpriteManagerDragDropData));
+                RemoveSpritesFromFolder(_currentFolder, dragged.Sprites);
+                foreach (Sprite draggedSprite in dragged.Sprites)
+                {
+                    draggedInto.Sprites.Add(draggedSprite);
+                }
+                RefreshSpriteDisplay();
+            }
+        }
+
+        private void FolderList_ItemTryDrag(object sender, TreeItemTryDragEventArgs e)
+        {
+            e.AllowedEffect = DragDropEffects.Move;
+        }
+
+        private void FolderList_ItemDragOver(object sender, TreeItemDragEventArgs e)
+        {
+            if ((e.DragItem != null) && (e.DragItem != _rootTreeNode) && (e.DropTarget != _rootTreeNode)
+                && (e.DragItem != e.DropTarget) && (e.DropTarget != null || e.ShowLine))
+            {
+                e.Effect = DragDropEffects.Move;
+            }
+            else
+            {
+                e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void FolderList_ItemDragDrop(object sender, TreeItemDragEventArgs e)
+        {
+            switch (e.DropZone)
+            {
+                case TargetDropZone.Top:
+                    MoveFolderBeforeFolder(e.DragItem, e.DropTarget);
+                    break;
+                case TargetDropZone.Bottom:
+                    MoveFolderAfterFolder(e.DragItem, e.DropTarget);
+                    break;
+                default:
+                    MoveFolderToFolder(e.DragItem, e.DropTarget);
+                    break;
+            }
+        }
+
+        private void MoveFolderBeforeFolder(TreeNode folder, TreeNode beforeFolder)
+        {
+            SpriteFolder movedSpriteFolder = _folders[folder.Name];
+            SpriteFolder beforeSpriteFolder = _folders[beforeFolder.Name];
+            SpriteFolder sourceParent = _folders[folder.Parent.Name];
+            SpriteFolder destParent = _folders[beforeFolder.Parent.Name];
+            sourceParent.SubFolders.Remove(movedSpriteFolder);
+            destParent.SubFolders.Insert(destParent.SubFolders.IndexOf(beforeSpriteFolder), movedSpriteFolder);
+
+            folder.Remove();
+            beforeFolder.Parent.Nodes.Insert(beforeFolder.Index, folder);
+        }
+
+        private void MoveFolderAfterFolder(TreeNode folder, TreeNode afterFolder)
+        {
+            SpriteFolder movedSpriteFolder = _folders[folder.Name];
+            SpriteFolder afterSpriteFolder = _folders[afterFolder.Name];
+            SpriteFolder sourceParent = _folders[folder.Parent.Name];
+            SpriteFolder destParent = _folders[afterFolder.Parent.Name];
+            sourceParent.SubFolders.Remove(movedSpriteFolder);
+            destParent.SubFolders.Insert(destParent.SubFolders.IndexOf(afterSpriteFolder) + 1, movedSpriteFolder);
+
+            folder.Remove();
+            afterFolder.Parent.Nodes.Insert(afterFolder.Index + 1, folder);
+        }
+
+        private void MoveFolderToFolder(TreeNode folder, TreeNode intoFolder)
+        {
+            SpriteFolder movedSpriteFolder = _folders[folder.Name];
+            SpriteFolder sourceParent = _folders[folder.Parent.Name];
+            SpriteFolder destParent = _folders[intoFolder.Name];
+            sourceParent.SubFolders.Remove(movedSpriteFolder);
+            destParent.SubFolders.Add(movedSpriteFolder);
+
+            folder.Remove();
+            intoFolder.Nodes.Add(folder);
+        }
+
+        #endregion // Folder Drag n Drop
 
         #region IObjectConfigurable
 

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -145,7 +145,6 @@
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
     <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\InputMotionMode.cs" />
-    <Compile Include="Enums\TargetDropZone.cs" />
     <Compile Include="Enums\TouchToMouseEmulationType.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />


### PR DESCRIPTION
Resolve #2595

1. Pick out a drag & drop implementation from ProjectTree into the TreeViewWithDragDrop control class. TreeViewWithDragDrop expands TreeView and provides support for dragging items within itself. It has 3 events: `ItemTryDrag` and `ItemDragOver` and `ItemDragDrop`, which may be used to customize the behavior. They tell whether to start dragging action, if currently dragged item is allowed to be dropped in the current location, and finally handle the drop.
2. Adjust ProjectTree to use TreeViewWithDragDrop type of control. Only 3 drag-related event handlers remain here: `ItemTryDrag`, `ItemDragOver` and `ItemDragDrop`. Everything else was moved to the TreeViewWithDragDrop class.
3. Make SpriteSelector use TreeViewWithDragDrop control for folders, and handle their dragging and dropping among themselves. It's important to keep the previously existing sprites drag n drop as well. So there currently are 2 possible drops: sprites dragged from the sprite list, and folders.

