### PR TITLE
Editor: script api header MoveStraight is void

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2935,7 +2935,7 @@ builtin managed struct Character {
 #endif // SCRIPT_API_v361
 #ifdef SCRIPT_API_v362
   /// Moves the character in a straight line as far as possible towards the co-ordinates, without walking animation. Useful for keyboard movement.
-  import function MoveStraight(int x, int y, BlockingStyle=eNoBlock);
+  import void MoveStraight(int x, int y, BlockingStyle=eNoBlock);
   /// Gets/sets whether the character turns on the spot when ordered to face the new standing direction.
   import attribute bool TurnWhenFacing;
   /// Gets the character this character is following


### PR DESCRIPTION
I think MoveStraight should be void and not function, since #2463, I wasn't sure if it was meant to have some return value