### PR TITLE
Script API: remove 2048 length limit for the variadic text functions

### DIFF
--- a/Engine/script/script_api.cpp
+++ b/Engine/script/script_api.cpp
@@ -252,7 +252,7 @@ size_t ScriptSprintf(char *buffer, size_t buf_length, const char *format,
             if (out_ptr)
             {
                 // snprintf returns maximal number of characters, so limit it with buffer size
-                out_ptr += std::min<ptrdiff_t>(snprintf_res, avail_outbuf);
+                out_ptr += std::min<ptrdiff_t>(snprintf_res, avail_outbuf - 1); // save 1 for terminator
             }
         }
         else
@@ -273,7 +273,7 @@ size_t ScriptSprintf(char *buffer, size_t buf_length, const char *format,
     // Terminate the string
     if (out_ptr)
     {
-        *(out_ptr++) = 0;
+        *out_ptr = 0;
     }
     
     return output_len;

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -33,18 +33,20 @@ typedef RuntimeScriptValue ScriptAPIObjectFunction(void *self, const RuntimeScri
 // Sprintf that takes either script values or common argument list from plugin.
 // Uses EITHER sc_args/sc_argc or varg_ptr as parameter list, whichever is not
 // NULL, with varg_ptr having HIGHER priority.
-const char *ScriptSprintf(char *buffer, size_t buf_length, const char *format,
+size_t ScriptSprintf(char *buffer, size_t buf_length, const char *format,
                           const RuntimeScriptValue *sc_args, int32_t sc_argc, va_list *varg_ptr);
 // Sprintf that takes script values as arguments
 inline const char *ScriptSprintf(char *buffer, size_t buf_length, const char *format, const RuntimeScriptValue *args, int32_t argc)
 {
-    return ScriptSprintf(buffer, buf_length, format, args, argc, nullptr);
+    ScriptSprintf(buffer, buf_length, format, args, argc, nullptr);
+    return buffer;
 }
-// Variadic sprintf (needed, because all arguments are pushed as pointer-sized values). Currently used only when plugin calls
-// exported engine function. Should be removed when this plugin issue is resolved.
+// Variadic sprintf (needed, because all arguments are pushed as pointer-sized values).
+// Currently used only when plugin calls exported engine function.
 inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *format, va_list &arg_ptr)
 {
-    return ScriptSprintf(buffer, buf_length, format, nullptr, 0, &arg_ptr);
+    ScriptSprintf(buffer, buf_length, format, nullptr, 0, &arg_ptr);
+    return buffer;
 }
 
 // Helper macro for registering an API function for both script and plugin,

--- a/Engine/test/scsprintf_test.cpp
+++ b/Engine/test/scsprintf_test.cpp
@@ -24,13 +24,13 @@ void cc_error(const char *, ...)
     // do nothing
 }
 
-const char *ScriptVSprintf__(char *buffer, size_t buf_length, const char *format, ...)
+size_t ScriptVSprintf__(char *buffer, size_t buf_length, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    const char *res_buffer = ScriptVSprintf(buffer, buf_length, format, args);
+    size_t res = ScriptVSprintf(buffer, buf_length, format, args);
     va_end(args);
-    return res_buffer;
+    return res;
 }
 
 TEST(ScSprintf, ScSprintf) {
@@ -47,45 +47,57 @@ TEST(ScSprintf, ScSprintf) {
     // Called-from-script variant
     //
     // Correct format, extra placeholder
-    const char *result =
+    size_t result =
         ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE,
             "testing ScriptSprintf:\nThis is int: %10d\nThis is float: %.4f\nThis is string: '%s'\nThis placeholder will be ignored: %d",
             params, 3);
-    ASSERT_TRUE(strcmp(result, "testing ScriptSprintf:\nThis is int:        123\nThis is float: 0.4560\nThis is string: 'string literal'\nThis placeholder will be ignored: %d") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "testing ScriptSprintf:\nThis is int:        123\nThis is float: 0.4560\nThis is string: 'string literal'\nThis placeholder will be ignored: %d") == 0);
+    ASSERT_EQ(result, 138);
     // Literal percent sign
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%d%%", params, 3);
-    ASSERT_TRUE(strcmp(result, "123%") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "123%") == 0);
+    ASSERT_EQ(result, 4);
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "123%%", NULL, 0);
-    ASSERT_TRUE(strcmp(result, "123%") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "123%") == 0);
+    ASSERT_EQ(result, 4);
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%%5d%%0.5f%%s", params, 3);
-    ASSERT_TRUE(strcmp(result, "%5d%0.5f%s") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%5d%0.5f%s") == 0);
+    ASSERT_EQ(result, 10);
 
     // Invalid format
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%zzzzzz", params, 3);
-    ASSERT_TRUE(strcmp(result, "%zzzzzz") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%zzzzzz") == 0);
+    ASSERT_EQ(result, 7);
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%12.34%d", params, 3);
-    ASSERT_TRUE(strcmp(result, "%12.34%d") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%12.34%d") == 0);
+    ASSERT_EQ(result, 8);
 
     // Not enough arguments
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%5d%0.5f%s", params, 0);
-    ASSERT_TRUE(strcmp(result, "%5d%0.5f%s") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%5d%0.5f%s") == 0);
+    ASSERT_EQ(result, 10);
 
     // Not enough buffer space
     result = ScriptSprintf(ScSfBuffer, 9, "12345678%d", params, 3);
-    ASSERT_TRUE(strcmp(result, "12345678") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "12345678") == 0);
+    ASSERT_EQ(result, 11);
     result = ScriptSprintf(ScSfBuffer, 11, "12345678%d", params, 3);
-    ASSERT_TRUE(strcmp(result, "1234567812") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "1234567812") == 0);
+    ASSERT_EQ(result, 11);
     // Not enough buffer space and not enough params
     result = ScriptSprintf(ScSfBuffer, 10, "12345678%d", params, 0);
-    ASSERT_TRUE(strcmp(result, "12345678%") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "12345678%") == 0);
+    ASSERT_EQ(result, 10);
     result = ScriptSprintf(ScSfBuffer, 11, "12345678%d", params, 0);
-    ASSERT_TRUE(strcmp(result, "12345678%d") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "12345678%d") == 0);
+    ASSERT_EQ(result, 10);
 
     // Test null string pointer in backward-compatibility mode
     loaded_game_file_version = kGameVersion_312;
     params[0].SetStringLiteral(NULL);
     result = ScriptSprintf(ScSfBuffer, 10, "A%sB", params, 1);
-    ASSERT_TRUE(strcmp(result, "A(null)B") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "A(null)B") == 0);
+    ASSERT_EQ(result, 8);
     loaded_game_file_version = kGameVersion_Undefined;
 
     //
@@ -98,30 +110,39 @@ TEST(ScSprintf, ScSprintf) {
         ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE,
             "testing ScriptVSprintf:\nThis is int: %10d\nThis is float: %.4f\nThis is string: '%s'\n",
             argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "testing ScriptVSprintf:\nThis is int:        123\nThis is float: 0.4560\nThis is string: 'string literal'\n") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "testing ScriptVSprintf:\nThis is int:        123\nThis is float: 0.4560\nThis is string: 'string literal'\n") == 0);
+    ASSERT_EQ(result, 103);
     // Literal percent sign
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%d%%", argi);
-    ASSERT_TRUE(strcmp(result, "123%") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "123%") == 0);
+    ASSERT_EQ(result, 4);
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "123%%");
-    ASSERT_TRUE(strcmp(result, "123%") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "123%") == 0);
+    ASSERT_EQ(result, 4);
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%%5d%%0.5f%%s");
-    ASSERT_TRUE(strcmp(result, "%5d%0.5f%s") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%5d%0.5f%s") == 0);
+    ASSERT_EQ(result, 10);
 
     // Invalid format
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%zzzzzz", argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "%zzzzzz") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%zzzzzz") == 0);
+    ASSERT_EQ(result, 7);
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%12.34%d", argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "%12.34%d") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "%12.34%d") == 0);
+    ASSERT_EQ(result, 8);
 
     // Not enough buffer space
     result = ScriptVSprintf__(ScSfBuffer, 9, "12345678%d", argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "12345678") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "12345678") == 0);
+    ASSERT_EQ(result, 11);
     result = ScriptVSprintf__(ScSfBuffer, 11, "12345678%d", argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "1234567812") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "1234567812") == 0);
+    ASSERT_EQ(result, 11);
 
     // Test null string pointer in backward-compatibility mode
     loaded_game_file_version = kGameVersion_312;
     result = ScriptVSprintf__(ScSfBuffer, 10, "A%sB", NULL);
-    ASSERT_TRUE(strcmp(result, "A(null)B") == 0);
+    ASSERT_TRUE(strcmp(ScSfBuffer, "A(null)B") == 0);
+    ASSERT_EQ(result, 8);
     loaded_game_file_version = kGameVersion_Undefined;
 }

--- a/Engine/test/scsprintf_test.cpp
+++ b/Engine/test/scsprintf_test.cpp
@@ -64,7 +64,7 @@ TEST(ScSprintf, ScSprintf) {
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%zzzzzz", params, 3);
     ASSERT_TRUE(strcmp(result, "%zzzzzz") == 0);
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%12.34%d", params, 3);
-    ASSERT_TRUE(strcmp(result, "%12.34123") == 0);
+    ASSERT_TRUE(strcmp(result, "%12.34%d") == 0);
 
     // Not enough arguments
     result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%5d%0.5f%s", params, 0);
@@ -111,7 +111,7 @@ TEST(ScSprintf, ScSprintf) {
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%zzzzzz", argi, argf, argcc);
     ASSERT_TRUE(strcmp(result, "%zzzzzz") == 0);
     result = ScriptVSprintf__(ScSfBuffer, STD_BUFFER_SIZE, "%12.34%d", argi, argf, argcc);
-    ASSERT_TRUE(strcmp(result, "%12.34123") == 0);
+    ASSERT_TRUE(strcmp(result, "%12.34%d") == 0);
 
     // Not enough buffer space
     result = ScriptVSprintf__(ScSfBuffer, 9, "12345678%d", argi, argf, argcc);


### PR DESCRIPTION
Fix #2398

This removes an arbitrary 2k chars limit for result of the script formatting API (such as String.Format).

I think there are still cases in the engine where the formatted string remains to be limited, but in most of them the data is assumed to be short (such as getting "location name). The only other notable case is the core function that creates a textual overlay, still where the final printed text is still limited by 2k chars.