### PR TITLE
Editor: fix ProjectTree's unreliable search for nodes

### DIFF
--- a/Editor/AGS.Editor/GUI/ProjectTree.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTree.cs
@@ -161,19 +161,19 @@ namespace AGS.Editor
 
         public void RemoveAllChildNodes(IEditorComponent plugin, string parentID)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(parentID, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(parentID, true);
+            if (node != null)
             {
-                results[0].Nodes.Clear();
+                node.Nodes.Clear();
             }
         }
 
         public void StartFromNode(IEditorComponent plugin, string id)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(id, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(id, true);
+            if (node != null)
             {
-                _lastAddedNode = results[0];
+                _lastAddedNode = node;
             }
             else
             {
@@ -183,38 +183,38 @@ namespace AGS.Editor
 
         public void ChangeNodeLabel(IEditorComponent plugin, string id, string newLabelText)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(id, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(id, true);
+            if (node != null)
             {
-                results[0].Text = newLabelText;
+                node.Text = newLabelText;
             }
         }
 
         public void ChangeNodeIcon(IEditorComponent plugin, string id, string newIconKey)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(id, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(id, true);
+            if (node != null)
             {
-                results[0].ImageKey = newIconKey;
-                results[0].SelectedImageKey = newIconKey;
+                node.ImageKey = newIconKey;
+                node.SelectedImageKey = newIconKey;
             }
         }
 
         public void SelectNode(IEditorComponent plugin, string id)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(id, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(id, true);
+            if (node != null)
             {
-                _projectTree.SelectedNode = results[0];
+                _projectTree.SelectedNode = node;
             }
         }
 
         public void ExpandNode(IEditorComponent plugin, string id)
         {
-            TreeNode[] results = _projectTree.Nodes.Find(id, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(id, true);
+            if (node != null)
             {
-                results[0].Expand();
+                node.Expand();
             }
         }
 
@@ -239,10 +239,10 @@ namespace AGS.Editor
         public void BeginLabelEdit(IEditorComponent plugin, string nodeID)
         {
             SelectNode(plugin, nodeID);
-            TreeNode[] results = _projectTree.Nodes.Find(nodeID, true);
-            if (results.Length > 0)
+            TreeNode node = _projectTree.Nodes.FindUnique(nodeID, true);
+            if (node != null)
             {
-                results[0].BeginEdit();
+                node.BeginEdit();
             }
         }
 

--- a/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
@@ -76,5 +76,13 @@ namespace AGS.Editor
             }
             return false;
         }
+
+        /// <summary>
+        /// Finds a TreeNode inside TreeNodeCollection using a unique case-sensitive key.
+        /// </summary>
+        public static TreeNode FindUnique(this TreeNodeCollection nodes, string name, bool searchAllChildren)
+        {
+            return nodes.Find(name, searchAllChildren).FirstOrDefault(n => n.Name == name);
+        }
     }
 }


### PR DESCRIPTION
Fix #2473

ProjectTree was using TreeNodeCollection.Find to get a TreeNode with certain Name, but according to MSDN this method does a case-insensitive search for some reason. In AGS Editor currently folder node names (item or folders) are given names that are case-sensitive. Such search could lead to mismatching nodes in case there's e.g. two folders which are only different in name case.

Wrote an extension method FindUnique that filters out precisely matching node name.

NOTE: For the reference TreeNode's Name is not the text that it displays, but its internal "key".
In case user gave two or more folders the same name, that would make their "text" or "title" be the same, but their Names will be made different.

This is achieved with this ugly but working hack:
https://github.com/adventuregamestudio/ags/blob/4e44e71f8258418006af6d9ba99d75fa4a4fada0/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs#L203-L210