### PR TITLE
Editor: report warnings about possibly unlinked event handlers

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Entities\CharacterIDChangedEventArgs.cs" />
     <Compile Include="Entities\CharacterRoomChangedEventArgs.cs" />
     <Compile Include="Entities\CompilationStepArgs.cs" />
+    <Compile Include="Entities\CompileWarningEx.cs" />
     <Compile Include="Entities\TreeItemDragEventArgs.cs" />
     <Compile Include="Entities\ExistingScriptHeaderToAdd.cs" />
     <Compile Include="Entities\ExistingFileToAdd.cs" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -226,6 +226,7 @@
     <Compile Include="GUI\NumberEntryWithInfoDialog.Designer.cs">
       <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\OutputPanelItem.cs" />
     <Compile Include="GUI\Progress.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -322,7 +322,7 @@ namespace AGS.Editor.Components
             }
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             IList<AudioClip> audioClips = _agsEditor.CurrentGame.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders();
             foreach (AudioClip ac in audioClips)
@@ -331,7 +331,7 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(ac));
                     ShowPaneForItem(GetNodeID(ac));
-                    return;
+                    return true;
                 }
             }
 
@@ -342,9 +342,11 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetClipTypeNodeID(clipType));
                     ShowPaneForItem(GetClipTypeNodeID(clipType));
-                    return;
+                    return true;
                 }
             }
+
+            return false;
         }
 
         private void ImportAudioFiles(string[] selectedFiles)

--- a/Editor/AGS.Editor/Components/BaseComponent.cs
+++ b/Editor/AGS.Editor/Components/BaseComponent.cs
@@ -55,8 +55,9 @@ namespace AGS.Editor.Components
         {
         }
 
-        public virtual void ShowItemPaneByName(string name)
+        public virtual bool ShowItemPaneByName(string name)
         {
+            return false;
         }
 
         public virtual IList<string> GetManagedScriptElements()

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -392,8 +392,8 @@ namespace AGS.Editor.Components
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)
                     {
-                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Character ({c.ID}) {c.ScriptName}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Character ({c.ID}) {c.ScriptName}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -394,8 +394,8 @@ namespace AGS.Editor.Components
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)
                     {
-                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Character ({c.ID}) {c.ScriptName}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithGameObject($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Character ({c.ID}) {c.ScriptName}'s Event pane",
+                            "Character", c.ScriptName, funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -376,13 +376,25 @@ namespace AGS.Editor.Components
             var errors = args.Messages;
             foreach (Character c in _agsEditor.CurrentGame.Characters)
             {
-                var missing = _agsEditor.Tasks.CheckMissingInteractionHandlers(c.Interactions);
-                if (missing == null || missing.Count == 0)
+                var funcs = _agsEditor.Tasks.FindInteractionHandlers(c.ScriptName, c.Interactions, true);
+                if (funcs == null || funcs.Length == 0)
                     continue;
 
-                foreach (var miss in missing)
+                for (int i = 0; i < funcs.Length; ++i)
                 {
-                    errors.Add(new CompileWarning($"Character ({c.ID}) {c.ScriptName}'s event {c.Interactions.Schema.FunctionSuffixes[miss]} function \"{c.Interactions.ScriptFunctionNames[miss]}\" not found in script {c.Interactions.ScriptModule}."));
+                    bool has_interaction = !string.IsNullOrEmpty(c.Interactions.ScriptFunctionNames[i]);
+                    bool has_function = funcs[i].HasValue;
+                    // If we have an assigned interaction function, but the function is not found - report a missing warning
+                    if (has_interaction && !has_function)
+                    {
+                        errors.Add(new CompileWarning($"Character ({c.ID}) {c.ScriptName}'s event {c.Interactions.Schema.FunctionSuffixes[i]} function \"{c.Interactions.ScriptFunctionNames[i]}\" not found in script {c.Interactions.ScriptModule}."));
+                    }
+                    // If we don't have an assignment, but has a similar function - report a possible unlinked function
+                    else if (!has_interaction && has_function)
+                    {
+                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Character ({c.ID}) {c.ScriptName}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                    }
                 }
             }
         }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -160,7 +160,7 @@ namespace AGS.Editor.Components
             return new string[] { "Character" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             IList<Character> characters = GetFlatList();
             foreach(Character c in characters)
@@ -169,9 +169,10 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(c));
                     ShowOrAddPane(c);
-                    return;
+                    return true;
                 }
             }
+            return false;
         }
 
         public void ShowPlayerCharacter()
@@ -387,7 +388,8 @@ namespace AGS.Editor.Components
                     // If we have an assigned interaction function, but the function is not found - report a missing warning
                     if (has_interaction && !has_function)
                     {
-                        errors.Add(new CompileWarning($"Character ({c.ID}) {c.ScriptName}'s event {c.Interactions.Schema.FunctionSuffixes[i]} function \"{c.Interactions.ScriptFunctionNames[i]}\" not found in script {c.Interactions.ScriptModule}."));
+                        errors.Add(new CompileWarningWithGameObject($"Character ({c.ID}) {c.ScriptName}'s event {c.Interactions.Schema.FunctionSuffixes[i]} function \"{c.Interactions.ScriptFunctionNames[i]}\" not found in script {c.Interactions.ScriptModule}.",
+                            "Character", c.ScriptName, true));
                     }
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)

--- a/Editor/AGS.Editor/Components/CursorsComponent.cs
+++ b/Editor/AGS.Editor/Components/CursorsComponent.cs
@@ -98,7 +98,7 @@ namespace AGS.Editor.Components
             return new string[] { "CursorMode" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             foreach (MouseCursor mc in _agsEditor.CurrentGame.Cursors)
             {
@@ -107,9 +107,10 @@ namespace AGS.Editor.Components
                     MouseCursor chosenCursor = mc;
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(chosenCursor));
                     ShowOrAddPane(chosenCursor);
-                    return;
+                    return true;
                 }
             }
+            return false;
         }
 
         public override void PropertyChanged(string propertyName, object oldValue)

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -234,7 +234,7 @@ namespace AGS.Editor.Components
             return new string[] { "Dialog" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             IList<Dialog> dialogs = GetFlatList();
             foreach (Dialog d in dialogs)
@@ -243,9 +243,10 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(d));
                     ShowPaneForDialog(d);
-                    return;
+                    return true;
                 }
             }
+            return false;
         }
 
         private DialogEditor ShowPaneForDialog(int dialogNumber)

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -129,7 +129,7 @@ namespace AGS.Editor.Components
             return new string[] { "FontType" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             foreach(AGS.Types.Font f in _agsEditor.CurrentGame.Fonts)
             {
@@ -138,9 +138,10 @@ namespace AGS.Editor.Components
                     AGS.Types.Font chosenFont = f;
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(chosenFont));
                     ShowOrAddPane(chosenFont);
-                    return;
+                    return true;
                 }
             }
+            return false;
         }
 
         public override void PropertyChanged(string propertyName, object oldValue)

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -466,13 +466,13 @@ namespace AGS.Editor.Components
                     {
                         if (guiObject.GUI != null)
                         {
-                            errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on GUI ({ngui.ID}) {ngui.Name}'s Event pane",
-                                funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                            errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on GUI ({ngui.ID}) {ngui.Name}'s Event pane",
+                                funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                         }
                         else
                         {
-                            errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {guiObject.Control.ControlType} ({guiObject.Control.ID}) {guiObject.Control.Name}'s Event pane",
-                                funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                            errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {guiObject.Control.ControlType} ({guiObject.Control.ID}) {guiObject.Control.Name}'s Event pane",
+                                funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                         }
                     }
                 }

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -200,7 +200,7 @@ namespace AGS.Editor.Components
             return new string[] { "GUI", "Label", "Button", "Slider", "ListBox", "TextBox", "InvWindow" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             IList<GUI> guis = GetFlatList();
             foreach (GUI g in guis)
@@ -209,7 +209,7 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(g));
                     ShowOrAddPane(g);
-                    return;
+                    return true;
                 }
                 
                 foreach(GUIControl gctrl in g.Controls)
@@ -219,10 +219,12 @@ namespace AGS.Editor.Components
                         _guiController.ProjectTree.SelectNode(this, GetNodeID(g));
                         ShowOrAddPane(g);
                         Factory.GUIController.SetPropertyGridObject(gctrl);
-                        return;
+                        return true;
                     }
                 }
             }
+
+            return false;
         }
 
         private void OnItemIDOrNameChanged(GUI item, bool name_only)
@@ -454,11 +456,13 @@ namespace AGS.Editor.Components
                     {
                         if (guiObject.GUI != null)
                         {
-                            errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                            errors.Add(new CompileWarningWithGameObject($"GUI ({ngui.ID}) {ngui.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}.",
+                                "GUI", ngui.Name, true));
                         }
                         else
                         {
-                            errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}: {guiObject.Control.ControlType} #{guiObject.Control.ID} {guiObject.Control.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                            errors.Add(new CompileWarningWithGameObject($"GUI ({ngui.ID}) {ngui.Name}: {guiObject.Control.ControlType} #{guiObject.Control.ID} {guiObject.Control.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}.",
+                                guiObject.Control.ControlType, guiObject.Control.Name, true));
                         }
                     }
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -470,13 +470,13 @@ namespace AGS.Editor.Components
                     {
                         if (guiObject.GUI != null)
                         {
-                            errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on GUI ({ngui.ID}) {ngui.Name}'s Event pane",
-                                funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
+                            errors.Add(new CompileWarningWithGameObject($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on GUI ({ngui.ID}) {ngui.Name}'s Event pane",
+                                "GUI", ngui.Name, funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                         }
                         else
                         {
-                            errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {guiObject.Control.ControlType} ({guiObject.Control.ID}) {guiObject.Control.Name}'s Event pane",
-                                funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
+                            errors.Add(new CompileWarningWithGameObject($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {guiObject.Control.ControlType} ({guiObject.Control.ID}) {guiObject.Control.Name}'s Event pane",
+                                guiObject.Control.ControlType, guiObject.Control.Name, funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                         }
                     }
                 }

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -381,19 +381,21 @@ namespace AGS.Editor.Components
             public NormalGUI GUI;
             public GUIControl Control;
 
-            public GUIObjectWithEvents(NormalGUI gui) { GUI = gui; }
-            public GUIObjectWithEvents(GUIControl control) { Control = control; }
+            public GUIObjectWithEvents(NormalGUI gui) { GUI = gui; Control = null; }
+            public GUIObjectWithEvents(GUIControl control) { GUI = null; Control = control; }
         }
 
         private class GUIEventReference
         {
             public GUIObjectWithEvents GUIObject;
+            public string ObjName;
             public string EventName;
             public string FunctionName;
 
             public GUIEventReference(GUIObjectWithEvents obj, string evtName, string fnName)
             {
                 GUIObject = obj;
+                ObjName = obj.GUI != null ? obj.GUI.Name : obj.Control.Name;
                 EventName = evtName;
                 FunctionName = fnName;
             }
@@ -436,26 +438,42 @@ namespace AGS.Editor.Components
                     }
                 }
 
-                var functionNames = objectEvents.Select(evt => evt.FunctionName);
-                var missing = _agsEditor.Tasks.CheckMissingEventHandlers(ngui.ScriptModule, functionNames.ToArray());
-                if (missing == null || missing.Count == 0)
+                var functionNames = objectEvents.Select(evt => !string.IsNullOrEmpty(evt.FunctionName) ? evt.FunctionName : $"{evt.ObjName}_{evt.EventName}");
+                var funcs = _agsEditor.Tasks.FindEventHandlers(ngui.ScriptModule, functionNames.ToArray());
+                if (funcs == null || funcs.Length == 0)
                     continue;
 
-                foreach (var miss in missing)
+                for (int i = 0; i < funcs.Length; ++i)
                 {
-                    GUIEventReference evtRef = objectEvents[miss];
+                    GUIEventReference evtRef = objectEvents[i];
                     GUIObjectWithEvents guiObject = evtRef.GUIObject;
-                    if (guiObject.GUI != null)
+                    bool has_interaction = !string.IsNullOrEmpty(evtRef.FunctionName);
+                    bool has_function = funcs[i].HasValue;
+                    // If we have an assigned interaction function, but the function is not found - report a missing warning
+                    if (has_interaction && !has_function)
                     {
-                        errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                        if (guiObject.GUI != null)
+                        {
+                            errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                        }
+                        else
+                        {
+                            errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}: {guiObject.Control.ControlType} #{guiObject.Control.ID} {guiObject.Control.Name}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                        }
                     }
-                    else if (guiObject.Control != null)
+                    // If we don't have an assignment, but has a similar function - report a possible unlinked function
+                    else if (!has_interaction && has_function)
                     {
-                        string typeName = guiObject.Control.ControlType;
-                        int objid = guiObject.Control.ID;
-                        string scriptName = guiObject.Control.Name;
-
-                        errors.Add(new CompileWarning($"GUI ({ngui.ID}) {ngui.Name}: {typeName} #{objid} {scriptName}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {ngui.ScriptModule}."));
+                        if (guiObject.GUI != null)
+                        {
+                            errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on GUI ({ngui.ID}) {ngui.Name}'s Event pane",
+                                funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        }
+                        else
+                        {
+                            errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {guiObject.Control.ControlType} ({guiObject.Control.ID}) {guiObject.Control.Name}'s Event pane",
+                                funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        }
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -292,8 +292,8 @@ namespace AGS.Editor.Components
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)
                     {
-                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Inventory ({inv.ID}) {inv.Name}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithGameObject($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Inventory ({inv.ID}) {inv.Name}'s Event pane",
+                            "InventoryItem", inv.Name, funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -289,8 +289,8 @@ namespace AGS.Editor.Components
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)
                     {
-                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Inventory ({inv.ID}) {inv.Name}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Inventory ({inv.ID}) {inv.Name}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -137,12 +137,14 @@ namespace AGS.Editor.Components
             return new string[] { "InventoryItem" };
         }
 
-        public override void ShowItemPaneByName(string name)
+        public override bool ShowItemPaneByName(string name)
         {
             InventoryItem selectedItem = _agsEditor.CurrentGame.RootInventoryItemFolder.FindInventoryItemByName(name, true);
-            if (selectedItem == null) return;
+            if (selectedItem == null)
+                return false;
             _guiController.ProjectTree.SelectNode(this, GetNodeID(selectedItem));
             ShowOrAddPane(selectedItem);
+            return true;
         }
 
         private void OnItemIDOrNameChanged(InventoryItem item, bool name_only)
@@ -284,7 +286,8 @@ namespace AGS.Editor.Components
                     // If we have an assigned interaction function, but the function is not found - report a missing warning
                     if (has_interaction && !has_function)
                     {
-                        errors.Add(new CompileWarning($"Inventory ({inv.ID}) {inv.Name}'s event {inv.Interactions.Schema.FunctionSuffixes[i]} function \"{inv.Interactions.ScriptFunctionNames[i]}\" not found in script {inv.Interactions.ScriptModule}."));
+                        errors.Add(new CompileWarningWithGameObject($"Inventory ({inv.ID}) {inv.Name}'s event {inv.Interactions.Schema.FunctionSuffixes[i]} function \"{inv.Interactions.ScriptFunctionNames[i]}\" not found in script {inv.Interactions.ScriptModule}.",
+                            "InventoryItem", inv.Name, true));
                     }
                     // If we don't have an assignment, but has a similar function - report a possible unlinked function
                     else if (!has_interaction && has_function)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1806,13 +1806,13 @@ namespace AGS.Editor.Components
                 {
                     if (roomObject.Room != null)
                     {
-                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Room {room.Number}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Room {room.Number}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                     else
                     {
-                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {evtRef.TypeName} ({evtRef.ID}) {evtRef.ObjName}'s Event pane",
-                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                        errors.Add(new CompileWarningWithFunction($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {evtRef.TypeName} ({evtRef.ID}) {evtRef.ObjName}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.Name, funcs[i].Value.LineNumber));
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1710,6 +1710,9 @@ namespace AGS.Editor.Components
         private class RoomEventReference
         {
             public RoomObjectWithEvents RoomObject;
+            public string TypeName;
+            public int ID;
+            public string ObjName;
             public string EventName;
             public string FunctionName;
 
@@ -1718,6 +1721,29 @@ namespace AGS.Editor.Components
                 RoomObject = obj;
                 EventName = evtName;
                 FunctionName = fnName;
+
+                if (RoomObject.Room != null)
+                {
+                    ObjName = "Room";
+                }
+                else if (RoomObject.Object != null)
+                {
+                    TypeName = "Object";
+                    ID = RoomObject.Object.ID;
+                    ObjName = RoomObject.Object.Name;
+                }
+                else if (RoomObject.Hotspot != null)
+                {
+                    TypeName = "Hotspot";
+                    ID = RoomObject.Hotspot.ID;
+                    ObjName = RoomObject.Hotspot.Name;
+                }
+                else if (RoomObject.Region != null)
+                {
+                    TypeName = "Region";
+                    ID = RoomObject.Region.ID;
+                    ObjName = $"Region{RoomObject.Region.ID}";
+                }
             }
         }
 
@@ -1752,48 +1778,42 @@ namespace AGS.Editor.Components
                         new RoomEventReference(objWithEvents, reg.Interactions.FunctionSuffixes[i], reg.Interactions.ScriptFunctionNames[i])));
             }
 
-            var functionNames = objectEvents.Select(evt => evt.FunctionName);
-            var missing = _agsEditor.Tasks.CheckMissingEventHandlers(room.Script.AutoCompleteData, functionNames.ToArray());
-            if (missing == null || missing.Count == 0)
+            var functionNames = objectEvents.Select(evt => !string.IsNullOrEmpty(evt.FunctionName) ? evt.FunctionName : $"{evt.ObjName}_{evt.EventName}");
+            var funcs = _agsEditor.Tasks.FindEventHandlers(room.Script.FileName, room.Script.AutoCompleteData, functionNames.ToArray());
+            if (funcs == null || funcs.Length == 0)
                 return;
 
-            foreach (var miss in missing)
+            for (int i = 0; i < funcs.Length; ++i)
             {
-                RoomEventReference evtRef = objectEvents[miss];
+                RoomEventReference evtRef = objectEvents[i];
                 RoomObjectWithEvents roomObject = evtRef.RoomObject;
-                if (roomObject.Room != null)
+                bool has_interaction = !string.IsNullOrEmpty(evtRef.FunctionName);
+                bool has_function = funcs[i].HasValue;
+                // If we have an assigned interaction function, but the function is not found - report a missing warning
+                if (has_interaction && !has_function)
                 {
-                    errors.Add(new CompileWarning($"Room {room.Number}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {room.ScriptFileName}."));
-                }
-                else
-                {
-                    string typeName;
-                    int objid;
-                    string scriptName;
-                    if (roomObject.Object != null)
+                    if (roomObject.Room != null)
                     {
-                        typeName = "Object";
-                        objid = roomObject.Object.ID;
-                        scriptName = roomObject.Object.Name;
-                    }
-                    else if (roomObject.Hotspot != null)
-                    {
-                        typeName = "Hotspot";
-                        objid = roomObject.Hotspot.ID;
-                        scriptName = roomObject.Hotspot.Name;
-                    }
-                    else if (roomObject.Region != null)
-                    {
-                        typeName = "Region";
-                        objid = roomObject.Region.ID;
-                        scriptName = "";
+                        errors.Add(new CompileWarning($"Room {room.Number}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {room.ScriptFileName}."));
                     }
                     else
                     {
-                        continue;
+                        errors.Add(new CompileWarning($"Room {room.Number}: {evtRef.TypeName} ({evtRef.ID}) {evtRef.ObjName}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {room.ScriptFileName}."));
                     }
-
-                    errors.Add(new CompileWarning($"Room {room.Number}: {typeName} ({objid}) {scriptName}'s event {evtRef.EventName} function \"{evtRef.FunctionName}\" not found in script {room.ScriptFileName}."));
+                }
+                // If we don't have an assignment, but has a similar function - report a possible unlinked function
+                else if (!has_interaction && has_function)
+                {
+                    if (roomObject.Room != null)
+                    {
+                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on Room {room.Number}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                    }
+                    else
+                    {
+                        errors.Add(new CompileWarning($"Function \"{funcs[i].Value.Name}\" looks like an event handler, but is not linked on {evtRef.TypeName} ({evtRef.ID}) {evtRef.ObjName}'s Event pane",
+                            funcs[i].Value.ScriptName, funcs[i].Value.LineNumber));
+                    }
                 }
             }
         }

--- a/Editor/AGS.Editor/Entities/CompileWarningEx.cs
+++ b/Editor/AGS.Editor/Entities/CompileWarningEx.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// CompileWarningWithFunction - stores a function name in addition to regular parameters.
+    /// </summary>
+    public class CompileWarningWithFunction : CompileWarning
+    {
+        private string _funcName = string.Empty;
+
+        public CompileWarningWithFunction(string message, string scriptName, string funcName, int lineNumber)
+			: base(message, scriptName, lineNumber)
+		{
+            _funcName = funcName;
+        }
+
+        public string FunctionName
+        {
+            get { return _funcName; }
+        }
+    }
+}

--- a/Editor/AGS.Editor/Entities/CompileWarningEx.cs
+++ b/Editor/AGS.Editor/Entities/CompileWarningEx.cs
@@ -21,4 +21,40 @@ namespace AGS.Editor
             get { return _funcName; }
         }
     }
+
+    /// <summary>
+    /// CompileWarningWithGameObject - adds game object's type and name to the warning message.
+    /// </summary>
+    public class CompileWarningWithGameObject : CompileWarning
+    {
+        private string _typeName = string.Empty;
+        private string _objectName = string.Empty;
+        private bool _isObjectEvent = false;
+
+        public CompileWarningWithGameObject(string message, string typeName, string objectName, bool isObjectEvent = false)
+            : base(message)
+        {
+            _typeName = typeName;
+            _objectName = objectName;
+            _isObjectEvent = isObjectEvent;
+        }
+
+        public string TypeName
+        {
+            get { return _typeName; }
+        }
+
+        public string ObjectName
+        {
+            get { return _objectName; }
+        }
+
+        /// <summary>
+        /// Tells whether this warning is related to object's events table.
+        /// </summary>
+        public bool IsObjectEvent
+        {
+            get { return _isObjectEvent; }
+        }
+    }
 }

--- a/Editor/AGS.Editor/Entities/CompileWarningEx.cs
+++ b/Editor/AGS.Editor/Entities/CompileWarningEx.cs
@@ -16,6 +16,11 @@ namespace AGS.Editor
             _funcName = funcName;
         }
 
+        public CompileWarningWithFunction(string message)
+            : base(message)
+        {
+        }
+
         public string FunctionName
         {
             get { return _funcName; }
@@ -25,8 +30,9 @@ namespace AGS.Editor
     /// <summary>
     /// CompileWarningWithGameObject - adds game object's type and name to the warning message.
     /// </summary>
-    public class CompileWarningWithGameObject : CompileWarning
+    public class CompileWarningWithGameObject : CompileWarningWithFunction
     {
+        private int _roomNumber = -1;
         private string _typeName = string.Empty;
         private string _objectName = string.Empty;
         private bool _isObjectEvent = false;
@@ -37,6 +43,37 @@ namespace AGS.Editor
             _typeName = typeName;
             _objectName = objectName;
             _isObjectEvent = isObjectEvent;
+        }
+
+        public CompileWarningWithGameObject(string message, string typeName, string objectName, string scriptName, string functionName, int lineNumber)
+            : base(message, scriptName, functionName, lineNumber)
+        {
+            _typeName = typeName;
+            _objectName = objectName;
+            _isObjectEvent = true;
+        }
+
+        public CompileWarningWithGameObject(string message, int roomNumber, string typeName, string objectName, bool isObjectEvent = false)
+            : base(message)
+        {
+            _roomNumber = roomNumber;
+            _typeName = typeName;
+            _objectName = objectName;
+            _isObjectEvent = isObjectEvent;
+        }
+
+        public CompileWarningWithGameObject(string message, int roomNumber, string typeName, string objectName, string scriptName, string functionName, int lineNumber)
+            : base(message, scriptName, functionName, lineNumber)
+        {
+            _roomNumber = roomNumber;
+            _typeName = typeName;
+            _objectName = objectName;
+            _isObjectEvent = true;
+        }
+
+        public int RoomNumber
+        {
+            get { return _roomNumber; }
         }
 
         public string TypeName

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -589,7 +589,7 @@ namespace AGS.Editor
             }
             else
             {
-                Factory.GUIController.ShowMessage("This symbol is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
+                Factory.GUIController.ShowMessage("This symbol is internally defined by AGS and probably corresponds to an in-game entity which does not support \"Go to\" at the moment.", MessageBoxIcon.Information);
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -554,15 +554,7 @@ namespace AGS.Editor
             {
                 if (!string.IsNullOrEmpty(typeName))
                 {
-                    BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptElement(typeName) as BaseComponent;
-                    if (component != null)
-                    {
-                        component.ShowItemPaneByName(symbolName);
-                    }
-                    else
-                    {
-                        Factory.GUIController.ShowMessage("This symbol is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
-                    }
+                    ZoomToComponentObject(typeName, symbolName);
                 }
                 else
                 {
@@ -577,6 +569,27 @@ namespace AGS.Editor
             else
             {
                 Factory.GUIController.ZoomToFile(scriptName, ZoomToFileZoomType.ZoomToCharacterPosition, scriptCharPos);
+            }
+        }
+
+        public void ZoomToComponentObject(string typeName, string objectName, bool selectEventsTab = false)
+        {
+            BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptElement(typeName) as BaseComponent;
+            if (component != null)
+            {
+                if (component.ShowItemPaneByName(objectName))
+                {
+                    if (selectEventsTab)
+                        Factory.GUIController.SelectEventsTabInPropertyGrid();
+                }
+                else
+                {
+                    Factory.GUIController.ShowMessage($"There was error trying to open an object {objectName} of type {typeName} for editing.", MessageBoxIcon.Information);
+                }
+            }
+            else
+            {
+                Factory.GUIController.ShowMessage("This symbol is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -530,6 +530,56 @@ namespace AGS.Editor
 			ZoomToFile(fileName, lineNumber);
 		}
 
+        /// <summary>
+        /// Tries to open a pane that contains an object described by the given script symbol.
+        /// * If a symbol is user-defined, then opens a corresponding user script.
+        /// * If a symbol is a game item, then opens that item's edit pane.
+        /// * If a symbol is a part of a scripting API, then launches the manual.
+        /// </summary>
+        public void ZoomToAnyScriptSymbol(string scriptName, string symbolName, string typeName, int scriptCharPos)
+        {
+            if (scriptName == AGSEditor.BUILT_IN_HEADER_FILE_NAME)
+            {
+                if (symbolName == "player")
+                {
+                    CharactersComponent charactersComponent = Factory.ComponentController.FindComponent<CharactersComponent>();
+                    charactersComponent.ShowPlayerCharacter();
+                }
+                else
+                {
+                    Factory.GUIController.LaunchHelpForKeyword(symbolName);
+                }
+            }
+            else if (scriptName == Tasks.AUTO_GENERATED_HEADER_NAME)
+            {
+                if (!string.IsNullOrEmpty(typeName))
+                {
+                    BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptElement(typeName) as BaseComponent;
+                    if (component != null)
+                    {
+                        component.ShowItemPaneByName(symbolName);
+                    }
+                    else
+                    {
+                        Factory.GUIController.ShowMessage("This symbol is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
+                    }
+                }
+                else
+                {
+                    Factory.GUIController.ShowMessage("This symbol is internally defined by AGS.", MessageBoxIcon.Information);
+                }
+            }
+            else if (scriptName == GlobalVariablesComponent.GLOBAL_VARS_HEADER_FILE_NAME)
+            {
+                IGlobalVariablesController globalVariables = (IGlobalVariablesController)Factory.ComponentController.FindComponentThatImplementsInterface(typeof(IGlobalVariablesController));
+                globalVariables.SelectGlobalVariable(symbolName);
+            }
+            else
+            {
+                Factory.GUIController.ZoomToFile(scriptName, ZoomToFileZoomType.ZoomToCharacterPosition, scriptCharPos);
+            }
+        }
+
         public void ZoomToFile(string fileName)
         {
             ZoomToFile(fileName, ZoomToFileZoomType.DoNotMoveCursor, 0, false);

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -92,6 +92,11 @@ namespace AGS.Editor
                 {
                     Factory.GUIController.ZoomToFile(error.ScriptName, (error as CompileWarningWithFunction).FunctionName);
                 }
+                else if (error is CompileWarningWithGameObject)
+                {
+                    var errorWithObject = error as CompileWarningWithGameObject;
+                    Factory.GUIController.ZoomToComponentObject(errorWithObject.TypeName, errorWithObject.ObjectName, errorWithObject.IsObjectEvent);
+                }
             }
         }
 

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -52,7 +52,9 @@ namespace AGS.Editor
                 foreach (CompileMessage error in _errors)
                 {
                     ListViewItem newItem = lvwResults.Items.Add(error.Message);
-					if (error is CompileError)
+                    newItem.Tag = error;
+
+                    if (error is CompileError)
 					{
 						newItem.ImageKey = "CompileErrorIcon";
 					}
@@ -79,16 +81,18 @@ namespace AGS.Editor
 			if (lvwResults.SelectedItems.Count > 0)
 			{
 				ListViewItem selectedItem = lvwResults.SelectedItems[0];
-				if (selectedItem.SubItems.Count > 1)
-				{
-                    int line = 0;
-                    if (selectedItem.SubItems.Count > 2 && selectedItem.SubItems[2].Text != null &&
-                        int.TryParse(selectedItem.SubItems[2].Text, out line))
-                    {
-                        Factory.GUIController.ZoomToFile(selectedItem.SubItems[1].Text, Convert.ToInt32(selectedItem.SubItems[2].Text));
-                    }
-				}
-			}
+                CompileMessage error = selectedItem.Tag as CompileMessage;
+                if (error.LineNumber > 0)
+                {
+                    Factory.GUIController.ZoomToFile(error.ScriptName, error.LineNumber);
+                }
+                // TODO: following is possibly a temporary hack, until we find a way
+                // to initialize post-step warnings that check event functions with line numbers.
+                else if (error is CompileWarningWithFunction)
+                {
+                    Factory.GUIController.ZoomToFile(error.ScriptName, (error as CompileWarningWithFunction).FunctionName);
+                }
+            }
         }
 
         private string ListItemToString(ListViewItem item)

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -34,8 +34,7 @@ namespace AGS.Editor
 
         public void SetMessage(string message, string imageKey)
         {
-            ListViewItem newItem = lvwResults.Items.Add(message);
-            newItem.ImageKey = imageKey;
+            ListViewItem newItem = lvwResults.Items.Add(new OutputPanelItem(message, imageKey));
         }
 
         public CompileMessages ErrorsToList
@@ -51,27 +50,7 @@ namespace AGS.Editor
             {
                 foreach (CompileMessage error in _errors)
                 {
-                    ListViewItem newItem = lvwResults.Items.Add(error.Message);
-                    newItem.Tag = error;
-
-                    if (error is CompileError)
-					{
-						newItem.ImageKey = "CompileErrorIcon";
-					}
-					else
-					{
-						newItem.ImageKey = "CompileWarningIcon";
-                    }
-
-                    if (error.ScriptName.Length > 0)
-                    {
-                        newItem.SubItems.Add(error.ScriptName);
-                    }
-
-                    if (error.ScriptName.Length > 0 && error.LineNumber > 0)
-                    {
-                        newItem.SubItems.Add(error.LineNumber.ToString());
-                    }
+                    ListViewItem newItem = lvwResults.Items.Add(new OutputPanelItem(error));
                 }
             }
         }
@@ -80,45 +59,9 @@ namespace AGS.Editor
         {
 			if (lvwResults.SelectedItems.Count > 0)
 			{
-				ListViewItem selectedItem = lvwResults.SelectedItems[0];
-                CompileMessage error = selectedItem.Tag as CompileMessage;
-                if (error.LineNumber > 0)
-                {
-                    Factory.GUIController.ZoomToFile(error.ScriptName, error.LineNumber);
-                }
-                // TODO: following is possibly a temporary hack, until we find a way
-                // to initialize post-step warnings that check event functions with line numbers.
-                else if (error is CompileWarningWithFunction)
-                {
-                    Factory.GUIController.ZoomToFile(error.ScriptName, (error as CompileWarningWithFunction).FunctionName);
-                }
-                else if (error is CompileWarningWithGameObject)
-                {
-                    var errorWithObject = error as CompileWarningWithGameObject;
-                    Factory.GUIController.ZoomToComponentObject(errorWithObject.TypeName, errorWithObject.ObjectName, errorWithObject.IsObjectEvent);
-                }
+                OutputPanelItem selectedItem = lvwResults.SelectedItems[0] as OutputPanelItem;
+                selectedItem.DefaultAction();
             }
-        }
-
-        private string ListItemToString(ListViewItem item)
-        {
-            string thisLine = string.Empty;
-            if (item.SubItems.Count > 1)
-            {
-                thisLine += item.SubItems[1].Text;  // filename
-
-                if ((item.SubItems.Count > 2) &&
-                    (item.SubItems[2].Text.Length > 0))
-                {
-                    thisLine += "(" + item.SubItems[2].Text + ")";  // line number
-                }
-            }
-            if (thisLine.Length > 0)
-            {
-                thisLine += ": ";
-            }
-            thisLine += item.SubItems[0].Text;
-            return thisLine;
         }
 
         private string ListItemsToString(IEnumerable list)
@@ -126,7 +69,7 @@ namespace AGS.Editor
             StringBuilder sb = new StringBuilder();
             foreach(ListViewItem item in list)
             {
-                sb.Append(ListItemToString(item));
+                sb.Append(item.ToString());
                 sb.Append(Environment.NewLine);
             }
             return sb.ToString();

--- a/Editor/AGS.Editor/GUI/OutputPanelItem.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanelItem.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Windows.Forms;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// OutputPanelItem is a ListViewItem descendant that wraps CompileMessage
+    /// and handles user interaction with this message.
+    /// </summary>
+    public class OutputPanelItem : ListViewItem
+    {
+        private const string IMAGE_KEY_ERROR = "CompileErrorIcon";
+        private const string IMAGE_KEY_WARNING = "CompileWarningIcon";
+        private CompileMessage _message;
+
+        /// <summary>
+        /// Construct OutputPanelItem using plain text.
+        /// </summary>
+        public OutputPanelItem(string text, string imageKey)
+            : base(text)
+        {
+            ImageKey = imageKey;
+        }
+
+        /// <summary>
+        /// Construct OutputPanelItem using CompileMessage.
+        /// </summary>
+        public OutputPanelItem(CompileMessage message)
+        {
+            _message = message;
+            Text = message.Message;
+
+            if (message is CompileError)
+            {
+                ImageKey = IMAGE_KEY_ERROR;
+            }
+            else
+            {
+                ImageKey = IMAGE_KEY_WARNING;
+            }
+
+            if (_message.ScriptName.Length > 0)
+            {
+                SubItems.Add(_message.ScriptName);
+            }
+
+            if (_message.ScriptName.Length > 0 && _message.LineNumber > 0)
+            {
+                SubItems.Add(_message.LineNumber.ToString());
+            }
+        }
+
+        public CompileMessage Message
+        {
+            get { return _message; }
+        }
+
+        public virtual void DefaultAction()
+        {
+            if (_message.LineNumber > 0)
+            {
+                Factory.GUIController.ZoomToFile(_message.ScriptName, _message.LineNumber);
+            }
+            // TODO: following is possibly a temporary hack, until we find a way
+            // to initialize post-step warnings that check event functions with line numbers.
+            else if (_message is CompileWarningWithFunction)
+            {
+                Factory.GUIController.ZoomToFile(_message.ScriptName, (_message as CompileWarningWithFunction).FunctionName);
+            }
+            else if (_message is CompileWarningWithGameObject)
+            {
+                var errorWithObject = _message as CompileWarningWithGameObject;
+                Factory.GUIController.ZoomToComponentObject(errorWithObject.TypeName, errorWithObject.ObjectName, errorWithObject.IsObjectEvent);
+            }
+        }
+
+        public override string ToString()
+        {
+            string thisLine = string.Empty;
+            if (SubItems.Count > 1)
+            {
+                thisLine += SubItems[1].Text;  // filename
+
+                if ((SubItems.Count > 2) &&
+                    (SubItems[2].Text.Length > 0))
+                {
+                    thisLine += "(" + SubItems[2].Text + ")";  // line number
+                }
+            }
+            if (thisLine.Length > 0)
+            {
+                thisLine += ": ";
+            }
+            thisLine += SubItems[0].Text;
+            return thisLine;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -625,60 +625,17 @@ namespace AGS.Editor
 
             if (found != null)
             {
-                if (foundInScript.FileName == AGSEditor.BUILT_IN_HEADER_FILE_NAME)
+                string scriptElementType = null;
+                if (found is ScriptVariable)
                 {
-                    if (_goToDefinition == "player")
-                    {
-                        CharactersComponent charactersComponent = Factory.ComponentController.FindComponent<CharactersComponent>();
-                        charactersComponent.ShowPlayerCharacter();
-                    }
-                    else
-                    {
-                        Factory.GUIController.LaunchHelpForKeyword(_goToDefinition);
-                    }
+                    scriptElementType = (found as ScriptVariable).Type;
                 }
-                else if (foundInScript.FileName == Tasks.AUTO_GENERATED_HEADER_NAME)
+                else if (found is ScriptEnumValue)
                 {
-                    string scriptElementType = null, scriptElementName = null;
-                    if (found is ScriptVariable)
-                    {
-                        ScriptVariable sVar = found as ScriptVariable;
-                        scriptElementType = sVar.Type;
-                        scriptElementName = sVar.VariableName;
-                    }
-                    else if (found is ScriptEnumValue)
-                    {
-                        ScriptEnumValue sEnum = found as ScriptEnumValue;
-                        scriptElementType = sEnum.Type;
-                        scriptElementName = sEnum.Name;
-                    }
+                    scriptElementType = (found as ScriptEnumValue).Type;
+                }
 
-                    if (!string.IsNullOrEmpty(scriptElementType))
-                    { 
-                        BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptElement(scriptElementType) as BaseComponent;
-                        if(component != null)
-                        {
-                            component.ShowItemPaneByName(scriptElementName);
-                        }
-                        else
-                        {
-                            Factory.GUIController.ShowMessage("This variable is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
-                        }
-                    }
-                    else
-                    {
-                        Factory.GUIController.ShowMessage("This is internally defined by AGS.", MessageBoxIcon.Information);
-                    }
-                }
-                else if (foundInScript.FileName == GlobalVariablesComponent.GLOBAL_VARS_HEADER_FILE_NAME)
-                {
-                    IGlobalVariablesController globalVariables = (IGlobalVariablesController)Factory.ComponentController.FindComponentThatImplementsInterface(typeof(IGlobalVariablesController));
-                    globalVariables.SelectGlobalVariable(_goToDefinition);
-                }
-                else
-                {
-                    Factory.GUIController.ZoomToFile(foundInScript.FileName, ZoomToFileZoomType.ZoomToCharacterPosition, found.StartsAtCharacterIndex);
-                }
+                Factory.GUIController.ZoomToAnyScriptSymbol(foundInScript.FileName, _goToDefinition, scriptElementType, found.StartsAtCharacterIndex);
             }
         }
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -999,7 +999,7 @@ namespace AGS.Editor
             return functionNames
                 .Select(f => {
                     var func = scriptData.FindFunction(f);
-                    return func != null ? new FunctionLocation(f, scriptName, -1) : (FunctionLocation?)null;
+                    return func != null ? new FunctionLocation(f, scriptName, 0) : (FunctionLocation?)null;
                 })
                 .ToArray();
         }

--- a/Editor/AGS.Types/Exceptions/CompileMessage.cs
+++ b/Editor/AGS.Types/Exceptions/CompileMessage.cs
@@ -6,8 +6,8 @@ namespace AGS.Types
 {
     public abstract class CompileMessage : ApplicationException
     {
-        private string _scriptName;
-        private int _lineNumber;
+        private string _scriptName = string.Empty;
+        private int _lineNumber = 0;
 
         public CompileMessage(string message, string scriptName, int lineNumber)
             : base(message)
@@ -19,15 +19,11 @@ namespace AGS.Types
         public CompileMessage(string message)
             : base(message)
         {
-            _scriptName = string.Empty;
-            _lineNumber = 0;
         }
 
         public CompileMessage(string message, Exception innerException)
             : base(message, innerException)
         {
-            _scriptName = string.Empty;
-            _lineNumber = 0;
         }
 
         public CompileMessage(CompileMessage other) : base(other.Message)


### PR DESCRIPTION
As suggested by @messengerbag, as a most primitive solution for #2550.
...and a complementary to #2556

This adds another type of post-compilation warning that reports a script function that *looks like* it's a event handler, but *not linked* to the object events.

The feature uses default function names, as configured in Interaction tables.
For example: `cEgo_Look`, `Room_Load` and so forth.

The reported warning uses following pattern:
```Function "ObjectName_EventName" looks like an event handler, but is not linked on ObjType (ID) ScriptName's Event pane```

Example:
![warnings--eventhandlers](https://github.com/user-attachments/assets/7c074f66-0eba-46c8-bef0-574e55e5a450)


**TODO:**
Option in Editor Preferences that turns this on and off?

Need to decide what happens if user double clicks the warning. Do we want it to go to the script, or to the object's Events Pane?
Or have both options, called from a context menu?
See also: #2589

Unfortunately, Autocomplete data, which we use for this kind of scanning, contains the index of the function's *starting character*, rather than a *line number*. I think the autocomplete may be amended to also have line numbers for script tokens.