### PR TITLE
Doc changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ If you have an issue in the tracker that you would like to work on, please let u
 
 # Pull Requests
 If it is your first pull request and you don't know where to start [contributing to an Open Source Project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) is a great resource for first-time contributors.
+
 To start, make a fork of the branch you are working on and create your own feature/fix branch. After you have finished your commits, please send a pull request. We'll review your pull request and may ask you to make some changes to the code before we merge it.
 For information on the project [AGS Info and Knowledge Base](https://github.com/adventuregamestudio/ags/wiki) has information on the history and current state of the project.
+
 Information on our coding conventions can be found at [AGS Coding Conventions](https://github.com/adventuregamestudio/ags/wiki/AGS-Coding-Conventions-(Cpp))
 Please be aware that many parts of the engine are still written in very old and often "dirty" code, and it may not be easy to understand the ties between different program parts. If you are having problems and can't find the needed information in the [AGS Info and Knowledge Base](https://github.com/adventuregamestudio/ags/wiki), please reach out to us, and we may be able to help.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+To contribute to AGS please follow the following guidelines
+
+# Code of Conduct
+* Examples of acceptable behavior
+  - Using welcoming and respectful language
+  - Gracefully accepting constructive criticism
+  - Being respectful of differing viewpoints
+
+* Examples of unacceptable behavior
+  - Sexualized language or imagery
+  - Insulting or derogatory comments
+  - Harassment
+  - Other conduct that would reasonably be considered inappropriate in a professional setting
+
+## Our Responsibility and Enforcement
+Project maintainers are responsible for clarifying the standards of acceptable behavior and will take appropriate and fair actions in response to unacceptable behavior.
+Project maintainers have the right to remove, edit, or reject comments, commits, code, or other contributions that are made in bad faith. Temporary or permanent bans may result from inappropriate, threatening, or offensive conduct.
+
+Concerns and reports can be made to ((Insert appropriate contact info here))
+
+## Attribution
+This Code of Conduct is partly adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) and is subject to change
+
+## Branch Organization and Releases
+The [`master`][master-br] branch is where the next planned version is being developed. It may contain unstable or untested code.
+
+Currently, `master` corresponds to 3.\* generation of the engine/IDE and maintains backward compatibility with previous releases - see also [Compatibility](#ags-game-compatibility). According to current plans, this branch should only receive improvements to the backend, system support, and performance. Changes to data formats and game scripts should be kept to a strict minimum to fill in the critical gaps in the engine's functionality.
+
+There's an [`ags4`][ags4-br] branch also active where we develop a future version currently named simply "ags4". There we introduce greater changes and cut much of the old version support.
+
+According to our plans, in the future `master` branch will be merged with `ags4`, while the backward compatible generation will remain as the `ags3` branch and only receive fixes and minor enhancements. But there's still some work to do in AGS 3.\*, so the exact moment that happens is unknown.
+
+For "official" releases we create `release-X.X.X` branches, that is to prepare the code for the final release and continue making patches to that release if a need arises. 
+
+Because of the low number of active developers we tend to only update the one latest release branch. If bugs are found in one of the older versions, then we advise you to update to the latest version first.
+
+Please note that while the `master` branch may contain changes to game data format and new script functions, we cannot guarantee that these will remain unchanged until the actual release. We only support data formats and script APIs that are in published releases. For that reason, it's best to use one of the actual releases if you'd like to make your own game with this tool.
+
+There may be other temporary development branches meant for preparing and testing large changes, but these are situational.
+
+# Bugs and Issues
+If you find a critical bug or issue with the current release and have a fix for it, please make a pull request. How to do this is discussed below in this guide. If you do not have a fix, please submit an issue in the [Issue Tracker](https://github.com/adventuregamestudio/ags/issues) so that we are made aware of the problem and can take steps to fix it.
+
+# Feature Requests and Program Changes
+If you would like a particular feature or change, please submit an issue with the [Issue Tracker](https://github.com/adventuregamestudio/ags/issues) so we can talk about the proposed change.
+
+# Issues
+If you have an issue in the tracker that you would like to work on, please let us know that you are working on the issue by commenting on it. This includes Issues you have created. Please tell us so that no one is duplicating effort.
+
+# Pull Requests
+If it is your first pull request and you don't know where to start [contributing to an Open Source Project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) is a great resource for first-time contributors.
+To start, make a fork of the branch you are working on and create your own feature/fix branch. After you have finished your commits, please send a pull request. We'll review your pull request and may ask you to make some changes to the code before we merge it.
+For information on the project [AGS Info and Knowledge Base](https://github.com/adventuregamestudio/ags/wiki) has information on the history and current state of the project.
+Information on our coding conventions can be found at [AGS Coding Conventions](https://github.com/adventuregamestudio/ags/wiki/AGS-Coding-Conventions-(Cpp))
+Please be aware that many parts of the engine are still written in very old and often "dirty" code, and it may not be easy to understand the ties between different program parts. If you are having problems and can't find the needed information in the [AGS Info and Knowledge Base](https://github.com/adventuregamestudio/ags/wiki), please reach out to us, and we may be able to help.

--- a/README.md
+++ b/README.md
@@ -9,25 +9,6 @@ Adventure Game Studio (AGS) - is the IDE and the engine meant for creating and r
 
 For community forums, games and more, go to the website: [www.adventuregamestudio.co.uk](https://www.adventuregamestudio.co.uk)
 
-
-## Branches and releases
-
-The [`master`][master-br] branch is where the next planned version is being developed. It may contain unstable or untested code.
-
-Currently, `master` corresponds to 3.\* generation of the engine/IDE and maintains backward compatibility with previous releases - see also [Compatibility](#ags-game-compatibility). According to current plans, this branch should only receive improvements to the backend, system support, and performance. Changes to data formats and game script should be kept to a strict minimum necessary to fill in the critical gaps in the engine's functionality.
-
-There's an [`ags4`][ags4-br] branch also active where we develop a future version currently named simply "ags4". There we introduce greater changes and cut much of the old version support.
-
-According to our plans, in the future `master` branch will be merged with `ags4`, while the backward compatible generation will remain as the `ags3` branch and only receive fixes and minor enhancements. But there's still some work to do in AGS 3.\*, so the exact moment that happens is unknown.
-
-For "official" releases we create `release-X.X.X` branches, that is to prepare the code for the final release and continue making patches to that release if a need arises. 
-
-Because of the low number of active developers we tend to only update the one latest release branch. If bugs are found in one of the older versions, then we advise you to update to the latest version first.
-
-Please note that while the `master` branch may contain changes to game data format and new script functions, we cannot guarantee that these will remain unchanged until the actual release. We only support data formats and script APIs that are in published releases. For that reason, it's best to use one of the actual releases if you'd like to make your own game with this tool.
-
-There may be other temporary development branches meant for preparing and testing large changes, but these are situational.
-
 ## Building and running
 
 To get started building the AGS engine, see the platform-specific instructions or forum threads:
@@ -86,25 +67,13 @@ There are other repositories which contain additional resources and may be of in
 
 ## Contributing
 
-If you'd like to contribute to the project the usual workflow is this: you fork our repository (unless you already did that), create a feature/fix branch, commit your changes to that branch, and then create a pull request. We will review your commits and sometimes may ask you to alter your code before merging it into our repository.
+If you would like to contribute to the project, please read the [CONTRIBUTING.md](./CONTRIBUTING.md) below is a brief summation of the process.
 
-We may accept patch files too if you send them to one of the project maintainers.
+* For minor bug fixes or code improvements, you need only create a fork of the repository, commit your changes to a branch, and submit a pull request. We will review your commits and may ask you to make alterations to your code if needed before merging it into our repository.
 
-For bug fixing and trivial code improvements that may be enough, but for more significant changes, completely new features or changes in the program design we ask you to first open an issue in the tracker and discuss it with the development team to make sure that suggested changes won't break anything, nor will be in conflict with existing program behavior or our development plans.
+We may also accept patch files if you send them to one of the project maintainers.
 
-Please be aware that big parts of the engine are still written in a very old and often "dirty" code, and it may not be easy to understand ties between different program parts. Because there's a low number of active developers involved in this project, our plans or design ideas are not always well documented, unfortunately. If you're in doubt - please discuss your ideas with us first.
-
-The [`master`][master-br] branch should be kept in a working state and compilable on all targeted platforms. The "release-X.X.X" branch is created to prepare the code for the respective release and continue making patches to that release. If you've found a critical issue in the latest release it should be fixed in the release-X.X.X branch when possible. The release branch is then either merged to master or if that's no longer convenient, - a fix is copied and applied to the master branch separately.
-
-Note that we usually only update the one latest release branch.
-
-Currently, the `master` branch should only receive improvements to existing functionality, performance, backend libraries, and so on.
-
-As been mentioned before, there's another branch called [`ags4`][ags4-br] where we do bigger changes, cut many of the older version support, and which should eventually become the main development branch. For more information about this split and its reasons, please refer to [#448](https://github.com/adventuregamestudio/ags/issues/448).
-
-There's also a Wiki in this repository which serves as a "knowledge base" for this project: [github.com/adventuregamestudio/ags/wiki](https://github.com/adventuregamestudio/ags/wiki)
-
-Among other things there we've got a coding convention, please check it before writing the engine code: [github.com/adventuregamestudio/ags/wiki/AGS-Coding-Conventions-(Cpp)](https://github.com/adventuregamestudio/ags/wiki/AGS-Coding-Conventions-(Cpp))
+* For new features or other larger contributions, please first open an issue in the [Issue Tracker](https://github.com/adventuregamestudio/ags/issues). Here, we can discuss the proposed changes with the development team to ensure they will stay consistent with existing program behavior and future development plans.
 
 
 ## Changes from Chris Jones' version of AGS

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -1,5 +1,7 @@
 # Adventure Game Studio - Windows
 
+The following are instructions on how to build the Engine and Editor if you don't want to manually build the files you can download the latest installer on our website at [https://www.adventuregamestudio.co.uk/site/ags/](https://www.adventuregamestudio.co.uk/site/ags/)
+
 ## Build Requirements
 
 * In common:


### PR DESCRIPTION
I edited some of the docs found in the repo.
I recommend further refining them to change things to reflect better what you want out of contributors.
The link that I added on the install instructions for Windows I recommend is added to the other build docs. I don't have access to other operating systems to test if the installer on the website works for them, so I didn't add the link.

Also, the README.md mentioned an Android app that could run games, but I was not able to find a discreet link that isn't just the releases. 

Feel free to let me know if you have questions.