### PR TITLE
Editor: add Length to Dynamic Array autocomplete

### DIFF
--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -350,8 +350,34 @@ namespace AGS.Editor
 					state.AddNextWord(thisWord);
 				}
             }
+
+            GenerateDynamicArrayStructs(newCache, structsLookup);
+
             scriptToCache.AutoCompleteData.CopyFrom(newCache);
 			scriptToCache.AutoCompleteData.Populated = true;
+        }
+
+        private static void GenerateDynamicArrayStructs(ScriptAutoCompleteData data, List<ScriptStruct> structsLookup)
+        {
+            foreach (var variable in data.Variables)
+            {
+                if (!variable.IsDynamicArray)
+                    continue;
+
+                string trueType = variable.Type;
+                string fakeStructName = trueType + "[]";
+                variable.Type = fakeStructName;
+                if (structsLookup.Find(s => s.Name == fakeStructName) != null)
+                    continue;
+
+                ScriptStruct dynArrStruct = new ScriptStruct(fakeStructName);
+                ScriptVariable lengthVar = new ScriptVariable("Length", "int", false, false, false, null, null, false, false, false, false, 0);
+                lengthVar.Description = "Returns length of this dynamic array.";
+                dynArrStruct.Variables.Add(lengthVar);
+                dynArrStruct.FullDefinition = true;
+                data.Structs.Add(dynArrStruct);
+                structsLookup.Add(dynArrStruct);
+            }
         }
 
         private static void AdjustFunctionListForExtenderFunction(List<ScriptStruct> structsLookup,

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -382,7 +382,7 @@ namespace AGS.Editor
                     continue;
 
                 ScriptStruct dynArrStruct = new ScriptStruct(fakeStructName);
-                ScriptVariable lengthVar = new ScriptVariable("Length", "int", false, false, false, null, null, false, false, false, false, 0);
+                ScriptVariable lengthVar = new ScriptVariable("Length", "int", false, false, false, null, null, false, false, false, false, true, 0);
                 lengthVar.Description = "Returns length of this dynamic array.";
                 dynArrStruct.Variables.Add(lengthVar);
                 dynArrStruct.FullDefinition = true;
@@ -605,6 +605,7 @@ namespace AGS.Editor
                     bool isPointer = false;
                     bool isStatic = false, isStaticOnly = false;
                     bool isNoInherit = false, isProtected = false;
+                    bool isReadonly = false;
                     string type = state.WordBeforeLast;
 					string varName = state.LastWord;
                     if (thisWord == "[")
@@ -639,6 +640,10 @@ namespace AGS.Editor
                     {
                         isProtected = true;
                     }
+                    if (state.IsWordInPreviousList("readonly"))
+                    {
+                        isReadonly = true;
+                    }
                     if (DoesCurrentLineHaveToken(script, AUTO_COMPLETE_STATIC_ONLY))
                     {
                         isStaticOnly = true;
@@ -651,7 +656,7 @@ namespace AGS.Editor
                     if (type != "struct")
                     {
                         //if (varName == "{") System.Diagnostics.Debugger.Break();
-                        ScriptVariable newVar = new ScriptVariable(varName, type, isArray, isDynamicArray, isPointer, state.InsideIfDefBlock, state.InsideIfNDefBlock, isStatic, isStaticOnly, isNoInherit, isProtected, state.CurrentScriptCharacterIndex);
+                        ScriptVariable newVar = new ScriptVariable(varName, type, isArray, isDynamicArray, isPointer, state.InsideIfDefBlock, state.InsideIfNDefBlock, isStatic, isStaticOnly, isNoInherit, isProtected, isReadonly, state.CurrentScriptCharacterIndex);
 
                         if (!string.IsNullOrEmpty(state.PreviousComment))
                         {
@@ -790,7 +795,7 @@ namespace AGS.Editor
                 }
                 if ((paramName.Length > 0) && (paramType.Length > 0))
                 {
-                    variables.Add(new ScriptVariable(paramName.ToString(), paramType.ToString(), false, isDynamicArray, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
+                    variables.Add(new ScriptVariable(paramName.ToString(), paramType.ToString(), false, isDynamicArray, isPointer, null, null, false, false, false, false, false, func.StartsAtCharacterIndex));
                 }
             }
             return;
@@ -839,7 +844,7 @@ namespace AGS.Editor
                         if (((nextWord == "=") || (nextWord == ";") || (nextWord == ",")) &&
                             (lastWord != "return") && (lastWord != "else"))
                         {
-							variables.Add(new ScriptVariable(variableName, lastWord, isArray, isDynamicArray, isPointer, null, null, false, false, false, false, (scriptToParse.Length - script.Length) + relativeCharacterIndex));
+							variables.Add(new ScriptVariable(variableName, lastWord, isArray, isDynamicArray, isPointer, null, null, false, false, false, false, false, (scriptToParse.Length - script.Length) + relativeCharacterIndex));
                         }
                         if (nextWord != ",")
                         {

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -564,7 +564,8 @@ namespace AGS.Editor
             {
                 if (!DoesCurrentLineHaveToken(script, AUTO_COMPLETE_IGNORE))
                 {
-                    bool isArray = false, isPointer = false;
+                    bool isArray = false, isDynamicArray = false;
+                    bool isPointer = false;
                     bool isStatic = false, isStaticOnly = false;
                     bool isNoInherit = false, isProtected = false;
                     string type = state.WordBeforeLast;
@@ -579,7 +580,8 @@ namespace AGS.Editor
 						varName = state.WordBeforeLast;
 						type = state.WordBeforeWordBeforeLast;
 						isArray = true;
-					}
+                        isDynamicArray = true;
+                    }
                     if (type == "*")
                     {
                         isPointer = true;
@@ -612,7 +614,7 @@ namespace AGS.Editor
                     if (type != "struct")
                     {
                         //if (varName == "{") System.Diagnostics.Debugger.Break();
-                        ScriptVariable newVar = new ScriptVariable(varName, type, isArray, isPointer, state.InsideIfDefBlock, state.InsideIfNDefBlock, isStatic, isStaticOnly, isNoInherit, isProtected, state.CurrentScriptCharacterIndex);
+                        ScriptVariable newVar = new ScriptVariable(varName, type, isArray, isDynamicArray, isPointer, state.InsideIfDefBlock, state.InsideIfNDefBlock, isStatic, isStaticOnly, isNoInherit, isProtected, state.CurrentScriptCharacterIndex);
 
                         if (!string.IsNullOrEmpty(state.PreviousComment))
                         {
@@ -733,9 +735,13 @@ namespace AGS.Editor
                         string variableName = nextWord;
                         nextWord = GetNextWord(ref script);
                         bool isArray = false;
+                        bool isDynamicArray = false;
                         if (nextWord == "[") 
                         {
                             isArray = true;
+                            if (PeekNextWord(script) == "]")
+                                isDynamicArray = true;
+
                             while ((script.Length > 0) && (GetNextWord(ref script) != "]")) ;
 							nextWord = GetNextWord(ref script);
                         }
@@ -743,7 +749,7 @@ namespace AGS.Editor
                         if (((nextWord == "=") || (nextWord == ";") || (nextWord == ",")) &&
                             (lastWord != "return") && (lastWord != "else"))
                         {
-							variables.Add(new ScriptVariable(variableName, lastWord, isArray, isPointer, null, null, false, false, false, false, (scriptToParse.Length - script.Length) + relativeCharacterIndex));
+							variables.Add(new ScriptVariable(variableName, lastWord, isArray, isDynamicArray, isPointer, null, null, false, false, false, false, (scriptToParse.Length - script.Length) + relativeCharacterIndex));
                         }
                         if (nextWord != ",")
                         {

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -760,28 +760,37 @@ namespace AGS.Editor
             string[] parameters = func.ParamList.Split(',');
             foreach (string thisParam in parameters)
             {
-                string param = thisParam.Trim();
+                FastString param = thisParam.Trim();
                 if (param.StartsWith("optional "))
                 {
                     param = param.Substring(9).Trim();
                 }
                 int index = param.Length - 1;
+
+                bool isDynamicArray = false;
+                if (index >= 0 && param[index] == ']')
+                {
+                    isDynamicArray = true;
+                    while (index >= 0 && param[index--] != '[');
+                    param = param.Substring(0, index + 1).Trim();
+                }
+
                 while ((index >= 0) &&
                        (Char.IsLetterOrDigit(param[index]) || param[index] == '_'))
                 {
                     index--;
                 }
-                string paramName = param.Substring(index + 1);
-                string paramType = param.Substring(0, index + 1).Trim();
+                FastString paramName = param.Substring(index + 1);
+                FastString paramType = param.Substring(0, index + 1).Trim();
                 bool isPointer = false;
-                if (paramType.EndsWith("*"))
+                if (paramType[paramType.Length - 1] == '*')
                 {
                     isPointer = true;
                     paramType = paramType.Substring(0, paramType.Length - 1).Trim();
                 }
                 if ((paramName.Length > 0) && (paramType.Length > 0))
                 {
-                    variables.Add(new ScriptVariable(paramName, paramType, false, false, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
+                    variables.Add(new ScriptVariable(paramName.ToString(), paramType.ToString(), false, isDynamicArray, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
                 }
             }
             return;

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -376,7 +376,7 @@ namespace AGS.Editor
                     continue;
 
                 string trueType = variable.Type;
-                string fakeStructName = trueType + "[]";
+                string fakeStructName = trueType + (variable.IsPointer ? "*[]" : "[]");
                 variable.Type = fakeStructName;
                 if (structsLookup.Find(s => s.Name == fakeStructName) != null)
                     continue;

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -2383,7 +2383,7 @@ namespace AGS.Editor
                 }
                 if ((paramName.Length > 0) && (paramType.Length > 0))
                 {
-                    variables.Add(new ScriptVariable(paramName, paramType, false, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
+                    variables.Add(new ScriptVariable(paramName, paramType, false, false, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -2353,41 +2353,6 @@ namespace AGS.Editor
             }
         }
 
-        private void AddFunctionParametersToVariableList(ScriptFunction func, List<ScriptVariable> variables)
-        {
-            if (func.ParamList.Length == 0)
-            {
-                return;
-            }
-            string[] parameters = func.ParamList.Split(',');
-            foreach (string thisParam in parameters)
-            {
-                string param = thisParam.Trim();
-                if (param.StartsWith("optional "))
-                {
-                    param = param.Substring(9).Trim();
-                }
-                int index = param.Length - 1;
-                while ((index >= 0) &&
-                       (Char.IsLetterOrDigit(param[index]) || param[index] == '_'))
-                {
-                    index--;
-                }
-                string paramName = param.Substring(index + 1);
-                string paramType = param.Substring(0, index + 1).Trim();
-                bool isPointer = false;
-                if (paramType.EndsWith("*"))
-                {
-                    isPointer = true;
-                    paramType = paramType.Substring(0, paramType.Length - 1).Trim();
-                }
-                if ((paramName.Length > 0) && (paramType.Length > 0))
-                {
-                    variables.Add(new ScriptVariable(paramName, paramType, false, false, isPointer, null, null, false, false, false, false, func.StartsAtCharacterIndex));
-                }
-            }
-        }
-
         private ScriptVariable FindLocalVariableWithName(int startAtPos, string nameToFind)
         {
             List<ScriptVariable> localVars = GetListOfLocalVariablesForCurrentPosition(false, startAtPos);
@@ -2463,8 +2428,9 @@ namespace AGS.Editor
                         startPos += openBracketOffset;
                         scriptExtract = scriptExtract.Substring(openBracketOffset);
                     }
-                    List<ScriptVariable> localVars = AutoComplete.GetLocalVariableDeclarationsFromScriptExtract(scriptExtract, startPos);
-                    AddFunctionParametersToVariableList(func, localVars);
+
+                    var localStructs = _autoCompleteForThis.AutoCompleteData.Structs;
+                    List<ScriptVariable> localVars = AutoComplete.GetLocalVariableDeclarations(func, localStructs, scriptExtract, startPos);
                     return localVars;
                 }
             }

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -2097,7 +2097,12 @@ namespace AGS.Editor
 
         private string ConstructVariableCalltipText(ScriptVariable variable, ScriptStruct owningStruct)
         {
-            string callTip = variable.Type;
+            string callTip = "";
+            if (variable.IsReadOnly)
+            {
+                callTip += "readonly ";
+            }
+            callTip += variable.Type;
             if (variable.IsArray)
             {
                 callTip += "[ ]";

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
@@ -6,7 +6,7 @@ namespace AGS.Types.AutoComplete
 {
     public class ScriptVariable : ScriptToken
     {
-        public ScriptVariable(string variableName, string type, bool isArray, bool isDynamicArray, bool isPointer, string ifDefOnly, string ifNDefOnly, bool isStatic, bool isStaticOnly, bool noInherit, bool isProtected, int scriptCharacterIndex)
+        public ScriptVariable(string variableName, string type, bool isArray, bool isDynamicArray, bool isPointer, string ifDefOnly, string ifNDefOnly, bool isStatic, bool isStaticOnly, bool noInherit, bool isProtected, bool isReadOnly, int scriptCharacterIndex)
         {
             VariableName = variableName;
             Type = type;
@@ -19,7 +19,8 @@ namespace AGS.Types.AutoComplete
             IsStaticOnly = isStaticOnly;
             NoInherit = noInherit;
             IsProtected = isProtected;
-			StartsAtCharacterIndex = scriptCharacterIndex;
+            IsReadOnly = isReadOnly;
+            StartsAtCharacterIndex = scriptCharacterIndex;
         }
 
         public string VariableName;
@@ -31,6 +32,7 @@ namespace AGS.Types.AutoComplete
         public bool NoInherit;
         public bool IsProtected;
         public bool IsDynamicArray;
+        public bool IsReadOnly;
 
         public override string ToString()
         {

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
@@ -34,7 +34,7 @@ namespace AGS.Types.AutoComplete
 
         public override string ToString()
         {
-            return "VAR: " + (IsStatic ? "static " : "") + Type + (IsPointer ? "*" : "") + (IsArray ? "[]" : "") + " " + VariableName;
+            return "VAR: " + (IsStatic ? "static " : "") + Type + (IsPointer && !IsDynamicArray ? "*" : "") + " " + VariableName + (IsArray && !IsDynamicArray ? "[]" : "");
         }
     }
 }

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptVariable.cs
@@ -6,11 +6,12 @@ namespace AGS.Types.AutoComplete
 {
     public class ScriptVariable : ScriptToken
     {
-        public ScriptVariable(string variableName, string type, bool isArray, bool isPointer, string ifDefOnly, string ifNDefOnly, bool isStatic, bool isStaticOnly, bool noInherit, bool isProtected, int scriptCharacterIndex)
+        public ScriptVariable(string variableName, string type, bool isArray, bool isDynamicArray, bool isPointer, string ifDefOnly, string ifNDefOnly, bool isStatic, bool isStaticOnly, bool noInherit, bool isProtected, int scriptCharacterIndex)
         {
             VariableName = variableName;
             Type = type;
             IsArray = isArray;
+            IsDynamicArray = isDynamicArray;
             IsPointer = isPointer;
             IfDefOnly = ifDefOnly;
             IfNDefOnly = ifNDefOnly;
@@ -29,6 +30,7 @@ namespace AGS.Types.AutoComplete
         public bool IsStaticOnly;
         public bool NoInherit;
         public bool IsProtected;
+        public bool IsDynamicArray;
 
         public override string ToString()
         {


### PR DESCRIPTION
fix #2599

This is working, please try.

~~this is the lowest effort for having Length in autocomplete for dynamic arrays. It looks like there are some refactoring opportunities both in the Autocomplete parser and int the typing parser in the Scintilla Wrapper, but they weren't clear for me.~~ I guess we switched for the highest effort.

~~One thing I am not doing here is adding the Length property to the call tip that shows up when the mouse over some property, I looked at the code and couldn't figure some nice way to add it there.~~ this was done

~~This adds a method `GetMembersOfDynamicArray()` that returns a hardcoded Scintilla formatted `Length` as property~~  Edit: switched for fakestruct approach.