### PR TITLE
Engine: Add System.DisplayFPS

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2527,6 +2527,8 @@ builtin struct System {
   import static int GetEngineInteger(EngineValueID value, int index = 0); // $AUTOCOMPLETESTATICONLY$
   /// Gets a runtime engine string by the given identifier; is meant for diagnostic purposes only
   import static String GetEngineString(EngineValueID value, int index = 0); // $AUTOCOMPLETESTATICONLY$
+  /// Gets/sets whether the engine displays the FPS counter
+  import static attribute bool DisplayFPS; // $AUTOCOMPLETESTATICONLY$
 #endif // SCRIPT_API_v362
 };
 

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -27,6 +27,7 @@
 #include "ac/system.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "debug/debug_log.h"
+#include "debug/debugger.h"
 #include "debug/out.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxfilter.h"
@@ -49,6 +50,7 @@ extern ScriptSystem scsystem;
 extern IGraphicsDriver *gfxDriver;
 extern CCAudioChannel ccDynamicAudio;
 extern volatile bool switched_away;
+extern FPSDisplayMode display_fps;
 
 bool System_GetHasInputFocus()
 {
@@ -337,6 +339,16 @@ String GetEngineValueName(EngineValueID value_id)
     }
 }
 
+bool System_GetDisplayFPS() {
+    return display_fps != kFPS_Hide;
+}
+
+void System_SetDisplayFPS(bool show_fps)
+{
+    if (display_fps != kFPS_Forced)
+        display_fps = show_fps ? kFPS_Display : kFPS_Hide;
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -521,6 +533,16 @@ RuntimeScriptValue Sc_System_GetEngineString(const RuntimeScriptValue *params, i
     API_SCALL_OBJ_PINT2(const char, myScriptStringImpl, System_GetEngineString);
 }
 
+RuntimeScriptValue Sc_System_GetDisplayFPS(const RuntimeScriptValue* params, int32_t param_count)
+{
+    API_SCALL_BOOL(System_GetDisplayFPS);
+}
+
+RuntimeScriptValue Sc_System_SetDisplayFPS(const RuntimeScriptValue* params, int32_t param_count)
+{
+    API_SCALL_VOID_PBOOL(System_SetDisplayFPS);
+}
+
 //=============================================================================
 //
 // Exclusive variadic API implementation for Plugins
@@ -569,6 +591,8 @@ void RegisterSystemAPI()
         { "System::Log^102",                  Sc_System_Log, ScPl_System_Log },
         { "System::GetEngineInteger^2",       API_FN_PAIR(System_GetEngineInteger) },
         { "System::GetEngineString^2",        API_FN_PAIR(System_GetEngineString) },
+        { "System::get_DisplayFPS",           API_FN_PAIR(System_GetDisplayFPS) },
+        { "System::set_DisplayFPS",           API_FN_PAIR(System_SetDisplayFPS) },
     };
 
     ccAddExternalFunctions(system_api);


### PR DESCRIPTION
This feels easier to use than remembering to do `Debug(4, 1)`.

This is picked from the discussion in #2436

I use `Debug(4, 1)` when evaluating performance of something I am making, with this I would instead do `System.DisplayFPS = true`, which is more readable, or a simple `on_key_press() { System.DisplayFPS = !System.DisplayFPS }`. This is more for testing quick things than actual final games, where one would probably use GetEngineInteger to retrieve proper fps and do a custom display.