### PR TITLE
Fix bug: 'import' functions cannot get a body at the same time

### DIFF
--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -3016,3 +3016,23 @@ TEST_F(Compile1, ExpressionNotFoundMessage2)
     EXPECT_NE(std::string::npos, err_msg.find("an expression"));
     EXPECT_NE(std::string::npos, err_msg.find("'do'"));
 }
+
+TEST_F(Compile1, ImportWithBody) {
+
+    // An "import" function must not be declared with body
+
+    char const *inpl = "\
+        import int func(void)               \n\
+        {                                   \n\
+            return 0;                       \n\
+        }                                   \n\
+        ";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'import'"));
+}


### PR DESCRIPTION
Fixes #2617 

The compiler didn't catch functions that are declared `import` and at the same time get a body. This is an error.

Example:
```
import int Func()   // ←'import' keyword
{    // ← function has a body
    return 0;
}
```

Add a Googletest that checks that this is now illegal.