### PR TITLE
AGS 4.0: implement Overlay.Flip

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1239,6 +1239,8 @@ builtin managed struct Overlay {
   readonly import attribute int  TintSaturation;
   /// Gets the Luminance of this overlay's colour tint.
   readonly import attribute int  TintLuminance;
+  /// Gets/sets the flip direction of this overlay.
+  import attribute eFlipDirection Flip;
 #endif // SCRIPT_API_v400
 };
 
@@ -1384,7 +1386,7 @@ import int  WaitInput(InputType inputs, int waitLoops = -1);
 #endif // SCRIPT_API_v36026
 /// Checks whether the specified key is currently held down.
 import bool IsKeyPressed(eKeyCode);
-import void FlipScreen(int way);
+import void FlipScreen(eFlipDirection way);
 /// Fast-forwards the game until the specified character finishes moving.
 import void SkipUntilCharacterStops(CHARID);
 /// Specifies the start of a skippable cutscene.

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2713,7 +2713,7 @@ static void construct_overlays()
             Bitmap *use_bmp = nullptr;
             if (is_software_mode)
             {
-                use_bmp = transform_sprite(over.GetImage(), overtx.Bmp, overtx.TempBmp, Size(over.scaleWidth, over.scaleHeight), over.rotation);
+                use_bmp = transform_sprite(over.GetImage(), overtx.Bmp, overtx.TempBmp, Size(over.scaleWidth, over.scaleHeight), over.rotation, over.GetFlip());
                 if (crop_walkbehinds && over.IsRoomLayer())
                 {
                     auto &use_cache = overtx.Bmp;
@@ -2741,6 +2741,7 @@ static void construct_overlays()
         if (!overtx.Ddb) continue;
         overtx.Ddb->SetOrigin(0.f, 0.f);
         overtx.Ddb->SetStretch(over.scaleWidth, over.scaleHeight);
+        overtx.Ddb->SetFlip(over.GetFlip());
         overtx.Ddb->SetRotation(over.rotation);
         overtx.Ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
         overtx.Ddb->SetBlendMode(over.blendMode);

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -117,10 +117,9 @@ void DynamicSprite_Resize(ScriptDynamicSprite *sds, int width, int height) {
 }
 
 void DynamicSprite_Flip(ScriptDynamicSprite *sds, int direction) {
-    if ((direction < 1) || (direction > 3))
-        quit("!DynamicSprite.Flip: invalid direction");
     if (sds->slot == 0)
         quit("!DynamicSprite.Flip: sprite has been deleted");
+    GraphicFlip flip = ValidateFlip("DynamicSprite.Flip", direction);
 
     // resize the sprite to the requested size
     Bitmap *sprite = spriteset[sds->slot];
@@ -128,7 +127,7 @@ void DynamicSprite_Flip(ScriptDynamicSprite *sds, int direction) {
         BitmapHelper::CreateTransparentBitmap(sprite->GetWidth(), sprite->GetHeight(), sprite->GetColorDepth()));
 
     // AGS script FlipDirection corresponds to internal GraphicFlip
-    new_pic->FlipBlt(sprite, 0, 0, static_cast<GraphicFlip>(direction));
+    new_pic->FlipBlt(sprite, 0, 0, flip);
 
     add_dynamic_sprite(sds->slot, std::move(new_pic));
     game_sprite_updated(sds->slot);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -625,6 +625,16 @@ bool ValidateSaveSlotRange(const char *api_name, int &min_slot, int &max_slot)
     return true;
 }
 
+GraphicFlip ValidateFlip(const char *apiname, int flip)
+{
+    if ((flip < kFlip_None) || (flip > kFlip_Both))
+    {
+        debug_script_warn("%s: invalid flip parameter (%d)", apiname, flip);
+        return kFlip_None;
+    }
+    return static_cast<GraphicFlip>(flip);
+}
+
 void AssertView(const char *apiname, int view)
 {
     // NOTE: we assume (here and below) that the view is already in an internal 0-based range.

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -71,6 +71,8 @@ ScriptSaveGameSortStyle ValidateSaveGameSort(const char *apiname, int save_sort)
 ScriptSortDirection ValidateSortDirection(const char *apiname, int sort_dir);
 // Save slot range validation; fixups min and max slots, returns if the resulting range is non-empty
 bool ValidateSaveSlotRange(const char *api_name, int &min_slot, int &max_slot);
+// Graphic parameter validation.
+Common::GraphicFlip ValidateFlip(const char *apiname, int flip);
 
 // View, loop, frame parameter assertions.
 // WARNING: these functions assume that view is already in an internal 0-based range.

--- a/Engine/ac/global_screen.cpp
+++ b/Engine/ac/global_screen.cpp
@@ -14,6 +14,7 @@
 #include "ac/common.h"
 #include "ac/gamesetup.h"
 #include "ac/draw.h"
+#include "ac/game.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
@@ -38,9 +39,9 @@ extern AGSPlatformDriver *platform;
 extern RGB palette[256];
 extern unsigned int loopcounter;
 
-void FlipScreen(int amount) {
-    if ((amount<0) | (amount>3)) quit("!FlipScreen: invalid argument (0-3)");
-    play.screen_flipped=amount;
+void FlipScreen(int direction) {
+    direction = ValidateFlip("FlipScreen", direction);
+    play.screen_flipped = direction;
 }
 
 class ShakeScreenState : public GameState

--- a/Engine/ac/global_screen.h
+++ b/Engine/ac/global_screen.h
@@ -18,7 +18,7 @@
 #ifndef __AGS_EE_AC__GLOBALSCREEN_H
 #define __AGS_EE_AC__GLOBALSCREEN_H
 
-void FlipScreen(int amount);
+void FlipScreen(int direction);
 void ShakeScreen(int severe);
 void ShakeScreenBackground (int delay, int amount, int length);
 void TintScreen(int red, int grn, int blu);

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -20,6 +20,7 @@
 #include "ac/characterextras.h"
 #include "ac/display.h"
 #include "ac/draw.h"
+#include "ac/game.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/global_translation.h"
@@ -194,6 +195,18 @@ void Overlay_SetWidth(ScriptOverlay *scover, int width)
 void Overlay_SetHeight(ScriptOverlay *scover, int height) {
     auto *over = GetOverlayValidate("Overlay.Height", scover);
     Overlay_SetScaledSize(*over, over->scaleWidth, height);
+}
+
+int Overlay_GetFlip(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.Flip", scover);
+    return over->GetFlip();
+}
+
+void Overlay_SetFlip(ScriptOverlay *scover, int flip)
+{
+    auto *over = GetOverlayValidate("Overlay.Flip", scover);
+    over->SetFlip(ValidateFlip("Overlay.Flip", flip));
 }
 
 int Overlay_GetValid(ScriptOverlay *scover)
@@ -831,6 +844,16 @@ RuntimeScriptValue Sc_Overlay_SetBlendMode(void *self, const RuntimeScriptValue 
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_Overlay_GetFlip(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetFlip);
+}
+
+RuntimeScriptValue Sc_Overlay_SetFlip(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetFlip);
+}
+
 RuntimeScriptValue Sc_Overlay_GetRotation(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_FLOAT(ScriptOverlay, Overlay_GetRotation);
@@ -1001,6 +1024,8 @@ void RegisterOverlayAPI()
         { "Overlay::set_BlendMode",       API_FN_PAIR(Overlay_SetBlendMode) },
         { "Overlay::get_Rotation",        API_FN_PAIR(Overlay_GetRotation) },
         { "Overlay::set_Rotation",        API_FN_PAIR(Overlay_SetRotation) },
+        { "Overlay::get_Flip",            API_FN_PAIR(Overlay_GetFlip) },
+        { "Overlay::set_Flip",            API_FN_PAIR(Overlay_SetFlip) },
     };
 
     ccAddExternalFunctions(overlay_api);

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -93,6 +93,12 @@ void ScreenOverlay::SetSpriteNum(int sprnum, int offx, int offy)
     MarkChanged();
 }
 
+void ScreenOverlay::SetFlip(GraphicFlip flip)
+{
+    _spritetf = GfxDef::GetFlagsFromFlip(flip);
+    MarkChanged();
+}
+
 void ScreenOverlay::SetTint(int red, int green, int blue, int opacity, int luminance)
 {
     tint_r = red;
@@ -180,7 +186,7 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
         tint_level = in->ReadInt8();
         tint_light = in->ReadInt32(); // tint light (or light level)
         // Reserved for transform options
-        in->ReadInt32(); // sprite transform flags1
+        _spritetf = (SpriteTransformFlags)in->ReadInt32(); // sprite transform flags1
         in->ReadInt32(); // sprite transform flags2
         in->ReadInt32(); // transform scale x
         in->ReadInt32(); // transform scale y
@@ -234,7 +240,7 @@ void ScreenOverlay::WriteToSavegame(Stream *out) const
     out->WriteInt8(tint_level);
     out->WriteInt32(tint_light); // tint light (or light level)
     // Reserved for transform options
-    out->WriteInt32(0); // sprite transform flags1
+    out->WriteInt32(_spritetf); // sprite transform flags1
     out->WriteInt32(0); // sprite transform flags2
     out->WriteInt32(0); // transform scale x
     out->WriteInt32(0); // transform scale y

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -100,6 +100,7 @@ struct ScreenOverlay
     bool IsSpriteShared() const { return (_flags & kOver_SpriteShared) != 0; }
     bool IsAutoPosition() const { return (_flags & kOver_AutoPosition) != 0; }
     bool IsRoomLayer() const { return (_flags & kOver_RoomLayer) != 0; }
+    Common::GraphicFlip GetFlip() const { return Common::GfxDef::GetFlipFromFlags(_spritetf); }
     bool HasTint() const { return (_flags & kOver_HasTint) != 0; }
     bool HasLightLevel() const { return (_flags & kOver_HasLightLevel) != 0; }
     void SetAutoPosition(int for_character)
@@ -128,6 +129,8 @@ struct ScreenOverlay
     void SetImage(std::unique_ptr<Common::Bitmap> pic, int offx = 0, int offy = 0);
     // Assigns a shared sprite to this overlay
     void SetSpriteNum(int sprnum, int offx = 0, int offy = 0);
+    // Assigns flip setting
+    void SetFlip(Common::GraphicFlip flip);
     // Assigns tint settings
     void SetTint(int red, int green, int blue, int opacity, int luminance);
     // Assigns light level
@@ -152,6 +155,7 @@ private:
 
     int _flags = 0; // OverlayFlags
     int _sprnum = 0; // sprite id
+    Common::SpriteTransformFlags _spritetf = Common::kSprTf_None;
     bool _hasChanged = false;
 };
 


### PR DESCRIPTION
By user request, this implements Overlay.Flip property that flips overlay graphic in 3 possible ways.

```
/// Gets/sets the flip direction of this overlay.
attribute eFlipDirection Overlay.Flip;
```

For storage and serialization this uses a new field of type "SpriteTransformationFlags", and a position which was reserved in ags4 save format a while ago. It has flip flags now, but more could be added later as necessary. There's a conversion between script parameter and this new flag set.

NOTE: Software renderer has some bugs in ags4 branch, so switching from some flip to "no flip" does not update the overlay image. I'm planning to address that separately, there's a unfinished code brought by one of the older merges, that was never made to work in completion.
