### PR TITLE
[WIP] AGS 4.0: rewrite ccInstance into non-forking ScriptExecutor

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -213,7 +213,7 @@ HGameFileError OpenMainGameFileFromDefaultAsset(MainGameSource &src, AssetManage
     return OpenMainGameFileBase(src);
 }
 
-HGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVersion data_ver)
+HGameFileError ReadDialogScript(UScript &dialog_script, Stream *in, GameDataVersion data_ver)
 {
     dialog_script.reset(ccScript::CreateFromStream(in));
     if (dialog_script == nullptr)
@@ -221,7 +221,7 @@ HGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVers
     return HGameFileError::None();
 }
 
-HGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, GameDataVersion data_ver)
+HGameFileError ReadScriptModules(std::vector<UScript> &sc_mods, Stream *in, GameDataVersion data_ver)
 {
     int count = in->ReadInt32();
     sc_mods.resize(count);

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -118,9 +118,9 @@ struct LoadedGameEntities
     GUICollection           GuiControls;
     std::vector<DialogTopic> Dialogs;
     std::vector<ViewStruct> Views;
-    PScript                 GlobalScript;
-    PScript                 DialogScript;
-    std::vector<PScript>    ScriptModules;
+    UScript                 GlobalScript;
+    UScript                 DialogScript;
+    std::vector<UScript>    ScriptModules;
     std::vector<PluginInfo> PluginInfos;
 
     // Original sprite data (when it was read into const-sized arrays)

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -11,7 +11,6 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #include "ac/common.h" // quit
 #include "game/room_file.h"
 #include "game/roomstruct.h"

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -41,13 +41,10 @@
 #include "ac/common_defines.h"
 #include "game/interactions.h"
 #include "gfx/gfx_def.h"
+#include "script/cc_script.h"
 #include "util/error.h"
 #include "util/geometry.h"
 #include "util/string_types.h"
-
-struct ccScript;
-struct SpriteInfo;
-typedef std::shared_ptr<ccScript> PScript;
 
 // TODO: move the following enums under AGS::Common namespace
 // later, when more engine source is put in AGS namespace and
@@ -316,10 +313,9 @@ public:
     // Event script links
     UInteractionEvents      EventHandlers;
     // Compiled room script
-    PScript                 CompiledScript;
+    UScript                 CompiledScript;
     // Various extended options with string values, meta-data etc
     StringMap               StrOptions;
-
 };
 
 

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -114,6 +114,7 @@
 #define CC_NUM_SCCMDS     76
 #define MAX_SCMD_ARGS     3     // maximal possible number of arguments
 
+#define EXPORT_NONE       0
 #define EXPORT_FUNCTION   1
 #define EXPORT_DATA       2
 

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -252,6 +252,21 @@ void RTTISerializer::Write(const RTTI &rtti, Stream *out)
     out->Seek(end_soff, kSeekBegin);
 }
 
+RTTI::RTTI(const RTTI &rtti)
+{
+    *this = rtti;
+}
+
+RTTI &RTTI::operator=(const RTTI &rtti)
+{
+    _locs = rtti._locs;
+    _types = rtti._types;
+    _fields = rtti._fields;
+    _strings = rtti._strings;
+    CreateQuickRefs();
+    return *this;
+}
+
 const RTTI::Location *RTTI::FindLocationByLocalID(uint32_t loc_id) const
 {
     if (loc_id >= _locs.size())
@@ -783,6 +798,28 @@ void ScriptTOCSerializer::Write(const ScriptTOC &toc, Stream *out)
     out->WriteInt32((uint32_t)(str_soff - toc_soff)); // strings table offset
     out->WriteInt32(toc._strings.size()); // string table size
     out->Seek(end_soff, kSeekBegin);
+}
+
+ScriptTOC::ScriptTOC(const ScriptTOC &toc)
+{
+    *this = toc;
+}
+
+ScriptTOC &ScriptTOC::operator=(const ScriptTOC &toc)
+{
+    _glVariables = toc._glVariables;
+    _locVariables = toc._locVariables;
+    _functions = toc._functions;
+    _fparams = toc._fparams;
+    _strings = toc._strings;
+    // FIXME: this is dangerous because of how RTTI is referenced using raw pointer
+    CreateQuickRefs(toc._rtti);
+    return *this;
+}
+
+void ScriptTOC::RebindRTTI(RTTI *rtti)
+{
+    CreateQuickRefs(rtti);
 }
 
 void ScriptTOC::CreateQuickRefs(const RTTI *rtti)

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -193,10 +193,10 @@ public:
         _strings.push_back(0); // guarantee zero-len string at index 0
     }
 
-    RTTI(const RTTI &rtti) = default;
+    RTTI(const RTTI &rtti);
     RTTI(RTTI &&rtti) = default;
 
-    RTTI &operator = (const RTTI &rtti) = default;
+    RTTI &operator = (const RTTI &rtti);
     RTTI &operator = (RTTI &&rtti) = default;
 
     bool IsEmpty() const { return _types.empty(); }
@@ -454,11 +454,11 @@ public:
         _strings.push_back(0); // guarantee zero-len string at index 0
     }
 
-    ScriptTOC(const ScriptTOC &rtti) = default;
-    ScriptTOC(ScriptTOC &&rtti) = default;
+    ScriptTOC(const ScriptTOC &toc);
+    ScriptTOC(ScriptTOC &&toc) = default;
 
-    ScriptTOC &operator = (const ScriptTOC &rtti) = default;
-    ScriptTOC &operator = (ScriptTOC &&rtti) = default;
+    ScriptTOC &operator = (const ScriptTOC &toc);
+    ScriptTOC &operator = (ScriptTOC &&toc) = default;
 
     bool IsEmpty() const { return _glVariables.empty() && _functions.empty(); }
     // Returns list of global variables
@@ -467,6 +467,10 @@ public:
     const std::vector<Variable> &GetLocalVariables() const { return _locVariables; }
     // Returns list of functions
     const std::vector<Function> &GetFunctions() const { return _functions; }
+
+    // Rebinds ScriptTOC collection with another RTTI object,
+    // updates "quick references"
+    void RebindRTTI(RTTI *rtti);
 
     //
     // Various helpers

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -108,8 +108,6 @@ ccScript &ccScript::operator =(const ccScript &src)
     sectionNames = src.sectionNames;
     sectionOffsets = src.sectionOffsets;
     rtti.reset(new RTTI(*src.rtti));
-
-    instances = 0; // don't copy reference count, since it's a new object
     return *this;
 }
 
@@ -171,7 +169,6 @@ void ccScript::Write(Stream *out)
 
 bool ccScript::Read(Stream *in)
 {
-    instances = 0;
     currentline = -1;
 
     char gotsig[5]{};

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -35,10 +35,10 @@ public:
     static const std::string unknownSectionName;
 
     std::string scriptname;
-    std::vector<char> globaldata;
+    std::vector<uint8_t> globaldata;
     std::vector<int32_t> code;    // executable byte-code, 32-bit per op or arg
     std::vector<char> strings;
-    std::vector<char> fixuptypes; // global data/string area/ etc
+    std::vector<uint8_t> fixuptypes; // global data/string area/ etc
     std::vector<int32_t> fixups;  // code array index to fixup (in ints)
     std::vector<std::string> imports; // names of imports
     std::vector<std::string> exports; // names of exports
@@ -50,8 +50,6 @@ public:
     // Extended information (optional)
     std::unique_ptr<RTTI> rtti;
     std::unique_ptr<ScriptTOC> sctoc;
-
-    int instances = 0; // reference count for this script object
 
     static ccScript *CreateFromStream(Common::Stream *in);
     static ccScript *CreateFromStream(const std::string &name, Common::Stream *in);
@@ -74,6 +72,6 @@ public:
     bool        Read(Common::Stream *in);
 };
 
-typedef std::shared_ptr<ccScript> PScript;
+typedef std::unique_ptr<ccScript> UScript;
 
 #endif // __CC_SCRIPT_H

--- a/Editor/AGS.Native/CompiledScript.h
+++ b/Editor/AGS.Native/CompiledScript.h
@@ -28,18 +28,17 @@ using namespace AGS::Types;
 public ref class CompiledScript : ICompiledScript
 {
 private:
-	PScript* _compiledScript;
+	UScript* _compiledScript;
 public:
-	CompiledScript(PScript script) 
+	CompiledScript(UScript &&script) 
 	{
-		_compiledScript = new PScript();
-		*_compiledScript = script;
+		_compiledScript = new UScript(std::move(script));
 	}
 
-	property PScript Data
+	property UScript &Data
 	{
-		PScript get() { return *_compiledScript; }
-		void set(PScript newScript) { *_compiledScript = newScript; }
+		UScript &get() { return *_compiledScript; }
+		void set(UScript &newScript) { *_compiledScript = std::move(newScript); }
 	}
 
 	~CompiledScript() 

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -134,7 +134,7 @@ public:
         }
 
         // Success, create new CompiledData
-        return gcnew CompiledScript(PScript(cc_script.release()));
+        return gcnew CompiledScript(std::move(cc_script));
     }
 };
 
@@ -223,7 +223,7 @@ public:
         }
 
         // Success, create new CompiledData
-        return gcnew CompiledScript(PScript(cc_script.release()));
+        return gcnew CompiledScript(std::move(cc_script));
     }
 };
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3057,7 +3057,7 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
     // Prepare script links
     convert_room_interactions_to_native(room, rs);
     if (room->Script && room->Script->CompiledData)
-	    rs.CompiledScript = ((AGS::Native::CompiledScript^)room->Script->CompiledData)->Data;
+	    rs.CompiledScript = std::move(((AGS::Native::CompiledScript^)room->Script->CompiledData)->Data);
 
     // Encoding hint
     rs.StrOptions["textencoding"].Format("%d", tcv->GetEncoding()->CodePage);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -43,10 +43,10 @@
 #include "ac/system.h"
 #include "debug/debug_log.h"
 #include "font/fonts.h"
-#include "script/cc_instance.h"
 #include "main/game_run.h"
 #include "platform/base/agsplatformdriver.h"
 #include "script/script.h"
+#include "script/scriptexecutor.h"
 #include "ac/spritecache.h"
 #include "gfx/ddb.h"
 #include "gfx/gfx_util.h"
@@ -202,7 +202,7 @@ static int run_dialog_request(int parmtr)
 {
     play.stop_dialog_at_end = DIALOG_RUNNING;
     RuntimeScriptValue params[]{ parmtr };
-    RunScriptFunction(gameinst.get(), "dialog_request", 1, params);
+    RunScriptFunction(gamescript.get(), "dialog_request", 1, params);
 
     if (play.stop_dialog_at_end == DIALOG_STOP)
     {
@@ -248,13 +248,13 @@ int run_dialog_script(int dialogID, int offse, int optionIndex)
   said_speech_line = 0;
   int result = RUN_DIALOG_STAY;
 
-  if (dialogScriptsInst)
+  if (dialogScriptsScript)
   {
     char func_name[100];
     snprintf(func_name, sizeof(func_name), "_run_dialog%d", dialogID);
     RuntimeScriptValue params[]{ optionIndex };
-    RunScriptFunction(dialogScriptsInst.get(), func_name, 1, params);
-    result = dialogScriptsInst->GetReturnValue();
+    RunScriptFunction(dialogScriptsScript.get(), func_name, 1, params);
+    result = scriptExecutor->GetReturnValue();
   }
 
   if (in_new_room > 0)
@@ -1365,16 +1365,16 @@ bool is_in_dialog()
 // TODO: this is ugly, but I could not come to a better solution at the time...
 void set_dialog_result_goto(int dlgnum)
 {
-    assert(dialogExec && dialogScriptsInst);
-    if (dialogScriptsInst)
-        dialogScriptsInst->SetReturnValue(dlgnum);
+    assert(dialogExec && scriptExecutor && scriptExecutor->GetRunningScript() == dialogScriptsScript.get());
+    if (scriptExecutor)
+        scriptExecutor->SetReturnValue(dlgnum);
 }
 
 void set_dialog_result_stop()
 {
-    assert(dialogExec && dialogScriptsInst);
-    if (dialogScriptsInst)
-        dialogScriptsInst->SetReturnValue(RUN_DIALOG_STOP_DIALOG);
+    assert(dialogExec && scriptExecutor && scriptExecutor->GetRunningScript() == dialogScriptsScript.get());
+    if (scriptExecutor)
+        scriptExecutor->SetReturnValue(RUN_DIALOG_STOP_DIALOG);
 }
 
 bool handle_state_change_in_dialog_request(const char *apiname, int dlgreq_retval)

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -13,14 +13,14 @@
 //=============================================================================
 #include "cc_dynamicarray.h"
 #include <string.h>
-#include "ac/dynobj/managedobjectpool.h"
 #include "ac/dynobj/dynobj_manager.h"
-#include "script/cc_instance.h"
-#include "script/cc_script.h" // RTTI
-#include "util/memorystream.h"
+#include "ac/dynobj/managedobjectpool.h"
 #include "ac/dynobj/scriptstring.h"
+#include "script/runtimescript.h"
+#include "util/memorystream.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 const char *CCDynamicArray::TypeName = "CCDynamicArr2";
 
@@ -81,8 +81,8 @@ void CCDynamicArray::Unserialize(int index, Stream *in, size_t data_sz)
     Header &hdr = reinterpret_cast<Header&>(*new_arr);
     if (type_id > 0)
     {
-        assert(ccInstance::GetRTTI()->GetTypes().size() > type_id);
-        is_managed = (ccInstance::GetRTTI()->GetTypes()[type_id].flags & RTTI::kType_Managed) != 0;
+        assert(RuntimeScript::GetJointRTTI()->GetTypes().size() > type_id);
+        is_managed = (RuntimeScript::GetJointRTTI()->GetTypes()[type_id].flags & RTTI::kType_Managed) != 0;
     }
     hdr.TypeID = type_id | (ARRAY_MANAGED_TYPE_FLAG * is_managed);
     hdr.ElemCount = elem_count;
@@ -120,8 +120,8 @@ void CCDynamicArray::TraverseRefs(void *address, PfnTraverseRefOp traverse_op)
     const RTTI::Type *ti = nullptr;
     if (type_id > 0)
     {
-        assert(ccInstance::GetRTTI()->GetTypes().size() > type_id);
-        ti = &ccInstance::GetRTTI()->GetTypes()[type_id];
+        assert(RuntimeScript::GetJointRTTI()->GetTypes().size() > type_id);
+        ti = &RuntimeScript::GetJointRTTI()->GetTypes()[type_id];
     }
 
     // Dynamic array of managed pointers: subref them directly
@@ -136,7 +136,7 @@ void CCDynamicArray::TraverseRefs(void *address, PfnTraverseRefOp traverse_op)
     // Dynamic array of regular structs that *may* contain managed pointers
     else if (ti && (ti->flags & RTTI::kType_Struct))
     {
-        const auto fref = ccInstance::GetRTTIHelper()->GetManagedOffsetsForType(type_id);
+        const auto fref = RuntimeScript::GetRTTIHelper()->GetManagedOffsetsForType(type_id);
         if (fref.second > fref.first)
         { // there are managed pointers inside!
             const uint8_t *elem_ptr = static_cast<const uint8_t*>(address);

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -17,11 +17,12 @@
 #include "ac/dynobj/managedobjectpool.h"
 #include "ac/dynobj/cc_dynamicarray.h"
 #include "script/cc_script.h"
-#include "script/cc_instance.h"
+#include "script/runtimescript.h"
 #include "util/memorystream.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 const char *ScriptUserObject::TypeName = "UserObj2";
 
@@ -106,8 +107,8 @@ void ScriptUserObject::TraverseRefs(void *address, PfnTraverseRefOp traverse_op)
     const Header &hdr = GetHeader(address);
     if (hdr.TypeId == 0u)
         return;
-    assert(ccInstance::GetRTTI()->GetTypes().size() > hdr.TypeId);
-    const auto *helper = ccInstance::GetRTTIHelper();
+    assert(RuntimeScript::GetJointRTTI()->GetTypes().size() > hdr.TypeId);
+    const auto *helper = RuntimeScript::GetRTTIHelper();
     const auto fref = helper->GetManagedOffsetsForType(hdr.TypeId);
     for (auto it = fref.first; it < fref.second; ++it)
     {

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -81,9 +81,9 @@ void run_claimable_event(const String &tsname, bool includeRoom, int numParams, 
     int eventClaimedOldValue = eventClaimed;
     eventClaimed = EVENT_INPROGRESS;
 
-    if (includeRoom && roominst)
+    if (includeRoom && roomscript)
     {
-        RunScriptFunction(roominst.get(), tsname, numParams, params);
+        RunScriptFunction(roomscript.get(), tsname, numParams, params);
         if (eventClaimed == EVENT_CLAIMED)
         {
             eventClaimed = eventClaimedOldValue;
@@ -92,9 +92,9 @@ void run_claimable_event(const String &tsname, bool includeRoom, int numParams, 
     }
 
     // run script modules
-    for (auto &module_inst : moduleInst)
+    for (auto &module_script : scriptModules)
     {
-        RunScriptFunction(module_inst.get(), tsname, numParams, params);
+        RunScriptFunction(module_script.get(), tsname, numParams, params);
         if (eventClaimed == EVENT_CLAIMED)
         {
             eventClaimed = eventClaimedOldValue;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -319,7 +319,7 @@ int RunAGSGame(const String &newgame, unsigned int mode, int data) {
 
         if (inside_script) {
             curscript->QueueAction(PostScriptAction(ePSARunAGSGame, mode | RAGMODE_LOADNOW, "RunAGSGame"));
-            ccInstance::GetCurrentInstance()->Abort();
+            scriptExecutor->Abort();
         }
         else
             load_new_game = mode | RAGMODE_LOADNOW;

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -37,7 +37,6 @@
 #include "ac/dynobj/cc_guiobject.h"
 #include "ac/dynobj/scriptobjects.h"
 #include "ac/dynobj/dynobj_manager.h"
-#include "script/cc_instance.h"
 #include "debug/debug_log.h"
 #include "device/mousew32.h"
 #include "gfx/gfxfilter.h"

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -410,12 +410,12 @@ HError LoadRoomScript(RoomStruct *room, int newnum)
     auto in = AssetMgr->OpenAsset(filename);
     if (in)
     {
-        PScript script(ccScript::CreateFromStream(in.get()));
+        auto script = UScript(ccScript::CreateFromStream(in.get()));
         if (!script)
             return new Error(String::FromFormat(
                 "Failed to load a script module: %s", filename.GetCStr()),
                 cc_get_error().ErrorString);
-        room->CompiledScript = script;
+        room->CompiledScript = std::move(script);
     }
     return HError::None();
 }
@@ -908,16 +908,14 @@ void check_new_room() {
 void compile_room_script() {
     cc_clear_error();
 
-    roominst = ccInstance::CreateFromScript(thisroom.CompiledScript);
+    roominst = ccInstance::CreateFromScript(RuntimeScript::Create(thisroom.CompiledScript.get(), "R"));
     if ((cc_has_error()) || (roominst==nullptr)) {
         quitprintf("Unable to create local script:\n%s", cc_get_error().ErrorString.GetCStr());
     }
 
-    if (!roominst->ResolveScriptImports())
+    roominst->GetScript()->RegisterExports(simp);
+    if (!roominst->GetScript()->ResolveImports(simp))
         quitprintf("Unable to resolve imports in room script:\n%s", cc_get_error().ErrorString.GetCStr());
-
-    if (!roominst->ResolveImportFixups())
-        quitprintf("Unable to resolve import fixups in room script:\n%s", cc_get_error().ErrorString.GetCStr());
 
     roominstFork = roominst->Fork();
     if (roominstFork == nullptr)

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -51,7 +51,6 @@
 #include "ac/dynobj/managedobjectpool.h"
 #include "ac/dynobj/scriptpathfinder.h"
 #include "gui/guimain.h"
-#include "script/cc_instance.h"
 #include "debug/debug_log.h"
 #include "debug/debugger.h"
 #include "debug/out.h"
@@ -274,12 +273,14 @@ ScriptPathfinder* Room_GetPathFinder()
 
 //=============================================================================
 
-void save_room_data_segment () {
+void save_room_data_segment ()
+{
     croom->FreeScriptData();
     
-    const auto &globaldata = roominst->GetGlobalData();
+    const auto &globaldata = roomscript->GetGlobalData();
     croom->tsdatasize = globaldata.size();
-    if (croom->tsdatasize > 0) {
+    if (croom->tsdatasize > 0)
+    {
         croom->tsdata.resize(croom->tsdatasize);
         memcpy(croom->tsdata.data(),&globaldata[0],croom->tsdatasize);
     }
@@ -316,7 +317,7 @@ void unload_old_room()
     }
 
     if (croom==nullptr) ;
-    else if (roominst!=nullptr) {
+    else if (roomscript) {
         save_room_data_segment();
         FreeRoomScriptInstance();
     }
@@ -630,14 +631,14 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             StopMoving(cc);
     }
 
-    roominst=nullptr;
+    roomscript = nullptr;
     if (debug_flags & DBG_NOSCRIPT) ;
     else if (thisroom.CompiledScript)
     {
         compile_room_script();
         if (been_here)
         {
-            const auto &globaldata = roominst->GetGlobalData();
+            const auto &globaldata = roomscript->GetGlobalData();
             if (croom->tsdatasize > globaldata.size())
             {
                 quitprintf("Restored Room %d script data size exceeds current script data (%zu vs %zu bytes).",
@@ -648,7 +649,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
                 Debug::Printf(kDbgMsg_Warn, "WARNING: Restored Room %d script data size is less than the current script data (%zu vs %zu bytes)",
                     newnum, croom->tsdatasize, globaldata.size());
             }
-            roominst->CopyGlobalData(croom->tsdata);
+            roomscript->CopyGlobalData(croom->tsdata);
         }
     }
     set_our_eip(207);
@@ -908,18 +909,14 @@ void check_new_room() {
 void compile_room_script() {
     cc_clear_error();
 
-    roominst = ccInstance::CreateFromScript(RuntimeScript::Create(thisroom.CompiledScript.get(), "R"));
-    if ((cc_has_error()) || (roominst==nullptr)) {
+    roomscript = RuntimeScript::Create(thisroom.CompiledScript.get(), "R");
+    if ((cc_has_error()) || (roomscript==nullptr)) {
         quitprintf("Unable to create local script:\n%s", cc_get_error().ErrorString.GetCStr());
     }
 
-    roominst->GetScript()->RegisterExports(simp);
-    if (!roominst->GetScript()->ResolveImports(simp))
+    roomscript->RegisterExports(simp);
+    if (!roomscript->ResolveImports(simp))
         quitprintf("Unable to resolve imports in room script:\n%s", cc_get_error().ErrorString.GetCStr());
-
-    roominstFork = roominst->Fork();
-    if (roominstFork == nullptr)
-        quitprintf("Unable to create forked room instance:\n%s", cc_get_error().ErrorString.GetCStr());
 
     repExecAlways.RoomHasFunction = true;
     lateRepExecAlways.RoomHasFunction = true;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -465,9 +465,9 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
 
     // Optionally dump joint RTTI into the log
-    if (logScriptRTTI && ccInstance::GetRTTI())
+    if (logScriptRTTI && RuntimeScript::GetJointRTTI())
     {
-        Debug::Printf(PrintRTTI(ccInstance::GetRTTI()->AsConstRTTI()));
+        Debug::Printf(PrintRTTI(RuntimeScript::GetJointRTTI()->AsConstRTTI()));
     }
     // Optionally dump room script's TOC into the log
     if (logScriptTOC && thisroom.CompiledScript && thisroom.CompiledScript->sctoc)

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -377,16 +377,8 @@ static void debug_script_print_impl(const String &msg, MessageType mt)
     String script_ref;
     ccInstance *curinst = ccInstance::GetCurrentInstance();
     if (curinst != nullptr) {
-        String scriptname;
-        if (curinst->GetScript() == gamescript)
-            scriptname = "G ";
-        else if (curinst->GetScript() == thisroom.CompiledScript)
-            scriptname = "R ";
-        else if (curinst->GetScript() == dialogScriptsScript)
-            scriptname = "D ";
-        else
-            scriptname = "? ";
-        script_ref.Format("[%s%d]", scriptname.GetCStr(), currentline);
+        String scriptname = curinst->GetScript()->GetTag();
+        script_ref.Format("[%s %d]", scriptname.GetCStr(), currentline);
     }
 
     Debug::Printf(kDbgGroup_Game, mt, "(room:%d)%s %s", displayed_room, script_ref.GetCStr(), msg.GetCStr());
@@ -675,7 +667,7 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
 
     if (pluginsWantingDebugHooks > 0) {
         // a plugin is handling the debugging
-        String scname = GetScriptName(ccinst);
+        String scname = ccinst->GetScript()->GetScriptName();
         pl_run_plugin_debug_hooks(scname.GetCStr(), linenum);
         return;
     }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -375,9 +375,8 @@ void shutdown_debug()
 static void debug_script_print_impl(const String &msg, MessageType mt)
 {
     String script_ref;
-    ccInstance *curinst = ccInstance::GetCurrentInstance();
-    if (curinst != nullptr) {
-        String scriptname = curinst->GetScript()->GetTag();
+    if (scriptExecutor && scriptExecutor->GetRunningScript()) {
+        String scriptname = scriptExecutor->GetRunningScript()->GetTag();
         script_ref.Format("[%s %d]", scriptname.GetCStr(), currentline);
     }
 
@@ -592,7 +591,7 @@ int check_for_messages_from_debugger()
             String req_id(req_id_str + 1, var_ref_str - req_id_str - 1);
             String var_ref(var_ref_str + 1, end_str - var_ref_str - 1);
             MemoryInspect::VariableInfo var_info;
-            HError err = MemoryInspect::QueryScriptVariableInContext(var_ref, var_info);
+            HError err = MemoryInspect::QueryScriptVariableInContext(scriptExecutor.get(), var_ref, var_info);
             std::vector<std::pair<String, String>> values;
             values.push_back(std::make_pair("ReqID", req_id));
             if (err)
@@ -663,23 +662,22 @@ int scrDebugWait = 0;
 extern int pluginsWantingDebugHooks;
 
 // allow LShift to single-step,  RShift to pause flow
-void scriptDebugHook (ccInstance *ccinst, int linenum) {
+void scriptDebugHook(ScriptExecutor *exec, int linenum)
+{
+    if (!exec || !exec->GetRunningScript())
+    {
+        return; // not inside script
+    }
 
-    if (pluginsWantingDebugHooks > 0) {
+    if (pluginsWantingDebugHooks > 0)
+    {
         // a plugin is handling the debugging
-        String scname = ccinst->GetScript()->GetScriptName();
+        String scname = exec->GetRunningScript()->GetScriptName();
         pl_run_plugin_debug_hooks(scname.GetCStr(), linenum);
         return;
     }
 
     // no plugin, use built-in debugger
-
-    if (ccinst == nullptr) 
-    {
-        // come out of script
-        return;
-    }
-
     if (break_on_next_script_step) 
     {
         break_on_next_script_step = 0;
@@ -687,7 +685,7 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
         return;
     }
 
-    String scriptName = ccinst->GetRunningInst()->GetScript()->GetSectionName(ccinst->GetPC());
+    String scriptName = exec->GetRunningScript()->GetSectionName(exec->GetPC());
     for (const auto & breakpoint : breakpoints)
     {
         if ((breakpoint.lineNumber == linenum) &&

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -19,8 +19,6 @@
 #include "util/ini_util.h"
 #include "util/string.h"
 
-class ccInstance;
-
 void init_debug(const AGS::Common::ConfigTree &cfg, bool stderr_only);
 void apply_debug_config(const AGS::Common::ConfigTree &cfg, bool finalize);
 void shutdown_debug();
@@ -38,9 +36,11 @@ void debug_script_log(const char *msg, ...);
 // Same as quit(), but with message formatting
 void quitprintf(const char *texx, ...);
 
+namespace AGS { namespace Engine { class ScriptExecutor; } }
+
 // Connect engine to external debugger, if one is available
 bool init_editor_debugging(const AGS::Common::ConfigTree &cfg);
 // allow LShift to single-step,  RShift to pause flow
-void scriptDebugHook (ccInstance *ccinst, int linenum) ;
+void scriptDebugHook(AGS::Engine::ScriptExecutor *exec, int linenum) ;
 
 #endif // __AC_DEBUG_LOG_H

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -11,14 +11,13 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #ifndef __AC_DEBUGGER_H
 #define __AC_DEBUGGER_H
 
 #include "util/string.h"
 
 struct IAGSEditorDebugger;
-struct ScriptPosition;
+namespace AGS { namespace Engine { struct ScriptPosition; } }
 
 extern int editor_debugging_enabled;
 extern int editor_debugging_initialized;
@@ -29,7 +28,7 @@ extern int break_on_next_script_step;
 int check_for_messages_from_debugger();
 bool send_state_to_debugger(const char *msg);
 bool send_exception_to_debugger(const char *qmsg);
-bool get_script_position(ScriptPosition &script_pos);
+bool get_script_position(AGS::Engine::ScriptPosition &script_pos);
 
 void check_debug_keys();
 

--- a/Engine/debug/memory_inspect.cpp
+++ b/Engine/debug/memory_inspect.cpp
@@ -36,6 +36,7 @@
 #include "ac/dynobj/dynobj_manager.h"
 #include "script/cc_common.h"
 #include "script/cc_instance.h"
+#include "script/runtimescript.h"
 #include "script/systemimports.h"
 #include "util/compress.h"
 #include "util/string_utils.h"
@@ -339,10 +340,10 @@ static bool TryGetGlobalVariable(const String &field_ref, const ccInstance *inst
     // Select the actual script at the top of the stack
     // (this could be a different script runnin on this instance, in case of far calls)
     const ccInstance *top_inst = inst->GetRunningInst();
-    if (!top_inst->GetScript()->sctoc)
+    if (!top_inst->GetScript()->GetTOC())
         return false; // no TOC
 
-    const auto &toc = *top_inst->GetScript()->sctoc;
+    const auto &toc = *top_inst->GetScript()->GetTOC();
     if (toc.GetGlobalVariables().empty())
         return false; // no global data
 
@@ -366,12 +367,12 @@ static bool TryGetGlobalVariable(const String &field_ref, const ccInstance *inst
         if (!import)
             return false;
 
-        if (import->InstancePtr)
+        if (import->ScriptPtr)
         {
             // Import from another script
             found_var = MemoryVariable(&var,
                 import->Value.GetDirectPtr(), nullptr,
-                import->InstancePtr->GetGlobalData().size());
+                import->ScriptPtr->GetGlobalData().size());
         }
         else
         {
@@ -392,11 +393,11 @@ static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
     // Select the actual script at the top of the stack
     // (this could be a different script runnin on this instance, in case of far calls)
     // NOTE: we will still use pc and stack of the current inst, since it's the one running!
-    const ccScript *top_script = inst->GetRunningInst()->GetScript().get();
-    if (!top_script->sctoc)
+    const RuntimeScript *top_script = inst->GetRunningInst()->GetScript();
+    if (!top_script->GetTOC())
         return false; // no TOC
 
-    const auto &toc = *top_script->sctoc;
+    const auto &toc = *top_script->GetTOC();
     if (toc.GetLocalVariables().empty())
         return false; // no local data
 

--- a/Engine/debug/memory_inspect.cpp
+++ b/Engine/debug/memory_inspect.cpp
@@ -35,8 +35,8 @@
 #include <algorithm>
 #include "ac/dynobj/dynobj_manager.h"
 #include "script/cc_common.h"
-#include "script/cc_instance.h"
 #include "script/runtimescript.h"
+#include "script/scriptexecutor.h"
 #include "script/systemimports.h"
 #include "util/compress.h"
 #include "util/string_utils.h"
@@ -334,16 +334,15 @@ struct MemoryVariable
         : Variable(var), MemoryPtr(mem_ptr), ObjMgr(mgr), MemorySize(mem_sz) {}
 };
 
-static bool TryGetGlobalVariable(const String &field_ref, const ccInstance *inst,
+static bool TryGetGlobalVariable(const String &field_ref, const ScriptExecutor *exec,
     MemoryVariable &found_var)
 {
-    // Select the actual script at the top of the stack
-    // (this could be a different script runnin on this instance, in case of far calls)
-    const ccInstance *top_inst = inst->GetRunningInst();
-    if (!top_inst->GetScript()->GetTOC())
+    // Select the current running script
+    const RuntimeScript *top_inst = exec->GetRunningScript();
+    if (!top_inst->GetTOC())
         return false; // no TOC
 
-    const auto &toc = *top_inst->GetScript()->GetTOC();
+    const auto &toc = *top_inst->GetTOC();
     if (toc.GetGlobalVariables().empty())
         return false; // no global data
 
@@ -387,13 +386,11 @@ static bool TryGetGlobalVariable(const String &field_ref, const ccInstance *inst
     }
 }
 
-static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
+static bool TryGetLocalVariable(const String &field_ref, const ScriptExecutor *exec,
      MemoryVariable &found_var)
 {
-    // Select the actual script at the top of the stack
-    // (this could be a different script runnin on this instance, in case of far calls)
-    // NOTE: we will still use pc and stack of the current inst, since it's the one running!
-    const RuntimeScript *top_script = inst->GetRunningInst()->GetScript();
+    // Select the current running script
+    const RuntimeScript *top_script = exec->GetRunningScript();
     if (!top_script->GetTOC())
         return false; // no TOC
 
@@ -402,7 +399,7 @@ static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
         return false; // no local data
 
     // TODO: use runtime TOC where we can guarantee sorted function list (or fixup TOC on load)
-    ScriptTOC::Function test_func; test_func.scope_begin = inst->GetPC(); test_func.scope_end = inst->GetPC() + 1;
+    ScriptTOC::Function test_func; test_func.scope_begin = exec->GetPC(); test_func.scope_end = exec->GetPC() + 1;
     auto func_it = std::lower_bound(toc.GetFunctions().begin(), toc.GetFunctions().end(), test_func,
         [](const ScriptTOC::Function &first, const ScriptTOC::Function &second)
         { return (first.scope_begin < second.scope_begin) && (first.scope_end <= second.scope_begin); });
@@ -416,12 +413,12 @@ static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
     // Find the latest variable which scope begins prior to the current script pos
     const ScriptTOC::Variable *var = func.local_data;
     for (const ScriptTOC::Variable *next_var = var;
-        next_var && next_var->scope_begin <= static_cast<uint32_t>(inst->GetPC());
+        next_var && next_var->scope_begin <= static_cast<uint32_t>(exec->GetPC());
         var = next_var, next_var = next_var->next_local);
 
     // FIXME: helper method returning stack? don't direct access!
     // Note this stack ptr is set *after* the last allocated local data
-    const auto *stack_ptr = inst->GetCurrentStack();
+    const auto *stack_ptr = exec->GetCurrentStack();
     const ScriptTOC::Variable *last_var = nullptr;
     // Scan local variable backwards before we find one that matches the name
     for (; var; var = var->prev_local)
@@ -429,7 +426,7 @@ static bool TryGetLocalVariable(const String &field_ref, const ccInstance *inst,
         assert(var->v_flags & ScriptTOC::kVariable_Local);
         // Skip if local variable's scope ends before current pos;
         // note we don't break, as this may be a nested scope inside a function
-        if (var->scope_end <= static_cast<uint32_t>(inst->GetPC()))
+        if (var->scope_end <= static_cast<uint32_t>(exec->GetPC()))
             continue;
 
         --stack_ptr;
@@ -472,16 +469,16 @@ struct FieldInfo
 // Try getting a registered variable from the current script's global memory,
 // or local memory (stack); or, if this is an imported variable, then lookup
 // the import table for its real address.
-static HError ParseScriptVariable(const String &field_ref, const ccInstance *inst,
+static HError ParseScriptVariable(const String &field_ref, const ScriptExecutor *exec,
     const RTTI &rtti, MemoryReference &mem_ref, FieldInfo &next_field_info)
 {
     MemoryVariable memvar;
     // First try local data
-    if (!TryGetLocalVariable(field_ref, inst, memvar))
+    if (!TryGetLocalVariable(field_ref, exec, memvar))
     {
         // Then try script's global variable;
         // this includes imported symbols from other scripts, plugins or engine
-        if (!TryGetGlobalVariable(field_ref, inst, memvar))
+        if (!TryGetGlobalVariable(field_ref, exec, memvar))
         {
             return new Error(String::FromFormat("Variable not found in the current scope: '%s'", field_ref.GetCStr()));
         }
@@ -491,7 +488,7 @@ static HError ParseScriptVariable(const String &field_ref, const ccInstance *ins
     const auto &var = *memvar.Variable;
     // resolve local script's type to a global type index
     // TODO: this should be resolved after loading script, similar to RTTI!
-    const ccInstance *top_inst = inst->GetRunningInst();
+    const RuntimeScript *top_inst = exec->GetRunningScript();
     const auto *l2gtypes = &top_inst->GetLocal2GlobalTypeMap();
     auto type_it = l2gtypes->find(var.f_typeid);
     if (type_it == l2gtypes->end())
@@ -606,7 +603,7 @@ static String GetNextVarSection(const String &var_ref, size_t &index, char &acce
 
 // Parses the naming chain item by item, and build mem_ref string,
 // containing set of instructions used to access and resolve actual memory
-static HError VariableRefToMemoryRef(const String &var_ref, const ccInstance *inst,
+static HError VariableRefToMemoryRef(const String &var_ref, const ScriptExecutor *exec,
     MemoryReference &mem_ref, FieldInfo &var_field_info)
 {
     const auto &rtti = RuntimeScript::GetJointRTTI()->AsConstRTTI();
@@ -622,7 +619,7 @@ static HError VariableRefToMemoryRef(const String &var_ref, const ccInstance *in
         if (access_type == 0)
         {
             // Try getting a variable in the current script
-            HError err = ParseScriptVariable(item, inst, rtti, mem_ref, next_field_info);
+            HError err = ParseScriptVariable(item, exec, rtti, mem_ref, next_field_info);
             if (!err)
                 return err;
         }
@@ -675,18 +672,17 @@ static HError VariableRefToMemoryRef(const String &var_ref, const ccInstance *in
     return HError::None();
 }
 
-HError QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_info)
+HError QueryScriptVariableInContext(const ScriptExecutor *exec, const String &var_ref, VariableInfo &var_info)
 {
     if (var_ref.IsNullOrSpace())
         return new Error("Bad input"); // no name
 
-    ccInstance *inst = ccInstance::GetCurrentInstance();
-    if (!inst)
+    if (!exec->GetRunningScript())
         return new Error("No running script"); // not in running script
     
     MemoryReference mem_ref;
     FieldInfo var_field_info;
-    HError err = VariableRefToMemoryRef(var_ref, inst, mem_ref, var_field_info);
+    HError err = VariableRefToMemoryRef(var_ref, exec, mem_ref, var_field_info);
     if (!err)
         return err; // failed to parse variable name chain
     

--- a/Engine/debug/memory_inspect.cpp
+++ b/Engine/debug/memory_inspect.cpp
@@ -609,7 +609,7 @@ static String GetNextVarSection(const String &var_ref, size_t &index, char &acce
 static HError VariableRefToMemoryRef(const String &var_ref, const ccInstance *inst,
     MemoryReference &mem_ref, FieldInfo &var_field_info)
 {
-    const auto &rtti = ccInstance::GetRTTI()->AsConstRTTI();
+    const auto &rtti = RuntimeScript::GetJointRTTI()->AsConstRTTI();
     FieldInfo last_field_info;
     FieldInfo next_field_info;
 

--- a/Engine/debug/memory_inspect.h
+++ b/Engine/debug/memory_inspect.h
@@ -20,6 +20,7 @@
 
 #include "util/error.h"
 #include "util/string.h"
+#include "script/scriptexecutor.h"
 
 namespace AGS
 {
@@ -53,7 +54,7 @@ namespace MemoryInspect
     // - imports from other scripts, plugins or engine itself.
     // Requirements: ScriptTOC and RTTI.
     // TODO: value format option?
-    HError QueryScriptVariableInContext(const String &var_ref, VariableInfo &var_info);
+    HError QueryScriptVariableInContext(const ScriptExecutor *exec, const String &var_ref, VariableInfo &var_info);
 }
 
 } // namespace Engine

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -519,10 +519,11 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     //
     if (!ents.GlobalScript)
         return new GameInitError(kGameInitErr_NoGlobalScript);
-    gamescript = ents.GlobalScript;
-    dialogScriptsScript = ents.DialogScript;
+    gamescript = std::move(RuntimeScript::Create(ents.GlobalScript.get(), "G"));
+    dialogScriptsScript= std::move(RuntimeScript::Create(ents.DialogScript.get(), "D"));
     numScriptModules = ents.ScriptModules.size();
-    scriptModules = ents.ScriptModules;
+    for (size_t i = 0; i < ents.ScriptModules.size(); ++i)
+        scriptModules.push_back(std::shared_ptr<RuntimeScript>(RuntimeScript::Create(ents.ScriptModules[i].get(), "M")));
     AllocScriptModules();
     if (create_global_script())
         return new GameInitError(kGameInitErr_ScriptLinkFailed, cc_get_error().ErrorString);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -46,6 +46,7 @@
 #include "script/exports.h"
 #include "script/script.h"
 #include "script/script_runtime.h"
+#include "util/memory_compat.h"
 #include "util/string_compat.h"
 #include "util/string_utils.h"
 
@@ -503,6 +504,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     // NOTE: we must do this before plugin start, because some plugins may
     // require access to script API at initialization time.
     //
+    scriptExecutor = std::make_unique<ScriptExecutor>();
     ccSetScriptAliveTimer(1000 / 60u, 1000u, 150000u);
     setup_script_exports(base_api, compat_api);
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -330,13 +330,13 @@ void DoBeforeRestore(PreservedParams &pp, SaveCmpSelection select_cmp)
     clear_drawobj_cache();
 
     // preserve script data sizes and cleanup scripts
-    pp.GlScDataSize = gameinst->GetGlobalData().size();
+    pp.GlScDataSize = gamescript->GetGlobalData().size();
     pp.ScriptModuleNames.resize(numScriptModules);
     pp.ScMdDataSize.resize(numScriptModules);
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        pp.ScriptModuleNames[i] = moduleInst[i]->GetScript()->GetScriptName();
-        pp.ScMdDataSize[i] = moduleInst[i]->GetGlobalData().size();
+        pp.ScriptModuleNames[i] = scriptModules[i]->GetScriptName();
+        pp.ScMdDataSize[i] = scriptModules[i]->GetGlobalData().size();
     }
 
     FreeAllScriptInstances();
@@ -367,13 +367,13 @@ void DoBeforeRestore(PreservedParams &pp, SaveCmpSelection select_cmp)
 void FillPreservedParams(PreservedParams &pp)
 {
     // preserve script data sizes
-    pp.GlScDataSize = gameinst->GetGlobalData().size();
+    pp.GlScDataSize = gamescript->GetGlobalData().size();
     pp.ScriptModuleNames.resize(numScriptModules);
     pp.ScMdDataSize.resize(numScriptModules);
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        pp.ScriptModuleNames[i] = moduleInst[i]->GetScript()->GetScriptName();
-        pp.ScMdDataSize[i] = moduleInst[i]->GetGlobalData().size();
+        pp.ScriptModuleNames[i] = scriptModules[i]->GetScriptName();
+        pp.ScMdDataSize[i] = scriptModules[i]->GetGlobalData().size();
     }
 }
 
@@ -584,7 +584,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
     // read the global data into the newly created script
     if (!r_data.GlobalScript.Data.empty())
     {
-        gameinst->CopyGlobalData(r_data.GlobalScript.Data);
+        gamescript->CopyGlobalData(r_data.GlobalScript.Data);
     }
 
     // restore the script module data
@@ -594,11 +594,11 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
         auto &scdata = sc_entry.second;
         if (scdata.Data.empty())
             continue;
-        for (auto &scmoduleinst : moduleInst)
+        for (auto &scmodule : scriptModules)
         {
-            if (name.Compare(scmoduleinst->GetScript()->GetScriptName()) == 0)
+            if (name.Compare(scmodule->GetScriptName()) == 0)
             {
-                scmoduleinst->CopyGlobalData(scdata.Data);
+                scmodule->CopyGlobalData(scdata.Data);
                 break;
             }
         }
@@ -846,7 +846,7 @@ void DoBeforeSave()
     if (displayed_room >= 0)
     {
         // update the current room script's data segment copy
-        if (roominst)
+        if (roomscript)
             save_room_data_segment();
     }
 }

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -623,7 +623,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
     // Apply restored RTTI placeholder, after current room was loaded;
     // remap typeids in the deserialized managed objects, where necessary
     std::unordered_map<uint32_t, uint32_t> loc_l2g, type_l2g;
-    ccInstance::JoinRTTI(r_data.GenRTTI, loc_l2g, type_l2g);
+    RuntimeScript::JoinRTTI(r_data.GenRTTI, loc_l2g, type_l2g);
     pool.RemapTypeids(type_l2g);
 
     // Reapply few parameters after room load

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1251,19 +1251,19 @@ enum ScriptModulesSvgVersion
 HSaveError WriteScriptModules(Stream *out)
 {
     // write the data segment of the global script
-    int data_len = gameinst->GetGlobalData().size();
+    int data_len = gamescript->GetGlobalData().size();
     out->WriteInt32(data_len);
     if (data_len > 0)
-        out->Write(gameinst->GetGlobalData().data(), data_len);
+        out->Write(gamescript->GetGlobalData().data(), data_len);
     // write the script modules data segments
     out->WriteInt32(numScriptModules);
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        StrUtil::WriteString(moduleInst[i]->GetScript()->GetScriptName(), out);
-        data_len = moduleInst[i]->GetGlobalData().size();
+        StrUtil::WriteString(scriptModules[i]->GetScriptName(), out);
+        data_len = scriptModules[i]->GetGlobalData().size();
         out->WriteInt32(data_len);
         if (data_len > 0)
-            out->Write(moduleInst[i]->GetGlobalData().data(), data_len);
+            out->Write(scriptModules[i]->GetGlobalData().data(), data_len);
     }
     return HSaveError::None();
 }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1591,8 +1591,8 @@ HSaveError WriteRTTI(Stream *out)
 {
     // Write the minimal necessary RTTI data, enough to resolve types when restoring a save;
     // NOTE: we might just dump whole RTTI here, if it's necessary to keep all field descs and names
-    const auto &rtti = ccInstance::GetRTTI()->AsConstRTTI();
-    const auto &helper = ccInstance::GetRTTIHelper();
+    const auto &rtti = RuntimeScript::GetJointRTTI()->AsConstRTTI();
+    const auto &helper = RuntimeScript::GetRTTIHelper();
     const auto &locs = rtti.GetLocations();
     const auto &types = rtti.GetTypes();
     // NOTE: we don't write IDs here, as the Joint RTTI assumes to have them strcitly sequential

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -135,19 +135,19 @@ HError LoadGameScripts(LoadedGameEntities &ents)
     auto in = AssetMgr->OpenAsset("GlobalScript.o");
     if (in)
     {
-        PScript script(ccScript::CreateFromStream("GlobalScript.asc", in.get()));
+        UScript script(ccScript::CreateFromStream("GlobalScript.asc", in.get()));
         if (!script)
             return MakeScriptLoadError("GlobalScript.o");
-        ents.GlobalScript = script;
+        ents.GlobalScript = std::move(script);
     }
     // Dialog script
     in = AssetMgr->OpenAsset("DialogScripts.o");
     if (in)
     {
-        PScript script(ccScript::CreateFromStream("__DialogScripts.asc", in.get()));
+        UScript script(ccScript::CreateFromStream("__DialogScripts.asc", in.get()));
         if (!script)
             return MakeScriptLoadError("DialogScripts.o");
-        ents.DialogScript = script;
+        ents.DialogScript = std::move(script);
     }
     // Script modules
     // First load a modules list
@@ -168,10 +168,10 @@ HError LoadGameScripts(LoadedGameEntities &ents)
         if (in)
         {
             String script_name = Path::ReplaceExtension(modules[i], "asc");
-            PScript script(ccScript::CreateFromStream(script_name.ToStdString(), in.get()));
+            UScript script(ccScript::CreateFromStream(script_name.ToStdString(), in.get()));
             if (!script)
                 return MakeScriptLoadError(modules[i].GetCStr());
-            ents.ScriptModules[i] = script;
+            ents.ScriptModules[i] = std::move(script);
         }
     }
     return HError::None();

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -629,15 +629,13 @@ int IAGSEngine::CallGameScriptFunction(const char *name, int32 globalScript, int
     if (inside_script)
         return -300;
 
-    ccInstance *toRun = GetScriptInstanceByType(globalScript ? kScTypeGame : kScTypeRoom);
-
+    RuntimeScript *run_script = GetScriptInstanceByType(globalScript ? kScTypeGame : kScTypeRoom);
     RuntimeScriptValue params[]{
         RuntimeScriptValue().SetPluginArgument(arg1),
         RuntimeScriptValue().SetPluginArgument(arg2),
         RuntimeScriptValue().SetPluginArgument(arg3),
     };
-    int toret = RunScriptFunction(toRun, name, numArgs, params);
-    return toret;
+    return RunScriptFunction(run_script, name, numArgs, params);
 }
 
 void IAGSEngine::NotifySpriteUpdated(int32 slot) {

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -104,11 +104,6 @@ struct FunctionCallStack
 };
 
 
-std::unique_ptr<JointRTTI> ccInstance::_rtti;
-std::unordered_map<String, uint32_t> ccInstance::_rttiLookup;
-std::unique_ptr<RTTIHelper> ccInstance::_rttiHelper;
-
-
 unsigned ccInstance::_timeoutCheckMs = 60u;
 unsigned ccInstance::_timeoutAbortMs = 0u;
 unsigned ccInstance::_maxWhileLoops = 0u;
@@ -137,26 +132,7 @@ std::unique_ptr<ccInstance> ccInstance::CreateEx(PRuntimeScript scri, const ccIn
     {
         return nullptr;
     }
-    // Join RTTI
-    if (!ccInstance::_rtti)
-        ccInstance::_rtti.reset(new JointRTTI());
-    if (!ccInstance::_rttiHelper)
-        ccInstance::_rttiHelper.reset(new RTTIHelper());
-    // TODO: not related to static members, move this to private _Create, and optimize for forks
-    if (scri->GetRTTI() && !scri->GetRTTI()->IsEmpty())
-    {
-        JoinRTTI(*scri->GetRTTI(), cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
-    }
     return cinst;
-}
-
-void ccInstance::JoinRTTI(const RTTI &rtti,
-    std::unordered_map<uint32_t, uint32_t> &loc_l2g,
-    std::unordered_map<uint32_t, uint32_t> &type_l2g)
-{
-    ccInstance::_rtti->Join(rtti, loc_l2g, type_l2g);
-    // TODO: optimize by updating only newly joint types
-    ccInstance::_rttiHelper->Generate(ccInstance::_rtti->AsConstRTTI());
 }
 
 void ccInstance::SetExecTimeout(const unsigned sys_poll_ms, const unsigned abort_ms,
@@ -1359,7 +1335,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             // which would replace a local typeid with a global one once the script is loaded;
             // but we need to implement such fixup in a compiler first.
             assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
-            const uint32_t global_tid = _runningInst->_typeidLocal2Global[arg_typeid];
+            const uint32_t global_tid = _runningInst->_typeidLocal2Global->at(arg_typeid);
             DynObjectRef ref = CCDynamicArray::CreateNew(global_tid, static_cast<uint32_t>(arg_elnum), arg_elsize);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
             break;
@@ -1391,7 +1367,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             // which would replace a local typeid with a global one once the script is loaded;
             // but we need to implement such fixup in a compiler first.
             assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
-            const uint32_t global_tid = _runningInst->_typeidLocal2Global[arg_typeid];
+            const uint32_t global_tid = _runningInst->_typeidLocal2Global->at(arg_typeid);
             DynObjectRef ref = ScriptUserObject::Create(global_tid, arg_size);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
             break;
@@ -1698,22 +1674,8 @@ bool ccInstance::_Create(PRuntimeScript script, const ccInstance *joined)
     _code = script->GetCode().data();
     _codesize = static_cast<int32_t>(script->GetCode().size());
     _code_fixups = script->GetCodeFixups().data();
-
-    // Generate lookup tables for script TOC (if available)
-    if (joined)
-    {
-        // FIXME: use shared ptr?
-        _globalVarLookup = joined->_globalVarLookup;
-    }
-    else if (script->GetTOC())
-    {
-        const auto &glvars = script->GetTOC()->GetGlobalVariables();
-        for (size_t i = 0; i < glvars.size(); ++i)
-        {
-            _globalVarLookup.insert(
-                std::make_pair(String(glvars[i].name), static_cast<uint32_t>(i)));
-        }
-    }
+    _rtti = RuntimeScript::GetJointRTTI();
+    _typeidLocal2Global = &script->GetLocal2GlobalTypeMap();
 
     _instanceof = script;
     _flags = 0;

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "script/cc_instance.h"
+#if defined (DISABLED)
 #include <cstdio>
 #include <deque>
 #include <string.h>
@@ -1836,3 +1837,5 @@ void ccInstance::PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t
     func_callstack.Head += num_entries;
     func_callstack.Count -= num_entries;
 }
+
+#endif // DISABLED

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -41,114 +41,6 @@ using namespace AGS::Common::Memory;
 using namespace AGS::Engine;
 
 
-enum ScriptOpArgIsReg
-{
-    kScOpNoArgIsReg     = 0,
-    kScOpArg1IsReg      = 0x0001,
-    kScOpArg2IsReg      = 0x0002,
-    kScOpArg3IsReg      = 0x0004,
-    kScOpOneArgIsReg    = kScOpArg1IsReg,
-    kScOpTwoArgsAreReg  = kScOpArg1IsReg | kScOpArg2IsReg,
-    kScOpTreeArgsAreReg = kScOpArg1IsReg | kScOpArg2IsReg | kScOpArg3IsReg
-};
-
-struct ScriptCommandInfo
-{
-    ScriptCommandInfo(const int32_t code, const char *cmdname, const int arg_count, const ScriptOpArgIsReg arg_is_reg)
-        : Code(code), CmdName(cmdname), ArgCount(arg_count)
-        , ArgIsReg {
-            (arg_is_reg & kScOpArg1IsReg) != 0, 
-            (arg_is_reg & kScOpArg2IsReg) != 0, 
-            (arg_is_reg & kScOpArg3IsReg) != 0
-        }
-    {}
-
-    const int32_t   Code = 0;
-    const char     *CmdName = nullptr;
-    const int       ArgCount = 0;
-    const bool      ArgIsReg[3]{};
-};
-
-const ScriptCommandInfo sccmd_info[CC_NUM_SCCMDS] =
-{
-    ScriptCommandInfo( 0                    , "NULL"              , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_ADD             , "addi"              , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_SUB             , "subi"              , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_REGTOREG        , "mov"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_WRITELIT        , "memwritelit"       , 2, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_RET             , "ret"               , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_LITTOREG        , "movl"              , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMREAD         , "memread4"          , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMWRITE        , "memwrite4"         , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MULREG          , "mul"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_DIVREG          , "div"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_ADDREG          , "add"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_SUBREG          , "sub"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_BITAND          , "and"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_BITOR           , "or"                , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_ISEQUAL         , "cmpeq"             , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_NOTEQUAL        , "cmpne"             , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_GREATER         , "gt"                , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_LESSTHAN        , "lt"                , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_GTE             , "gte"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_LTE             , "lte"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_AND             , "land"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_OR              , "lor"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_CALL            , "call"              , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMREADB        , "memread1"          , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMREADW        , "memread2"          , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMWRITEB       , "memwrite1"         , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMWRITEW       , "memwrite2"         , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_JZ              , "jzi"               , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_PUSHREG         , "push"              , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_POPREG          , "pop"               , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_JMP             , "jmpi"              , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_MUL             , "muli"              , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_CALLEXT         , "farcall"           , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_PUSHREAL        , "farpush"           , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_SUBREALSTACK    , "farsubsp"          , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_LINENUM         , "sourceline"        , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_CALLAS          , "callscr"           , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_THISBASE        , "thisaddr"          , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_NUMFUNCARGS     , "setfuncargs"       , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_MODREG          , "mod"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_XORREG          , "xor"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_NOTREG          , "not"               , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_SHIFTLEFT       , "shl"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_SHIFTRIGHT      , "shr"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_CALLOBJ         , "callobj"           , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_CHECKBOUNDS     , "checkbounds"       , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMWRITEPTR     , "memwrite.ptr"      , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMREADPTR      , "memread.ptr"       , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMZEROPTR      , "memwrite.ptr.0"    , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMINITPTR      , "meminit.ptr"       , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_LOADSPOFFS      , "load.sp.offs"      , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_CHECKNULL       , "checknull.ptr"     , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_FADD            , "faddi"             , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_FSUB            , "fsubi"             , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_FMULREG         , "fmul"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FDIVREG         , "fdiv"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FADDREG         , "fadd"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FSUBREG         , "fsub"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FGREATER        , "fgt"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FLESSTHAN       , "flt"               , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FGTE            , "fgte"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_FLTE            , "flte"              , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_ZEROMEMORY      , "zeromem"           , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_CREATESTRING    , "newstring"         , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_STRINGSEQUAL    , "streq"             , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_STRINGSNOTEQ    , "strne"             , 2, kScOpTwoArgsAreReg ),
-    ScriptCommandInfo( SCMD_CHECKNULLREG    , "checknull"         , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_LOOPCHECKOFF    , "loopcheckoff"      , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_MEMZEROPTRND    , "memwrite.ptr.0.nd" , 0, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_JNZ             , "jnzi"              , 1, kScOpNoArgIsReg ),
-    ScriptCommandInfo( SCMD_DYNAMICBOUNDS   , "dynamicbounds"     , 1, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_NEWARRAY        , "newarray"          , 3, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_NEWUSEROBJECT   , "newuserobject"     , 2, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_NEWUSEROBJECT2  , "newuserobject2"    , 3, kScOpOneArgIsReg ),
-    ScriptCommandInfo( SCMD_NEWARRAY2       , "newarray2"         , 3, kScOpOneArgIsReg ),
-};
-
 const char *regnames[] = { "null", "sp", "mar", "ax", "bx", "cx", "op", "dx" };
 const char *fixupnames[] = { "null", "fix_gldata", "fix_func", "fix_string", "fix_import", "fix_datadata", "fix_stack" };
 
@@ -232,12 +124,12 @@ void ccInstance::FreeInstanceStack()
     InstThreads.clear();
 }
 
-std::unique_ptr<ccInstance> ccInstance::CreateFromScript(PScript scri)
+std::unique_ptr<ccInstance> ccInstance::CreateFromScript(PRuntimeScript scri)
 {
     return CreateEx(scri, nullptr);
 }
 
-std::unique_ptr<ccInstance> ccInstance::CreateEx(PScript scri, const ccInstance *joined)
+std::unique_ptr<ccInstance> ccInstance::CreateEx(PRuntimeScript scri, const ccInstance *joined)
 {
     // allocate and copy all the memory with data, code and strings across
     std::unique_ptr<ccInstance> cinst(new ccInstance());
@@ -251,9 +143,9 @@ std::unique_ptr<ccInstance> ccInstance::CreateEx(PScript scri, const ccInstance 
     if (!ccInstance::_rttiHelper)
         ccInstance::_rttiHelper.reset(new RTTIHelper());
     // TODO: not related to static members, move this to private _Create, and optimize for forks
-    if (scri->rtti && !scri->rtti->IsEmpty())
+    if (scri->GetRTTI() && !scri->GetRTTI()->IsEmpty())
     {
-        JoinRTTI(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
+        JoinRTTI(*scri->GetRTTI(), cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
     }
     return cinst;
 }
@@ -273,11 +165,6 @@ void ccInstance::SetExecTimeout(const unsigned sys_poll_ms, const unsigned abort
     _timeoutCheckMs = sys_poll_ms;
     _timeoutAbortMs = abort_ms;
     _maxWhileLoops = abort_loops;
-}
-
-ccInstance::ccInstance()
-    : _exportLookup('$', true /* allow to match symbols with more appendages */)
-{
 }
 
 ccInstance::~ccInstance()
@@ -379,30 +266,6 @@ void ccInstance::AbortAndDestroy()
     }
 
 
-bool ccInstance::FindExportedFunction(const String &fn_name, int32_t &start_at, int32_t &num_args) const
-{
-    const uint32_t exp_index = _exportLookup.GetIndexOfAny(fn_name);
-    if (exp_index == UINT32_MAX)
-        return false;
-
-    const int32_t etype = (_instanceof->export_addr[exp_index] >> 24L) & 0x000ff;
-    if (etype != EXPORT_FUNCTION)
-        return false; // not a function
-    start_at = (_instanceof->export_addr[exp_index] & 0x00ffffff);
-
-    const String &exp_name = _instanceof->exports[exp_index];
-    assert(exp_name.GetLength() >= fn_name.GetLength());
-    if (exp_name.GetLength() <= fn_name.GetLength())
-    {
-        num_args = 0; // unknown, registered without args info
-    }
-    else
-    {
-        num_args = atoi(&exp_name[fn_name.GetLength() + 1]);
-    }
-    return true;
-}
-
 ccInstError ccInstance::CallScriptFunction(const String &funcname, int32_t numargs, const RuntimeScriptValue *params)
 {
     cc_clear_error();
@@ -427,7 +290,7 @@ ccInstError ccInstance::CallScriptFunction(const String &funcname, int32_t numar
     }
 
     int start_at, export_args;
-    if (!FindExportedFunction(funcname, start_at, export_args))
+    if (!_instanceof->FindExportedFunction(funcname, start_at, export_args))
     {
         cc_error("function '%s' not found", funcname.GetCStr());
         return kInstErr_FuncNotFound;
@@ -1287,7 +1150,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             int32_t instId = codeOp.Instruction.InstanceId;
             // determine the offset into the code of the instance we want
             _runningInst = loadedInstances[instId];
-            uintptr_t callAddr = reg1.PtrU8 - reinterpret_cast<uint8_t*>(_runningInst->_code);
+            uintptr_t callAddr = reg1.PtrU8 - reinterpret_cast<const uint8_t*>(_runningInst->_code);
             if (callAddr % sizeof(uintptr_t) != 0)
             {
                 cc_error("call address not aligned");
@@ -1689,13 +1552,13 @@ ccInstError ccInstance::Run(int32_t curpc)
 
 String ccInstance::GetCallStack(const int maxLines) const
 {
-    String buffer = String::FromFormat("in \"%s\", line %d\n", _runningInst->_instanceof->GetSectionName(_pc).c_str(), _lineNumber);
+    String buffer = String::FromFormat("in \"%s\", line %d\n", _runningInst->_instanceof->GetSectionName(_pc).GetCStr(), _lineNumber);
 
     int linesDone = 0;
     for (uint32_t j = _callStackSize; (j-- > 0) && (linesDone < maxLines); linesDone++)
     {
         String lineBuffer = String::FromFormat("from \"%s\", line %d\n",
-            _callStackCodeInst[j]->_instanceof->GetSectionName(_callStackAddr[j]).c_str(), _callStackLineNumber[j]);
+            _callStackCodeInst[j]->_instanceof->GetSectionName(_callStackAddr[j]).GetCStr(), _callStackLineNumber[j]);
         buffer.Append(lineBuffer);
         if (linesDone == maxLines - 1)
             buffer.Append("(and more...)\n");
@@ -1711,8 +1574,7 @@ void ccInstance::GetScriptPosition(ScriptPosition &script_pos) const
 
 RuntimeScriptValue ccInstance::GetSymbolAddress(const String &symname) const
 {
-    uint32_t exp_index = _exportLookup.GetIndexOfAny(symname);
-    return (exp_index < UINT32_MAX) ? _exports[exp_index] : RuntimeScriptValue();
+    return _instanceof->GetSymbolAddress(symname);
 }
 
 void ccInstance::DumpInstruction(const ScriptOperation &op) const
@@ -1808,45 +1670,20 @@ void ccInstance::NotifyAlive()
     _lastAliveTs = AGS_FastClock::now();
 }
 
-bool ccInstance::_Create(PScript scri, const ccInstance *joined)
+bool ccInstance::_Create(PRuntimeScript script, const ccInstance *joined)
 {
-    if ((scri == nullptr) && (joined != nullptr))
-        scri = joined->_instanceof;
-
-    if (scri == nullptr) {
-        cc_error("null pointer passed");
+    assert(script || (joined && joined->_instanceof));
+    if ((script == nullptr) && (joined != nullptr))
+        script = joined->_instanceof;
+    if (script == nullptr)
+    {
+        cc_error("ccInstance: internal error, script is null");
         return false;
     }
 
-    if (joined != nullptr) {
-        // share memory space with an existing instance (ie. this is a thread/fork)
-        _scriptData = joined->_scriptData;
-    } 
-    else {
-        // create own memory space
-        // NOTE: globalvars are created in CreateGlobalVars()
-        _scriptData.reset(new ResolvedScriptData());
-
-        if (scri->globaldata.size() > 0)
-        {
-            _scriptData->globaldata.resize(scri->globaldata.size());
-            std::copy(scri->globaldata.begin(), scri->globaldata.end(), _scriptData->globaldata.begin());
-        }
-
-        if (scri->code.size() > 0)
-        {
-            _scriptData->code.resize(scri->code.size());
-            _scriptData->code_fixups.resize(scri->code.size());
-            // 64 bit: Read code into 8 byte array, necessary for being able to perform
-            // relocations on the references.
-            for (size_t i = 0; i < scri->code.size(); ++i)
-                _scriptData->code[i] = scri->code[i];
-        }
-    }
-
     // just use the pointer to the strings since they don't change
-    _strings = scri->strings.size() > 0 ? scri->strings.data() : "";
-    _stringsize = scri->strings.size();
+    _strings = script->GetStrings().size() > 0 ? script->GetStrings().data() : "";
+    _stringsize = script->GetStrings().size();
 
     // Create a stack
     // The size of a stack is quite an arbitrary choice; there's no way to deduce number of stack
@@ -1857,94 +1694,10 @@ bool ccInstance::_Create(PScript scri, const ccInstance *joined)
     _stackdataBegin = _stackdata.data();
     _stackdataPtr = _stackdata.data();
 
-    // find a LoadedInstance slot for it
-    for (int i = 0; i < MAX_LOADED_INSTANCES; i++) {
-        if (loadedInstances[i] == nullptr) {
-            loadedInstances[i] = this;
-            _loadedInstanceId = i;
-            break;
-        }
-        if (i == MAX_LOADED_INSTANCES - 1) {
-            cc_error("too many active instances");
-            return false;
-        }
-    }
-
     // Setup fast access pointers
-    _code = _scriptData->code.data();
-    _codesize = static_cast<int32_t>(_scriptData->code.size());
-    _code_fixups = _scriptData->code_fixups.data();
-
-    if (!joined)
-    {
-        if (!CreateGlobalVars(scri.get()))
-        {
-            return false;
-        }
-        if (!CreateRuntimeCodeFixups(scri.get()))
-        {
-            return false;
-        }
-    }
-
-    // Resolve script exports; this is done for each script instance,
-    // CHECKME: why? they seem to reference shared data
-    _exports.resize(scri->exports.size());
-    _exportLookup.Clear();
-    // find the real address of the exports
-    for (size_t i = 0; i < scri->exports.size(); i++)
-    {
-        const int32_t etype = (scri->export_addr[i] >> 24L) & 0x000ff;
-        const int32_t eaddr = (scri->export_addr[i] & 0x00ffffff);
-        if (etype == EXPORT_FUNCTION)
-        {
-            // NOTE: unfortunately, there seems to be no way to know if
-            // that's an extender function that expects object pointer
-            _exports[i].SetCodePtr(reinterpret_cast<uint8_t*>(_code) 
-                + (static_cast<uintptr_t>(eaddr) * sizeof(uintptr_t)));
-        }
-        else if (etype == EXPORT_DATA)
-        {
-            ScriptVariable *gl_var = FindGlobalVar(eaddr);
-            if (gl_var)
-            {
-                _exports[i].SetGlobalVar(&gl_var->RValue);
-            }
-            else
-            {
-                cc_error("cannot resolve global variable, key = %d", eaddr);
-                return false;
-            }
-        }
-        else
-        {
-            cc_error("internal export fixup error");
-            return false;
-        }
-
-        _exportLookup.Add(scri->exports[i], i);
-    }
-
-    _instanceof = scri;
-    _flags = 0;
-    if (joined != nullptr)
-        _flags = INSTF_SHAREDATA;
-    scri->instances++;
-
-    if ((scri->instances == 1) && (ccGetOption(SCOPT_AUTOIMPORT) != 0))
-    {
-        // import all the exported stuff from this script
-        for (size_t i = 0; i < scri->exports.size(); i++)
-        {
-            String name = scri->exports[i];
-            name.Replace('$', '^'); // replace exported name separator with imported name separator
-            if (!ccAddExternalScriptSymbol(name, _exports[i], this))
-            {
-                cc_error("Export table overflow at '%s'", scri->exports[i].c_str());
-                return false;
-            }
-        }
-    }
+    _code = script->GetCode().data();
+    _codesize = static_cast<int32_t>(script->GetCode().size());
+    _code_fixups = script->GetCodeFixups().data();
 
     // Generate lookup tables for script TOC (if available)
     if (joined)
@@ -1952,14 +1705,44 @@ bool ccInstance::_Create(PScript scri, const ccInstance *joined)
         // FIXME: use shared ptr?
         _globalVarLookup = joined->_globalVarLookup;
     }
-    else if (scri->sctoc)
+    else if (script->GetTOC())
     {
-        const auto &glvars = scri->sctoc->GetGlobalVariables();
+        const auto &glvars = script->GetTOC()->GetGlobalVariables();
         for (size_t i = 0; i < glvars.size(); ++i)
         {
             _globalVarLookup.insert(
                 std::make_pair(String(glvars[i].name), static_cast<uint32_t>(i)));
         }
+    }
+
+    _instanceof = script;
+    _flags = 0;
+    if (joined != nullptr)
+        _flags = INSTF_SHAREDATA;
+
+    // Find a LoadedInstance slot for it
+    if (joined == nullptr)
+    {
+        // For primary instances (non-forks) loaded instance ID must match the script linking index
+        _loadedInstanceId = _instanceof->GetLinkIndex();
+        loadedInstances[_loadedInstanceId] = this;
+    }
+    else
+    {
+        for (int i = 1; i < MAX_LOADED_INSTANCES; i++)
+        {
+            if (loadedInstances[i] == nullptr)
+            {
+                loadedInstances[i] = this;
+                _loadedInstanceId = i;
+                break;
+            }
+        }
+    }
+    if (_loadedInstanceId == 0)
+    {
+        cc_error("Too many active instances");
+        return false;
     }
 
     // Reset execution state
@@ -1971,27 +1754,16 @@ bool ccInstance::_Create(PScript scri, const ccInstance *joined)
 
 void ccInstance::Free()
 {
-    // When the base script has no more "instances",
-    // remove all script exports
-    if (_instanceof != nullptr) {
-        _instanceof->instances--;
-        if (_instanceof->instances == 0)
-        {
-            simp.RemoveScriptExports(this);
-        }
-    }
+    _instanceof = nullptr;
 
     // remove from the Active Instances list
     if (loadedInstances[_loadedInstanceId] == this)
         loadedInstances[_loadedInstanceId] = nullptr;
 
-    _scriptData = nullptr;
     _code = nullptr;
     _codesize = 0;
     _strings = nullptr;
     _stringsize = 0u;
-
-    _exports = {};
 
     _stack = {};
     _stackdata = {};
@@ -1999,269 +1771,10 @@ void ccInstance::Free()
     _stackdataPtr = {};
 }
 
-bool ccInstance::ResolveScriptImports()
-{
-    assert(_instanceof);
-    if (!_instanceof)
-        return false;
-
-    // Script keeps the information of what imports are used as an array of names.
-    // When an import is referenced in the code, it's addressed by its index in this
-    // array. Different scripts have differing arrays of imports; indexes
-    // into 'imports[]' are NOT unique and relative to the respective script only.
-    // To allow real-time import use, the sequence of imports in 'imports[]'
-    // and 'resolved_imports[]' should not be modified.
-
-    const ccScript *scri = _instanceof.get();
-    const size_t numimports = scri->imports.size();
-    if (numimports == 0)
-    {
-        // [PGB] AFAICS there's nothing wrong with not having any imports, and
-        // it doesn't lead to trouble. However, if it turns out that we do need
-        // to return 'false' here, we should also report why with a 'Debug::Printf()' call.
-        return true;
-    }
-
-    auto &resolved_imports = _scriptData->resolved_imports;
-    resolved_imports.resize(numimports);
-    size_t errors = 0, last_err_idx = 0;
-    for (size_t import_idx = 0; import_idx < scri->imports.size(); ++import_idx)
-    {
-        if (scri->imports[import_idx].empty())
-        {
-            resolved_imports[import_idx] = UINT32_MAX;
-            continue;
-        }
-
-        resolved_imports[import_idx] = simp.GetIndexOfAny(String::Wrapper(scri->imports[import_idx].c_str()));
-        if (resolved_imports[import_idx] == UINT32_MAX)
-        {
-            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[import_idx].c_str(), scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "<unknown>");
-            errors++;
-            last_err_idx = import_idx;
-        }
-    }
-
-    if (errors > 0)
-        cc_error("in %s: %d unresolved imports (last: %s)",
-            scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "<unknown>",
-            errors,
-            scri->imports[last_err_idx].c_str());
-
-    return errors == 0;
-}
-
-// TODO: it is possible to deduce global var's size at start with
-// certain accuracy after all global vars are registered. Each
-// global var's size would be limited by closest next var's ScAddress
-// and globaldatasize.
-bool ccInstance::CreateGlobalVars(const ccScript *scri)
-{
-    ScriptVariable glvar;
-    uint8_t *globaldata = _scriptData->globaldata.data();
-
-    // Step One: deduce global variables from fixups
-    for (size_t i = 0; i < scri->fixuptypes.size(); ++i)
-    {
-        switch (scri->fixuptypes[i])
-        {
-        case FIXUP_GLOBALDATA:
-            // GLOBALDATA fixup takes relative address of global data element from code array;
-            // this is the address of actual data
-            glvar.ScAddress = (int32_t)_code[scri->fixups[i]];
-            glvar.RValue.SetData(globaldata + glvar.ScAddress, 0);
-            break;
-        case FIXUP_DATADATA:
-            {
-            // DATADATA fixup takes relative address of global data element from fixups array;
-            // this is the address of element, which stores address of actual data
-            glvar.ScAddress = scri->fixups[i];
-            const int32_t data_addr = BBOp::Int32FromLE(*(int32_t*)&globaldata[glvar.ScAddress]);
-            if (glvar.ScAddress - data_addr != 200 /* size of old AGS string */)
-            {
-                // CHECKME: probably replace with mere warning in the log?
-                cc_error("unexpected old-style string's alignment");
-                return false;
-            }
-            // TODO: register this explicitly as a string instead (can do this later)
-            glvar.RValue.SetScriptObject(globaldata + data_addr, &GlobalStaticManager);
-            }
-            break;
-        default:
-            // other fixups are of no use here
-            continue;
-        }
-
-        AddGlobalVar(glvar);
-    }
-
-    // Step Two: deduce global variables from exports
-    for (size_t i = 0; i < scri->exports.size(); ++i)
-    {
-        const int32_t etype = (scri->export_addr[i] >> 24L) & 0x000ff;
-        const int32_t eaddr = (scri->export_addr[i] & 0x00ffffff);
-        if (etype == EXPORT_DATA)
-        {
-            // NOTE: old-style strings could not be exported in AGS,
-            // no need to worry about these here
-            glvar.ScAddress = eaddr;
-            glvar.RValue.SetData(globaldata + glvar.ScAddress, 0);
-            AddGlobalVar(glvar);
-        }
-    }
-
-    return true;
-}
-
-bool ccInstance::AddGlobalVar(const ScriptVariable &glvar)
-{
-    // NOTE:
-    // We suppress the error here, because unfortunately at least one existing
-    // game ("Metal Dead", built with AGS 3.21.1115) fails to pass this check.
-    // It has been found that this may be caused by a global variable of zero
-    // size (an instance of empty struct) placed in the end of the script.
-    // TODO: invent some workaround?
-    // TODO: enable the error back in AGS 4, as this is not a normal behavior.
-    const int32_t globaldatasize = static_cast<int32_t>(_scriptData->globaldata.size());
-    if (glvar.ScAddress < 0 || glvar.ScAddress >= globaldatasize)
-    {
-        /* return false; */
-        Debug::Printf(kDbgMsg_Warn, "WARNING: global variable refers to data beyond allocated buffer (%d, %d)", glvar.ScAddress, globaldatasize);
-    }
-    _scriptData->globalvars.insert(std::make_pair(glvar.ScAddress, glvar));
-    return true;
-}
-
-ScriptVariable *ccInstance::FindGlobalVar(const int32_t var_addr)
-{
-    // NOTE: see comment for AddGlobalVar()
-    const int32_t globaldatasize = static_cast<int32_t>(_scriptData->globaldata.size());
-    if (var_addr < 0 || var_addr >= globaldatasize)
-    {
-        /*
-        return nullptr;
-        */
-        Debug::Printf(kDbgMsg_Warn, "WARNING: looking up for global variable beyond allocated buffer (%d, %d)", var_addr, globaldatasize);
-    }
-    const auto it = _scriptData->globalvars.find(var_addr);
-    return it != _scriptData->globalvars.end() ? &it->second : nullptr;
-}
-
-static int DetermineScriptLine(const int32_t *code, const size_t codesz, const size_t at_pc)
-{
-    int line = -1;
-    for (size_t pc = 0; (pc <= at_pc) && (pc < codesz); ++pc)
-    {
-        const int op = code[pc] & INSTANCE_ID_REMOVEMASK;
-        if (op < 0 || op >= CC_NUM_SCCMDS) return -1;
-        if (pc + sccmd_info[op].ArgCount >= codesz) return -1;
-        if (op == SCMD_LINENUM)
-            line = code[pc + 1];
-        pc += sccmd_info[op].ArgCount;
-    }
-    return line;
-}
-
-static void cc_error_fixups(const ccScript *scri, const size_t pc, const char *fmt, ...)
-{
-    va_list ap;
-    va_start(ap, fmt);
-    const String displbuf = String::FromFormatV(fmt, ap);
-    va_end(ap);
-    const char *scname = scri->sectionNames.size() > 0 ? scri->sectionNames[0].c_str() : "?";
-    if (pc == SIZE_MAX)
-    {
-        cc_error("in script %s: %s", scname, displbuf.GetCStr());
-    }
-    else
-    {
-        const int line = DetermineScriptLine(scri->code.data(), scri->code.size(), pc);
-        cc_error("in script %s around line %d: %s", scname, line, displbuf.GetCStr());
-    }
-}
-
-bool ccInstance::CreateRuntimeCodeFixups(const ccScript *scri)
-{
-    uint8_t *code_fixups = _scriptData->code_fixups.data();
-
-    for (size_t i = 0; i < scri->fixups.size(); ++i)
-    {
-        if (scri->fixuptypes[i] == FIXUP_DATADATA)
-        {
-            continue;
-        }
-
-        const int32_t fixup = scri->fixups[i];
-        if (fixup < 0 || static_cast<size_t>(fixup) >= scri->code.size())
-        {
-            cc_error_fixups(scri, SIZE_MAX, "bad fixup at %d (fixup type %d, bytecode pos %d, bytecode range is 0..%d)",
-                i,  scri->fixuptypes[i], fixup, scri->code.size());
-            return false;
-        }
-
-        code_fixups[fixup] = scri->fixuptypes[i];
-
-        switch (scri->fixuptypes[i])
-        {
-        case FIXUP_GLOBALDATA:
-            {
-                ScriptVariable *gl_var = FindGlobalVar(static_cast<int32_t>(_code[fixup]));
-                if (!gl_var)
-                {
-                    cc_error_fixups(scri, fixup, "cannot resolve global variable (bytecode pos %d, key %d)", fixup, static_cast<int32_t>(_code[fixup]));
-                    return false;
-                }
-                _code[fixup] = (intptr_t)gl_var;
-            }
-            break;
-        case FIXUP_FUNCTION:
-        case FIXUP_STRING:
-        case FIXUP_STACK:
-        case FIXUP_IMPORT:
-            break; // do nothing yet
-        default:
-            cc_error_fixups(scri, SIZE_MAX, "unknown fixup type: %d (fixup num %d)", scri->fixuptypes[i], i);
-            return false;
-        }
-    }
-    return true;
-}
-
-bool ccInstance::ResolveImportFixups()
-{
-    assert(_instanceof);
-    if (!_instanceof)
-        return false;
-
-    const ccScript *scri = _instanceof.get();
-    const auto &resolved_imports = _scriptData->resolved_imports;
-    for (size_t fixup_idx = 0; fixup_idx < scri->fixups.size(); ++fixup_idx)
-    {
-        if (scri->fixuptypes[fixup_idx] != FIXUP_IMPORT)
-            continue;
-
-        uint32_t const fixup = scri->fixups[fixup_idx];
-        uint32_t const import_index = resolved_imports[_code[fixup]];
-        ScriptImport const *import = simp.GetByIndex(import_index);
-        if (!import)
-        {
-            cc_error("cannot resolve import, key = %d", import_index);
-            cc_error_fixups(scri, fixup, "cannot resolve import (bytecode pos %d, key %d)", fixup, import_index);
-            return false;
-        }
-        _code[fixup] = import_index;
-        // If the call is to another script function next CALLEXT
-        // must be replaced with CALLAS
-        if (import->InstancePtr != nullptr && (_code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
-            _code[fixup + 1] = SCMD_CALLAS | (import->InstancePtr->_loadedInstanceId << INSTANCE_ID_SHIFT);
-    }
-    return true;
-}
 
 void ccInstance::CopyGlobalData(const std::vector<uint8_t> &data)
 {
-    const size_t copy_sz = std::min(data.size(), _scriptData->globaldata.size());
-    std::copy(data.begin(), data.begin() + copy_sz, _scriptData->globaldata.begin());
+    _instanceof->CopyGlobalData(data);
 }
 
 void ccInstance::PushValueToStack(const RuntimeScriptValue &rval)

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -26,8 +26,8 @@
 #include "script/cc_reflecthelper.h"
 #include "script/cc_script.h"  // ccScript
 #include "script/cc_internal.h"  // bytecode constants
+#include "script/runtimescript.h"
 #include "script/runtimescriptvalue.h"
-#include "script/systemimports.h"
 #include "util/string.h"
 
 using namespace AGS;
@@ -46,10 +46,6 @@ using namespace AGS;
 
 // 256 because we use 8 bits to hold instance number
 #define MAX_LOADED_INSTANCES 256
-
-#define INSTANCE_ID_SHIFT 24LL
-#define INSTANCE_ID_MASK  0x00000000000000ffLL
-#define INSTANCE_ID_REMOVEMASK 0x0000000000ffffffLL
 
 // Script executor debugging flag:
 // enables mistake checks, but slows things down!
@@ -84,18 +80,6 @@ struct ScriptOperation
     inline int Arg3i() const { return Args[2].IValue; }
 };
 
-struct ScriptVariable
-{
-    ScriptVariable()
-    {
-        ScAddress   = -1; // address = 0 is valid one, -1 means undefined
-    }
-
-    int32_t             ScAddress;  // original 32-bit relative data address, written in compiled script;
-                                    // if we are to use Map or HashMap, this could be used as Key
-    RuntimeScriptValue  RValue;
-};
-
 struct FunctionCallStack;
 
 struct ScriptPosition
@@ -128,6 +112,8 @@ enum ccInstError
 // Running instance of the script
 class ccInstance
 {
+    using RuntimeScript = AGS::Engine::RuntimeScript;
+    using PRuntimeScript = std::shared_ptr<RuntimeScript>;
 public:
     // returns the currently executing instance, or NULL if none
     static ccInstance *GetCurrentInstance(void);
@@ -136,8 +122,8 @@ public:
     // when destroying all script instances, e.g. on game quit.
     static void FreeInstanceStack();
     // create a runnable instance of the supplied script
-    static std::unique_ptr<ccInstance> CreateFromScript(PScript script);
-    static std::unique_ptr<ccInstance> CreateEx(PScript scri, const ccInstance * joined);
+    static std::unique_ptr<ccInstance> CreateFromScript(PRuntimeScript script);
+    static std::unique_ptr<ccInstance> CreateEx(PRuntimeScript script, const ccInstance * joined);
     static void SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
     static const JointRTTI *GetRTTI() { return _rtti.get(); }
     static const Engine::RTTIHelper *GetRTTIHelper() { return _rttiHelper.get(); }
@@ -149,16 +135,16 @@ public:
         std::unordered_map<uint32_t, uint32_t> &loc_l2g,
         std::unordered_map<uint32_t, uint32_t> &type_l2g);
 
-    ccInstance();
+    ccInstance() = default;
     ~ccInstance();
 
     // Get the script that this Instance represents
-    PScript GetScript() const { return _instanceof; }
+    AGS::Engine::RuntimeScript *GetScript() const { return _instanceof.get(); }
     // Get the currently executed instance, which may be this instance,
     // or another one in case of a nested "far call"
     ccInstance *GetRunningInst() const { return _runningInst; }
     // Get a readonly access to the global script data
-    const std::vector<uint8_t> &GetGlobalData() const { return _scriptData->globaldata; }
+    const std::vector<uint8_t> &GetGlobalData() const { return _instanceof->GetGlobalData(); }
     // Get current program pointer (position in bytecode)
     int     GetPC() const { return _pc; }
     // Gets the top entry of this instance's stack
@@ -191,13 +177,6 @@ public:
     // Notifies that the game was being updated (script not hanging)
     void    NotifyAlive();
 
-    // For each import, find the instance that corresponds to it and save it
-    // in resolved_imports[]. Return whether the function is successful
-    bool    ResolveScriptImports();
-    // Using resolved_imports[], resolve the IMPORT fixups
-    // Also change CALLEXT op-codes to CALLAS when they pertain to a script instance 
-    bool    ResolveImportFixups();
-
     // Copies global data values over to this instance;
     // copies not more than the allocated size of global data
     void    CopyGlobalData(const std::vector<uint8_t> &data);
@@ -211,18 +190,9 @@ public:
 
 
 private:
-    bool    _Create(PScript scri, const ccInstance * joined);
+    bool    _Create(PRuntimeScript scri, const ccInstance * joined);
     // free the memory associated with the instance
     void    Free();
-
-    bool    CreateGlobalVars(const ccScript *scri);
-    bool    AddGlobalVar(const ScriptVariable &glvar);
-    ScriptVariable *FindGlobalVar(int32_t var_addr);
-    bool    CreateRuntimeCodeFixups(const ccScript *scri);
-
-    // Searches for the function among this script's exports,
-    // on success returns its starting position in bytecode, and number of arguments
-    bool    FindExportedFunction(const Common::String &fn_name, int32_t &start_at, int32_t &num_args) const;
 
     // Begin executing script starting from the given bytecode index
     ccInstError Run(int32_t curpc);
@@ -246,36 +216,13 @@ private:
     void    PushToFuncCallStack(FunctionCallStack &func_callstack, const RuntimeScriptValue &rval);
     void    PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t num_entries);
 
-    // Represented script object
-    PScript _instanceof;
     int32_t _loadedInstanceId = 0;
     int     _flags = 0; // INSTF_* flags
-
-    // Runtime variant of script data, fixups and imports,
-    // resolved after loading all the game scripts,
-    // and possibly shared among multiple script instance forks.
-    struct ResolvedScriptData
-    {
-        // Script's global data (for global variables)
-        std::vector<uint8_t>    globaldata;
-        // Executed byte-code. Unlike ccScript's code array which is int32_t, the one
-        // in ccInstance must be intptr_t to accomodate real pointers placed after
-        // performing fixups.
-        std::vector<intptr_t>   code;
-        std::vector<uint8_t>    code_fixups;
-        // Resolved global variables
-        std::unordered_map<int32_t, ScriptVariable> globalvars;
-        // Array of real import indexes used in script
-        std::vector<uint32_t>   resolved_imports;
-    };
-    std::shared_ptr<ResolvedScriptData> _scriptData;
-    // This script's exports
-    // TODO: not sure why these are not shared among forks, review this later
-    std::vector<RuntimeScriptValue> _exports;
-    ScriptSymbolsMap _exportLookup; // must be a sorted map, we use partial name matches
+    // Represented script object
+    PRuntimeScript _instanceof;
 
     // Code pointers for faster access
-    intptr_t   *_code = nullptr;
+    const intptr_t *_code = nullptr;
     uint32_t    _codesize = 0; // size of code is limited under 32-bit due to bytecode format
     const uint8_t *_code_fixups = nullptr;
     const char *_strings = nullptr; // pointer to ccScript's string data

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -23,7 +23,6 @@
 #include <unordered_map>
 
 #include "ac/timer.h"
-#include "script/cc_reflecthelper.h"
 #include "script/cc_script.h"  // ccScript
 #include "script/cc_internal.h"  // bytecode constants
 #include "script/runtimescript.h"
@@ -125,15 +124,6 @@ public:
     static std::unique_ptr<ccInstance> CreateFromScript(PRuntimeScript script);
     static std::unique_ptr<ccInstance> CreateEx(PRuntimeScript script, const ccInstance * joined);
     static void SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
-    static const JointRTTI *GetRTTI() { return _rtti.get(); }
-    static const Engine::RTTIHelper *GetRTTIHelper() { return _rttiHelper.get(); }
-    // Joins custom provided RTTI into the global collection;
-    // fills in maps for locid and typeid remap which may be used to know
-    // which *global* ids were assigned to this particular rtti's entries.
-    // Updates RTTIHelper correspondingly.
-    static void JoinRTTI(const RTTI &rtti,
-        std::unordered_map<uint32_t, uint32_t> &loc_l2g,
-        std::unordered_map<uint32_t, uint32_t> &type_l2g);
 
     ccInstance() = default;
     ~ccInstance();
@@ -184,9 +174,9 @@ public:
     // Returns a dictionary that maps local script's typeid to global typeid (in joint RTTI)
     // Requires RTTI
     const std::unordered_map<uint32_t, uint32_t> &
-        GetLocal2GlobalTypeMap() const { return _typeidLocal2Global; }
+        GetLocal2GlobalTypeMap() const { return _instanceof->GetLocal2GlobalTypeMap(); }
     const std::unordered_map<Common::String, uint32_t> &
-        GetGlobalVariableLookup() const { return _globalVarLookup; }
+        GetGlobalVariableLookup() const { return _instanceof->GetGlobalVariableLookup(); }
 
 
 private:
@@ -227,19 +217,9 @@ private:
     const uint8_t *_code_fixups = nullptr;
     const char *_strings = nullptr; // pointer to ccScript's string data
     size_t      _stringsize = 0u;
-
-    // RTTI tables
-    static std::unique_ptr<JointRTTI> _rtti;
-    // Full name to global id (global id is an actual index in the joint rtti table)
-    static std::unordered_map<Common::String, uint32_t> _rttiLookup;
-    // Helper data for quicker RTTI analyzis
-    static std::unique_ptr<Engine::RTTIHelper> _rttiHelper;
-    // Map local script's location id to global (program-wide)
-    std::unordered_map<uint32_t, uint32_t> _locidLocal2Global;
-    // Map local script's type id to global (program-wide)
-    std::unordered_map<uint32_t, uint32_t> _typeidLocal2Global;
-    // Global variables name-to-index lookup (in script's TOC)
-    std::unordered_map<Common::String, uint32_t> _globalVarLookup;
+    // Table pointers for simplicity
+    const JointRTTI *_rtti = nullptr;
+    const std::unordered_map<uint32_t, uint32_t> *_typeidLocal2Global = nullptr;
 
     // Virtual machine state
     RuntimeScriptValue _registers[CC_NUM_REGISTERS]; // registers

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -18,6 +18,7 @@
 #ifndef __CC_INSTANCE_H
 #define __CC_INSTANCE_H
 
+#if defined (DISABLED)
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -252,5 +253,7 @@ private:
     // Last time the script was noted of being "alive"
     AGS_FastClock::time_point _lastAliveTs;
 };
+
+#endif // DISABLED
 
 #endif // __CC_INSTANCE_H

--- a/Engine/script/executingscript.h
+++ b/Engine/script/executingscript.h
@@ -19,8 +19,9 @@
 #define __AGS_EE_SCRIPT__EXECUTINGSCRIPT_H
 
 #include <vector>
-#include "script/cc_instance.h"
 #include "gfx/bitmap.h"
+#include "script/runtimescript.h"
+#include "script/runtimescriptvalue.h"
 
 #define MAX_SCRIPT_EVT_PARAMS  4
 
@@ -92,7 +93,7 @@ struct PostScriptAction
     Common::String Name;
     Common::String Text;
     mutable std::unique_ptr<Common::Bitmap> Image;
-    ScriptPosition Position;
+    AGS::Engine::ScriptPosition Position;
 
     PostScriptAction() = default;
     PostScriptAction(PostScriptActionType type, int data, const Common::String &name, const Common::String &text = {},
@@ -108,11 +109,7 @@ struct PostScriptAction
 
 struct ExecutingScript
 {
-    // Instance refers either to one of the global instances,
-    // or a ForkedInst created for this purpose
-    ccInstance *Inst = nullptr;
-    // owned fork; CHECKME: this seem unused in the current engine
-    std::unique_ptr<ccInstance> ForkedInst{};
+    const AGS::Engine::RuntimeScript *Script = nullptr;
     std::vector<PostScriptAction> PostScriptActions;
     std::vector<QueuedScript> ScFnQueue;
 

--- a/Engine/script/runtimescript.cpp
+++ b/Engine/script/runtimescript.cpp
@@ -139,9 +139,14 @@ static void cc_error_fixups(const RuntimeScript *scri, const int32_t pc, const c
     }
 }
 
+
 const String RuntimeScript::_noname = "(unknown)";
 const String RuntimeScript::_unknownSectionName = "(unknown section)";
 RuntimeScript *RuntimeScript::_linkedScripts[RuntimeScript::MaxLinkedScripts] = { nullptr };
+
+std::unique_ptr<JointRTTI> RuntimeScript::_jointRtti;
+std::unordered_map<String, uint32_t> RuntimeScript::_rttiLookup;
+std::unique_ptr<RTTIHelper> RuntimeScript::_rttiHelper;
 
 RuntimeScript::RuntimeScript()
     : _exportLookup('$', true /* allow to match symbols with more appendages */)
@@ -180,7 +185,26 @@ RuntimeScript::RuntimeScript(const String &tag)
         return nullptr;
     }
 
+    // Join RTTI
+    if (!RuntimeScript::_jointRtti)
+        RuntimeScript::_jointRtti.reset(new JointRTTI());
+    if (!RuntimeScript::_rttiHelper)
+        RuntimeScript::_rttiHelper.reset(new RTTIHelper());
+    if (run_script->GetRTTI() && !run_script->GetRTTI()->IsEmpty())
+    {
+        JoinRTTI(*run_script->GetRTTI(), run_script->_locidLocal2Global, run_script->_typeidLocal2Global);
+    }
+
     return run_script;
+}
+
+/* static */ void RuntimeScript::JoinRTTI(const RTTI &rtti,
+    std::unordered_map<uint32_t, uint32_t> &loc_l2g,
+    std::unordered_map<uint32_t, uint32_t> &type_l2g)
+{
+    _jointRtti->Join(rtti, loc_l2g, type_l2g);
+    // TODO: optimize by updating only newly joint types
+    _rttiHelper->Generate(_jointRtti->AsConstRTTI());
 }
 
 RuntimeScript::~RuntimeScript()
@@ -293,6 +317,17 @@ bool RuntimeScript::Create(const ccScript *script)
         return false;
     if (!CreateExports())
         return false;
+
+    // Generate lookup tables for script TOC (if available)
+    if (_toc)
+    {
+        const auto &glvars = _toc->GetGlobalVariables();
+        for (size_t i = 0; i < glvars.size(); ++i)
+        {
+            _globalVarLookup.insert(
+                std::make_pair(String(glvars[i].name), static_cast<uint32_t>(i)));
+        }
+    }
 
     return true;
 }

--- a/Engine/script/runtimescript.cpp
+++ b/Engine/script/runtimescript.cpp
@@ -198,6 +198,11 @@ RuntimeScript::RuntimeScript(const String &tag)
     return run_script;
 }
 
+/* static */ RuntimeScript *RuntimeScript::GetLinkedScript(uint8_t linkid)
+{
+    return _linkedScripts[linkid];
+}
+
 /* static */ void RuntimeScript::JoinRTTI(const RTTI &rtti,
     std::unordered_map<uint32_t, uint32_t> &loc_l2g,
     std::unordered_map<uint32_t, uint32_t> &type_l2g)

--- a/Engine/script/runtimescript.cpp
+++ b/Engine/script/runtimescript.cpp
@@ -1,0 +1,580 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "script/runtimescript.h"
+#include "script/cc_common.h"
+#include "script/script_runtime.h"
+#include "util/memory_compat.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+using namespace AGS::Common;
+
+const ScriptCommandInfo sccmd_info[CC_NUM_SCCMDS] =
+{
+    ScriptCommandInfo( 0                    , "NULL"              , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_ADD             , "addi"              , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_SUB             , "subi"              , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_REGTOREG        , "mov"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_WRITELIT        , "memwritelit"       , 2, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_RET             , "ret"               , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_LITTOREG        , "movl"              , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMREAD         , "memread4"          , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMWRITE        , "memwrite4"         , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MULREG          , "mul"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_DIVREG          , "div"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_ADDREG          , "add"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_SUBREG          , "sub"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_BITAND          , "and"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_BITOR           , "or"                , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_ISEQUAL         , "cmpeq"             , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_NOTEQUAL        , "cmpne"             , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_GREATER         , "gt"                , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_LESSTHAN        , "lt"                , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_GTE             , "gte"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_LTE             , "lte"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_AND             , "land"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_OR              , "lor"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_CALL            , "call"              , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMREADB        , "memread1"          , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMREADW        , "memread2"          , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMWRITEB       , "memwrite1"         , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMWRITEW       , "memwrite2"         , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_JZ              , "jzi"               , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_PUSHREG         , "push"              , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_POPREG          , "pop"               , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_JMP             , "jmpi"              , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_MUL             , "muli"              , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_CALLEXT         , "farcall"           , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_PUSHREAL        , "farpush"           , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_SUBREALSTACK    , "farsubsp"          , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_LINENUM         , "sourceline"        , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_CALLAS          , "callscr"           , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_THISBASE        , "thisaddr"          , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_NUMFUNCARGS     , "setfuncargs"       , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_MODREG          , "mod"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_XORREG          , "xor"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_NOTREG          , "not"               , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_SHIFTLEFT       , "shl"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_SHIFTRIGHT      , "shr"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_CALLOBJ         , "callobj"           , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_CHECKBOUNDS     , "checkbounds"       , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMWRITEPTR     , "memwrite.ptr"      , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMREADPTR      , "memread.ptr"       , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMZEROPTR      , "memwrite.ptr.0"    , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMINITPTR      , "meminit.ptr"       , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_LOADSPOFFS      , "load.sp.offs"      , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_CHECKNULL       , "checknull.ptr"     , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_FADD            , "faddi"             , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_FSUB            , "fsubi"             , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_FMULREG         , "fmul"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FDIVREG         , "fdiv"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FADDREG         , "fadd"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FSUBREG         , "fsub"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FGREATER        , "fgt"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FLESSTHAN       , "flt"               , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FGTE            , "fgte"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_FLTE            , "flte"              , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_ZEROMEMORY      , "zeromem"           , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_CREATESTRING    , "newstring"         , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_STRINGSEQUAL    , "streq"             , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_STRINGSNOTEQ    , "strne"             , 2, kScOpTwoArgsAreReg ),
+    ScriptCommandInfo( SCMD_CHECKNULLREG    , "checknull"         , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_LOOPCHECKOFF    , "loopcheckoff"      , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_MEMZEROPTRND    , "memwrite.ptr.0.nd" , 0, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_JNZ             , "jnzi"              , 1, kScOpNoArgIsReg ),
+    ScriptCommandInfo( SCMD_DYNAMICBOUNDS   , "dynamicbounds"     , 1, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_NEWARRAY        , "newarray"          , 3, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_NEWUSEROBJECT   , "newuserobject"     , 2, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_NEWUSEROBJECT2  , "newuserobject2"    , 3, kScOpOneArgIsReg ),
+    ScriptCommandInfo( SCMD_NEWARRAY2       , "newarray2"         , 3, kScOpOneArgIsReg ),
+};
+
+// FIXME: move to some "script helpers" module
+static int DetermineScriptLine(const std::vector<intptr_t> &code, const int32_t at_pc)
+{
+    if (at_pc < 0)
+        return 0;
+
+    int line = -1;
+    for (uint32_t pc = 0; (pc <= static_cast<uint32_t>(at_pc)) && (pc < code.size()); ++pc)
+    {
+        const int op = code[pc] & INSTANCE_ID_REMOVEMASK;
+        if (op < 0 || op >= CC_NUM_SCCMDS) return -1;
+        if (pc + sccmd_info[op].ArgCount >= code.size()) return -1;
+        if (op == SCMD_LINENUM)
+            line = code[pc + 1];
+        pc += sccmd_info[op].ArgCount;
+    }
+    return line;
+}
+
+static void cc_error_fixups(const RuntimeScript *scri, const int32_t pc, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    const String displbuf = String::FromFormatV(fmt, ap);
+    va_end(ap);
+    if (pc == INT32_MAX)
+    {
+        cc_error("in script %s: %s", scri->GetScriptName().GetCStr(), displbuf.GetCStr());
+    }
+    else
+    {
+        const int line = DetermineScriptLine(scri->GetCode(), pc);
+        cc_error("in script %s around line %d: %s", scri->GetScriptName().GetCStr(), line, displbuf.GetCStr());
+    }
+}
+
+const String RuntimeScript::_noname = "(unknown)";
+const String RuntimeScript::_unknownSectionName = "(unknown section)";
+RuntimeScript *RuntimeScript::_linkedScripts[RuntimeScript::MaxLinkedScripts] = { nullptr };
+
+RuntimeScript::RuntimeScript()
+    : _exportLookup('$', true /* allow to match symbols with more appendages */)
+{
+}
+
+RuntimeScript::RuntimeScript(const String &tag)
+    : _exportLookup('$', true /* allow to match symbols with more appendages */)
+    , _tag(tag)
+{
+}
+
+/* static */ std::unique_ptr<RuntimeScript> RuntimeScript::Create(const ccScript *script, const String &tag)
+{
+    if (!script)
+        return nullptr;
+
+    auto run_script = std::make_unique<RuntimeScript>(tag);
+    if (!run_script->Create(script))
+        return nullptr;
+
+    // Find a linking slot for the new script
+    for (size_t i = MinLinkedScriptIndex; i < MaxLinkedScripts; i++)
+    {
+        if (_linkedScripts[i] == nullptr)
+        {
+            run_script->_linkIndex = static_cast<uint8_t>(i);
+            _linkedScripts[i] = run_script.get();
+            break;
+        }
+    }
+
+    if (run_script->_linkIndex == 0u)
+    {
+        cc_error("Too many linked scripts");
+        return nullptr;
+    }
+
+    return run_script;
+}
+
+RuntimeScript::~RuntimeScript()
+{
+    if ((_linkIndex > 0u) && (_linkedScripts[_linkIndex] == this))
+        _linkedScripts[_linkIndex] = nullptr;
+}
+
+const String &RuntimeScript::GetScriptName() const
+{
+    if (!_scriptname.IsEmpty())
+        return _scriptname;
+    // In a regular script sections contain an optional list of headers in an order
+    // they were included, and the script body's own name as the last element.
+    if (_sectionNames.size() > 0)
+        return _sectionNames.back();
+    return _noname;
+}
+
+const String &RuntimeScript::GetSectionName(int32_t offset) const
+{
+    size_t sect_idx = 0;
+    for (; sect_idx < _sectionOffsets.size(); ++sect_idx)
+    {
+        if (_sectionOffsets[sect_idx] < offset)
+            continue;
+        break;
+    }
+
+    // if no sections in script, return unknown
+    if (sect_idx == 0)
+        return _unknownSectionName;
+
+    return _sectionNames[sect_idx - 1];
+}
+
+RuntimeScriptValue RuntimeScript::GetSymbolAddress(const String &symname) const
+{
+    uint32_t exp_index = _exportLookup.GetIndexOfAny(symname);
+    return (exp_index < UINT32_MAX) ? _resolvedExports[exp_index].Value : RuntimeScriptValue();
+}
+
+bool RuntimeScript::FindExportedFunction(const String &fn_name, int32_t &start_at, int32_t &num_args) const
+{
+    const uint32_t exp_index = _exportLookup.GetIndexOfAny(fn_name);
+    if (exp_index == SIZE_MAX)
+        return false;
+
+    if (_resolvedExports[exp_index].Type != EXPORT_FUNCTION)
+        return false; // not a function
+
+    start_at = _resolvedExports[exp_index].Offset;
+    const String &exp_name = _exports[exp_index];
+    assert(exp_name.GetLength() >= fn_name.GetLength());
+    if (exp_name.GetLength() <= fn_name.GetLength())
+    {
+        num_args = 0; // unknown, registered without args info
+    }
+    else
+    {
+        num_args = atoi(&exp_name[fn_name.GetLength() + 1]);
+    }
+    return true;
+}
+
+void RuntimeScript::CopyGlobalData(const std::vector<uint8_t> &data)
+{
+    const size_t copy_sz = std::min(data.size(), _globaldata.size());
+    std::copy(data.begin(), data.begin() + copy_sz, _globaldata.begin());
+}
+
+bool RuntimeScript::Create(const ccScript *script)
+{
+    // Copy loaded script data over
+    _scriptname = script->scriptname;
+    _globaldata = script->globaldata;
+    // Read code into array of intptr_t, necessary for being able to
+    // store direct memory addresses at runtime
+    _code.resize(script->code.size());
+    for (size_t i = 0; i < script->code.size(); ++i)
+        _code[i] = script->code[i];
+    _fixups = script->fixups;
+    _fixuptypes = script->fixuptypes;
+    _codeFixups.resize(script->code.size());
+    _strings = script->strings;
+    for (const auto &i : script->imports)
+        _imports.emplace_back(i);
+    for (const auto &e : script->exports)
+        _exports.emplace_back(e);
+    _exportAddr = script->export_addr;
+    for (const auto &sn : script->sectionNames)
+        _sectionNames.emplace_back(sn);
+    _sectionOffsets = script->sectionOffsets;
+    // Auxiliary script data
+    if (script->rtti)
+    {
+        _rtti = std::make_unique<RTTI>(*script->rtti);
+    }
+    if (script->sctoc)
+    {
+        _toc = std::make_unique<ScriptTOC>(*script->sctoc);
+        _toc->RebindRTTI(_rtti.get());
+    }
+
+    // Generate runtime data
+    if (!CreateGlobalVars())
+        return false;
+    if (!CreateRuntimeCodeFixups())
+        return false;
+    if (!CreateExports())
+        return false;
+
+    return true;
+}
+
+void RuntimeScript::RegisterExports(SystemImports &simp)
+{
+    // Do not register exports if SCOPT_AUTOIMPORT is not set
+    if (ccGetOption(SCOPT_AUTOIMPORT) == 0)
+        return;
+
+    for (size_t i = 0; i < _exports.size(); i++)
+    {
+        String name = _exports[i];
+        name.Replace('$', '^'); // replace exported name separator with imported name separator
+        ccAddExternalScriptSymbol(name, _resolvedExports[i].Value, this);
+    }
+}
+
+void RuntimeScript::UnRegisterExports(SystemImports &simp)
+{
+    simp.RemoveScriptExports(this);
+}
+
+bool RuntimeScript::ResolveImports(const SystemImports &simp)
+{
+    // Script keeps the information of what imports are used as an array of names.
+    // When an import is referenced in the code, it's addressed by its index in this
+    // array. Different scripts have differing arrays of imports; indexes
+    // into 'imports[]' are NOT unique and relative to the respective script only.
+    // To allow real-time import use, the sequence of imports in 'imports[]'
+    // and 'resolved_imports[]' should not be modified.
+
+    const size_t numimports = _imports.size();
+    if (numimports == 0)
+    {
+        // [PGB] AFAICS there's nothing wrong with not having any imports, and
+        // it doesn't lead to trouble. However, if it turns out that we do need
+        // to return 'false' here, we should also report why with a 'Debug::Printf()' call.
+        return true;
+    }
+
+    auto &resolved_imports = _resolvedImports;
+    resolved_imports.resize(numimports);
+    size_t errors = 0, last_err_idx = 0;
+    for (size_t import_idx = 0; import_idx < _imports.size(); ++import_idx)
+    {
+        if (_imports[import_idx].IsEmpty())
+        {
+            resolved_imports[import_idx] = UINT32_MAX;
+            continue;
+        }
+
+        resolved_imports[import_idx] = simp.GetIndexOfAny(_imports[import_idx]);
+        if (resolved_imports[import_idx] == UINT32_MAX)
+        {
+            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", _imports[import_idx].GetCStr(), GetScriptName().GetCStr());
+            errors++;
+            last_err_idx = import_idx;
+        }
+    }
+
+    if (errors > 0)
+    {
+        cc_error("in %s: %d unresolved imports (last: %s)",
+            GetScriptName().GetCStr(),
+            errors,
+            _imports[last_err_idx].GetCStr());
+        return false;
+    }
+
+    ResolveImportFixups();
+    return true;
+}
+
+bool RuntimeScript::ResolveImportFixups()
+{
+    const auto &resolved_imports = _resolvedImports;
+    for (size_t fixup_idx = 0; fixup_idx < _fixups.size(); ++fixup_idx)
+    {
+        if (_fixuptypes[fixup_idx] != FIXUP_IMPORT)
+            continue;
+
+        uint32_t const fixup = _fixups[fixup_idx];
+        uint32_t const import_index = resolved_imports[_code[fixup]];
+        ScriptImport const *import = simp.GetByIndex(import_index);
+        if (!import)
+        {
+            cc_error("cannot resolve import, key = %d", import_index);
+            cc_error_fixups(this, fixup, "cannot resolve import (bytecode pos %d, key %d)", fixup, import_index);
+            return false;
+        }
+        _code[fixup] = import_index;
+        // If the call is to another script function, then CALLEXT must be replaced with CALLAS
+        if (import->ScriptID > 0u && (_code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
+            _code[fixup + 1] = SCMD_CALLAS | (import->ScriptID << INSTANCE_ID_SHIFT);
+    }
+    return true;
+}
+
+// TODO: it is possible to deduce global var's size at start with
+// certain accuracy after all global vars are registered. Each
+// global var's size would be limited by closest next var's ScAddress
+// and globaldatasize.
+bool RuntimeScript::CreateGlobalVars()
+{
+    ScriptVariable glvar;
+    uint8_t *globaldata = _globaldata.data();
+
+    // Step One: deduce global variables from fixups
+    for (size_t i = 0; i < _fixuptypes.size(); ++i)
+    {
+        switch (_fixuptypes[i])
+        {
+        case FIXUP_GLOBALDATA:
+            // GLOBALDATA fixup takes relative address of global data element from code array;
+            // this is the address of actual data
+            glvar.ScAddress = (int32_t)_code[_fixups[i]];
+            glvar.RValue.SetData(globaldata + glvar.ScAddress, 0);
+            break;
+        case FIXUP_DATADATA:
+            {
+            // DATADATA fixup takes relative address of global data element from fixups array;
+            // this is the address of element, which stores address of actual data
+            glvar.ScAddress = _fixups[i];
+            const int32_t data_addr = BBOp::Int32FromLE(*(int32_t*)&globaldata[glvar.ScAddress]);
+            if (glvar.ScAddress - data_addr != 200 /* size of old AGS string */)
+            {
+                // CHECKME: probably replace with mere warning in the log?
+                cc_error("unexpected old-style string's alignment");
+                return false;
+            }
+            // TODO: register this explicitly as a string instead (can do this later)
+            glvar.RValue.SetScriptObject(globaldata + data_addr, &GlobalStaticManager);
+            }
+            break;
+        default:
+            // other fixups are of no use here
+            continue;
+        }
+
+        AddGlobalVar(glvar);
+    }
+
+    // Step Two: deduce global variables from exports
+    for (size_t i = 0; i < _exports.size(); ++i)
+    {
+        const int32_t etype = (_exportAddr[i] >> 24L) & 0x000ff;
+        const int32_t eaddr = (_exportAddr[i] & 0x00ffffff);
+        if (etype == EXPORT_DATA)
+        {
+            // NOTE: old-style strings could not be exported in AGS,
+            // no need to worry about these here
+            glvar.ScAddress = eaddr;
+            glvar.RValue.SetData(globaldata + glvar.ScAddress, 0);
+            AddGlobalVar(glvar);
+        }
+    }
+
+    return true;
+}
+
+bool RuntimeScript::AddGlobalVar(const ScriptVariable &glvar)
+{
+    // NOTE:
+    // We suppress the error here, because unfortunately at least one existing
+    // game ("Metal Dead", built with AGS 3.21.1115) fails to pass this check.
+    // It has been found that this may be caused by a global variable of zero
+    // size (an instance of empty struct) placed in the end of the script.
+    // TODO: invent some workaround?
+    // TODO: enable the error back in AGS 4, as this is not a normal behavior.
+    const int32_t globaldatasize = static_cast<int32_t>(_globaldata.size());
+    if (glvar.ScAddress < 0 || glvar.ScAddress >= globaldatasize)
+    {
+        /* return false; */
+        Debug::Printf(kDbgMsg_Warn, "WARNING: global variable refers to data beyond allocated buffer (%d, %d)", glvar.ScAddress, globaldatasize);
+    }
+    _globalvars.insert(std::make_pair(glvar.ScAddress, glvar));
+    return true;
+}
+
+ScriptVariable *RuntimeScript::FindGlobalVar(const int32_t var_addr)
+{
+    // NOTE: see comment for AddGlobalVar()
+    const int32_t globaldatasize = static_cast<int32_t>(_globaldata.size());
+    if (var_addr < 0 || var_addr >= globaldatasize)
+    {
+        /*
+        return nullptr;
+        */
+        Debug::Printf(kDbgMsg_Warn, "WARNING: looking up for global variable beyond allocated buffer (%d, %d)", var_addr, globaldatasize);
+    }
+    const auto it = _globalvars.find(var_addr);
+    return it != _globalvars.end() ? &it->second : nullptr;
+}
+
+bool RuntimeScript::CreateRuntimeCodeFixups()
+{
+    uint8_t *code_fixups = _codeFixups.data();
+
+    for (size_t i = 0; i < _fixups.size(); ++i)
+    {
+        if (_fixuptypes[i] == FIXUP_DATADATA)
+        {
+            continue;
+        }
+
+        const int32_t fixup = _fixups[i];
+        if (fixup < 0 || static_cast<size_t>(fixup) >= _code.size())
+        {
+            cc_error_fixups(this, INT32_MAX, "bad fixup at %d (fixup type %d, bytecode pos %d, bytecode range is 0..%d)",
+                i,  _fixuptypes[i], fixup, static_cast<int32_t>(_code.size()));
+            return false;
+        }
+
+        code_fixups[fixup] = _fixuptypes[i];
+
+        switch (_fixuptypes[i])
+        {
+        case FIXUP_GLOBALDATA:
+            {
+                ScriptVariable *gl_var = FindGlobalVar(static_cast<int32_t>(_code[fixup]));
+                if (!gl_var)
+                {
+                    cc_error_fixups(this, fixup, "cannot resolve global variable (bytecode pos %d, key %d)", fixup, static_cast<int32_t>(_code[fixup]));
+                    return false;
+                }
+                _code[fixup] = (intptr_t)gl_var;
+            }
+            break;
+        case FIXUP_FUNCTION:
+        case FIXUP_STRING:
+        case FIXUP_STACK:
+        case FIXUP_IMPORT:
+            break; // do nothing yet
+        default:
+            cc_error_fixups(this, INT32_MAX, "unknown fixup type: %d (fixup num %d)", _fixuptypes[i], i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RuntimeScript::CreateExports()
+{
+    // Find the real addresses of the exports
+    for (size_t i = 0; i < _exports.size(); i++)
+    {
+        const int32_t etype = (_exportAddr[i] >> 24L) & 0x000ff;
+        const int32_t eaddr = (_exportAddr[i] & 0x00ffffff);
+        ResolvedExport res_exp;
+        res_exp.Type = etype;
+        res_exp.Offset = eaddr;
+        if (etype == EXPORT_FUNCTION)
+        {
+            // NOTE: unfortunately, there seems to be no way to know if
+            // that's an extender function that expects object pointer
+            res_exp.Value.SetCodePtr(_code.data() + static_cast<uintptr_t>(eaddr));
+        }
+        else if (etype == EXPORT_DATA)
+        {
+            ScriptVariable *gl_var = FindGlobalVar(eaddr);
+            if (gl_var)
+            {
+                res_exp.Value.SetGlobalVar(&gl_var->RValue);
+            }
+            else
+            {
+                cc_error("cannot resolve global variable, key = %d", eaddr);
+                return false;
+            }
+        }
+        else
+        {
+            cc_error("internal export fixup error");
+            return false;
+        }
+
+        _resolvedExports.push_back(res_exp);
+        _exportLookup.Add(_exports[i], i);
+    }
+
+    return true;
+}
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/script/runtimescript.h
+++ b/Engine/script/runtimescript.h
@@ -168,8 +168,9 @@ private:
     // in RuntimeScript must be intptr_t to accomodate real pointers placed after
     // performing fixups.
     std::vector<intptr_t>   _code;
-    std::vector<int32_t>    _fixups;  // code array index to fixup (in ints)
-    std::vector<uint8_t>    _fixuptypes; // global data/string area/ etc
+    std::vector<int32_t>    _fixups; // code array index to fixup (in ints)
+    std::vector<uint8_t>    _fixupTypes; // FIXUP_* type per fixup index
+    std::vector<int32_t>    _fixupValues; // fixup values per fixup index
     std::vector<uint8_t>    _codeFixups; // fixup type per each code entry
     // Resolved global variables
     std::unordered_map<int32_t, ScriptVariable> _globalvars;

--- a/Engine/script/runtimescript.h
+++ b/Engine/script/runtimescript.h
@@ -1,0 +1,206 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_EE_SCRIPT__RUNTIMESCRIPT_H
+#define __AGS_EE_SCRIPT__RUNTIMESCRIPT_H
+#include <memory>
+#include <vector>
+#include "script/cc_internal.h" // FIXME: should not be included into this header
+#include "script/cc_script.h"
+#include "script/runtimescriptvalue.h"
+#include "script/systemimports.h"
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+#define INSTANCE_ID_SHIFT       24LL
+#define INSTANCE_ID_MASK        0x00000000000000ffLL
+#define INSTANCE_ID_REMOVEMASK  0x0000000000ffffffLL
+
+enum ScriptOpArgIsReg
+{
+    kScOpNoArgIsReg     = 0,
+    kScOpArg1IsReg      = 0x0001,
+    kScOpArg2IsReg      = 0x0002,
+    kScOpArg3IsReg      = 0x0004,
+    kScOpOneArgIsReg    = kScOpArg1IsReg,
+    kScOpTwoArgsAreReg  = kScOpArg1IsReg | kScOpArg2IsReg,
+    kScOpTreeArgsAreReg = kScOpArg1IsReg | kScOpArg2IsReg | kScOpArg3IsReg
+};
+
+struct ScriptCommandInfo
+{
+    ScriptCommandInfo(const int32_t code, const char *cmdname, const int arg_count, const ScriptOpArgIsReg arg_is_reg)
+        : Code(code), CmdName(cmdname), ArgCount(arg_count)
+        , ArgIsReg {
+            (arg_is_reg & kScOpArg1IsReg) != 0, 
+            (arg_is_reg & kScOpArg2IsReg) != 0, 
+            (arg_is_reg & kScOpArg3IsReg) != 0
+        }
+    {}
+
+    const int32_t   Code = 0;
+    const char     *CmdName = nullptr;
+    const int       ArgCount = 0;
+    const bool      ArgIsReg[3]{};
+};
+
+// FIXME: move this elsewhere, make available for both RuntimeScript and ccInstance (script runner)
+extern const ScriptCommandInfo sccmd_info[CC_NUM_SCCMDS];
+
+
+struct ScriptVariable
+{
+    ScriptVariable() = default;
+
+    // original 32-bit relative data address, written in compiled script;
+    // if we are to use Map or HashMap, this could be used as Key
+    int32_t             ScAddress = -1;
+    RuntimeScriptValue  RValue;
+};
+
+// Runtime variant of script data, fixups and imports,
+// resolved after loading all the game scripts,
+// and possibly shared among multiple script instance forks.
+class RuntimeScript
+{
+    using String = AGS::Common::String;
+    static const String _noname;
+    static const String _unknownSectionName;
+public:
+    RuntimeScript();
+    RuntimeScript(const String &tag);
+    ~RuntimeScript();
+
+    static std::unique_ptr<RuntimeScript> Create(const ccScript *script, const String &tag);
+
+    struct ResolvedExport
+    {
+        int Type = EXPORT_NONE; // EXPORT_* value
+        int Offset = 0; // bytecode offset
+        RuntimeScriptValue Value; // real pointer to data or executable code
+
+        ResolvedExport() = default;
+        ResolvedExport(int type, int offset, const RuntimeScriptValue &value)
+            : Type(type), Offset(offset), Value(value) {}
+    };
+
+    // Get this script's name
+    const String &GetScriptName() const;
+    // Get an optional tag
+    // TODO: this is for debugging purposes, review later
+    const String &GetTag() const { return _tag; }
+    // Returns the index that this script is assigned on linking stage
+    uint8_t     GetLinkIndex() const { return _linkIndex; }
+    // Get a readonly access to the script's bytecode
+    const std::vector<intptr_t> &GetCode() const { return _code; }
+    // Get a readonly access to the bytecode fixups
+    const std::vector<uint8_t> &GetCodeFixups() const { return _codeFixups; }
+    // Get a readonly access to the global script data
+    const std::vector<uint8_t> &GetGlobalData() const { return _globaldata; }
+    // Get a readonly access to the script's literal strings
+    const std::vector<char> &GetStrings() const { return _strings; }
+    // Get a readonly access to the script's export names
+    const std::vector<String> &GetExports() const { return _exports; }
+    // Get a readonly access to the resolved exports
+    const std::vector<ResolvedExport> &GetResolvedExports() const { return _resolvedExports; }
+    // Get script section's name at a given bytecode offset
+    const String &GetSectionName(int32_t offset) const;
+    // Get an optional table of contents for this script
+    const ScriptTOC *GetTOC() const { return _toc.get(); }
+    const RTTI *GetRTTI() const { return _rtti.get(); }
+
+    // Get the address of an exported symbol (function or variable) in the script
+    RuntimeScriptValue GetSymbolAddress(const String &symname) const;
+    // Searches for the function among this script's exports,
+    // on success returns its starting position in bytecode, and number of arguments
+    bool    FindExportedFunction(const String &fn_name, int32_t &start_at, int32_t &num_args) const;
+
+    // Copies global data values over to this instance;
+    // copies not more than the allocated size of global data
+    void    CopyGlobalData(const std::vector<uint8_t> &data);
+
+    // Adds this script's exports to the symbol table
+    void    RegisterExports(SystemImports &simp);
+    // Removes this script's exports from the symbol table
+    void    UnRegisterExports(SystemImports &simp);
+    // Links this script to others, resolving import/exports
+    bool    ResolveImports(const SystemImports &simp);
+
+private:
+    bool    Create(const ccScript *script);
+
+    bool    CreateGlobalVars();
+    bool    AddGlobalVar(const ScriptVariable &glvar);
+    ScriptVariable *FindGlobalVar(int32_t var_addr);
+    bool    CreateRuntimeCodeFixups();
+    bool    CreateExports();
+
+    // Using resolved imports array, resolve the IMPORT fixups
+    // Also change CALLEXT op-codes to CALLAS when they pertain to a runtime script 
+    bool    ResolveImportFixups();
+
+    // 256 because we use 8 bits to hold instance number
+    static const size_t MinLinkedScriptIndex = 1u;
+    static const size_t MaxLinkedScripts = 256u;
+    static RuntimeScript *  _linkedScripts[MaxLinkedScripts];
+
+    // This script's name
+    String                  _scriptname;
+    String                  _tag;
+    uint8_t                 _linkIndex = 0;
+    // Script's global data (for global variables)
+    std::vector<uint8_t>    _globaldata;
+    // Executed byte-code. Unlike ccScript's code array which is int32_t, the one
+    // in RuntimeScript must be intptr_t to accomodate real pointers placed after
+    // performing fixups.
+    std::vector<intptr_t>   _code;
+    std::vector<int32_t>    _fixups;  // code array index to fixup (in ints)
+    std::vector<uint8_t>    _fixuptypes; // global data/string area/ etc
+    std::vector<uint8_t>    _codeFixups; // fixup type per each code entry
+    // Resolved global variables
+    std::unordered_map<int32_t, ScriptVariable> _globalvars;
+    // Literal string data
+    std::vector<char>       _strings;
+    // This script's import names
+    std::vector<String>     _imports;
+    // Array of real import indexes used in script
+    std::vector<uint32_t>   _resolvedImports;
+    // This script's export names
+    std::vector<String>     _exports;
+    // Export addresses: high byte is type; low 24-bits are offset in bytecode
+    std::vector<int32_t>    _exportAddr;
+    std::vector<ResolvedExport> _resolvedExports;
+    ScriptSymbolsMap        _exportLookup;
+    // "Sections" allow the interpreter to find out which bit
+    // of the code came from header files, and which from the main file
+    std::vector<String>     _sectionNames;
+    // Section offsets (relative to bytecode)
+    std::vector<int32_t>    _sectionOffsets;
+
+    // Extended information (optional)
+    // RTTI, runtime type info: used for garbage collection, and debugging
+    std::unique_ptr<RTTI>   _rtti;
+    // Script table of contents (for debugging purposes)
+    std::unique_ptr<ScriptTOC> _toc;
+};
+
+typedef std::shared_ptr<RuntimeScript> PRuntimeScript;
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_SCRIPT__RUNTIMESCRIPT_H

--- a/Engine/script/runtimescript.h
+++ b/Engine/script/runtimescript.h
@@ -73,6 +73,17 @@ struct ScriptVariable
     RuntimeScriptValue  RValue;
 };
 
+struct ScriptPosition
+{
+    ScriptPosition() = default;
+    ScriptPosition(const Common::String &section, int32_t line)
+        : Section(section), Line(line) {}
+
+    Common::String  Section;
+    int32_t         Line = 0;
+};
+
+
 // Runtime variant of script data, fixups and imports,
 // resolved after loading all the game scripts,
 // and possibly shared among multiple script instance forks.

--- a/Engine/script/runtimescript.h
+++ b/Engine/script/runtimescript.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <vector>
 #include "script/cc_internal.h" // FIXME: should not be included into this header
+#include "script/cc_reflecthelper.h"
 #include "script/cc_script.h"
 #include "script/runtimescriptvalue.h"
 #include "script/systemimports.h"
@@ -86,6 +87,13 @@ public:
     ~RuntimeScript();
 
     static std::unique_ptr<RuntimeScript> Create(const ccScript *script, const String &tag);
+    // Joins custom provided RTTI into the global collection;
+    // fills in maps for locid and typeid remap which may be used to know
+    // which *global* ids were assigned to this particular rtti's entries.
+    // Updates RTTIHelper correspondingly.
+    static void JoinRTTI(const RTTI &rtti,
+        std::unordered_map<uint32_t, uint32_t> &loc_l2g,
+        std::unordered_map<uint32_t, uint32_t> &type_l2g);
 
     struct ResolvedExport
     {
@@ -139,6 +147,18 @@ public:
     void    UnRegisterExports(SystemImports &simp);
     // Links this script to others, resolving import/exports
     bool    ResolveImports(const SystemImports &simp);
+
+
+    // TODO: move the "static" contents to a separate class that links RuntimeScripts
+    // together (something like ScriptProgram?)
+    static const JointRTTI *GetJointRTTI() { return _jointRtti.get(); }
+    static const Engine::RTTIHelper *GetRTTIHelper() { return _rttiHelper.get(); }
+    // Returns a dictionary that maps local script's typeid to global typeid (in joint RTTI)
+    // Requires RTTI
+    const std::unordered_map<uint32_t, uint32_t> &
+        GetLocal2GlobalTypeMap() const { return _typeidLocal2Global; }
+    const std::unordered_map<Common::String, uint32_t> &
+        GetGlobalVariableLookup() const { return _globalVarLookup; }
 
 private:
     bool    Create(const ccScript *script);
@@ -197,6 +217,20 @@ private:
     std::unique_ptr<RTTI>   _rtti;
     // Script table of contents (for debugging purposes)
     std::unique_ptr<ScriptTOC> _toc;
+
+    // RTTI tables
+    static std::unique_ptr<JointRTTI> _jointRtti;
+    // Full name to global id (global id is an actual index in the joint rtti table)
+    static std::unordered_map<Common::String, uint32_t> _rttiLookup;
+    // Helper data for quicker RTTI analyzis
+    static std::unique_ptr<Engine::RTTIHelper> _rttiHelper;
+
+    // Map local script's location id to global (program-wide)
+    std::unordered_map<uint32_t, uint32_t> _locidLocal2Global;
+    // Map local script's type id to global (program-wide)
+    std::unordered_map<uint32_t, uint32_t> _typeidLocal2Global;
+    // Global variables name-to-index lookup (in script's TOC)
+    std::unordered_map<Common::String, uint32_t> _globalVarLookup;
 };
 
 typedef std::shared_ptr<RuntimeScript> PRuntimeScript;

--- a/Engine/script/runtimescript.h
+++ b/Engine/script/runtimescript.h
@@ -86,7 +86,11 @@ public:
     RuntimeScript(const String &tag);
     ~RuntimeScript();
 
+    // Create new RuntimeScript instance from the given loaded script data
     static std::unique_ptr<RuntimeScript> Create(const ccScript *script, const String &tag);
+    // Gets RuntimeScript by its linking ID
+    // FIXME: move this to another class that contains all linked scripts
+    static RuntimeScript *GetLinkedScript(uint8_t linkid);
     // Joins custom provided RTTI into the global collection;
     // fills in maps for locid and typeid remap which may be used to know
     // which *global* ids were assigned to this particular rtti's entries.

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -20,7 +20,7 @@
 
 #include "ac/dynobj/cc_scriptobject.h"
 #include "ac/dynobj/cc_staticarray.h"
-#include "script/script_api.h"
+#include "script/script_api.h" // FIXME: find a way to not include this big header
 #include "util/memory.h"
 
 enum ScriptValueType

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -59,11 +59,7 @@ ExecutingScript *curscript = nullptr; // non-owning ptr
 
 PRuntimeScript gamescript;
 PRuntimeScript dialogScriptsScript;
-UInstance gameinst;
-UInstance roominst;
-UInstance dialogScriptsInst;
-UInstance gameinstFork;
-UInstance roominstFork;
+PRuntimeScript roomscript;
 
 int num_scripts=0;
 int post_script_cleanup_stack = 0;
@@ -85,13 +81,13 @@ NonBlockingScriptFunction runDialogOptionCloseFunc("dialog_options_close", 1);
 ScriptSystem scsystem;
 
 std::vector<AGS::Engine::PRuntimeScript> scriptModules;
-std::vector<UInstance> moduleInst;
-std::vector<UInstance> moduleInstFork;
 std::vector<RuntimeScriptValue> moduleRepExecAddr;
 size_t numScriptModules = 0;
 
+std::unique_ptr<ScriptExecutor> scriptExecutor;
 
-static bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc);
+
+static bool DoRunScriptFuncCantBlock(const RuntimeScript *script, NonBlockingScriptFunction* funcToRun, bool hasTheFunc);
 
 
 void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
@@ -102,20 +98,19 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
     funcToRun->AtLeastOneImplementationExists = false;
 
     // run modules
-    // modules need a forkedinst for this to work
     for (size_t i = 0; i < numScriptModules; ++i) {
-        funcToRun->ModuleHasFunction[i] = DoRunScriptFuncCantBlock(moduleInstFork[i].get(), funcToRun, funcToRun->ModuleHasFunction[i]);
+        funcToRun->ModuleHasFunction[i] = DoRunScriptFuncCantBlock(scriptModules[i].get(), funcToRun, funcToRun->ModuleHasFunction[i]);
 
         if (room_changes_was != play.room_changes)
             return;
     }
 
-    funcToRun->GlobalScriptHasFunction = DoRunScriptFuncCantBlock(gameinstFork.get(), funcToRun, funcToRun->GlobalScriptHasFunction);
+    funcToRun->GlobalScriptHasFunction = DoRunScriptFuncCantBlock(gamescript.get(), funcToRun, funcToRun->GlobalScriptHasFunction);
 
     if (room_changes_was != play.room_changes)
         return;
 
-    funcToRun->RoomHasFunction = DoRunScriptFuncCantBlock(roominstFork.get(), funcToRun, funcToRun->RoomHasFunction);
+    funcToRun->RoomHasFunction = DoRunScriptFuncCantBlock(roomscript.get(), funcToRun, funcToRun->RoomHasFunction);
 }
 
 // Returns 0 normally, or -1 to indicate that the event has
@@ -161,33 +156,25 @@ int run_interaction_script(const ObjectEvent &obj_evt, const InteractionEvents *
     return 0;
 }
 
-int create_global_script() {
+int create_global_script()
+{
     constexpr int kscript_create_error = -3; // FIXME: use global script error code
 
     ccSetOption(SCOPT_AUTOIMPORT, 1);
 
     // NOTE: this function assumes that the module lists have their elements preallocated!
 
-    std::vector<ccInstance*> all_insts; // gather all to resolve exports below
+    std::vector<RuntimeScript*> all_insts; // gather all to resolve exports below
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        moduleInst[i] = ccInstance::CreateFromScript(scriptModules[i]);
-        if (!moduleInst[i])
-            return kscript_create_error;
-        all_insts.push_back(moduleInst[i].get()); // this is only for temp reference
+        all_insts.push_back(scriptModules[i].get());
     }
 
-    gameinst = ccInstance::CreateFromScript(gamescript);
-    if (!gameinst)
-        return kscript_create_error;
-    all_insts.push_back(gameinst.get()); // this is only for temp reference
+    all_insts.push_back(gamescript.get());
 
     if (dialogScriptsScript)
     {
-        dialogScriptsInst = ccInstance::CreateFromScript(dialogScriptsScript);
-        if (!dialogScriptsInst)
-            return kscript_create_error;
-        all_insts.push_back(dialogScriptsInst.get()); // this is only for temp reference
+        all_insts.push_back(dialogScriptsScript.get());
     }
 
     //
@@ -195,30 +182,21 @@ int create_global_script() {
     // Register all the script exports
     for (auto &inst : all_insts)
     {
-        inst->GetScript()->RegisterExports(simp);
+        inst->RegisterExports(simp);
     }
     // Resolve all the script imports (these include both engine API and script exports)
     for (auto &inst : all_insts)
     {
-        if (!inst->GetScript()->ResolveImports(simp))
+        if (!inst->ResolveImports(simp))
             return kscript_create_error;
     }
 
-    // Create the forks for 'repeatedly_execute_always' after resolving
-    // because they copy their respective originals including the resolve information
+    // Record addresses for 'repeatedly_execute'
+    // TODO: find out why do we have to do that here
     for (size_t module_idx = 0; module_idx < numScriptModules; module_idx++)
     {
-        auto fork = moduleInst[module_idx]->Fork();
-        if (!fork)
-            return kscript_create_error;
-
-        moduleInstFork[module_idx] = std::move(fork);
-        moduleRepExecAddr[module_idx] = moduleInst[module_idx]->GetSymbolAddress(REP_EXEC_NAME);
+        moduleRepExecAddr[module_idx] = scriptModules[module_idx]->GetSymbolAddress(REP_EXEC_NAME);
     }
-
-    gameinstFork = gameinst->Fork();
-    if (gameinstFork == nullptr)
-        return kscript_create_error;
 
     ccSetOption(SCOPT_AUTOIMPORT, 0);
 
@@ -227,8 +205,8 @@ int create_global_script() {
     {
         for (const auto &inst : all_insts)
         {
-            if (inst->GetScript()->GetTOC())
-                Debug::Printf(PrintScriptTOC(*inst->GetScript()->GetTOC(), inst->GetScript()->GetScriptName().GetCStr()));
+            if (inst->GetTOC())
+                Debug::Printf(PrintScriptTOC(*inst->GetTOC(), inst->GetScriptName().GetCStr()));
         }
     }
 
@@ -237,46 +215,32 @@ int create_global_script() {
 
 void cancel_all_scripts()
 {
-    for (int i = 0; i < num_scripts; ++i)
-    {
-        auto &sc = scripts[i];
-        if (sc.Inst)
-        {
-            (sc.ForkedInst) ?
-                sc.Inst->AbortAndDestroy() :
-                sc.Inst->Abort();
-        }
-        sc = {}; // FIXME: store in vector and erase?
-    }
+    scriptExecutor->Abort();
     num_scripts = 0;
-    // in case the script is running on non-blocking thread (rep-exec-always etc)
-    auto inst = ccInstance::GetCurrentInstance();
-    if (inst)
-        inst->Abort();
 }
 
-ccInstance *GetScriptInstanceByType(ScriptType sc_type)
+RuntimeScript *GetScriptInstanceByType(ScriptType sc_type)
 {
     if (sc_type == kScTypeGame)
-        return gameinst.get();
+        return gamescript.get();
     else if (sc_type == kScTypeRoom)
-        return roominst.get();
+        return roomscript.get();
     return nullptr;
 }
 
-bool DoesScriptFunctionExist(ccInstance *sci, const String &fn_name)
+bool DoesScriptFunctionExist(const RuntimeScript *script, const String &fn_name)
 {
-    return sci->GetSymbolAddress(fn_name).Type == kScValCodePtr;
+    return script->GetSymbolAddress(fn_name).Type == kScValCodePtr;
 }
 
 bool DoesScriptFunctionExistInModules(const String &fn_name)
 {
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        if (DoesScriptFunctionExist(moduleInst[i].get(), fn_name))
+        if (DoesScriptFunctionExist(scriptModules[i].get(), fn_name))
             return true;
     }
-    return DoesScriptFunctionExist(gameinst.get(), fn_name);
+    return DoesScriptFunctionExist(gamescript.get(), fn_name);
 }
 
 // Reports a warning in case a requested event handler function was not run
@@ -320,20 +284,21 @@ void QueueScriptFunction(ScriptType sc_type, const ScriptFunctionRef &fn_ref,
     }
 }
 
-static bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc)
+static bool DoRunScriptFuncCantBlock(const RuntimeScript *script, NonBlockingScriptFunction* funcToRun, bool hasTheFunc)
 {
     if (!hasTheFunc)
         return(false);
 
     no_blocking_functions++;
-    ccInstError result = sci->CallScriptFunction(funcToRun->FunctionName, funcToRun->ParamCount, funcToRun->Params);
+    const ScriptExecError result = scriptExecutor->Run(
+        script, funcToRun->FunctionName, funcToRun->Params, funcToRun->ParamCount);
 
-    if (result == kInstErr_FuncNotFound)
+    if (result == kScExecErr_FuncNotFound)
     {
         // the function doens't exist, so don't try and run it again
         hasTheFunc = false;
     }
-    else if ((result != kInstErr_None) && (result != kInstErr_Aborted))
+    else if ((result != kScExecErr_None) && (result != kScExecErr_Aborted))
     {
         quit_with_script_error(funcToRun->FunctionName);
     }
@@ -347,22 +312,22 @@ static bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction*
     return(hasTheFunc);
 }
 
-static RunScFuncResult PrepareTextScript(ccInstance *sci, const String &tsname)
+static RunScFuncResult PrepareTextScript(const RuntimeScript *script, const String &tsname)
 {
-    assert(sci);
+    assert(script);
     cc_clear_error();
-    if (!DoesScriptFunctionExist(sci, tsname))
+    if (!DoesScriptFunctionExist(script, tsname))
     {
         cc_error("no such function in script");
         return kScFnRes_NotFound;
     }
-    if (sci->IsBeingRun())
+    if (scriptExecutor->IsBeingRun())
     {
         cc_error("script is already in execution");
         return kScFnRes_ScriptBusy;
     }
     ExecutingScript exscript;
-    exscript.Inst = sci;
+    exscript.Script = script;
     scripts[num_scripts] = std::move(exscript);
     curscript = &scripts[num_scripts];
     num_scripts++;
@@ -373,9 +338,9 @@ static RunScFuncResult PrepareTextScript(ccInstance *sci, const String &tsname)
     return kScFnRes_Done;
 }
 
-RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t numParam, const RuntimeScriptValue *params)
+RunScFuncResult RunScriptFunction(const RuntimeScript *script, const String &tsname, size_t numParam, const RuntimeScriptValue *params)
 {
-    assert(sci);
+    assert(script);
     int oldRestoreCount = gameHasBeenRestored;
     // TODO: research why this is really necessary, and refactor to avoid such hacks!
     // First, save the current ccError state
@@ -386,7 +351,7 @@ RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t 
     // also abort Script A because ccError is a global variable.
     ScriptError cachedCcError = cc_get_error();
 
-    const RunScFuncResult res = PrepareTextScript(sci, tsname);
+    const RunScFuncResult res = PrepareTextScript(script, tsname);
     if (res != kScFnRes_Done)
     {
         if (res != kScFnRes_NotFound)
@@ -395,8 +360,8 @@ RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t 
         return res;
     }
 
-    const ccInstError inst_ret = curscript->Inst->CallScriptFunction(tsname, numParam, params);
-    if ((inst_ret != kInstErr_None) && (inst_ret != kInstErr_FuncNotFound) && (inst_ret != kInstErr_Aborted))
+    const ScriptExecError inst_ret = scriptExecutor->Run(curscript->Script, tsname, params, numParam);
+    if ((inst_ret != kScExecErr_None) && (inst_ret != kScExecErr_FuncNotFound) && (inst_ret != kScExecErr_Aborted))
     {
         quit_with_script_error(tsname);
     }
@@ -418,8 +383,8 @@ RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t 
         eventClaimed = EVENT_CLAIMED;
 
     // Convert any instance exec error into RunScriptFunction result;
-    // NOTE: only kInstErr_FuncNotFound and kInstErr_Aborted can reach here
-    if (inst_ret == kInstErr_FuncNotFound)
+    // NOTE: only kScExecErr_FuncNotFound and kScExecErr_Aborted can reach here
+    if (inst_ret == kScExecErr_FuncNotFound)
         return kScFnRes_NotFound;
     return kScFnRes_Done;
 }
@@ -428,17 +393,17 @@ bool RunScriptFunctionInModules(const String &tsname, size_t param_count, const 
 {
     bool result = false;
     for (size_t i = 0; i < numScriptModules; ++i)
-        result |= RunScriptFunction(moduleInst[i].get(), tsname, param_count, params) == kScFnRes_Done;
-    result |= RunScriptFunction(gameinst.get(), tsname, param_count, params) == kScFnRes_Done;
+        result |= RunScriptFunction(scriptModules[i].get(), tsname, param_count, params) == kScFnRes_Done;
+    result |= RunScriptFunction(gamescript.get(), tsname, param_count, params) == kScFnRes_Done;
     return result;
 }
 
 bool RunScriptFunctionInRoom(const String &tsname, size_t param_count, const RuntimeScriptValue *params)
 {
-    if (!roominst)
+    if (!roomscript)
         return false; // room is not loaded yet
 
-    return RunScriptFunction(roominst.get(), tsname, param_count, params) == kScFnRes_Done;
+    return RunScriptFunction(roomscript.get(), tsname, param_count, params) == kScFnRes_Done;
 }
 
 // Run non-claimable event in all script modules, *excluding* room;
@@ -450,7 +415,7 @@ static bool RunEventInModules(const String &tsname, size_t param_count, const Ru
     const int restore_game_count_was = gameHasBeenRestored;
     for (size_t i = 0; i < numScriptModules; ++i)
     {
-        const RunScFuncResult ret = RunScriptFunction(moduleInst[i].get(), tsname, param_count, params);
+        const RunScFuncResult ret = RunScriptFunction(scriptModules[i].get(), tsname, param_count, params);
         if (ret != kScFnRes_NotFound)
         {
             // Break on room change or save restoration,
@@ -464,7 +429,7 @@ static bool RunEventInModules(const String &tsname, size_t param_count, const Ru
         }
     }
     // Try global script last
-    return RunScriptFunction(gameinst.get(), tsname, param_count, params) == kScFnRes_Done;
+    return RunScriptFunction(gamescript.get(), tsname, param_count, params) == kScFnRes_Done;
 }
 
 // Run non-claimable event in all script modules, *excluding* room;
@@ -489,14 +454,14 @@ static bool RunEventInModule(const ScriptFunctionRef &fn_ref, size_t param_count
     {
         for (size_t i = 0; i < numScriptModules; ++i)
         {
-            if (fn_ref.ModuleName.Compare(moduleInst[i]->GetScript()->GetScriptName()) == 0)
+            if (fn_ref.ModuleName.Compare(scriptModules[i]->GetScriptName()) == 0)
             {
-                return RunScriptFunction(moduleInst[i].get(), fn_ref.FuncName, param_count, params) == kScFnRes_Done;
+                return RunScriptFunction(scriptModules[i].get(), fn_ref.FuncName, param_count, params) == kScFnRes_Done;
             }
         }
     }
     // Try global script last, for backwards compatibility
-    return RunScriptFunction(gameinst.get(), fn_ref.FuncName, param_count, params) == kScFnRes_Done;
+    return RunScriptFunction(gamescript.get(), fn_ref.FuncName, param_count, params) == kScFnRes_Done;
 }
 
 // Run claimable event in all script modules, *including* room;
@@ -510,7 +475,7 @@ static bool RunClaimableEvent(const String &tsname, size_t param_count, const Ru
     // Break on event claim
     if (eventWasClaimed)
         return true; // suppose if claimed then some function ran successfully
-    return RunScriptFunction(gameinst.get(), tsname, param_count, params) == kScFnRes_Done;
+    return RunScriptFunction(gamescript.get(), tsname, param_count, params) == kScFnRes_Done;
 }
 
 bool RunScriptFunctionAuto(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count, const RuntimeScriptValue *params)
@@ -543,8 +508,7 @@ bool RunScriptFunctionAuto(ScriptType sc_type, const ScriptFunctionRef &fn_ref, 
 void AllocScriptModules()
 {
     // NOTE: this preallocation possibly required to safeguard some algorithms
-    moduleInst.resize(numScriptModules);
-    moduleInstFork.resize(numScriptModules);
+    scriptModules.resize(numScriptModules);
     moduleRepExecAddr.resize(numScriptModules);
     repExecAlways.ModuleHasFunction.resize(numScriptModules, true);
     lateRepExecAlways.ModuleHasFunction.resize(numScriptModules, true);
@@ -564,33 +528,25 @@ void AllocScriptModules()
 
 void FreeAllScriptInstances()
 {
-    ccInstance::FreeInstanceStack();
     FreeRoomScriptInstance();
 
-    if (gameinst)
-        gameinst->GetScript()->UnRegisterExports(simp);
-    if (dialogScriptsInst)
-        dialogScriptsInst->GetScript()->UnRegisterExports(simp);
-    for (auto &module : moduleInst)
-        module->GetScript()->UnRegisterExports(simp);
+    if (gamescript)
+        gamescript->UnRegisterExports(simp);
+    if (dialogScriptsScript)
+        dialogScriptsScript->UnRegisterExports(simp);
+    for (auto &module : scriptModules)
+        module->UnRegisterExports(simp);
 
-    // NOTE: don't know why, but Forks must be deleted prior to primary inst,
-    // or bad things will happen; TODO: investigate and make this less fragile
-    gameinstFork.reset();
-    gameinst.reset();
-    dialogScriptsInst.reset();
-    moduleInstFork.clear();
-    moduleInst.clear();
+    gamescript.reset();
+    dialogScriptsScript.reset();
+    scriptModules.clear();
 }
 
 void FreeRoomScriptInstance()
 {
-    if (roominst)
-        roominst->GetScript()->UnRegisterExports(simp);
-    // NOTE: don't know why, but Forks must be deleted prior to primary inst,
-    // or bad things will happen; TODO: investigate and make this less fragile
-    roominstFork.reset();
-    roominst.reset();
+    if (roomscript)
+        roomscript->UnRegisterExports(simp);
+    roomscript.reset();
 }
 
 void FreeGlobalScripts()
@@ -634,7 +590,6 @@ void post_script_cleanup()
     if (num_scripts > 0)
     { // save until the end of function
         copyof = std::move(scripts[num_scripts - 1]);
-        copyof.ForkedInst.reset(); // don't need it further
         num_scripts--; // FIXME: store in vector and erase?
     }
     inside_script--;
@@ -815,10 +770,9 @@ ExecutingScript *get_executingscript()
 
 bool get_script_position(ScriptPosition &script_pos)
 {
-    ccInstance *cur_instance = ccInstance::GetCurrentInstance();
-    if (cur_instance)
+    if (scriptExecutor)
     {
-        cur_instance->GetScriptPosition(script_pos);
+        scriptExecutor->GetScriptPosition(script_pos);
         return true;
     }
     return false;

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -45,6 +45,7 @@
 #include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern int gameHasBeenRestored, displayed_room;
@@ -56,8 +57,8 @@ extern bool logScriptTOC;
 ExecutingScript scripts[MAX_SCRIPT_AT_ONCE];
 ExecutingScript *curscript = nullptr; // non-owning ptr
 
-PScript gamescript;
-PScript dialogScriptsScript;
+PRuntimeScript gamescript;
+PRuntimeScript dialogScriptsScript;
 UInstance gameinst;
 UInstance roominst;
 UInstance dialogScriptsInst;
@@ -83,7 +84,7 @@ NonBlockingScriptFunction runDialogOptionCloseFunc("dialog_options_close", 1);
 
 ScriptSystem scsystem;
 
-std::vector<PScript> scriptModules;
+std::vector<AGS::Engine::PRuntimeScript> scriptModules;
 std::vector<UInstance> moduleInst;
 std::vector<UInstance> moduleInstFork;
 std::vector<RuntimeScriptValue> moduleRepExecAddr;
@@ -189,12 +190,17 @@ int create_global_script() {
         all_insts.push_back(dialogScriptsInst.get()); // this is only for temp reference
     }
 
-    // Resolve the script imports after all the scripts have been loaded 
+    //
+    // Script linking stage
+    // Register all the script exports
     for (auto &inst : all_insts)
     {
-        if (!inst->ResolveScriptImports())
-            return kscript_create_error;
-        if (!inst->ResolveImportFixups())
+        inst->GetScript()->RegisterExports(simp);
+    }
+    // Resolve all the script imports (these include both engine API and script exports)
+    for (auto &inst : all_insts)
+    {
+        if (!inst->GetScript()->ResolveImports(simp))
             return kscript_create_error;
     }
 
@@ -221,8 +227,8 @@ int create_global_script() {
     {
         for (const auto &inst : all_insts)
         {
-            if (inst->GetScript()->sctoc)
-                Debug::Printf(PrintScriptTOC(*inst->GetScript()->sctoc, inst->GetScript()->sectionNames[0].c_str()));
+            if (inst->GetScript()->GetTOC())
+                Debug::Printf(PrintScriptTOC(*inst->GetScript()->GetTOC(), inst->GetScript()->GetScriptName().GetCStr()));
         }
     }
 
@@ -561,6 +567,13 @@ void FreeAllScriptInstances()
     ccInstance::FreeInstanceStack();
     FreeRoomScriptInstance();
 
+    if (gameinst)
+        gameinst->GetScript()->UnRegisterExports(simp);
+    if (dialogScriptsInst)
+        dialogScriptsInst->GetScript()->UnRegisterExports(simp);
+    for (auto &module : moduleInst)
+        module->GetScript()->UnRegisterExports(simp);
+
     // NOTE: don't know why, but Forks must be deleted prior to primary inst,
     // or bad things will happen; TODO: investigate and make this less fragile
     gameinstFork.reset();
@@ -572,6 +585,8 @@ void FreeAllScriptInstances()
 
 void FreeRoomScriptInstance()
 {
+    if (roominst)
+        roominst->GetScript()->UnRegisterExports(simp);
     // NOTE: don't know why, but Forks must be deleted prior to primary inst,
     // or bad things will happen; TODO: investigate and make this less fragile
     roominstFork.reset();
@@ -596,19 +611,6 @@ void FreeGlobalScripts()
     runDialogOptionTextInputHandlerFunc.ModuleHasFunction.clear();
     runDialogOptionRepExecFunc.ModuleHasFunction.clear();
     runDialogOptionCloseFunc.ModuleHasFunction.clear();
-}
-
-String GetScriptName(ccInstance *sci)
-{
-    // TODO: have script name a ccScript's member?
-    // TODO: check script modules too?
-    if (!sci)
-        return "Not in a script";
-    else if (sci->GetScript() == gamescript)
-        return "Global script";
-    else if (sci->GetScript() == thisroom.CompiledScript)
-        return String::FromFormat("Room %d script", displayed_room);
-    return "Unknown script";
 }
 
 //=============================================================================

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -149,9 +149,6 @@ void    FreeRoomScriptInstance();
 // this frees all of the bytecode and runtime script memory.
 void    FreeGlobalScripts();
 
-
-String  GetScriptName(ccInstance *sci);
-
 //=============================================================================
 
 // Makes a old-style interaction function name (for interaction list "run script" command)
@@ -170,8 +167,6 @@ String  cc_get_callstack(int max_lines = INT_MAX);
 // Gets current ExecutingScript object
 ExecutingScript *get_executingscript();
 
-extern PScript gamescript;
-extern PScript dialogScriptsScript;
 // [ikm] we keep ccInstances saved in unique_ptrs globally for now
 // (e.g. as opposed to shared_ptrs), because the script handling part of the
 // engine is quite fragile and prone to errors whenever the instance is not
@@ -207,7 +202,9 @@ extern NonBlockingScriptFunction runDialogOptionTextInputHandlerFunc;
 extern NonBlockingScriptFunction runDialogOptionRepExecFunc;
 extern NonBlockingScriptFunction runDialogOptionCloseFunc;
 
-extern std::vector<PScript> scriptModules;
+extern AGS::Engine::PRuntimeScript gamescript;
+extern AGS::Engine::PRuntimeScript dialogScriptsScript;
+extern std::vector<AGS::Engine::PRuntimeScript> scriptModules;
 extern std::vector<UInstance> moduleInst;
 extern std::vector<UInstance> moduleInstFork;
 extern std::vector<RuntimeScriptValue> moduleRepExecAddr;

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -16,10 +16,11 @@
 
 #include <memory>
 #include <vector>
-#include "script/cc_instance.h"
-#include "script/executingscript.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "game/interactions.h"
+#include "script/executingscript.h"
+#include "script/runtimescript.h"
+#include "script/scriptexecutor.h"
 #include "util/string.h"
 
 using AGS::Common::String;
@@ -109,9 +110,9 @@ enum RunScFuncResult
     kScFnRes_ScriptBusy = -3,       // script is already being executed
 };
 
-ccInstance *GetScriptInstanceByType(ScriptType sc_type);
+AGS::Engine::RuntimeScript *GetScriptInstanceByType(ScriptType sc_type);
 // Tests if a function exists in the given script module
-bool    DoesScriptFunctionExist(ccInstance *sci, const String &fn_name);
+bool    DoesScriptFunctionExist(const AGS::Engine::RuntimeScript *script, const String &fn_name);
 // Tests if a function exists in any of the regular script module, *except* room script
 bool    DoesScriptFunctionExistInModules(const String &fn_name);
 // Queues a script function to be run either called by the engine or from another script;
@@ -124,7 +125,7 @@ void    QueueScriptFunction(ScriptType sc_type, const String &fn_name, size_t pa
 void    QueueScriptFunction(ScriptType sc_type, const ScriptFunctionRef &fn_ref, size_t param_count = 0,
     const RuntimeScriptValue *params = nullptr, std::weak_ptr<bool> result = {});
 // Try to run a script function on a given script instance
-RunScFuncResult RunScriptFunction(ccInstance *sci, const String &tsname, size_t param_count = 0,
+RunScFuncResult RunScriptFunction(const AGS::Engine::RuntimeScript *script, const String &tsname, size_t param_count = 0,
     const RuntimeScriptValue *params = nullptr);
 // Run a script function in all the regular script modules, in order, where available
 // includes globalscript, but not the current room script.
@@ -161,29 +162,11 @@ void    quit_with_script_error(const String &fn_name);
 void    can_run_delayed_command();
 
 // Gets current running script position
-bool    get_script_position(ScriptPosition &script_pos);
+bool    get_script_position(AGS::Engine::ScriptPosition &script_pos);
 String  cc_get_callstack(int max_lines = INT_MAX);
 
 // Gets current ExecutingScript object
 ExecutingScript *get_executingscript();
-
-// [ikm] we keep ccInstances saved in unique_ptrs globally for now
-// (e.g. as opposed to shared_ptrs), because the script handling part of the
-// engine is quite fragile and prone to errors whenever the instance is not
-// **deleted** in precise time. This is related to:
-// - ccScript's "instances" counting, which affects script exports reg/unreg;
-// - loadedInstances array.
-// One of the examples is the save restoration, that may occur in the midst
-// of a post-script cleanup process, whilst the engine's stack still has
-// references to the ccInstances that are going to be deleted on cleanup.
-// Ideally, this part of the engine should be refactored awhole with a goal
-// to make it safe and consistent.
-typedef std::unique_ptr<ccInstance> UInstance;
-extern UInstance gameinst;
-extern UInstance roominst;
-extern UInstance dialogScriptsInst;
-extern UInstance gameinstFork;
-extern UInstance roominstFork;
 
 extern int num_scripts;
 extern int post_script_cleanup_stack;
@@ -205,9 +188,10 @@ extern NonBlockingScriptFunction runDialogOptionCloseFunc;
 extern AGS::Engine::PRuntimeScript gamescript;
 extern AGS::Engine::PRuntimeScript dialogScriptsScript;
 extern std::vector<AGS::Engine::PRuntimeScript> scriptModules;
-extern std::vector<UInstance> moduleInst;
-extern std::vector<UInstance> moduleInstFork;
+extern AGS::Engine::PRuntimeScript roomscript;
 extern std::vector<RuntimeScriptValue> moduleRepExecAddr;
 extern size_t numScriptModules;
+
+extern std::unique_ptr<AGS::Engine::ScriptExecutor> scriptExecutor;
 
 #endif // __AGS_EE_SCRIPT__SCRIPT_H

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -18,6 +18,7 @@
 #include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "script/cc_common.h"
+#include "script/script.h"
 #include "script/systemimports.h"
 
 using namespace AGS::Engine;
@@ -141,13 +142,12 @@ new_line_hook_type new_line_hook = nullptr;
 void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout,
     unsigned abort_loops)
 {
-    ccInstance::SetExecTimeout(sys_poll_timeout, abort_timeout, abort_loops);
+    scriptExecutor->SetExecTimeout(sys_poll_timeout, abort_timeout, abort_loops);
 }
 
-void ccNotifyScriptStillAlive () {
-    ccInstance *cur_inst = ccInstance::GetCurrentInstance();
-    if (cur_inst)
-        cur_inst->NotifyAlive();
+void ccNotifyScriptStillAlive ()
+{
+    scriptExecutor->NotifyAlive();
 }
 
 void ccSetDebugHook(new_line_hook_type jibble)

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -20,6 +20,7 @@
 #include "script/cc_common.h"
 #include "script/systemimports.h"
 
+using namespace AGS::Engine;
 
 bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *scfn, void *dirfn)
 {
@@ -63,9 +64,9 @@ bool ccAddExternalScriptObjectHandle(const String &name, void *ptr)
      return simp.Add(name, RuntimeScriptValue().SetScriptObject(ptr, &GlobalStaticManager), nullptr, kScValHint_Handle) != UINT32_MAX;
 }
 
-bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst)
+bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, RuntimeScript *script)
 {
-    return simp.Add(name, prval, inst) != UINT32_MAX;
+    return simp.Add(name, prval, script) != UINT32_MAX;
 }
 
 void ccRemoveExternalSymbol(const String &name)

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -16,7 +16,8 @@
 
 #include "util/memory_compat.h"    // std::size
 #include "script/cc_script.h"      // ccScript
-#include "script/cc_instance.h"    // ccInstance
+#include "script/runtimescript.h"
+#include "script/runtimescriptvalue.h"
 
 struct IScriptObject;
 
@@ -87,7 +88,8 @@ void *ccGetSymbolAddressForPlugin(const String &name);
 void *ccGetScriptObjectAddress(const String &name, const String &type);
 
 // DEBUG HOOK
-typedef void (*new_line_hook_type) (ccInstance *, int);
+namespace AGS { namespace Engine { class ScriptExecutor; } }
+typedef void (*new_line_hook_type) (AGS::Engine::ScriptExecutor *, int);
 void ccSetDebugHook(new_line_hook_type jibble);
 
 // Set the script interpreter timeout values:

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -65,7 +65,7 @@ bool ccAddExternalStaticArray(const String &name, void *ptr, CCStaticObjectArray
 bool ccAddExternalScriptObject(const String &name, void *ptr, IScriptObject *manager);
 bool ccAddExternalScriptObjectHandle(const String &name, void *ptr);
 // Register script own functions (defined in the linked scripts)
-bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst);
+bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, AGS::Engine::RuntimeScript *script);
 // Remove the script access to a variable or function in your program
 void ccRemoveExternalSymbol(const String &name);
 // Remove all external symbols, allowing you to start from scratch

--- a/Engine/script/scriptexecutor.cpp
+++ b/Engine/script/scriptexecutor.cpp
@@ -11,79 +11,40 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#include "script/cc_instance.h"
-#include <cstdio>
-#include <deque>
-#include <string.h>
-#include "ac/common.h"
+#include "script/scriptexecutor.h"
 #include "ac/sys_events.h"
 #include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "ac/dynobj/managedobjectpool.h"
-#include "ac/dynobj/scriptstring.h"
 #include "ac/dynobj/scriptuserobject.h"
-#include "gui/guidefines.h"
-#include "debug/debug_log.h"
-#include "debug/out.h"
 #include "script/cc_common.h"
-#include "script/script.h"
 #include "script/script_runtime.h"
-#include "script/systemimports.h"
-#include "util/bbop.h"
-#include "util/stream.h"
-#include "util/textstreamwriter.h"
-#include "util/file.h"
 #include "util/memory.h"
-#include "util/string_utils.h" // linux strnicmp definition
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
-using namespace AGS::Engine;
 
-
+// FIXME: don't use global var like this
 extern new_line_hook_type new_line_hook;
 
-ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = { nullptr };
-
-// Instance thread stack holds a list of running or suspended script instances;
-// In AGS currently only one thread is running, others are waiting in the queue.
-// An example situation is repeatedly_execute_always callback running while
-// another instance is waiting at the blocking action or Wait().
-std::deque<ccInstance*> InstThreads;
 // [IKM] 2012-10-21:
 // NOTE: This is temporary solution (*sigh*, one of many) which allows certain
 // exported functions return value as a RuntimeScriptValue object;
 // Of 2012-12-20: now used only for plugin exports
 // FIXME: re-investigate this, find if it's possible to get rid of this.
-extern RuntimeScriptValue GlobalReturnValue;
+RuntimeScriptValue GlobalReturnValue;
 
-
-String cc_get_callstack(int max_lines)
+namespace AGS
 {
-    String callstack;
-    for (auto sci = InstThreads.crbegin(); sci != InstThreads.crend(); ++sci)
-    {
-        if (callstack.IsEmpty())
-            callstack.Append("in the active script:\n");
-        else
-            callstack.Append("in the waiting script:\n");
-        callstack.Append((*sci)->GetCallStack(max_lines));
-    }
-    return callstack;
-}
-
+namespace Engine
+{
 
 // Function call stack is used to temporarily store
 // values before passing them to script function
-#define MAX_FUNC_PARAMS 20
 // An inverted parameter stack
 struct FunctionCallStack
 {
-    FunctionCallStack()
-    {
-        Head = MAX_FUNC_PARAMS - 1;
-        Count = 0;
-    }
+    FunctionCallStack() = default;
 
     inline RuntimeScriptValue *GetHead()
     {
@@ -94,75 +55,138 @@ struct FunctionCallStack
         return &Entries[Head + Count];
     }
 
+    const static size_t MAX_FUNC_PARAMS = 20u;
     RuntimeScriptValue  Entries[MAX_FUNC_PARAMS + 1];
-    int                 Head;
-    int                 Count;
+    size_t              Head = MAX_FUNC_PARAMS - 1;
+    size_t              Count = 0u;
 };
 
+// Size of stack in RuntimeScriptValues (aka distinct variables)
+#define CC_STACK_SIZE       256
+// Size of stack in bytes (raw data storage)
+#define CC_STACK_DATA_SIZE  (1024 * sizeof(int32_t))
+#define MAX_CALL_STACK      128
 
-unsigned ccInstance::_timeoutCheckMs = 60u;
-unsigned ccInstance::_timeoutAbortMs = 0u;
-unsigned ccInstance::_maxWhileLoops = 0u;
-
-
-ccInstance *ccInstance::GetCurrentInstance()
+ScriptExecutor::ScriptExecutor()
 {
-    return InstThreads.size() > 0 ? InstThreads.back() : nullptr;
+    // Create a stack
+    // The size of a stack is quite an arbitrary choice; there's no way to deduce number of stack
+    // entries needed without knowing amount of local variables (at least)
+    _stack.resize(CC_STACK_SIZE);
+    _stackdata.resize(CC_STACK_DATA_SIZE);
+    _stackBegin = _stack.data();
+    _stackdataBegin = _stackdata.data();
+    _stackdataPtr = _stackdata.data();
 }
 
-void ccInstance::FreeInstanceStack()
+ScriptExecError ScriptExecutor::Run(const RuntimeScript *script, const String &funcname, const RuntimeScriptValue *params, size_t param_count)
 {
-    InstThreads.clear();
-}
+    cc_clear_error();
+    currentline = 0; // FIXME: stop using a global variable
 
-std::unique_ptr<ccInstance> ccInstance::CreateFromScript(PRuntimeScript scri)
-{
-    return CreateEx(scri, nullptr);
-}
-
-std::unique_ptr<ccInstance> ccInstance::CreateEx(PRuntimeScript scri, const ccInstance *joined)
-{
-    // allocate and copy all the memory with data, code and strings across
-    std::unique_ptr<ccInstance> cinst(new ccInstance());
-    if (!cinst->_Create(scri, joined))
+    assert(param_count == 0 || params);
+    if (param_count > 0 && !params)
     {
-        return nullptr;
+        cc_error("internal error in ScriptExecutor::Run");
+        return kScExecErr_Generic;
     }
-    return cinst;
+
+    if ((param_count >= FunctionCallStack::MAX_FUNC_PARAMS) || (param_count < 0))
+    {
+        cc_error("invalid number of function arguments %d, supported range is %d - %d", param_count, 0, FunctionCallStack::MAX_FUNC_PARAMS - 1);
+        return kScExecErr_InvalidArgNum;
+    }
+
+    int start_at, export_args;
+    if (!script->FindExportedFunction(funcname, start_at, export_args))
+    {
+        cc_error("function '%s' not found", funcname.GetCStr());
+        return kScExecErr_FuncNotFound;
+    }
+
+    // NOTE: passing more parameters than expected by the function is fine:
+    // the function args are pushed to the stack in REVERSE order, first
+    // parameters are always the last, so function code knows how to find them
+    // using negative offsets, and does not care about any preceding entries.
+    // But if there's not enough parameters, then we cannot call this function.
+    if (export_args > param_count)
+    {
+        cc_error("Not enough parameters to exported function '%s' (expected %d, supplied %d)",
+            funcname.GetCStr(), export_args, param_count);
+        return kScExecErr_InvalidArgNum;
+    }
+
+    // Allow to pass less parameters if script callback has less declared args
+    param_count = std::min<size_t>(param_count, export_args);
+    // Prepare executor for run
+    _flags &= ~kScExecState_Aborted;
+    _pc = 0;
+    _lineNumber = 0;
+    _returnValue = 0;
+
+    const ScriptExecError reterr = Run(script, start_at, params, param_count);
+
+    // Clear exec state
+    _pc = 0;
+    _lineNumber = 0;
+    _returnValue = 0;
+    currentline = 0;
+
+    if (reterr != kScExecErr_None)
+        return reterr;
+
+    // NOTE that if proper multithreading is added this will need
+    // to be reconsidered, since the GC could be run in the middle 
+    // of a RET from a function or something where there is an 
+    // object with ref count 0 that is in use
+    pool.RunGarbageCollectionIfAppropriate();
+
+    if (new_line_hook)
+        new_line_hook(nullptr, 0);
+
+    if (_flags & kScExecState_Aborted)
+    {
+        _flags &= ~kScExecState_Aborted;
+        return kScExecErr_Aborted;
+    }
+
+    return kScExecErr_None;
 }
 
-void ccInstance::SetExecTimeout(const unsigned sys_poll_ms, const unsigned abort_ms,
-    const unsigned abort_loops)
+void ScriptExecutor::Abort()
+{
+    if (_pc != 0)
+        _flags |= kScExecState_Aborted;
+}
+    
+void ScriptExecutor::SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops)
 {
     _timeoutCheckMs = sys_poll_ms;
     _timeoutAbortMs = abort_ms;
     _maxWhileLoops = abort_loops;
 }
 
-ccInstance::~ccInstance()
+void ScriptExecutor::NotifyAlive()
 {
-    Free();
+    _flags |= kScExecState_Running;
+    _lastAliveTs = AGS_FastClock::now();
 }
 
-std::unique_ptr<ccInstance> ccInstance::Fork()
-{
-    return CreateEx(_instanceof, this);
-}
+//-----------------------------------------------------------------------------
+//
+// Script execution routine follows.
+//
+//-----------------------------------------------------------------------------
 
-void ccInstance::Abort()
-{
-    if (_pc != 0)
-        _flags |= INSTF_ABORTED;
-}
-
-void ccInstance::AbortAndDestroy()
-{
-    Abort();
-    _flags |= INSTF_FREE;
-}
+// Script executor debugging flag:
+// enables mistake checks, but slows things down!
+#ifndef DEBUG_CC_EXEC
+#define DEBUG_CC_EXEC (AGS_PLATFORM_DEBUG)
+#endif
 
 // ASSERT_CC_OP tests for the internal function call return value and
-// returns failure on error
+// returns failure on error. These assertions are slowing things down
+// when executing excessive scripts, and so are disabled in Release build.
 #if (DEBUG_CC_EXEC)
 
 #define CC_ERROR_IF(COND, ERROR, ...) \
@@ -176,7 +200,7 @@ void ccInstance::AbortAndDestroy()
     if (COND) \
     { \
         cc_error(ERROR, ##__VA_ARGS__); \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     }
 
 #define CC_ERROR_IF_RETVAL(COND, T, ERROR, ...) \
@@ -189,7 +213,7 @@ void ccInstance::AbortAndDestroy()
 #define ASSERT_CC_ERROR() \
     if (cc_has_error()) \
     { \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     }
 
 #else
@@ -202,14 +226,14 @@ void ccInstance::AbortAndDestroy()
 #endif // DEBUG_CC_EXEC
 
 
-// Two stack assertions that are always enabled:
+// A number of stack assertions that are always enabled:
 // ASSERT_STACK_SPACE_AVAILABLE tests that we do not exceed stack limit
 #define ASSERT_STACK_SPACE_AVAILABLE(N_VALS, N_BYTES) \
     if ((_registers[SREG_SP].RValue + N_VALS - _stackBegin) >= CC_STACK_SIZE || \
         (_stackdataPtr + N_BYTES - _stackdataBegin) >= CC_STACK_DATA_SIZE) \
     { \
         cc_error("stack overflow, attempted to grow from %zu by %zu bytes", (size_t)(_stackdataPtr - _stackdataBegin), (size_t)(N_BYTES)); \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     }
 
 // ASSERT_STACK_SPACE_BYTES tests that we do not exceed stack limit
@@ -225,7 +249,7 @@ void ccInstance::AbortAndDestroy()
     if (_registers[SREG_SP].RValue - N < _stackBegin) \
     { \
         cc_error("stack underflow"); \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     }
 
 // ASSERT_STACK_UNWINDED tests that the stack pointer is at the expected position
@@ -233,122 +257,61 @@ void ccInstance::AbortAndDestroy()
     if ((_registers[SREG_SP].RValue > STACK_VAL.RValue) || \
         (_stackdataPtr > DATA_PTR)) \
     { \
-        cc_error("stack is not unwinded after function call, %zu bytes remain", (size_t)(_stackdataPtr - DATA_PTR)); \
-        return kInstErr_Generic; \
+        cc_error("stack is not unwinded after function call, %d bytes remain", (_stackdataPtr - DATA_PTR)); \
+        return kScExecErr_Generic; \
     }
 
 
-ccInstError ccInstance::CallScriptFunction(const String &funcname, int32_t numargs, const RuntimeScriptValue *params)
+ScriptExecError ScriptExecutor::Run(const RuntimeScript *script, int32_t curpc, const RuntimeScriptValue *params, size_t param_count)
 {
-    cc_clear_error();
-    currentline = 0;
+    // Setup current script
+    SetCurrentScript(script);
 
-    if (numargs > 0 && !params)
-    {
-        cc_error("internal error in ccInstance::CallScriptFunction");
-        return kInstErr_Generic;
-    }
-
-    if ((numargs >= MAX_FUNCTION_PARAMS) || (numargs < 0))
-    {
-        cc_error("invalid number of function arguments %d, supported range is %d - %d", numargs, 0, MAX_FUNCTION_PARAMS - 1);
-        return kInstErr_InvalidArgNum;
-    }
-
-    if (_pc != 0)
-    {
-        cc_error("instance already being executed");
-        return kInstErr_Busy;
-    }
-
-    int start_at, export_args;
-    if (!_instanceof->FindExportedFunction(funcname, start_at, export_args))
-    {
-        cc_error("function '%s' not found", funcname.GetCStr());
-        return kInstErr_FuncNotFound;
-    }
-
-    // NOTE: passing more parameters than expected by the function is fine:
-    // the function args are pushed to the stack in REVERSE order, first
-    // parameters are always the last, so function code knows how to find them
-    // using negative offsets, and does not care about any preceding entries.
-    // But if there's not enough parameters, then we cannot call this function.
-    if (export_args > numargs)
-    {
-        cc_error("Not enough parameters to exported function '%s' (expected %d, supplied %d)",
-            funcname.GetCStr(), export_args, numargs);
-        return kInstErr_Generic;
-    }
-
-    // Prepare instance for run
-    _flags &= ~INSTF_ABORTED;
-    // Allow to pass less parameters if script callback has less declared args
-    numargs = std::min(numargs, export_args);
     // object pointer needs to start zeroed
     _registers[SREG_OP].SetScriptObject(nullptr, nullptr);
     _registers[SREG_SP].SetStackPtr( _stack.data() );
     _stackdataPtr = _stackdata.data();
     // NOTE: Pushing parameters to stack in reverse order
-    ASSERT_STACK_SPACE_VALS(numargs + 1 /* return address */);
-    for (int i = numargs - 1; i >= 0; --i)
+    ASSERT_STACK_SPACE_VALS(param_count + 1 /* return address */);
+    for (int i = param_count - 1; i >= 0; --i)
     {
         PushValueToStack(params[i]);
     }
     // Push placeholder for the return value (it will be popped before ret)
     PushValueToStack(RuntimeScriptValue().SetInt32(0));
 
-    InstThreads.push_back(this); // push instance thread
-    _runningInst = this;
-    const ccInstError reterr = Run(start_at);
+    const ScriptExecError reterr = Run(curpc);
+
     // Cleanup before returning, even if error
-    ASSERT_STACK_SIZE(numargs);
-    PopValuesFromStack(numargs);
-    _pc = 0;
-    currentline = 0;
-    InstThreads.pop_back(); // pop instance thread
-    if (reterr != kInstErr_None)
+    ASSERT_STACK_SIZE(param_count);
+    PopValuesFromStack(param_count);
+    if (reterr != kScExecErr_None)
         return reterr;
 
-    // NOTE that if proper multithreading is added this will need
-    // to be reconsidered, since the GC could be run in the middle 
-    // of a RET from a function or something where there is an 
-    // object with ref count 0 that is in use
-    pool.RunGarbageCollectionIfAppropriate();
-
-    if (new_line_hook)
-        new_line_hook(nullptr, 0);
-
-    if (_flags & INSTF_ABORTED) {
-        _flags &= ~INSTF_ABORTED;
-
-        if (_flags & INSTF_FREE)
-            Free();
-        return kInstErr_Aborted;
+    // Final assert: stack must be reset to where it was before starting this script
+    if (!(_flags & kScExecState_Aborted))
+    {
+        ASSERT_STACK_UNWINDED(_registers[SREG_SP], _stackdata.data());
     }
-
-    ASSERT_STACK_UNWINDED(RuntimeScriptValue().SetStackPtr(_stack.data()), _stackdata.data());
-    return cc_has_error() ? kInstErr_Generic : kInstErr_None;
+    return cc_has_error() ? kScExecErr_Generic : kScExecErr_None;
 }
 
 // Macros to maintain the call stack
 #define PUSH_CALL_STACK() \
-    if (_callStackSize >= MAX_CALL_STACK) { \
+    if (_callstack.size() >= MAX_CALL_STACK) { \
         cc_error("CallScriptFunction stack overflow (recursive call error?)"); \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     } \
-    _callStackLineNumber[_callStackSize] = _lineNumber;  \
-    _callStackCodeInst[_callStackSize] = _runningInst;  \
-    _callStackAddr[_callStackSize] = _pc;  \
-    _callStackSize++ 
+    _callstack.push_back(ScriptExecPosition(_current, _pc, _lineNumber));
 
 #define POP_CALL_STACK() \
-    if (_callStackSize < 1) { \
+    if (_callstack.size() < 1) { \
         cc_error("CallScriptFunction stack underflow -- internal error"); \
-        return kInstErr_Generic; \
+        return kScExecErr_Generic; \
     } \
-    _callStackSize--;\
-    _lineNumber = _callStackLineNumber[_callStackSize];\
-    currentline = _lineNumber
+    _lineNumber = _callstack.back().LineNumber; \
+    currentline = _lineNumber; \
+    _callstack.pop_back();
 
 
 // Return stack ptr at given offset from stack head;
@@ -423,16 +386,44 @@ inline bool FixupArgument(RuntimeScriptValue &arg, const int fixup, const uintpt
 }
 
 
+// FIXME: get rid of this
 #define MAXNEST 50  // number of recursive function calls allowed
-ccInstError ccInstance::Run(int32_t curpc)
+
+struct ScriptInstruction
+{
+    ScriptInstruction() = default;
+    ScriptInstruction(int code, int instid) : Code(code), InstanceId(instid) {}
+
+    int32_t	Code = 0;
+    int32_t	InstanceId = 0;
+};
+
+struct ScriptOperation
+{
+	ScriptInstruction   Instruction;
+	RuntimeScriptValue	Args[MAX_SCMD_ARGS];
+	int				    ArgCount = 0;
+
+    // Helper functions for clarity of intent:
+    // returns argN, 1-based
+    inline const RuntimeScriptValue &Arg1() const { return Args[0]; }
+    inline const RuntimeScriptValue &Arg2() const { return Args[1]; }
+    inline const RuntimeScriptValue &Arg3() const { return Args[2]; }
+    // returns argN as a integer literal
+    inline int Arg1i() const { return Args[0].IValue; }
+    inline int Arg2i() const { return Args[1].IValue; }
+    inline int Arg3i() const { return Args[2].IValue; }
+};
+
+ScriptExecError ScriptExecutor::Run(int32_t curpc)
 {
     _pc = curpc;
     _returnValue = -1;
 
-    if ((curpc < 0) || (static_cast<uint32_t>(curpc) >= _runningInst->_codesize))
+    if ((curpc < 0) || (static_cast<uint32_t>(curpc) >= _codesize))
     {
         cc_error("specified code offset is not valid");
-        return kInstErr_Generic;
+        return kScExecErr_Generic;
     }
 
     int32_t thisbase[MAXNEST], funcstart[MAXNEST];
@@ -442,12 +433,8 @@ ccInstError ccInstance::Run(int32_t curpc)
     int next_call_needs_object = 0;
     thisbase[0] = 0;
     funcstart[0] = _pc;
-    ccInstance *codeInst = _runningInst;
     ScriptOperation codeOp;
     FunctionCallStack func_callstack;
-#if DEBUG_CC_EXEC
-    const bool dump_opcodes = ccGetOption(SCOPT_DEBUGRUN) != 0;
-#endif
     int loopIterationCheckDisabled = 0;
     unsigned loopIterations = 0u; // any loop iterations (needed for timeout test)
     unsigned loopCheckIterations = 0u; // loop iterations accumulated only if check is enabled
@@ -457,7 +444,7 @@ ccInstError ccInstance::Run(int32_t curpc)
 
     /* Main bytecode execution loop */
     //=====================================================================
-    while ((_flags & INSTF_ABORTED) == 0)
+    while ((_flags & kScExecState_Aborted) == 0)
     {
         // WARNING: a time-critical code ahead;
         // trying to pick some of the code out to separate function(s)
@@ -466,7 +453,7 @@ ccInstError ccInstance::Run(int32_t curpc)
         //
         /* Read operation */
         //=====================================================================
-        codeOp.Instruction.Code = codeInst->_code[_pc];
+        codeOp.Instruction.Code = _code[_pc];
         codeOp.Instruction.InstanceId = (codeOp.Instruction.Code >> INSTANCE_ID_SHIFT) & INSTANCE_ID_MASK;
         codeOp.Instruction.Code &= INSTANCE_ID_REMOVEMASK; // now this is pure instruction code
 
@@ -475,21 +462,21 @@ ccInstError ccInstance::Run(int32_t curpc)
 
         codeOp.ArgCount = sccmd_info[codeOp.Instruction.Code].ArgCount;
 
-        CC_ERROR_IF_RETCODE(_pc + codeOp.ArgCount >= codeInst->_codesize,
-            "unexpected end of code data (%d; %d)", _pc + codeOp.ArgCount, codeInst->_codesize);
+        CC_ERROR_IF_RETCODE(_pc + codeOp.ArgCount >= _codesize,
+            "unexpected end of code data (%d; %d)", _pc + codeOp.ArgCount, _codesize);
 
 
         // Read arguments; use switch as it proved to be faster than the loop
         switch (codeOp.ArgCount)
         {
         case 3:
-            codeOp.Args[2].SetInt32(static_cast<int32_t>(codeInst->_code[_pc + 3]));
+            codeOp.Args[2].SetInt32(static_cast<int32_t>(_code[_pc + 3]));
             /* fall-through */
         case 2:
-            codeOp.Args[1].SetInt32(static_cast<int32_t>(codeInst->_code[_pc + 2]));
+            codeOp.Args[1].SetInt32(static_cast<int32_t>(_code[_pc + 2]));
             /* fall-through */
         case 1:
-            codeOp.Args[0].SetInt32(static_cast<int32_t>(codeInst->_code[_pc + 1]));
+            codeOp.Args[0].SetInt32(static_cast<int32_t>(_code[_pc + 1]));
             break;
         default:
             break;
@@ -498,13 +485,6 @@ ccInstError ccInstance::Run(int32_t curpc)
         /* End read operation */
         //=====================================================================
 
-#if (DEBUG_CC_EXEC)
-        if (dump_opcodes)
-        {
-            DumpInstruction(codeOp);
-        }
-#endif
-
         /* Perform operation */
         //=====================================================================
         switch (codeOp.Instruction.Code)
@@ -512,8 +492,9 @@ ccInstError ccInstance::Run(int32_t curpc)
         case SCMD_LINENUM:
             _lineNumber = codeOp.Arg1i();
             currentline = _lineNumber;
-            if (new_line_hook)
-                new_line_hook(this, currentline);
+            // FIXME!!! -- restore this
+            //if (new_line_hook)
+            //    new_line_hook(this, currentline);
             break;
         case SCMD_ADD:
         {
@@ -593,7 +574,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             // be only up to 4 bytes large;
             // I guess that's an obsolete way to do WRITE, WRITEW and WRITEB
             const auto arg_size = codeOp.Arg1i();
-            FixupArgument(codeOp.Args[1], codeInst->_code_fixups[_pc + 2], codeInst->_code[_pc + 2], _stackBegin, codeInst->_strings);
+            FixupArgument(codeOp.Args[1], _code_fixups[_pc + 2], _code[_pc + 2], _stackBegin, _strings);
             ASSERT_CC_ERROR();
             const auto &arg_value = codeOp.Arg2();
             switch (arg_size)
@@ -626,7 +607,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (_pc == 0)
             {
                 _returnValue = _registers[SREG_AX].IValue;
-                return kInstErr_None;
+                return kScExecErr_None;
             }
             POP_CALL_STACK();
             continue; // continue so that the PC doesn't get overwritten
@@ -634,7 +615,7 @@ ccInstError ccInstance::Run(int32_t curpc)
         case SCMD_LITTOREG:
         {
             auto &reg1 = _registers[codeOp.Arg1i()];
-            FixupArgument(codeOp.Args[1], codeInst->_code_fixups[_pc + 2], codeInst->_code[_pc + 2], _stackBegin, codeInst->_strings);
+            FixupArgument(codeOp.Args[1], _code_fixups[_pc + 2], _code[_pc + 2], _stackBegin, _strings);
             ASSERT_CC_ERROR();
             const auto &arg_value = codeOp.Arg2();
             reg1 = arg_value;
@@ -675,7 +656,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (reg2.IValue == 0)
             {
                 cc_error("!Integer divide by zero");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             reg1.SetInt32(reg1.IValue / reg2.IValue);
             break;
@@ -780,7 +761,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (reg2.IValue == 0)
             {
                 cc_error("!Integer divide by zero");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             reg1.SetInt32(reg1.IValue % reg2.IValue);
             break;
@@ -798,7 +779,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (curnest >= MAXNEST - 1)
             {
                 cc_error("!call stack overflow, recursive call problem?");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
 
             PUSH_CALL_STACK();
@@ -890,9 +871,9 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (arg_lit < 0)
             {
                 ++loopIterations;
-                if (_flags & INSTF_RUNNING)
+                if (_flags & kScExecState_Running)
                 { // was notified still running, don't do anything
-                    _flags &= ~INSTF_RUNNING;
+                    _flags &= ~kScExecState_Running;
                     loopIterations = 0u;
                     loopCheckIterations = 0u;
                 }
@@ -900,7 +881,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                     (++loopCheckIterations > _maxWhileLoops))
                 {
                     cc_error("!Script appears to be hung (a while loop ran %d times). The problem may be in a calling function; check the call stack.", loopCheckIterations);
-                    return kInstErr_Generic;
+                    return kScExecErr_Generic;
                 }
                 else if ((loopIterations & 0x3FF) == 0 && // test each 1024 loops (arbitrary)
                     (std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -929,7 +910,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                 (reg1.IValue >= arg_lit))
             {
                 cc_error("!Array index out of bounds (index: %d, bounds: 0..%d)", reg1.IValue, arg_lit - 1);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             break;
         }
@@ -950,7 +931,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                     int elementSize = (hdr.TotalSize / hdr.ElemCount);
                     cc_error("!Array index out of bounds (index: %d, bounds: 0..%d)", reg1.IValue / elementSize, hdr.ElemCount - 1);
                 }
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             break;
         }
@@ -997,7 +978,7 @@ ccInstError ccInstance::Run(int32_t curpc)
 
             int32_t newHandle = ccGetObjectHandleFromAddress(address);
             if (newHandle == -1)
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
 
             if (handle != newHandle)
             {
@@ -1038,7 +1019,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             // like memwriteptr, but doesn't attempt to free the old one
             int32_t newHandle = ccGetObjectHandleFromAddress(address);
             if (newHandle == -1)
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
 
             ccAddObjectReference(newHandle);
             _registers[SREG_MAR].WriteInt32(newHandle);
@@ -1070,7 +1051,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (_registers[SREG_MAR].IsNull())
             {
                 cc_error("!Null pointer referenced");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             break;
         case SCMD_CHECKNULLREG:
@@ -1079,7 +1060,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (reg1.IsNull())
             {
                 cc_error("!Null string referenced");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             break;
         }
@@ -1116,31 +1097,31 @@ ccInstError ccInstance::Run(int32_t curpc)
             PushValueToStack(RuntimeScriptValue().SetInt32(0));
 
             const int oldpc = _pc;
-            ccInstance *wasRunning = _runningInst;
+            const RuntimeScript *was_running = _current;
 
             // extract the instance ID
-            int32_t instId = codeOp.Instruction.InstanceId;
+            const int32_t instance_id = codeOp.Instruction.InstanceId;
             // determine the offset into the code of the instance we want
-            _runningInst = loadedInstances[instId];
-            uintptr_t callAddr = reg1.PtrU8 - reinterpret_cast<const uint8_t*>(_runningInst->_code);
+            const RuntimeScript *next_to_run = RuntimeScript::GetLinkedScript(instance_id);
+            uintptr_t callAddr = reg1.PtrU8 - reinterpret_cast<const uint8_t*>(next_to_run->GetCode().data());
             if (callAddr % sizeof(uintptr_t) != 0)
             {
                 cc_error("call address not aligned");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             callAddr /= sizeof(uintptr_t); // size of ccScript::code elements
+            SetCurrentScript(next_to_run); // switch to the new script
 
             if (Run(static_cast<int32_t>(callAddr)))
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
 
-            _runningInst = wasRunning;
-
-            if ((_flags & INSTF_ABORTED) == 0)
+            if ((_flags & kScExecState_Aborted) == 0)
                 ASSERT_STACK_UNWINDED(oldstack, oldstackdata);
 
-            next_call_needs_object = 0;
+            SetCurrentScript(was_running); // switch back to the previous script
 
             _pc = oldpc;
+            next_call_needs_object = 0;
             was_just_callas = func_callstack.Count;
             num_args_to_func = -1;
             POP_CALL_STACK();
@@ -1219,7 +1200,7 @@ ccInstError ccInstance::Run(int32_t curpc)
 
             if (cc_has_error())
             {
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
 
             _registers[SREG_AX] = return_value;
@@ -1252,7 +1233,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (reg1.IsNull())
             {
                 cc_error("!Null pointer referenced");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             switch (reg1.Type)
             {
@@ -1276,7 +1257,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                 break;
             default:
                 cc_error("internal error: SCMD_CALLOBJ argument is not an object of built-in or user-defined type");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             next_call_needs_object = 1;
             break;
@@ -1310,7 +1291,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (arg_elnum < 0)
             {
                 cc_error("Invalid size for dynamic array; requested: %d, range: 0..%d", arg_elnum, INT32_MAX);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             DynObjectRef ref = CCDynamicArray::CreateOld(static_cast<uint32_t>(arg_elnum), arg_elsize, arg_managed);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
@@ -1325,13 +1306,13 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (arg_elnum < 0)
             {
                 cc_error("Invalid size for dynamic array; requested: %d, range: 0..%d", arg_elnum, INT32_MAX);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             // TODO: this likely may be optimized by doing a fixup,
             // which would replace a local typeid with a global one once the script is loaded;
             // but we need to implement such fixup in a compiler first.
-            assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
-            const uint32_t global_tid = _runningInst->_typeidLocal2Global->at(arg_typeid);
+            assert(_rtti && !_rtti->IsEmpty());
+            const uint32_t global_tid = _typeidLocal2Global->at(arg_typeid);
             DynObjectRef ref = CCDynamicArray::CreateNew(global_tid, static_cast<uint32_t>(arg_elnum), arg_elsize);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
             break;
@@ -1343,7 +1324,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (arg_size > INT32_MAX)
             {
                 cc_error("Invalid size for user object; requested: %u, range: 0..%d", arg_size, INT32_MAX);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             DynObjectRef ref = ScriptUserObject::Create(RTTI::NoType, arg_size);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
@@ -1357,13 +1338,13 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (arg_size > INT32_MAX)
             {
                 cc_error("Invalid size for user object; requested: %u, range: 0..%d", arg_size, INT32_MAX);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             // TODO: this likely may be optimized by doing a fixup,
             // which would replace a local typeid with a global one once the script is loaded;
             // but we need to implement such fixup in a compiler first.
-            assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
-            const uint32_t global_tid = _runningInst->_typeidLocal2Global->at(arg_typeid);
+            assert(_rtti && !_rtti->IsEmpty());
+            const uint32_t global_tid = _typeidLocal2Global->at(arg_typeid);
             DynObjectRef ref = ScriptUserObject::Create(global_tid, arg_size);
             reg1.SetScriptObject(ref.Obj, ref.Mgr);
             break;
@@ -1396,7 +1377,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if (reg2.FValue == 0.0)
             {
                 cc_error("!Floating point divide by zero");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             reg1.SetFloat(reg1.FValue / reg2.FValue);
             break;
@@ -1460,7 +1441,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             {
                 cc_error("internal error: stack tail address expected on SCMD_ZEROMEMORY instruction, reg[MAR] type is %d",
                     _registers[SREG_MAR].Type);
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             break;
         }
@@ -1479,7 +1460,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if ((reg1.IsNull()) || (reg2.IsNull()))
             {
                 cc_error("!Null pointer referenced");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             else
             {
@@ -1496,7 +1477,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             if ((reg1.IsNull()) || (reg2.IsNull()))
             {
                 cc_error("!Null pointer referenced");
-                return kInstErr_Generic;
+                return kScExecErr_Generic;
             }
             else
             {
@@ -1512,233 +1493,30 @@ ccInstError ccInstance::Run(int32_t curpc)
             break;
         default:
             cc_error("instruction %d is not implemented", codeOp.Instruction.Code);
-            return kInstErr_Generic;
+            return kScExecErr_Generic;
         }
         /* End perform operation */
         //=====================================================================
 
         _pc += codeOp.ArgCount + 1;
     }
-    return kInstErr_None;
+    return kScExecErr_None;
 }
 
-String ccInstance::GetCallStack(const int maxLines) const
+void ScriptExecutor::SetCurrentScript(const RuntimeScript *script)
 {
-    String buffer = String::FromFormat("in \"%s\", line %d\n", _runningInst->_instanceof->GetSectionName(_pc).GetCStr(), _lineNumber);
-
-    int linesDone = 0;
-    for (uint32_t j = _callStackSize; (j-- > 0) && (linesDone < maxLines); linesDone++)
-    {
-        String lineBuffer = String::FromFormat("from \"%s\", line %d\n",
-            _callStackCodeInst[j]->_instanceof->GetSectionName(_callStackAddr[j]).GetCStr(), _callStackLineNumber[j]);
-        buffer.Append(lineBuffer);
-        if (linesDone == maxLines - 1)
-            buffer.Append("(and more...)\n");
-    }
-    return buffer;
+    _current    = script;
+    _code       = _current->GetCode().data();
+    _codesize   = _current->GetCode().size();
+    _code_fixups = _current->GetCodeFixups().data();
+    _strings    = _current->GetStrings().data();
+    _stringsize = _current->GetStrings().size();
+    // Table pointers
+    _rtti       = RuntimeScript::GetJointRTTI();
+    _typeidLocal2Global = &_current->GetLocal2GlobalTypeMap();
 }
 
-void ccInstance::GetScriptPosition(ScriptPosition &script_pos) const
-{
-    script_pos.Section = _runningInst->_instanceof->GetSectionName(_pc);
-    script_pos.Line    = _lineNumber;
-}
-
-RuntimeScriptValue ccInstance::GetSymbolAddress(const String &symname) const
-{
-    return _instanceof->GetSymbolAddress(symname);
-}
-
-const char *regnames[] = { "null", "sp", "mar", "ax", "bx", "cx", "op", "dx" };
-const char *fixupnames[] = { "null", "fix_gldata", "fix_func", "fix_string", "fix_import", "fix_datadata", "fix_stack" };
-
-void ccInstance::DumpInstruction(const ScriptOperation &op) const
-{
-    // line_num local var should be shared between all the instances
-    static int line_num = 0;
-
-    if (op.Instruction.Code == SCMD_LINENUM)
-    {
-        line_num = op.Args[0].IValue;
-        return;
-    }
-
-    auto data_s = File::OpenFile("script.log", kFile_Create, kStream_Write);
-    TextStreamWriter writer(std::move(data_s));
-    writer.WriteFormat("Line %3d, IP:%8d (SP:%p) ", line_num, _pc, _registers[SREG_SP].RValue);
-
-    const ScriptCommandInfo &cmd_info = sccmd_info[op.Instruction.Code];
-    writer.WriteString(cmd_info.CmdName);
-
-    for (int i = 0; i < cmd_info.ArgCount; ++i)
-    {
-        if (i > 0)
-        {
-            writer.WriteChar(',');
-        }
-        if (cmd_info.ArgIsReg[i])
-        {
-            writer.WriteFormat(" %s", regnames[op.Args[i].IValue]);
-        }
-        else
-        {
-            RuntimeScriptValue arg = op.Args[i];
-            if (arg.Type == kScValStackPtr || arg.Type == kScValGlobalVar)
-            {
-                arg = *arg.RValue;
-            }
-            switch(arg.Type) {
-            case kScValInteger:
-            case kScValPluginArg:
-                writer.WriteFormat(" %d", arg.IValue);
-                break;
-            case kScValFloat:
-                writer.WriteFormat(" %f", arg.FValue);
-                break;
-            case kScValStringLiteral:
-                writer.WriteFormat(" \"%s\"", arg.Ptr);
-                break;
-            case kScValStackPtr:
-            case kScValGlobalVar:
-                writer.WriteFormat(" %p", arg.RValue);
-                break;
-            case kScValData:
-            case kScValCodePtr:
-                writer.WriteFormat(" %p", arg.GetPtrWithOffset());
-                break;
-            case kScValStaticArray:
-            case kScValScriptObject:
-            case kScValStaticFunction:
-            case kScValObjectFunction:
-            case kScValPluginFunction:
-            case kScValPluginObject:
-            {
-                String name = simp.FindName(arg);
-                if (!name.IsEmpty())
-                {
-                    writer.WriteFormat(" &%s", name.GetCStr());
-                }
-                else
-                {
-                    writer.WriteFormat(" %p", arg.GetPtrWithOffset());
-                }
-             }
-                break;
-            case kScValUndefined:
-				writer.WriteString("undefined");
-                break;
-             }
-        }
-    }
-    writer.WriteLineBreak();
-    // the writer will delete data stream internally
-}
-
-bool ccInstance::IsBeingRun() const
-{
-    return _pc != 0;
-}
-
-void ccInstance::NotifyAlive()
-{
-    _flags |= INSTF_RUNNING;
-    _lastAliveTs = AGS_FastClock::now();
-}
-
-bool ccInstance::_Create(PRuntimeScript script, const ccInstance *joined)
-{
-    assert(script || (joined && joined->_instanceof));
-    if ((script == nullptr) && (joined != nullptr))
-        script = joined->_instanceof;
-    if (script == nullptr)
-    {
-        cc_error("ccInstance: internal error, script is null");
-        return false;
-    }
-
-    // just use the pointer to the strings since they don't change
-    _strings = script->GetStrings().size() > 0 ? script->GetStrings().data() : "";
-    _stringsize = script->GetStrings().size();
-
-    // Create a stack
-    // The size of a stack is quite an arbitrary choice; there's no way to deduce number of stack
-    // entries needed without knowing amount of local variables (at least)
-    _stack.resize(CC_STACK_SIZE);
-    _stackdata.resize(CC_STACK_DATA_SIZE);
-    _stackBegin = _stack.data();
-    _stackdataBegin = _stackdata.data();
-    _stackdataPtr = _stackdata.data();
-
-    // Setup fast access pointers
-    _code = script->GetCode().data();
-    _codesize = static_cast<int32_t>(script->GetCode().size());
-    _code_fixups = script->GetCodeFixups().data();
-    _rtti = RuntimeScript::GetJointRTTI();
-    _typeidLocal2Global = &script->GetLocal2GlobalTypeMap();
-
-    _instanceof = script;
-    _flags = 0;
-    if (joined != nullptr)
-        _flags = INSTF_SHAREDATA;
-
-    // Find a LoadedInstance slot for it
-    if (joined == nullptr)
-    {
-        // For primary instances (non-forks) loaded instance ID must match the script linking index
-        _loadedInstanceId = _instanceof->GetLinkIndex();
-        loadedInstances[_loadedInstanceId] = this;
-    }
-    else
-    {
-        for (int i = 1; i < MAX_LOADED_INSTANCES; i++)
-        {
-            if (loadedInstances[i] == nullptr)
-            {
-                loadedInstances[i] = this;
-                _loadedInstanceId = i;
-                break;
-            }
-        }
-    }
-    if (_loadedInstanceId == 0)
-    {
-        cc_error("Too many active instances");
-        return false;
-    }
-
-    // Reset execution state
-    _pc = 0;
-    _lineNumber = 0;
-    currentline = -1; // FIXME: refactor this to not use global vars
-    return true;
-}
-
-void ccInstance::Free()
-{
-    _instanceof = nullptr;
-
-    // remove from the Active Instances list
-    if (loadedInstances[_loadedInstanceId] == this)
-        loadedInstances[_loadedInstanceId] = nullptr;
-
-    _code = nullptr;
-    _codesize = 0;
-    _strings = nullptr;
-    _stringsize = 0u;
-
-    _stack = {};
-    _stackdata = {};
-    _stackBegin = nullptr;
-    _stackdataPtr = {};
-}
-
-
-void ccInstance::CopyGlobalData(const std::vector<uint8_t> &data)
-{
-    _instanceof->CopyGlobalData(data);
-}
-
-void ccInstance::PushValueToStack(const RuntimeScriptValue &rval)
+void ScriptExecutor::PushValueToStack(const RuntimeScriptValue &rval)
 {
     // Write value to the stack tail and advance stack ptr
     _registers[SREG_SP].WriteValue(rval);
@@ -1746,7 +1524,7 @@ void ccInstance::PushValueToStack(const RuntimeScriptValue &rval)
     _registers[SREG_SP].RValue++;
 }
 
-void ccInstance::PushDataToStack(const int32_t num_bytes)
+void ScriptExecutor::PushDataToStack(const int32_t num_bytes)
 {
     CC_ERROR_IF(_registers[SREG_SP].RValue->IsValid(), "internal error: valid data beyond stack ptr");
     // Assign pointer to data block to the stack tail, advance both stack ptr and stack data ptr
@@ -1756,7 +1534,7 @@ void ccInstance::PushDataToStack(const int32_t num_bytes)
     _registers[SREG_SP].RValue++;
 }
 
-RuntimeScriptValue ccInstance::PopValueFromStack()
+RuntimeScriptValue ScriptExecutor::PopValueFromStack()
 {
     // rewind stack ptr to the last valid value, decrement stack data ptr if needed and invalidate the stack tail
     _registers[SREG_SP].RValue--;
@@ -1766,7 +1544,7 @@ RuntimeScriptValue ccInstance::PopValueFromStack()
     return rval;
 }
 
-void ccInstance::PopValuesFromStack(const int32_t num_entries = 1)
+void ScriptExecutor::PopValuesFromStack(const int32_t num_entries = 1)
 {
     for (int i = 0; i < num_entries; ++i)
     {
@@ -1777,7 +1555,7 @@ void ccInstance::PopValuesFromStack(const int32_t num_entries = 1)
     }
 }
 
-void ccInstance::PopDataFromStack(const int32_t num_bytes)
+void ScriptExecutor::PopDataFromStack(const int32_t num_bytes)
 {
     int32_t total_pop = 0;
     while (total_pop < num_bytes && _registers[SREG_SP].RValue > _stackBegin)
@@ -1793,7 +1571,7 @@ void ccInstance::PopDataFromStack(const int32_t num_bytes)
     CC_ERROR_IF(total_pop > num_bytes, "stack pointer points inside local variable after pop, stack corrupted?");
 }
 
-RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(const int32_t rw_offset)
+RuntimeScriptValue ScriptExecutor::GetStackPtrOffsetRw(const int32_t rw_offset)
 {
     int32_t total_off = 0;
     RuntimeScriptValue *stack_entry = _registers[SREG_SP].RValue;
@@ -1812,9 +1590,9 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(const int32_t rw_offset)
     return stack_ptr;
 }
 
-void ccInstance::PushToFuncCallStack(FunctionCallStack &func_callstack, const RuntimeScriptValue &rval)
+void ScriptExecutor::PushToFuncCallStack(FunctionCallStack &func_callstack, const RuntimeScriptValue &rval)
 {
-    if (func_callstack.Count >= MAX_FUNC_PARAMS)
+    if (func_callstack.Count >= FunctionCallStack::MAX_FUNC_PARAMS)
     {
         cc_error("function callstack overflow");
         return;
@@ -1825,7 +1603,7 @@ void ccInstance::PushToFuncCallStack(FunctionCallStack &func_callstack, const Ru
     func_callstack.Count++;
 }
 
-void ccInstance::PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t num_entries)
+void ScriptExecutor::PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t num_entries)
 {
     if (func_callstack.Count == 0)
     {
@@ -1836,3 +1614,6 @@ void ccInstance::PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t
     func_callstack.Head += num_entries;
     func_callstack.Count -= num_entries;
 }
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/script/scriptexecutor.cpp
+++ b/Engine/script/scriptexecutor.cpp
@@ -23,9 +23,12 @@
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
+using namespace AGS::Engine;
 
 // FIXME: don't use global var like this
 extern new_line_hook_type new_line_hook;
+// FIXME: do something with this, don't use global variable
+extern std::unique_ptr<ScriptExecutor> scriptExecutor;
 
 // [IKM] 2012-10-21:
 // NOTE: This is temporary solution (*sigh*, one of many) which allows certain
@@ -33,6 +36,14 @@ extern new_line_hook_type new_line_hook;
 // Of 2012-12-20: now used only for plugin exports
 // FIXME: re-investigate this, find if it's possible to get rid of this.
 RuntimeScriptValue GlobalReturnValue;
+
+
+String cc_get_callstack(int max_lines)
+{
+    // TODO: support separation onto groups, which have engine calls between
+    return scriptExecutor->GetCallStack(max_lines);
+}
+
 
 namespace AGS
 {
@@ -157,6 +168,34 @@ void ScriptExecutor::Abort()
 {
     if (_pc != 0)
         _flags |= kScExecState_Aborted;
+}
+
+void ScriptExecutor::GetScriptPosition(ScriptPosition &script_pos) const
+{
+    if (!_current)
+        return;
+
+    script_pos.Section = _current->GetSectionName(_pc);
+    script_pos.Line    = _lineNumber;
+}
+
+String ScriptExecutor::GetCallStack(const int maxLines) const
+{
+    if (!_current)
+        return {};
+
+    String buffer = String::FromFormat("in \"%s\", line %d\n", _current->GetSectionName(_pc).GetCStr(), _lineNumber);
+
+    int linesDone = 0;
+    for (auto it = _callstack.crbegin(); it != _callstack.crend() && (linesDone < maxLines); linesDone++, ++it)
+    {
+        String lineBuffer = String::FromFormat("from \"%s\", line %d\n",
+            it->Script->GetSectionName(it->PC).GetCStr(), it->LineNumber);
+        buffer.Append(lineBuffer);
+        if (linesDone == maxLines - 1)
+            buffer.Append("(and more...)\n");
+    }
+    return buffer;
 }
     
 void ScriptExecutor::SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops)

--- a/Engine/script/scriptexecutor.cpp
+++ b/Engine/script/scriptexecutor.cpp
@@ -303,13 +303,30 @@ void ScriptExecutor::NotifyAlive()
 
 ScriptExecError ScriptExecutor::Run(const RuntimeScript *script, int32_t curpc, const RuntimeScriptValue *params, size_t param_count)
 {
+    const bool is_nested_run = _callstack.size() > 0;
     // Setup current script
     SetCurrentScript(script);
 
+    RuntimeScriptValue * const oldstack_begin = _stackBegin;
+    uint8_t * const oldstackdata_begin = _stackdataBegin;
+
+    if (is_nested_run)
+    {
+        _stackBegin = _registers[SREG_SP].RValue;
+        _stackdataBegin = _stackdataPtr;
+    }
+    else
+    {
+        _registers[SREG_SP].SetStackPtr(_stackBegin);
+        _stackdataPtr = _stackdataBegin;
+    }
+
+    const RuntimeScriptValue oldstack = _registers[SREG_SP];
+    const uint8_t * const oldstackdata = _stackdataPtr;
+
     // object pointer needs to start zeroed
     _registers[SREG_OP].SetScriptObject(nullptr, nullptr);
-    _registers[SREG_SP].SetStackPtr( _stack.data() );
-    _stackdataPtr = _stackdata.data();
+
     // NOTE: Pushing parameters to stack in reverse order
     ASSERT_STACK_SPACE_VALS(param_count + 1 /* return address */);
     for (int i = param_count - 1; i >= 0; --i)
@@ -330,8 +347,14 @@ ScriptExecError ScriptExecutor::Run(const RuntimeScript *script, int32_t curpc, 
     // Final assert: stack must be reset to where it was before starting this script
     if (!(_flags & kScExecState_Aborted))
     {
-        ASSERT_STACK_UNWINDED(_registers[SREG_SP], _stackdata.data());
+        ASSERT_STACK_UNWINDED(oldstack, oldstackdata);
     }
+    if (is_nested_run)
+    {
+        _stackBegin = oldstack_begin;
+        _stackdataBegin = oldstackdata_begin;
+    }
+    SetCurrentScript(nullptr);
     return cc_has_error() ? kScExecErr_Generic : kScExecErr_None;
 }
 
@@ -1112,6 +1135,8 @@ ScriptExecError ScriptExecutor::Run(int32_t curpc)
         case SCMD_CALLAS:
         {
             PUSH_CALL_STACK();
+            const RuntimeScript *was_running = _current;
+            const int oldpc = _pc;
 
             // Call to a function in another script
             const auto &reg1 = _registers[codeOp.Arg1i()];
@@ -1135,9 +1160,6 @@ ScriptExecError ScriptExecutor::Run(int32_t curpc)
             // Push placeholder for the return value (it will be popped before ret)
             PushValueToStack(RuntimeScriptValue().SetInt32(0));
 
-            const int oldpc = _pc;
-            const RuntimeScript *was_running = _current;
-
             // extract the instance ID
             const int32_t instance_id = codeOp.Instruction.InstanceId;
             // determine the offset into the code of the instance we want
@@ -1157,17 +1179,22 @@ ScriptExecError ScriptExecutor::Run(int32_t curpc)
             if ((_flags & kScExecState_Aborted) == 0)
                 ASSERT_STACK_UNWINDED(oldstack, oldstackdata);
 
+            POP_CALL_STACK();
             SetCurrentScript(was_running); // switch back to the previous script
-
             _pc = oldpc;
             next_call_needs_object = 0;
             was_just_callas = func_callstack.Count;
             num_args_to_func = -1;
-            POP_CALL_STACK();
             break;
         }
         case SCMD_CALLEXT:
         {
+            PUSH_CALL_STACK();
+            const RuntimeScript *was_running = _current;
+            const int oldpc = _pc;
+            const RuntimeScriptValue oldstack = _registers[SREG_SP];
+            const uint8_t * const oldstackdata = _stackdataPtr;
+
             // Call to a real 'C' code function
             const auto &reg1 = _registers[codeOp.Arg1i()];
 
@@ -1242,6 +1269,12 @@ ScriptExecError ScriptExecutor::Run(int32_t curpc)
                 return kScExecErr_Generic;
             }
 
+            if ((_flags & kScExecState_Aborted) == 0)
+                ASSERT_STACK_UNWINDED(oldstack, oldstackdata);
+
+            POP_CALL_STACK();
+            SetCurrentScript(was_running); // switch back to the previous script
+            _pc = oldpc;
             _registers[SREG_AX] = return_value;
             next_call_needs_object = 0;
             num_args_to_func = -1;
@@ -1545,14 +1578,28 @@ ScriptExecError ScriptExecutor::Run(int32_t curpc)
 void ScriptExecutor::SetCurrentScript(const RuntimeScript *script)
 {
     _current    = script;
-    _code       = _current->GetCode().data();
-    _codesize   = _current->GetCode().size();
-    _code_fixups = _current->GetCodeFixups().data();
-    _strings    = _current->GetStrings().data();
-    _stringsize = _current->GetStrings().size();
-    // Table pointers
-    _rtti       = RuntimeScript::GetJointRTTI();
-    _typeidLocal2Global = &_current->GetLocal2GlobalTypeMap();
+    if (_current)
+    {
+        _code       = _current->GetCode().data();
+        _codesize   = _current->GetCode().size();
+        _code_fixups = _current->GetCodeFixups().data();
+        _strings    = _current->GetStrings().data();
+        _stringsize = _current->GetStrings().size();
+        // Table pointers
+        _rtti       = RuntimeScript::GetJointRTTI();
+        _typeidLocal2Global = &_current->GetLocal2GlobalTypeMap();
+    }
+    else
+    {
+        _code       = nullptr;
+        _codesize   = 0u;
+        _code_fixups = nullptr;
+        _strings    = nullptr;
+        _stringsize = 0u;
+        // Table pointers
+        _rtti       = nullptr;
+        _typeidLocal2Global = nullptr;
+    }
 }
 
 void ScriptExecutor::PushValueToStack(const RuntimeScriptValue &rval)

--- a/Engine/script/scriptexecutor.h
+++ b/Engine/script/scriptexecutor.h
@@ -65,6 +65,23 @@ public:
     // Schedule abortion of the current script execution;
     // the actual stop will occur whenever control returns to the ScriptExecutor.
     void    Abort();
+
+    // Tells whether this instance is in the process of executing the byte-code
+    bool    IsBeingRun() const { return _pc != 0; }
+    // Get the currently executed script
+    const RuntimeScript *GetRunningScript() const { return _current; }
+    // Get current program pointer (position in bytecode)
+    int     GetPC() const { return _pc; }
+    // Get the script's execution position
+    void    GetScriptPosition(ScriptPosition &script_pos) const;
+    // Get the script's execution position and callstack as human-readable text
+    Common::String GetCallStack(int max_lines = INT_MAX) const;
+    // Gets the top entry of this instance's stack
+    const RuntimeScriptValue *GetCurrentStack() const { return _registers[SREG_SP].RValue; }
+    // Get latest return value
+    int     GetReturnValue() const { return _returnValue; }
+    // TODO: this is a hack, required for dialog script; redo this later!
+    void    SetReturnValue(int val) { _returnValue = val; }
     
     // Configures script executor timeout in case of a "hanging" script
     void    SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);

--- a/Engine/script/scriptexecutor.h
+++ b/Engine/script/scriptexecutor.h
@@ -1,0 +1,148 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2024 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_EE_SCRIPT__SCRIPTEXECUTOR_H
+#define __AGS_EE_SCRIPT__SCRIPTEXECUTOR_H
+
+#include <deque>
+#include "ac/timer.h"
+#include "script/runtimescript.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+enum ScriptExecError
+{
+    kScExecErr_None = 0, // ok
+    kScExecErr_Aborted = 100, // aborted by request
+    kScExecErr_Generic = -1, // any generic exec error; use cc_get_error()
+    kScExecErr_FuncNotFound = -2, // requested function is not found in script
+    kScExecErr_InvalidArgNum = -3, // invalid number of args (not in supported range)
+    kScExecErr_Busy = -4, // is busy executing script (unused?)
+};
+
+enum ScriptExecState
+{
+    kScExecState_None    = 0x00,
+    kScExecState_Aborted = 0x01, // scheduled to abort
+    kScExecState_Running = 0x02  // set by main code to confirm script isn't stuck
+};
+
+// ScriptPosition defines position in the executed script
+struct ScriptExecPosition
+{
+    const RuntimeScript *Script = nullptr;
+    int32_t PC = 0;
+    int32_t LineNumber = 0;
+
+    ScriptExecPosition(const RuntimeScript *script, int pc, int linenumber)
+        : Script(script), PC(pc), LineNumber(linenumber) {}
+};
+
+struct FunctionCallStack;
+
+
+class ScriptExecutor
+{
+    using String = Common::String;
+public:
+    ScriptExecutor();
+
+    // Begin executing the function in the given script, passing an array of parameters
+    ScriptExecError Run(const RuntimeScript *script, const String &funcname, const RuntimeScriptValue *params, size_t param_count);
+    // Schedule abortion of the current script execution;
+    // the actual stop will occur whenever control returns to the ScriptExecutor.
+    void    Abort();
+    
+    // Configures script executor timeout in case of a "hanging" script
+    void    SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
+    // Notifies that the game was being updated (script not hanging)
+    void    NotifyAlive();
+
+private:
+    // Begin executing the given script starting from the given bytecode index
+    ScriptExecError Run(const RuntimeScript *script, int32_t curpc, const RuntimeScriptValue *params, size_t param_count);
+    // Begin executing latest run script starting from the given bytecode index
+    ScriptExecError Run(int32_t curpc);
+
+    // Sets current script and fast-access pointers
+    void    SetCurrentScript(const RuntimeScript *script);
+    // Stack processing
+    // Push writes new value and increments stack ptr;
+    // stack ptr now points to the __next empty__ entry
+    void    PushValueToStack(const RuntimeScriptValue &rval);
+    void    PushDataToStack(int32_t num_bytes);
+    // Pop decrements stack ptr, returns last stored value and invalidates! stack tail;
+    // stack ptr now points to the __next empty__ entry
+    RuntimeScriptValue PopValueFromStack();
+    // helper function to pop & dump several values
+    void    PopValuesFromStack(int32_t num_entries);
+    void    PopDataFromStack(int32_t num_bytes);
+    // Return stack ptr at given offset from stack tail;
+    // Offset is in data bytes; program stack ptr is __not__ changed
+    RuntimeScriptValue GetStackPtrOffsetRw(int32_t rw_offset);
+
+    // Function call stack processing
+    void    PushToFuncCallStack(FunctionCallStack &func_callstack, const RuntimeScriptValue &rval);
+    void    PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t num_entries);
+
+    //
+    // Virtual machine state
+    // Executed script callstack, contains previous script positions
+    std::deque<ScriptExecPosition> _callstack; // deque for easier iterating over
+    // Registers
+    RuntimeScriptValue _registers[CC_NUM_REGISTERS];
+    // Data stack, contains function args, local variables, temporary values
+    std::vector<RuntimeScriptValue> _stack;
+    // An array for keeping stack data; stack entries reference data of variable size from here
+    std::vector<uint8_t> _stackdata;
+    RuntimeScriptValue *_stackBegin = nullptr; // fast-access ptr to beginning of _stack
+    uint8_t    *_stackdataBegin = nullptr; // fast-access ptr to beginning of _stackdata
+    uint8_t    *_stackdataPtr = nullptr; // points to the next unused byte in stack data array
+
+    // Current executed script
+    const RuntimeScript *_current = nullptr;
+    // Code pointers for faster access to the current script
+    const intptr_t *_code = nullptr;
+    uint32_t    _codesize = 0; // size of code is limited under 32-bit due to bytecode format
+    const uint8_t *_code_fixups = nullptr;
+    const char *_strings = nullptr; // pointer to ccScript's string data
+    size_t      _stringsize = 0u;
+    // Table pointers for simplicity
+    const JointRTTI *_rtti = nullptr;
+    const std::unordered_map<uint32_t, uint32_t> *_typeidLocal2Global = nullptr;
+    
+    uint32_t    _flags = kScExecState_None; // executor state flags ScriptExecState
+    int         _pc = 0; // program counter
+    int         _lineNumber = 0; // source code line number
+    int         _returnValue = 0; // last executed function's return value
+
+    // Minimal timeout: how much time may pass without any engine update
+    // before we want to check on the situation and do system poll
+    unsigned _timeoutCheckMs = 0u;
+    // Critical timeout: how much time may pass without any engine update
+    // before we abort or post a warning
+    unsigned _timeoutAbortMs = 0u;
+    // Maximal while loops without any engine update in between,
+    // after which the interpreter will abort
+    unsigned _maxWhileLoops = 0u;
+    // Last time the script was noted of being "alive"
+    AGS_FastClock::time_point _lastAliveTs;
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_SCRIPT__SCRIPTEXECUTOR_H

--- a/Engine/script/systemimports.cpp
+++ b/Engine/script/systemimports.cpp
@@ -22,6 +22,13 @@ SystemImports simp;
 SystemImports simp_for_plugin;
 
 
+ScriptImport::ScriptImport(const String &name, const RuntimeScriptValue &rval, const RuntimeScript *script, ScriptValueHint val_hint)
+    : Name(name), Value(rval), ScriptPtr(script), ValueHint(val_hint)
+{
+    if (script)
+        ScriptID = script->GetLinkIndex();
+}
+
 void ScriptSymbolsMap::Add(const String &name, uint32_t index)
 {
     _lookup[name] = index;
@@ -125,7 +132,7 @@ SystemImports::SystemImports()
 {
 }
 
-uint32_t SystemImports::Add(const String &name, const RuntimeScriptValue &value, const ccInstance *inst, ScriptValueHint val_hint)
+uint32_t SystemImports::Add(const String &name, const RuntimeScriptValue &value, const RuntimeScript *script, ScriptValueHint val_hint)
 {
     assert(value.IsValid());
     uint32_t ixof = GetIndexOf(name);
@@ -133,7 +140,7 @@ uint32_t SystemImports::Add(const String &name, const RuntimeScriptValue &value,
     if (ixof != UINT32_MAX)
     {
         // Only allow override if not a script-exported function
-        if (inst == nullptr)
+        if (script == nullptr)
         {
             _imports[ixof] = ScriptImport(name, value, nullptr, val_hint);
         }
@@ -151,9 +158,9 @@ uint32_t SystemImports::Add(const String &name, const RuntimeScriptValue &value,
     }
 
     if (ixof == _imports.size())
-        _imports.emplace_back(name, value, inst, val_hint);
+        _imports.emplace_back(name, value, script, val_hint);
     else
-        _imports[ixof] = ScriptImport(name, value, inst, val_hint);
+        _imports[ixof] = ScriptImport(name, value, script, val_hint);
     _lookup.Add(name, ixof);
     return ixof;
 }
@@ -197,9 +204,9 @@ String SystemImports::FindName(const RuntimeScriptValue &value) const
     return String();
 }
 
-void SystemImports::RemoveScriptExports(const ccInstance *inst)
+void SystemImports::RemoveScriptExports(const RuntimeScript *script)
 {
-    if (!inst)
+    if (!script)
     {
         return;
     }
@@ -209,7 +216,7 @@ void SystemImports::RemoveScriptExports(const ccInstance *inst)
         if (import.Name.IsEmpty())
             continue;
 
-        if (import.InstancePtr == inst)
+        if (import.ScriptPtr == script)
         {
             _lookup.Remove(import.Name);
             import = {};

--- a/Engine/script/systemimports.cpp
+++ b/Engine/script/systemimports.cpp
@@ -14,7 +14,7 @@
 #include "script/systemimports.h"
 #include <stdlib.h>
 #include <string.h>
-#include "script/cc_instance.h"
+#include "script/runtimescript.h"
 
 using namespace AGS::Common;
 

--- a/Engine/script/systemimports.h
+++ b/Engine/script/systemimports.h
@@ -60,34 +60,38 @@ private:
     std::map<String, uint32_t> _lookup;
 };
 
-class ccInstance;
+namespace AGS { namespace Engine { class RuntimeScript; } }
 
 struct ScriptImport
 {
     using String = AGS::Common::String;
+    using RuntimeScript = AGS::Engine::RuntimeScript;
 
     ScriptImport() = default;
-    ScriptImport(const String &name, const RuntimeScriptValue &rval, const ccInstance *inst, ScriptValueHint val_hint = kScValHint_Unknown)
-        : Name(name), Value(rval), InstancePtr(inst) {}
+    ScriptImport(const String &name, const RuntimeScriptValue &rval, const RuntimeScript *script, ScriptValueHint val_hint = kScValHint_Unknown);
 
     String              Name;
     RuntimeScriptValue  Value;
-    const ccInstance   *InstancePtr = nullptr;
+    // Numeric index of a runtime script to which this import belongs
+    uint8_t             ScriptID = 0u;
     ScriptValueHint     ValueHint = kScValHint_Unknown;
+    // Fast access reference to the script
+    const RuntimeScript *ScriptPtr = nullptr;
 };
 
 class SystemImports
 {
     using String = AGS::Common::String;
+    using RuntimeScript = AGS::Engine::RuntimeScript;
 public:
     SystemImports();
 
     // Adds a resolved import under given name
-    uint32_t Add(const String &name, const RuntimeScriptValue &value, const ccInstance *inst, ScriptValueHint val_hint = kScValHint_Unknown);
+    uint32_t Add(const String &name, const RuntimeScriptValue &value, const RuntimeScript *script, ScriptValueHint val_hint = kScValHint_Unknown);
     // Removes an import
     void Remove(const String &name);
     // Removes all imports registered for the given script instance
-    void RemoveScriptExports(const ccInstance *inst);
+    void RemoveScriptExports(const RuntimeScript *script);
     // Clears the map, removes all entries
     void Clear();
     // Gets an import by exact name match

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -655,6 +655,7 @@
     <ClCompile Include="..\..\Engine\script\cc_reflecthelper.cpp" />
     <ClCompile Include="..\..\Engine\script\executingscript.cpp" />
     <ClCompile Include="..\..\Engine\script\exports.cpp" />
+    <ClCompile Include="..\..\Engine\script\runtimescript.cpp" />
     <ClCompile Include="..\..\Engine\script\runtimescriptvalue.cpp" />
     <ClCompile Include="..\..\Engine\script\script.cpp" />
     <ClCompile Include="..\..\Engine\script\script_api.cpp" />
@@ -916,6 +917,7 @@
     <ClInclude Include="..\..\Engine\script\cc_reflecthelper.h" />
     <ClInclude Include="..\..\Engine\script\executingscript.h" />
     <ClInclude Include="..\..\Engine\script\exports.h" />
+    <ClInclude Include="..\..\Engine\script\runtimescript.h" />
     <ClInclude Include="..\..\Engine\script\runtimescriptvalue.h" />
     <ClInclude Include="..\..\Engine\script\script.h" />
     <ClInclude Include="..\..\Engine\script\script_api.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -658,6 +658,7 @@
     <ClCompile Include="..\..\Engine\script\runtimescript.cpp" />
     <ClCompile Include="..\..\Engine\script\runtimescriptvalue.cpp" />
     <ClCompile Include="..\..\Engine\script\script.cpp" />
+    <ClCompile Include="..\..\Engine\script\scriptexecutor.cpp" />
     <ClCompile Include="..\..\Engine\script\script_api.cpp" />
     <ClCompile Include="..\..\Engine\script\script_runtime.cpp" />
     <ClCompile Include="..\..\Engine\script\systemimports.cpp" />
@@ -920,6 +921,7 @@
     <ClInclude Include="..\..\Engine\script\runtimescript.h" />
     <ClInclude Include="..\..\Engine\script\runtimescriptvalue.h" />
     <ClInclude Include="..\..\Engine\script\script.h" />
+    <ClInclude Include="..\..\Engine\script\scriptexecutor.h" />
     <ClInclude Include="..\..\Engine\script\script_api.h" />
     <ClInclude Include="..\..\Engine\script\script_runtime.h" />
     <ClInclude Include="..\..\Engine\script\systemimports.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -792,6 +792,9 @@
     <ClCompile Include="..\..\Engine\platform\windows\setup\advancedpagedialog.cpp">
       <Filter>Source Files\setup</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\script\runtimescript.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1585,6 +1588,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptrestoredsaveinfo.h">
       <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\script\runtimescript.h">
+      <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -795,6 +795,9 @@
     <ClCompile Include="..\..\Engine\script\runtimescript.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\script\scriptexecutor.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1590,6 +1593,9 @@
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\script\runtimescript.h">
+      <Filter>Header Files\script</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\script\scriptexecutor.h">
       <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This is an experiment in a WIP stage currently.

**Purpose:**
* reorganize ccInstance class, separate "runtime script data" and "script execution";
* make it work without "forks", which are currently made to let run "repeatedly_execute_always" while another script is suspended;
* as a consequence, in theory support any number of nested script calls made through the nested engine API calls, i.e. interleaved engine -> script -> engine -> script -> etc, which may be wanted for delegates/function pointers to work (see discussion in #1409).

**What is done**
1. The former organization ccScript - ccInstance is expanded into: ccScript - RuntimeScript - ScriptExecutor, where
    * ccScript is a loaded script data;
    * RuntimeScript is a script prepared for execution, with fixups and imports resolved, and linked with other scripts;
    * ScriptExecutor is a object that executes RuntimeScripts.
2. Engine no longer keeps ccScripts, only use them for creating RuntimeScripts.
3. RuntimeScripts don't make any "forks", there's strictly 1 per each script, and no need for more.
4. There's a single ScriptExecutor object, which tracks a callstack of RuntimeScripts passed into it, capable of starting nested script runs while there's another/other script execution suspended.

In the situation where a script would call a blocking action, such as Wait() function, for example,
previously engine would do this:
* run base ccInstance for some script event
* call Wait()
* run forked ccInstance for "repeatedly_execute_always"

after this change it will do:
* call ScriptExecutor::Run for some script event
* call Wait()
* call ScriptExecutor::Run for "repeatedly_execute_always"
