### PR TITLE
Engine Plugin API: add CreateDynamicArray()

### DIFF
--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -47,7 +47,7 @@ public:
     }
 
     // Create managed array object and return a pointer to the beginning of a buffer
-    static DynObjectRef Create(int numElements, int elementSize, bool isManagedType);
+    static DynObjectRef Create(uint32_t elem_count, uint32_t elem_size, bool is_managed);
 
     // return the type name of the object
     const char *GetType() override;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -868,6 +868,16 @@ void *IAGSEngine::CreateDynamicArray(size_t elem_count, size_t elem_size, bool i
     return obj_ref.Obj;
 }
 
+size_t IAGSEngine::GetDynamicArrayLength(const void *arr)
+{
+    return arr ? CCDynamicArray::GetHeader(arr).ElemCount : 0u;
+}
+
+size_t IAGSEngine::GetDynamicArraySize(const void *arr)
+{
+    return arr ? CCDynamicArray::GetHeader(arr).TotalSize : 0u;
+}
+
 // *********** General plugin implementation **********
 
 void pl_stop_plugins() {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -37,6 +37,7 @@
 #include "ac/sys_events.h"
 #include "ac/view.h"
 #include "ac/dynobj/dynobj_manager.h"
+#include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/scriptstring.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "debug/debug_log.h"
@@ -98,7 +99,7 @@ extern RoomStatus *croom;
 // **************** PLUGIN IMPLEMENTATION ****************
 
 
-const int PLUGIN_API_VERSION = 29;
+const int PLUGIN_API_VERSION = 30;
 struct EnginePlugin
 {
     EnginePlugin() {
@@ -717,7 +718,7 @@ void* IAGSEngine::GetManagedObjectAddressByKey(int key) {
 
 const char* IAGSEngine::CreateScriptString(const char *fromText) {
     const char *string = CreateNewScriptString(fromText);
-    // Should be still standard dynamic object, because not managed by plugin
+    // Should be standard dynamic object, because not managed by plugin
     ccInstance::SetPluginReturnValue(RuntimeScriptValue().SetScriptObject((void*)string, &myScriptStringImpl));
     return string;
 }
@@ -846,6 +847,25 @@ void IAGSEngine::Log(int level, const char *fmt, ...)
     plugin.logbuf.AppendFmtv(fmt, argptr);
     DbgMgr.Print(kDbgGroup_Plugin, static_cast<MessageType>(level), plugin.logbuf);
     va_end(argptr);
+}
+
+void *IAGSEngine::CreateDynamicArray(size_t elem_count, size_t elem_size, bool is_managed_type)
+{
+    if (elem_count > INT32_MAX || elem_size > INT32_MAX || (static_cast<uint64_t>(elem_count) * elem_size) > UINT32_MAX)
+    {
+        debug_script_warn("IAGSEngine::CreateDynamicArray: requested array size exceeds the supported limit");
+        return nullptr;
+    }
+    if (is_managed_type && elem_size != sizeof(int32_t))
+    {
+        debug_script_warn("IAGSEngine::CreateDynamicArray: managed handles must have elem_size = 4, requested %zu instead", elem_size);
+        return nullptr;
+    }
+
+    auto obj_ref = CCDynamicArray::Create(static_cast<uint32_t>(elem_count), static_cast<uint32_t>(elem_size), is_managed_type);
+    // Should be standard dynamic object, because not managed by plugin
+    ccInstance::SetPluginReturnValue(RuntimeScriptValue().SetScriptObject(obj_ref.Obj, &globalDynamicArray));
+    return obj_ref.Obj;
 }
 
 // *********** General plugin implementation **********

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -665,6 +665,22 @@ public:
   // *** BELOW ARE INTERFACE VERSION 29 AND ABOVE ONLY
   // Print message to the engine's log, under one of the log levels AGSLOG_LEVEL_*.
   AGSIFUNC(void)  Log(int level, const char *fmt, ...);
+
+  // *** BELOW ARE INTERFACE VERSION 30 AND ABOVE ONLY
+  // Create a new dynamic array, allocating space for the given number of elements
+  // of the given size. Optionally instructs to create an array for managed handles,
+  // in which case the element size must be sizeof(int32).
+  // IMPORTANT: you MUST correctly tell if this is going to be an array of handles, because
+  // otherwise engine won't know to release their references, which may lead to memory leaks.
+  // IMPORTANT: when writing handles into this array, you MUST inc ref count for each one
+  // of them (see IncrementManagedObjectRefCount), otherwise these objects may get disposed
+  // before the array itself, making these handles invalid!
+  // Dynamic arrays have their meta data allocated prior to array of elements;
+  // this function returns a pointer to the element array, which you may write to.
+  // You may return this pointer from the registered plugin's function just like any other
+  // managed object pointer.
+  AGSIFUNC(void*) CreateDynamicArray(size_t elem_count, size_t elem_size, bool is_managed_type);
+
 };
 
 

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -680,7 +680,12 @@ public:
   // You may return this pointer from the registered plugin's function just like any other
   // managed object pointer.
   AGSIFUNC(void*) CreateDynamicArray(size_t elem_count, size_t elem_size, bool is_managed_type);
-
+  // Retrieves dynamic array's length (number of elements).
+  // You should pass a dynamic array object either received from the engine in your registered
+  // script function, or created by you with CreateDynamicArray().
+  AGSIFUNC(size_t) GetDynamicArrayLength(const void *arr);
+  // Retrieves dynamic array's size (total capacity in bytes).
+  AGSIFUNC(size_t) GetDynamicArraySize(const void *arr);
 };
 
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1432,25 +1432,25 @@ ccInstError ccInstance::Run(int32_t curpc)
         case SCMD_NEWARRAY:
         {
             auto &reg1 = _registers[codeOp.Arg1i()];
-            const auto arg_elsize = codeOp.Arg2i();
-            const auto arg_managed = codeOp.Arg3().GetAsBool();
-            int numElements = reg1.IValue;
-            if (numElements < 0)
+            const int arg_elnum = reg1.IValue;
+            const uint32_t arg_elsize = static_cast<uint32_t>(codeOp.Arg2i());
+            const bool arg_managed = codeOp.Arg3().GetAsBool();
+            if (arg_elnum < 0)
             {
-                cc_error("Invalid size for dynamic array; requested: %d, range: 0..%d", numElements, INT32_MAX);
+                cc_error("Invalid size for dynamic array; requested: %d, range: 0..%d", arg_elnum, INT32_MAX);
                 return kInstErr_Generic;
             }
-            DynObjectRef ref = CCDynamicArray::Create(numElements, arg_elsize, arg_managed);
+            DynObjectRef ref = CCDynamicArray::Create(static_cast<uint32_t>(arg_elnum), arg_elsize, arg_managed);
             reg1.SetScriptObject(ref.Obj, &globalDynamicArray);
             break;
         }
         case SCMD_NEWUSEROBJECT:
         {
             auto &reg1 = _registers[codeOp.Arg1i()];
-            const auto arg_size = codeOp.Arg2i();
-            if (arg_size < 0)
+            const uint32_t arg_size = static_cast<uint32_t>(codeOp.Arg2i());
+            if (arg_size > INT32_MAX)
             {
-                cc_error("Invalid size for user object; requested: %d (or %d), range: 0..%d", arg_size, arg_size, INT_MAX);
+                cc_error("Invalid size for user object; requested: %u, range: 0..%d", arg_size, INT32_MAX);
                 return kInstErr_Generic;
             }
             DynObjectRef ref = ScriptUserObject::Create(arg_size);


### PR DESCRIPTION
Resolve #2313

This adds IAGSEngine::CreateDynamicArray, GetDynamicArrayLength and GetDynamicArraySize:

```
  // Create a new dynamic array, allocating space for the given number of elements
  // of the given size. Optionally instructs to create an array for managed handles,
  // in which case the element size must be sizeof(int32).
  // IMPORTANT: you MUST correctly tell if this is going to be an array of handles, because
  // otherwise engine won't know to release their references, which may lead to memory leaks.
  // IMPORTANT: when writing handles into this array, you MUST inc ref count for each one
  // of them (see IncrementManagedObjectRefCount), otherwise these objects may get disposed
  // before the array itself, making these handles invalid!
  // Dynamic arrays have their meta data allocated prior to array of elements;
  // this function returns a pointer to the element array, which you may write to.
  // You may return this pointer from the registered plugin's function just like any other
  // managed object pointer.
  AGSIFUNC(void*) CreateDynamicArray(size_t elem_count, size_t elem_size, bool is_managed_type);
  // Retrieves dynamic array's length (number of elements).
  // You should pass a dynamic array object either received from the engine in your registered
  // script function, or created by you with CreateDynamicArray().
  AGSIFUNC(size_t) GetDynamicArrayLength(const void *arr);
  // Retrieves dynamic array's size (total capacity in bytes).
  AGSIFUNC(size_t) GetDynamicArraySize(const void *arr);
```

This lets plugins to create and return dynamic arrays in their own functions. So you can have plugin functions that return dynamic array to user script.

To be honest, this method is not trivial, plugin authors have to take care to properly init array.
Specifically, when writing array of managed handles, they must not forget to add 1 extra reference to each of the objects they put there, this reference is "owned" by array. If you don't do that, the object may in theory get disposed before array gets disposed.

Following are example of using this method, which I used to test in a dummy plugin:

```
void* MyPlugin_TestArray(int length)
{
    void *arr = GetAGS()->CreateDynamicArray(length, sizeof(int32_t), false);
    int32_t *arr_int = static_cast<int32_t*>(arr);
    for (int i = 0; i < length; ++i)
    {
        arr_int[i] = i;
    }
    return arr;
}

void* MyPlugin_TestManagedArray(int length)
{
    std::vector<int32_t> string_handles;
    for (int i = 0; i < length; ++i)
    {
        const char *script_string =
            GetAGS()->CreateScriptString((std::string("some text {") + std::to_string(i) + std::string("}")).c_str());
        GetAGS()->IncrementManagedObjectRefCount((void*)script_string);
        string_handles.push_back(GetAGS()->GetManagedObjectKeyByAddress((void*)script_string));
    }
    
    void *arr = GetAGS()->CreateDynamicArray(length, sizeof(int32_t), true);
    int32_t *arr_handles = static_cast<int32_t*>(arr);
    for (int i = 0; i < length; ++i)
    {
        arr_handles[i] = string_handles[i];
    }
    return arr;
}
```