### PR TITLE
Script API: add Room.Name and Room.Number

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -154,8 +154,9 @@ enum GameDataVersion
     kGameVersion_400_09         = 4000009,
     kGameVersion_400_10         = 4000010,
     kGameVersion_400_11         = 4000011,
+    kGameVersion_400_13         = 4000013,
     kGameVersion_LowSupported   = kGameVersion_360_21,
-    kGameVersion_Current        = kGameVersion_400_11
+    kGameVersion_Current        = kGameVersion_400_13
 };
 
 // Data format version of the loaded game

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -206,7 +206,8 @@ HGameFileError GameSetupStruct::read_audio(Common::Stream *in, GameDataVersion d
 
 void GameSetupStruct::read_room_names(Stream *in, GameDataVersion data_ver)
 {
-    if (options[OPT_DEBUGMODE] != 0)
+    if ((filever >= kGameVersion_400_13) ||
+        (options[OPT_DEBUGMODE] != 0))
     {
         uint32_t room_count = in->ReadInt32();
         for (int i = 0; i < room_count; ++i)

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -210,10 +210,12 @@ void GameSetupStruct::read_room_names(Stream *in, GameDataVersion data_ver)
         (options[OPT_DEBUGMODE] != 0))
     {
         uint32_t room_count = in->ReadInt32();
+        roomNumbers.resize(room_count);
         for (int i = 0; i < room_count; ++i)
         {
             int room_number = in->ReadInt32();
             String room_name = String::FromStream(in);
+            roomNumbers[i] = room_number;
             roomNames.insert(std::make_pair(room_number, room_name));
         }
     }

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -208,18 +208,13 @@ void GameSetupStruct::read_room_names(Stream *in, GameDataVersion data_ver)
 {
     if (options[OPT_DEBUGMODE] != 0)
     {
-        roomCount = in->ReadInt32();
-        roomNumbers.resize(roomCount);
-        roomNames.resize(roomCount);
-        for (int i = 0; i < roomCount; ++i)
+        uint32_t room_count = in->ReadInt32();
+        for (int i = 0; i < room_count; ++i)
         {
-            roomNumbers[i] = in->ReadInt32();
-            roomNames[i].Read(in);
+            int room_number = in->ReadInt32();
+            String room_name = String::FromStream(in);
+            roomNames.insert(std::make_pair(room_number, room_name));
         }
-    }
-    else
-    {
-        roomCount = 0;
     }
 }
 

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -68,6 +68,8 @@ struct GameSetupStruct : public GameSetupStructBase
     char              saveGameFileExtension[MAX_SG_EXT_LENGTH] = { 0 };
     // NOTE: saveGameFolderName is generally used to create game subdirs in common user directories
     Common::String    saveGameFolderName;
+    // Existing room numbers
+    std::vector<int>  roomNumbers;
     // Saved room names, known during the game compilation;
     // may be used to learn the total number of registered rooms
     std::map<int, Common::String> roomNames;

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -48,7 +48,7 @@ struct GameSetupStruct : public GameSetupStructBase
     std::vector<UInteractionEvents> invScripts;
     // TODO: why we do not use this in the engine instead of
     // loaded_game_file_version?
-    int               filever = 0;  // just used by editor
+    GameDataVersion   filever = kGameVersion_Undefined;
     Common::String    compiled_with; // version of AGS this data was created by
     char              lipSyncFrameLetters[MAXLIPSYNCFRAMES][50] = {{ 0 }};
     AGS::Common::PropertySchema propSchema;

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -68,9 +68,9 @@ struct GameSetupStruct : public GameSetupStructBase
     char              saveGameFileExtension[MAX_SG_EXT_LENGTH] = { 0 };
     // NOTE: saveGameFolderName is generally used to create game subdirs in common user directories
     Common::String    saveGameFolderName;
-    int               roomCount = 0;
-    std::vector<int>  roomNumbers;
-    std::vector<Common::String> roomNames;
+    // Saved room names, known during the game compilation;
+    // may be used to learn the total number of registered rooms
+    std::map<int, Common::String> roomNames;
     std::vector<ScriptAudioClip> audioClips;
     std::vector<AudioClipType> audioClipTypes;
     // number of accessible game audio channels (the ones under direct user control)

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -381,6 +381,13 @@ HError ReadExt_400_CustomProps(RoomStruct *room, Stream *in, RoomFileVersion dat
     return HError::None();
 }
 
+HError ReadExt_400_RoomNames(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
+{
+    room->ScriptName = StrUtil::ReadString(in);
+    room->Name = StrUtil::ReadString(in);
+    return HError::None();
+}
+
 HError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const String &ext_id,
     soff_t block_len, RoomFileVersion data_ver)
 {
@@ -433,6 +440,10 @@ HError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const St
     else if (ext_id.CompareNoCase("v400_customprops") == 0)
     {
         return ReadExt_400_CustomProps(room, in, data_ver);
+    }
+    else if (ext_id.CompareNoCase("v400_roomnames") == 0)
+    {
+        return ReadExt_400_RoomNames(room, in, data_ver);
     }
 
     return new RoomFileError(kRoomFileErr_UnknownBlockType,
@@ -724,6 +735,12 @@ void WriteExt_400_CustomProps(const RoomStruct *room, Stream *out)
     }
 }
 
+void WriteExt_400_RoomNames(const RoomStruct *room, Stream *out)
+{
+    StrUtil::WriteString(room->ScriptName, out);
+    StrUtil::WriteString(room->Name, out);
+}
+
 HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersion data_ver)
 {
     if (data_ver < kRoomVersion_Current)
@@ -755,6 +772,7 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
     WriteRoomBlock(room, "ext_ags399", WriteExt399, out);
     WriteRoomBlock(room, "v400_walkopts", WriteExt_400_WalkareaOpts, out);
     WriteRoomBlock(room, "v400_customprops", WriteExt_400_CustomProps, out);
+    WriteRoomBlock(room, "v400_roomnames", WriteExt_400_RoomNames, out);
 
     // Write end of room file
     out->WriteByte(kRoomFile_EOF);

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -246,6 +246,11 @@ public:
     // Init default room state
     void            InitDefaults();
 
+    // Gets this room's human-readable name (description)
+    const String &GetName() const { return Name; }
+    // Gets this room's script name
+    const String &GetScriptName() const { return ScriptName; }
+
     // Gets bitmap of particular mask layer
     Bitmap *GetMask(RoomAreaMask mask) const;
     // Sets bitmap for the particular mask layer;
@@ -275,6 +280,10 @@ public:
     // the room must have behavior specific to certain version of AGS.
     int32_t                 DataVersion;
 
+    // This room's name (description)
+    String                  Name;
+    // This room's scriptname. This is a reserved field atm.
+    String                  ScriptName;
     // Room region masks resolution. Defines the relation between room and mask units.
     // Mask point is calculated as roompt / MaskResolution. Must be >= 1.
     int32_t                 MaskResolution;
@@ -319,7 +328,6 @@ public:
     PScript                 CompiledScript;
     // Various extended options with string values, meta-data etc
     StringMap               StrOptions;
-
 };
 
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1769,19 +1769,16 @@ namespace AGS.Editor
                 writer.Write(0); // reserved
             }
             writer.Write(0); // [DEPRECATED]
-            if (game.Settings.DebugMode)
+            writer.Write(game.Rooms.Count);
+            for (int i = 0; i < game.Rooms.Count; ++i)
             {
-                writer.Write(game.Rooms.Count);
-                for (int i = 0; i < game.Rooms.Count; ++i)
+                IRoom room = game.Rooms[i];
+                writer.Write(room.Number);
+                if (room.Description != null)
                 {
-                    IRoom room = game.Rooms[i];
-                    writer.Write(room.Number);
-                    if (room.Description != null)
-                    {
-                        FilePutNullTerminatedString(TextProperty(room.Description), 500, writer);
-                    }
-                    else writer.Write((byte)0);
+                    FilePutNullTerminatedString(TextProperty(room.Description), writer);
                 }
+                else writer.Write((byte)0);
             }
 
             //

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2751,7 +2751,9 @@ builtin struct Game {
   readonly import static attribute int SpriteColorDepth[];
   /// Gets the total number of the rooms in game.
   readonly import static attribute int RoomCount;
-  /// Gets the room's name (description) by its index, returns null if such room does not exist.
+  /// Gets the existing room numbers by a sequential index (from 0 to RoomCount - 1); returns -1 if index is not valid.
+  readonly import static attribute int RoomNumbers[];
+  /// Gets the room's name (description) by the room's number; returns null if such room does not exist.
   readonly import static attribute String RoomNames[];
 #endif // SCRIPT_API_v400
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -845,6 +845,10 @@ builtin struct Room {
   import static bool Exists(int room);   // $AUTOCOMPLETESTATICONLY$
 #endif // SCRIPT_API_v360
 #ifdef SCRIPT_API_v400
+  /// Gets the current Room's number
+  import static readonly attribute int Number; // $AUTOCOMPLETESTATICONLY$
+  /// Gets the current Room's name (description)
+  import static readonly attribute String Name; // $AUTOCOMPLETESTATICONLY$
   /// Accesses the Hotspots in the current room.
   import static readonly attribute Hotspot *Hotspots[];   // $AUTOCOMPLETESTATICONLY$
   /// Accesses the Objects in the current room.
@@ -855,7 +859,7 @@ builtin struct Room {
   import static readonly attribute WalkableArea *WalkableAreas[];   // $AUTOCOMPLETESTATICONLY$
   /// Accesses the Walk-behinds in the current room.
   import static readonly attribute Walkbehind *Walkbehinds[];   // $AUTOCOMPLETESTATICONLY$
-  /// Gets this Room's Pathfinder object that lets find route around walkable areas.
+  /// Gets the current Room's Pathfinder object that lets find route around walkable areas.
   import static readonly attribute Pathfinder *PathFinder;   // $AUTOCOMPLETESTATICONLY$
   /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character in the current room.
   import static attribute float FaceDirectionRatio;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2749,6 +2749,10 @@ builtin struct Game {
   import static attribute float FaceDirectionRatio;
   /// Gets the color depth of the specified sprite.
   readonly import static attribute int SpriteColorDepth[];
+  /// Gets the total number of the rooms in game.
+  readonly import static attribute int RoomCount;
+  /// Gets the room's name (description) by its index, returns null if such room does not exist.
+  readonly import static attribute String RoomNames[];
 #endif // SCRIPT_API_v400
 };
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2954,8 +2954,10 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
     // to be saved using native procedure.
     //
     TextConverter^ tcv = TextHelper::GetGameTextConverter();
-    rs.MaskResolution = room->MaskResolution;
 
+    rs.Name = tcv->ConvertTextProperty(room->Description);
+    rs.ScriptName = ""; // reserved
+    rs.MaskResolution = room->MaskResolution;
 	rs.GameID = room->GameID;
 	rs.Edges.Bottom = room->BottomEdgeY;
 	rs.Edges.Left = room->LeftEdgeX;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -915,6 +915,20 @@ void Game_SetFaceDirectionRatio(float ratio)
     play.face_dir_ratio = ratio;
 }
 
+int Game_GetRoomCount()
+{
+    return game.roomNames.size();
+}
+
+const char* Game_GetRoomName(int index)
+{
+    auto it_room = game.roomNames.find(index);
+    if (it_room == game.roomNames.end())
+        return nullptr;
+
+    return CreateNewScriptString(it_room->second);
+}
+
 void *Game_GetSaveSlots(int min_slot, int max_slot, int save_sort, int sort_dir)
 {
     if (!ValidateSaveSlotRange("Game.GetSaveSlots", min_slot, max_slot))
@@ -1955,6 +1969,16 @@ RuntimeScriptValue Sc_Game_SetFaceDirectionRatio(const RuntimeScriptValue *param
     API_SCALL_VOID_PFLOAT(Game_SetFaceDirectionRatio);
 }
 
+RuntimeScriptValue Sc_Game_GetRoomCount(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Game_GetRoomCount);
+}
+
+RuntimeScriptValue Sc_Game_GetRoomName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT(const char, myScriptStringImpl, Game_GetRoomName);
+}
+
 RuntimeScriptValue Sc_Game_GetSaveSlots(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJ_PINT4(void, globalDynamicArray, Game_GetSaveSlots);
@@ -2028,6 +2052,8 @@ void RegisterGameAPI()
         { "Game::geti_Cameras",                           API_FN_PAIR(Game_GetAnyCamera) },
         { "Game::get_FaceDirectionRatio",                 API_FN_PAIR(Game_GetFaceDirectionRatio) },
         { "Game::set_FaceDirectionRatio",                 API_FN_PAIR(Game_SetFaceDirectionRatio) },
+        { "Game::get_RoomCount",                          API_FN_PAIR(Game_GetRoomCount) },
+        { "Game::geti_RoomNames",                         API_FN_PAIR(Game_GetRoomName) },
     };
 
     ccAddExternalFunctions(game_api);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -917,12 +917,19 @@ void Game_SetFaceDirectionRatio(float ratio)
 
 int Game_GetRoomCount()
 {
-    return game.roomNames.size();
+    return game.roomNumbers.size();
 }
 
-const char* Game_GetRoomName(int index)
+int Game_GetRoomNumber(int index)
 {
-    auto it_room = game.roomNames.find(index);
+    if (index < 0 || index >= game.roomNumbers.size())
+        return -1;
+    return game.roomNumbers[index];
+}
+
+const char* Game_GetRoomName(int room_number)
+{
+    auto it_room = game.roomNames.find(room_number);
     if (it_room == game.roomNames.end())
         return nullptr;
 
@@ -1974,6 +1981,11 @@ RuntimeScriptValue Sc_Game_GetRoomCount(const RuntimeScriptValue *params, int32_
     API_SCALL_INT(Game_GetRoomCount);
 }
 
+RuntimeScriptValue Sc_Game_GetRoomNumber(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(Game_GetRoomNumber);
+}
+
 RuntimeScriptValue Sc_Game_GetRoomName(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJ_PINT(const char, myScriptStringImpl, Game_GetRoomName);
@@ -2053,6 +2065,7 @@ void RegisterGameAPI()
         { "Game::get_FaceDirectionRatio",                 API_FN_PAIR(Game_GetFaceDirectionRatio) },
         { "Game::set_FaceDirectionRatio",                 API_FN_PAIR(Game_SetFaceDirectionRatio) },
         { "Game::get_RoomCount",                          API_FN_PAIR(Game_GetRoomCount) },
+        { "Game::geti_RoomNumbers",                       API_FN_PAIR(Game_GetRoomNumber) },
         { "Game::geti_RoomNames",                         API_FN_PAIR(Game_GetRoomName) },
     };
 

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -117,18 +117,17 @@ void script_debug(int cmdd,int dataa) {
     else if (cmdd==3) 
     {
         int goToRoom = -1;
-        if (game.roomCount == 0)
+        if (game.roomNames.size() == 0)
         {
-            char inroomtex[80];
-            snprintf(inroomtex, sizeof(inroomtex), "!Enter new room: (in room %d)", displayed_room);
+            String inroomtex = String::FromFormat("!Enter new room: (in room %d)", displayed_room);
             setup_for_dialog();
-            goToRoom = enternumberwindow(inroomtex);
+            goToRoom = enternumberwindow(inroomtex.GetCStr());
             restore_after_dialog();
         }
         else
         {
             setup_for_dialog();
-            goToRoom = roomSelectorWindow(displayed_room, game.roomCount, game.roomNumbers, game.roomNames);
+            goToRoom = roomSelectorWindow(displayed_room, game.roomNames);
             restore_after_dialog();
         }
         if (goToRoom >= 0) 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -205,6 +205,16 @@ void Room_SetFaceDirectionRatio(float ratio)
     croom->face_dir_ratio = ratio;
 }
 
+const char *Room_GetName()
+{
+    return CreateNewScriptString(thisroom.GetName());
+}
+
+int Room_GetNumber()
+{
+    return displayed_room;
+}
+
 bool Room_Exists(int room)
 {
     String room_filename;
@@ -1087,6 +1097,16 @@ RuntimeScriptValue Sc_Room_SetFaceDirectionRatio(const RuntimeScriptValue *param
     API_SCALL_VOID_PFLOAT(Room_SetFaceDirectionRatio);
 }
 
+RuntimeScriptValue Sc_Room_GetName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char *, myScriptStringImpl, Room_GetName);
+}
+
+RuntimeScriptValue Sc_Room_GetNumber(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Room_GetNumber);
+}
+
 // void (int xx,int yy,int mood)
 RuntimeScriptValue Sc_RoomProcessClick(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1149,6 +1169,8 @@ void RegisterRoomAPI()
         { "Room::get_Width",                          API_FN_PAIR(Room_GetWidth) },
         { "Room::get_FaceDirectionRatio",             API_FN_PAIR(Room_GetFaceDirectionRatio) },
         { "Room::set_FaceDirectionRatio",             API_FN_PAIR(Room_SetFaceDirectionRatio) },
+        { "Room::get_Name",                           API_FN_PAIR(Room_GetName) },
+        { "Room::get_Number",                         API_FN_PAIR(Room_GetNumber) },
         { "Room::geti_Hotspots",                      API_FN_PAIR(Room_GetiHotspots) },
         { "Room::geti_Objects",                       API_FN_PAIR(Room_GetiObjects) },
         { "Room::geti_Regions",                       API_FN_PAIR(Room_GetiRegions) },

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -378,7 +378,7 @@ void enterstringwindow(const char *prompttext, char *dst_buf, size_t dst_sz)
   snprintf(dst_buf, dst_sz, "%s", buffer2);
 }
 
-int enternumberwindow(char *prompttext)
+int enternumberwindow(const char *prompttext)
 {
   char ourbuf[200];
   enterstringwindow(prompttext, ourbuf, sizeof(ourbuf));
@@ -387,8 +387,7 @@ int enternumberwindow(char *prompttext)
   return atoi(ourbuf);
 }
 
-int roomSelectorWindow(int currentRoom, int numRooms,
-    const std::vector<int> &roomNumbers, const std::vector<String> &roomNames)
+int roomSelectorWindow(int currentRoom, const std::map<int, String> &roomNames)
 {
   char labeltext[200];
   strcpy(labeltext, GUIDialog_Strings[MSG_SAVEDIALOG]);
@@ -404,14 +403,17 @@ int roomSelectorWindow(int currentRoom, int numRooms,
     CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 80, 145, 60, 10, "Cancel");
 
   CSCISendControlMessage(ctrllist, CLB_CLEAR, 0, 0);    // clear the list box
-  for (int aa = 0; aa < numRooms; aa++)
+  int cur_sel = 0;
+  std::map<int, int> room_item_index;
+  for (const auto &name : roomNames)
   {
-    snprintf(buff, sizeof(buff), "%3d %s", roomNumbers[aa], roomNames[aa].GetCStr());
+    snprintf(buff, sizeof(buff), "%3d %s", name.first, name.second.GetCStr());
     CSCISendControlMessage(ctrllist, CLB_ADDITEM, 0, (intptr_t)&buff[0]);
-    if (roomNumbers[aa] == currentRoom)
+    if (name.first == currentRoom)
     {
-      CSCISendControlMessage(ctrllist, CLB_SETCURSEL, aa, 0);
+      CSCISendControlMessage(ctrllist, CLB_SETCURSEL, cur_sel, 0);
     }
+    room_item_index[cur_sel++] = name.first;
   }
 
   int ctrlok = CSCICreateControl(CNT_PUSHBUTTON | CNF_DEFAULT, 10, 145, 60, 10, "OK");
@@ -447,7 +449,8 @@ int roomSelectorWindow(int currentRoom, int numRooms,
       int cursel = CSCISendControlMessage(ctrllist, CLB_GETCURSEL, 0, 0);
       if (cursel >= 0) 
       {
-        snprintf(buffer2, sizeof(buffer2), "%d", roomNumbers[cursel]);
+        int room_index = room_item_index[cursel];
+        snprintf(buffer2, sizeof(buffer2), "%d", room_index);
         CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (intptr_t)&buffer2[0]);
       }
     }

--- a/Engine/gui/guidialog.h
+++ b/Engine/gui/guidialog.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_GUI__GUIDIALOG_H
 #define __AGS_EE_GUI__GUIDIALOG_H
 
+#include <map>
 #include <vector>
 #include "util/string.h"
 
@@ -35,9 +36,8 @@ void refresh_gui_screen();
 int  loadgamedialog(int min_slot, int max_slot);
 int  savegamedialog(int min_slot, int max_slot);
 void enterstringwindow(const char *prompttext, char *dst_buf, size_t dst_sz);
-int  enternumberwindow(char *prompttext);
-int  roomSelectorWindow(int currentRoom, int numRooms,
-    const std::vector<int> &roomNumbers, const std::vector<AGS::Common::String> &roomNames);
+int  enternumberwindow(const char *prompttext);
+int  roomSelectorWindow(int currentRoom, const std::map<int, AGS::Common::String> &roomNames);
 int  myscimessagebox(const char *lpprompt, char *btn1, char *btn2);
 int  quitdialog();
 


### PR DESCRIPTION
Resolves #1135.

Adds 3 static readonly properties to Game struct:
```
/// Gets the total number of the rooms in game.
static readonly attribute int Game.RoomCount;
/// Gets the existing room numbers by a sequential index (from 0 to RoomCount - 1); returns -1 if index is not valid.
static readonly attribute int RoomNumbers[];
/// Gets the room's name (description) by the room's number; returns null if such room does not exist.
static readonly attribute String Game.RoomNames[];
```

Adds 2 static readonly properties to Room struct:
```
/// Gets the current Room's number
static readonly attribute int Room.Number;
/// Gets the current Room's name (description)
static readonly attribute String Room.Name;
```

The only caveat is that room descriptions were not saved in the room itself, so I had to add them to room format.