### PR TITLE
Make object sorting position on screen deterministic in case of equal z-order

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -100,6 +100,12 @@ struct DrawState
     // Whether there are currently remnants of a on-screen effect
     bool ScreenIsDirty = false;
 
+    // The base of DrawIndex range that may be allocated to dynamically
+    // created objects; set after initing static game objects.
+    uint32_t FixedDrawIndexBase = 0u;
+    // Next allocated DrawIndex index
+    uint32_t NextDrawIndex = 0u;
+
     // A map of shared "control blocks" per each sprite used
     // when preparing object textures. "Control block" is currently just
     // an integer which lets to check whether the object texture is in sync
@@ -130,6 +136,11 @@ struct ObjTexture
 {
     // Sprite ID
     uint32_t SpriteID = UINT32_MAX;
+    // DrawIndex is a persistent arbitrary number allocated for the drawable object,
+    // that is used to resolve z-sorting in case of equal z;
+    // this is meant to keep object's sorting order fixed, and avoid random sorting
+    // swaps when the list of objects changes.
+    uint32_t DrawIndex = 0u;
     // Raw bitmap; used for software render mode,
     // or when particular object types require generated image.
     std::unique_ptr<Bitmap> Bmp;
@@ -167,6 +178,7 @@ struct ObjTexture
     ObjTexture &operator =(ObjTexture &&o)
     {
         SpriteID = o.SpriteID;
+        DrawIndex = o.DrawIndex;
         if (Ddb)
         {
             assert(gfxDriver);
@@ -736,13 +748,19 @@ void init_game_drawdata()
 {
     // character and object caches
     charcache.resize(game.numcharacters);
-    for (int i = 0; i < MAX_ROOM_OBJECTS; ++i)
+    for (size_t i = 0; i < (size_t)MAX_ROOM_OBJECTS; ++i)
         objcache[i] = ObjectCache();
 
+    size_t draw_index = 1u; // DrawIndex 0 is reserved for walk-behinds
     size_t actsps_num = game.numcharacters + MAX_ROOM_OBJECTS;
     actsps.resize(actsps_num);
+    for (auto &actsp : actsps)
+        actsp.DrawIndex = draw_index++;
 
     guibg.resize(game.numgui);
+    for (auto &guidraw : guibg)
+        guidraw.DrawIndex = draw_index++;
+
     gui_render_tex.resize(game.numgui);
     size_t guio_num = 0;
     // Prepare GUI cache lists and build the quick reference for controls cache
@@ -753,6 +771,9 @@ void init_game_drawdata()
         guio_num += gui.GetControlCount();
     }
     guiobjbg.resize(guio_num);
+
+    drawstate.FixedDrawIndexBase = draw_index;
+    drawstate.NextDrawIndex = draw_index;
 }
 
 extern void dispose_engine_overlay();
@@ -1011,6 +1032,11 @@ void on_roomcamera_changed(Camera *cam)
 void mark_object_changed(int objid)
 {
     objcache[objid].y = -9999;
+}
+
+void reset_drawobj_dynamic_index()
+{
+    drawstate.NextDrawIndex = drawstate.FixedDrawIndexBase;
 }
 
 void reset_drawobj_for_overlay(int objnum)
@@ -2015,7 +2041,7 @@ void prepare_objects_for_drawing()
             Size(obj.last_width, obj.last_height), atx, aty, usebasel,
             (obj.flags & OBJF_NOWALKBEHINDS) == 0, obj.transparent, hw_accel);
         // Finally, add the texture to the draw list
-        add_to_sprite_list(actsp.Ddb, atx, aty, usebasel);
+        add_to_sprite_list(actsp.Ddb, atx, aty, usebasel, actsp.DrawIndex);
     }
 }
 
@@ -2125,7 +2151,7 @@ void prepare_characters_for_drawing()
             Size(chex.width, chex.height), atx, aty, usebasel,
             (chin.flags & CHF_NOWALKBEHINDS) == 0, chin.transparency, hw_accel);
         // Finally, add the texture to the draw list
-        add_to_sprite_list(actsp.Ddb, atx, aty, usebasel);
+        add_to_sprite_list(actsp.Ddb, atx, aty, usebasel, actsp.DrawIndex);
     }
 }
 
@@ -2159,7 +2185,7 @@ static void add_roomovers_for_drawing()
         if (!over.IsRoomLayer()) continue; // not a room layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
-        add_to_sprite_list(overtxs[over.type].Ddb, pos.X, pos.Y, over.zorder, over.creation_id);
+        add_to_sprite_list(overtxs[over.type].Ddb, pos.X, pos.Y, over.zorder, overtxs[over.type].DrawIndex);
     }
 }
 
@@ -2208,8 +2234,8 @@ void prepare_room_sprites()
                     if (wbobj.Ddb)
                     {
                         add_to_sprite_list(wbobj.Ddb, wbobj.Pos.X, wbobj.Pos.Y,
-                            croom->walkbehind_base[wb], INT32_MIN);
-                        // when baselines are equal, walk-behinds must be sorted back, so tag as INT32_MIN
+                            croom->walkbehind_base[wb], 0u);
+                        // when baselines are equal, walk-behinds must be sorted back, so draw index = 0
                     }
                 }
             }
@@ -2428,7 +2454,7 @@ void draw_gui_and_overlays()
         if (over.IsRoomLayer()) continue; // not a ui layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
-        add_to_sprite_list(overtxs[over.type].Ddb, pos.X, pos.Y, over.zorder, over.creation_id);
+        add_to_sprite_list(overtxs[over.type].Ddb, pos.X, pos.Y, over.zorder, overtxs[over.type].DrawIndex);
     }
 
     // Add GUIs
@@ -2516,7 +2542,7 @@ void draw_gui_and_overlays()
                 gui_ddb = gui_render_tex[index];
             }
             gui_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(gui.Transparency));
-            add_to_sprite_list(gui_ddb, gui.X, gui.Y, gui.ZOrder, index);
+            add_to_sprite_list(gui_ddb, gui.X, gui.Y, gui.ZOrder, guibg[index].DrawIndex);
         }
     }
 
@@ -2667,6 +2693,12 @@ static void construct_overlays()
         if (over.transparency == 255) continue; // skip fully transparent
 
         auto &overtx = overtxs[i];
+        if (overtxs[i].DrawIndex == 0u)
+        {
+            overtxs[i].DrawIndex = drawstate.NextDrawIndex;
+            drawstate.NextDrawIndex = (drawstate.NextDrawIndex == UINT32_MAX) ? drawstate.FixedDrawIndexBase : drawstate.NextDrawIndex + 1;
+        }
+
         bool has_changed = over.HasChanged();
         // If walk behinds are drawn over the cached object sprite, then check if positions were updated
         if (crop_walkbehinds && over.IsRoomLayer())

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -82,6 +82,9 @@ void on_roomcamera_changed(Camera *cam);
 void mark_object_changed(int objid);
 // TODO: write a generic drawable/objcache system where each object
 // allocates a drawable for itself, and disposes one if being removed.
+// Resets drawing index for dynamic objects
+void reset_drawobj_dynamic_index();
+// Resets drawable object for this overlay
 void reset_drawobj_for_overlay(int objnum);
 // Marks all game objects which reference this sprite for redraw
 void notify_sprite_changed(int sprnum, bool deleted);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -302,11 +302,6 @@ struct GamePlayState
     //
     // Total number of existing overlays, only for the reference
     int  overlay_count = 0;
-    // Incrementing index of creation, assigned to overlays.
-    // Currently is used when resolving sorting conflicts with equal z-order.
-    // TODO: this method theoretically can overflow, but was added still as a quick fix;
-    // investigate better solutions later.
-    int  overlay_creation_id = 0;
     // Is there a QFG4-style dialog overlay on screen (contains overlay ID)
     int  complete_overlay_on = 0;
     // Is there a blocking text overlay on screen (contains overlay ID)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -414,10 +414,11 @@ void remove_screen_overlay(int type)
 
     reset_drawobj_for_overlay(type);
 
-    // If all overlays have been removed, reset creation index (helps vs overflows)
     play.overlay_count--;
+    // If all overlays have been removed, reset dynamic draw index (helps vs overflows);
+    // we do this here, because overlays are the only dynamic objects atm
     if (play.overlay_count == 0)
-        play.overlay_creation_id = 0;
+        reset_drawobj_dynamic_index();
 }
 
 void remove_all_overlays()
@@ -454,7 +455,6 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
 
     ScreenOverlay over;
     over.type = type;
-    over.creation_id = play.overlay_creation_id++;
     if (piccy)
     {
         over.SetImage(std::unique_ptr<Bitmap>(piccy), has_alpha, pic_offx, pic_offy);

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -59,8 +59,6 @@ struct ScreenOverlay
 {
     // Overlay's "type" is a merged special overlay ID and internal container index
     int type = -1;
-    // Arbitrary creation order index, meant for resolving equal z-sorting
-    int creation_id = 0;
     int timeout = 0;
     // Note that x,y are overlay's properties, that define its position in script;
     // but real drawn position is x + offsetX, y + offsetY;


### PR DESCRIPTION
Fix #2311

This is a quick solution for resolving objects with identical z-order, in which case we'd like to keep their relative sort persistent, and avoid random sorting "swaps".

This is achieved by a combined comparison in sort's "less" function:
- first compare if (z1 < z2);
- if (z1 == z2), then compare if (drawindex1 < drawindex2)

Global DrawIndex is allocated for each drawable object in game (except for gui controls that are sorted only among each other).
Static objects are reserved draw indexes at the game init.
Dynamic objects (currently only Overlays) have one assigned for them when they are *drawn for the first time*.

DrawIndex is ever incrementing counter. When it reaches max value (of uint32_t), it overflows and gets reset to the "base dynamic index", which is set once to the number of all the static game objects.
Also, DrawIndex is reset whenever all dynamic objects are removed; which in current engine happens when all overlays are removed either by command or when a room changes.

DrawIndex replaces use of GUI.ID and Overlay's "creation_id" for this purpose.

Walk-behinds always receive DrawIndex = 0, because
a) they cannot be sorted among themselves due to their nature (as cut-outs from room bg);
b) by classic AGS logic they must draw behind objects and characters when their baselines match walk-behind.

There's a side effect where, in case of equal z-order, objects always have lower position in sort compared to characters, and both objects and characters have lower position than room overlays. Similarly, guis will have lower position compared to screen overlays. I don't know if that matches original AGS behavior; but probably it was random, because neither objects nor chars were ever fixed for this problem.