### PR TITLE
Script API: remake RestoredSaveInfo.Result into indexed property

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3399,7 +3399,7 @@ managed struct RestoredSaveInfo
 {
   import attribute bool Cancel;
   import attribute SaveComponentSelection RetryWithoutComponents;
-  import readonly attribute RestoredSaveResult Result;
+  import readonly attribute bool Result[]; // RestoredSaveResult
 
   import readonly attribute int Slot;
   import readonly attribute String Description;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3397,26 +3397,46 @@ enum RestoredSaveResult
 
 managed struct RestoredSaveInfo
 {
+  /// Gets/sets whether this game's save should be cancelled.
   import attribute bool Cancel;
+  /// Gets/sets whether this game's save should be reloaded again without particular components.
   import attribute SaveComponentSelection RetryWithoutComponents;
-  import readonly attribute bool Result[]; // RestoredSaveResult
+  /// Gets the result of restoring this save. Use RestoredSaveResult values as index in this array to learn whether particular case is present.
+  import readonly attribute bool Result[];
 
+  /// Gets the save's slot number.
   import readonly attribute int Slot;
+  /// Gets the save's description string, which it was written with.
   import readonly attribute String Description;
+  /// Gets the version of the engine which wrote this save.
   import readonly attribute String EngineVersion;
+  /// Gets the room number this save was made in.
   import readonly attribute int Room;
+  /// Gets the number of Audio Types present in this save.
   import readonly attribute int AudioClipTypeCount;
+  /// Gets the number of Characters present in this save.
   import readonly attribute int CharacterCount;
+  /// Gets the number of Dialogs present in this save.
   import readonly attribute int DialogCount;
+  /// Gets the number of GUIs present in this save.
   import readonly attribute int GUICount;
+  /// Gets the number of controls on each GUI present in this save.
   import readonly attribute int GUIControlCount[];
+  /// Gets the number of Inventory Items present in this save.
   import readonly attribute int InventoryItemCount;
+  /// Gets the number of Cursors present in this save.
   import readonly attribute int CursorCount;
+  /// Gets the number of Views present in this save.
   import readonly attribute int ViewCount;
+  /// Gets the number of loops in each View present in this save.
   import readonly attribute int ViewLoopCount[];
+  /// Gets the number of frames in each View present in this save.
   import readonly attribute int ViewFrameCount[];
+  /// Gets the total size of the global script data (variables), in bytes, present in this save.
   import readonly attribute int GlobalScriptDataSize;
+  /// Gets the number of script modules (except for the global script) present in this save.
   import readonly attribute int ScriptModuleCount;
+  /// Gets the total size of each of the script module's data (variables), in bytes, present in this save.
   import readonly attribute int ScriptModuleDataSize[];
 };
 #endif

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -1040,9 +1040,9 @@ void SaveInfo_SetRetryWithoutComponents(ScriptRestoredSaveInfo *info, int cmp_se
     info->SetRetryWithoutComponents(static_cast<SaveCmpSelection>(cmp_selection));
 }
 
-int SaveInfo_GetResult(ScriptRestoredSaveInfo *info)
+bool SaveInfo_GetResult(ScriptRestoredSaveInfo *info, int flags)
 {
-    return info->GetResult();
+    return (info->GetResult() & flags) != 0;
 }
 
 int SaveInfo_GetSlot(ScriptRestoredSaveInfo *info)
@@ -1172,7 +1172,7 @@ RuntimeScriptValue Sc_SaveInfo_SetRetryWithoutComponents(void *self, const Runti
 
 RuntimeScriptValue Sc_SaveInfo_GetResult(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(ScriptRestoredSaveInfo, SaveInfo_GetResult);
+    API_OBJCALL_BOOL_PINT(ScriptRestoredSaveInfo, SaveInfo_GetResult);
 }
 
 RuntimeScriptValue Sc_SaveInfo_GetSlot(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -1267,7 +1267,7 @@ void RegisterSaveInfoAPI()
         { "RestoredSaveInfo::set_Cancel",               API_FN_PAIR(SaveInfo_SetCancel) },
         { "RestoredSaveInfo::get_RetryWithoutComponents", API_FN_PAIR(SaveInfo_GetRetryWithoutComponents) },
         { "RestoredSaveInfo::set_RetryWithoutComponents", API_FN_PAIR(SaveInfo_SetRetryWithoutComponents) },
-        { "RestoredSaveInfo::get_Result",               API_FN_PAIR(SaveInfo_GetResult) },
+        { "RestoredSaveInfo::geti_Result",              API_FN_PAIR(SaveInfo_GetResult) },
         { "RestoredSaveInfo::get_Slot",                 API_FN_PAIR(SaveInfo_GetSlot) },
         { "RestoredSaveInfo::get_Description",          API_FN_PAIR(SaveInfo_GetDescription) },
         { "RestoredSaveInfo::get_EngineVersion",        API_FN_PAIR(SaveInfo_GetEngineVersion) },


### PR DESCRIPTION
This is to get opinion on the possible change.

When documenting the new ["validate_restored_save" callback](https://github.com/adventuregamestudio/ags-manual/wiki/ValidateRestoredSave) I began to wonder if preseting RestoredSaveInfo.Result property as a set of flags would be convenient to users. Majority of AGS users don't use flag sets very often, and finding out whether a certain flag is set may be confusing to some of them (if not to many of them).

One idea that came to me is to turn this property into a array of bools instead, where each pseudo-element is a flag.

In simple words, instead of doing this:
```
    if ((info.Result & eRestoredSave_MissingData) != 0)
    if ((info.Result & eRestoredSave_Prescan) == 0)
```
users would do this:
```
    if (info.Result[eRestoredSave_MissingData])
    if (!info.Result[eRestoredSave_Prescan])
```
