### PR TITLE
Script API: remake RestoredSaveInfo.Result into multiple bool properties

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3387,19 +3387,14 @@ enum SaveComponentSelection
 };
 
 #ifdef SCRIPT_API_v362
-enum RestoredSaveResult
-{
-  eRestoredSave_ClearData   = 0x01,
-  eRestoredSave_MissingData = 0x08,
-  eRestoredSave_ExtraData   = 0x10,
-  eRestoredSave_Prescan     = 0x20
-};
-
 managed struct RestoredSaveInfo
 {
   import attribute bool Cancel;
   import attribute SaveComponentSelection RetryWithoutComponents;
-  import readonly attribute RestoredSaveResult Result;
+
+  import readonly attribute bool IsPrescan;
+  import readonly attribute bool HasExtraData;
+  import readonly attribute bool HasMissingData;
 
   import readonly attribute int Slot;
   import readonly attribute String Description;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3389,29 +3389,51 @@ enum SaveComponentSelection
 #ifdef SCRIPT_API_v362
 managed struct RestoredSaveInfo
 {
+  /// Gets/sets whether this game's save should be cancelled.
   import attribute bool Cancel;
+  /// Gets/sets whether this game's save should be reloaded again without particular components.
   import attribute SaveComponentSelection RetryWithoutComponents;
 
+  /// Gets whether this save was only prescanned, and not loaded into the game.
   import readonly attribute bool IsPrescan;
+  /// Gets whether this save has extra data that cannot be directly applied to the current game.
   import readonly attribute bool HasExtraData;
+  /// Gets whether this save has less data than in the current game.
   import readonly attribute bool HasMissingData;
 
+  /// Gets the save's slot number.
   import readonly attribute int Slot;
+  /// Gets the save's description string, which it was written with.
   import readonly attribute String Description;
+  /// Gets the version of the engine which wrote this save.
   import readonly attribute String EngineVersion;
+  /// Gets the room number this save was made in.
   import readonly attribute int Room;
+  /// Gets the number of Audio Types present in this save.
   import readonly attribute int AudioClipTypeCount;
+  /// Gets the number of Characters present in this save.
   import readonly attribute int CharacterCount;
+  /// Gets the number of Dialogs present in this save.
   import readonly attribute int DialogCount;
+  /// Gets the number of GUIs present in this save.
   import readonly attribute int GUICount;
+  /// Gets the number of controls on each GUI present in this save.
   import readonly attribute int GUIControlCount[];
+  /// Gets the number of Inventory Items present in this save.
   import readonly attribute int InventoryItemCount;
+  /// Gets the number of Cursors present in this save.
   import readonly attribute int CursorCount;
+  /// Gets the number of Views present in this save.
   import readonly attribute int ViewCount;
+  /// Gets the number of loops in each View present in this save.
   import readonly attribute int ViewLoopCount[];
+  /// Gets the number of frames in each View present in this save.
   import readonly attribute int ViewFrameCount[];
+  /// Gets the total size of the global script data (variables), in bytes, present in this save.
   import readonly attribute int GlobalScriptDataSize;
+  /// Gets the number of script modules (except for the global script) present in this save.
   import readonly attribute int ScriptModuleCount;
+  /// Gets the total size of each of the script module's data (variables), in bytes, present in this save.
   import readonly attribute int ScriptModuleDataSize[];
 };
 #endif

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -1040,9 +1040,19 @@ void SaveInfo_SetRetryWithoutComponents(ScriptRestoredSaveInfo *info, int cmp_se
     info->SetRetryWithoutComponents(static_cast<SaveCmpSelection>(cmp_selection));
 }
 
-int SaveInfo_GetResult(ScriptRestoredSaveInfo *info)
+bool SaveInfo_HasExtraData(ScriptRestoredSaveInfo *info)
 {
-    return info->GetResult();
+    return (info->GetResult() & kSaveRestore_ExtraDataInSave) != 0;
+}
+
+bool SaveInfo_HasMissingData(ScriptRestoredSaveInfo *info)
+{
+    return (info->GetResult() & kSaveRestore_MissingDataInSave) != 0;
+}
+
+bool SaveInfo_IsPrescan(ScriptRestoredSaveInfo *info)
+{
+    return (info->GetResult() & kSaveRestore_Prescan) != 0;
 }
 
 int SaveInfo_GetSlot(ScriptRestoredSaveInfo *info)
@@ -1170,9 +1180,19 @@ RuntimeScriptValue Sc_SaveInfo_SetRetryWithoutComponents(void *self, const Runti
     API_OBJCALL_VOID_PINT(ScriptRestoredSaveInfo, SaveInfo_SetRetryWithoutComponents);
 }
 
-RuntimeScriptValue Sc_SaveInfo_GetResult(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_SaveInfo_HasExtraData(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(ScriptRestoredSaveInfo, SaveInfo_GetResult);
+    API_OBJCALL_BOOL(ScriptRestoredSaveInfo, SaveInfo_HasExtraData);
+}
+
+RuntimeScriptValue Sc_SaveInfo_HasMissingData(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptRestoredSaveInfo, SaveInfo_HasMissingData);
+}
+
+RuntimeScriptValue Sc_SaveInfo_IsPrescan(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptRestoredSaveInfo, SaveInfo_IsPrescan);
 }
 
 RuntimeScriptValue Sc_SaveInfo_GetSlot(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -1267,7 +1287,9 @@ void RegisterSaveInfoAPI()
         { "RestoredSaveInfo::set_Cancel",               API_FN_PAIR(SaveInfo_SetCancel) },
         { "RestoredSaveInfo::get_RetryWithoutComponents", API_FN_PAIR(SaveInfo_GetRetryWithoutComponents) },
         { "RestoredSaveInfo::set_RetryWithoutComponents", API_FN_PAIR(SaveInfo_SetRetryWithoutComponents) },
-        { "RestoredSaveInfo::get_Result",               API_FN_PAIR(SaveInfo_GetResult) },
+        { "RestoredSaveInfo::get_IsPrescan",            API_FN_PAIR(SaveInfo_IsPrescan) },
+        { "RestoredSaveInfo::get_HasExtraData",         API_FN_PAIR(SaveInfo_HasExtraData) },
+        { "RestoredSaveInfo::get_HasMissingData",       API_FN_PAIR(SaveInfo_HasMissingData) },
         { "RestoredSaveInfo::get_Slot",                 API_FN_PAIR(SaveInfo_GetSlot) },
         { "RestoredSaveInfo::get_Description",          API_FN_PAIR(SaveInfo_GetDescription) },
         { "RestoredSaveInfo::get_EngineVersion",        API_FN_PAIR(SaveInfo_GetEngineVersion) },


### PR DESCRIPTION
This is an alternative to #2632, they are mutually exclusive.

When documenting the new ["validate_restored_save" callback](https://github.com/adventuregamestudio/ags-manual/wiki/ValidateRestoredSave) I began to wonder if preseting RestoredSaveInfo.Result property as a set of flags would be convenient to users. Majority of AGS users don't use flag sets very often, and finding out whether a certain flag is set may be confusing to some of them (if not to many of them).

I am wondering now why did I make them set of flags in api at all. Maybe that was complete unnecessary.
Besides, there's not many flags there which may be needed for the end user.

This PR replaces a single RestoredSaveInfo.Result with a set of 3 boolean properties:
```
  /// Gets whether this save was only prescanned, and not loaded into the game.
  import readonly attribute bool IsPrescan;
  /// Gets whether this save has extra data that cannot be directly applied to the current game.
  import readonly attribute bool HasExtraData;
  /// Gets whether this save has less data than in the current game.
  import readonly attribute bool HasMissingData;
```

Also removes enum RestoredSaveResult completely from script api (it is still used internally by the engine though).