### PR TITLE
adjust CI and docker for VS2019 compatibility using VS2022

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,29 +8,29 @@ build_windows_task:
     dockerfile: ci/windows/Dockerfile
     os_version: 2019
   env:
-    AGS_LIBOGG_LIB: C:\Lib\Xiph\x86
-    AGS_LIBTHEORA_LIB: C:\Lib\Xiph\x86
-    AGS_LIBVORBIS_LIB: C:\Lib\Xiph\x86
+    AGS_LIBOGG_LIB_VS19: C:\Lib\Xiph\x86
+    AGS_LIBTHEORA_LIB_VS19: C:\Lib\Xiph\x86
+    AGS_LIBVORBIS_LIB_VS19: C:\Lib\Xiph\x86
     AGS_SDL_INCLUDE: C:\Lib\SDL2\include
     AGS_SDL_SOUND_INCLUDE: C:\Lib\SDL_sound\src
     AGS_SDL_LIB: C:\Lib\SDL2\lib\x86
-    AGS_SDL_SOUND_LIB: C:\Lib\SDL_sound\lib\x86
+    AGS_SDL_SOUND_LIB_VS19: C:\Lib\SDL_sound\lib\x86
   build_debug_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Debug /p:Platform=Win32 /maxcpucount /nologo
+    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=Win32 /maxcpucount /nologo
   build_tools_debug_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Tools.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Debug /p:Platform=x86 /maxcpucount /nologo
+    msbuild Tools.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=x86 /maxcpucount /nologo
   build_release_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
   build_tools_release_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Tools.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x86 /maxcpucount /nologo
+    msbuild Tools.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x86 /maxcpucount /nologo
   engine_pdb_artifacts:
     path: Solutions/.build/*/acwin.pdb
   delete_engine_pdb_script: >
@@ -42,9 +42,9 @@ build_windows_task:
     cd Solutions/ &&
     rd /s /q .build
   build_x64_release_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+    msbuild Engine.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
   engine_x64_pdb_artifacts:
     path: Solutions/.build/*/acwin.pdb
   delete_x64_engine_pdb_script: >
@@ -311,13 +311,12 @@ build_editor_task:
       - type Editor\AGS.Editor.Tests\packages.config
     populate_script: nuget restore Solutions\AGS.Editor.Full.sln
   build_debug_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     set "UseEnv=true" &&
     copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
-    set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&
-    msbuild AGS.Editor.Full.sln /p:PlatformToolset=v140 /p:Configuration=Debug /p:Platform="Win32" /maxcpucount /nologo"
+    msbuild AGS.Editor.Full.sln /p:PlatformToolset=v142 /p:VCToolsVersion=14.29.30133 /p:Configuration=Debug /p:Platform="Win32" /maxcpucount /nologo"
   test_debug_script: |
     curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
     pushd Solutions\packages\NUnit.ConsoleRunner.3.*
@@ -325,13 +324,12 @@ build_editor_task:
     popd
     cmd /v:on /c "!RUNNER! Editor\AGS.Editor.Tests\bin\Debug\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
   build_release_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     set "UseEnv=true" &&
     copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
-    set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&
-    msbuild AGS.Editor.Full.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform="Win32" /maxcpucount /nologo"
+    msbuild AGS.Editor.Full.sln /p:PlatformToolset=v142 /p:VCToolsVersion=14.29.30133 /p:Configuration=Release /p:Platform="Win32" /maxcpucount /nologo"
   test_release_script: |
     curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
     pushd Solutions\packages\NUnit.ConsoleRunner.3.*
@@ -483,28 +481,28 @@ ags_windows_tests_task:
     BUILD_CONFIG: Release
   get_submodule_script: git submodule update --init Common/libsrc/googletest
   build_compiler_test_runner_x86_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Compiler.Lib.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+    msbuild Compiler.Lib.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
   run_compiler_tests_script: Solutions\.test\Release\Compiler.Lib.Test.exe
   build_ags_test_runner_x86_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Tests.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+    msbuild Tests.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
   run_common_tests_x86_script: Solutions\.test\Release\Common.Lib.Test.exe
   run_engine_tests_x86_script: Solutions\.test\Release\Engine.App.Test.exe
   cleanup_script: >
     cd Solutions/ &&
     rd /s /q .test 
   build_compiler_test_runner_x64_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Compiler.Lib.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+    msbuild Compiler.Lib.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
   run_compiler_tests_x64_script: Solutions\.test\Release\Compiler.Lib.Test.exe
   build_ags_test_runner_x64_script: >
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" &&
     cd Solutions &&
-    msbuild Tests.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+    msbuild Tests.sln /m /property:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
   run_common_tests_x64_script: Solutions\.test\Release\Common.Lib.Test.exe
   run_engine_tests_x64_script: Solutions\.test\Release\Engine.App.Test.exe
 

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -24,32 +24,33 @@
     <RootNamespace>AGS.Native</RootNamespace>
     <Keyword>AtlProj</Keyword>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>true</CLRSupport>

--- a/Editor/AGS.Native/NativeDLL.vcxproj.filters
+++ b/Editor/AGS.Native/NativeDLL.vcxproj.filters
@@ -216,9 +216,6 @@
     <ClInclude Include="NativeMethods.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Scripting.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\Native\ac\actiontype.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
@@ -232,6 +229,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SpriteFileReader_NET.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IScriptCompiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CompiledScript.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Solutions/AGS.Editor.Full.sln
+++ b/Solutions/AGS.Editor.Full.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Native Libraries", "Native Libraries", "{AD076495-5CEC-4149-B448-0E24AF8B2C2E}"
 EndProject

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -54,40 +54,40 @@
     <ProjectGuid>{463A715C-3EF3-47C7-AC7F-D97660149C49}</ProjectGuid>
     <RootNamespace>CommonLib</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -105,12 +105,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|Win32'" Label="Configuration">

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -93,13 +93,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -115,12 +115,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Solutions/Compiler.App/Compiler.App.vcxproj
+++ b/Solutions/Compiler.App/Compiler.App.vcxproj
@@ -38,51 +38,51 @@
     <ProjectGuid>{328E0769-7941-4093-8BF9-0E138955F44C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CompilerApp</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Solutions/Compiler.Lib.sln
+++ b/Solutions/Compiler.Lib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Compiler.Lib", "Compiler.Lib\Compiler.Lib.vcxproj", "{7B621FC0-BFD0-40E4-800A-0CD5E5707532}"
 EndProject
@@ -55,5 +55,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6296B736-E37A-42D4-B73F-6001D9BB666F}
 	EndGlobalSection
 EndGlobal

--- a/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj
+++ b/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj
@@ -22,28 +22,29 @@
     <ProjectGuid>{EADA878B-2D85-484A-AA0A-1F19C40D2D2A}</ProjectGuid>
     <RootNamespace>CompilerLibTest</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Solutions/Compiler.Lib/Compiler.Lib.vcxproj
+++ b/Solutions/Compiler.Lib/Compiler.Lib.vcxproj
@@ -38,51 +38,51 @@
     <ProjectGuid>{7B621FC0-BFD0-40E4-800A-0CD5E5707532}</ProjectGuid>
     <RootNamespace>CompilerLib</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -38,51 +38,51 @@
     <ProjectGuid>{49A909AF-49F3-451D-B6DF-839159E54A01}</ProjectGuid>
     <RootNamespace>EngineApp</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Solutions/Engine.sln
+++ b/Solutions/Engine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common.Lib", "Common.Lib\Common.Lib.vcxproj", "{463A715C-3EF3-47C7-AC7F-D97660149C49}"
 EndProject
@@ -57,5 +57,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B529F582-F0F0-4BCE-9AD3-5A66162203FB}
 	EndGlobalSection
 EndGlobal

--- a/Solutions/Tests.App/Common.Lib.Test.vcxproj
+++ b/Solutions/Tests.App/Common.Lib.Test.vcxproj
@@ -79,32 +79,32 @@
     <ProjectGuid>{212724F9-66FC-4BB6-97F5-975CA10EFFEB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>EngineAppTest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tests.App/Engine.App.Test.vcxproj
+++ b/Solutions/Tests.App/Engine.App.Test.vcxproj
@@ -35,32 +35,32 @@
     <ProjectGuid>{E5EBFBA9-1617-412B-843E-682609C65100}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>EngineAppTest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tests.sln
+++ b/Solutions/Tests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common.Lib.Test", "Tests.App\Common.Lib.Test.vcxproj", "{212724F9-66FC-4BB6-97F5-975CA10EFFEB}"
 EndProject
@@ -9,30 +9,33 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Engine.App.Test", "Tests.Ap
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|Win32 = Debug|Win32
-		Release|x64 = Release|x64
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|x64.ActiveCfg = Debug|x64
-		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|x64.Build.0 = Debug|x64
 		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|Win32.ActiveCfg = Debug|Win32
 		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|Win32.Build.0 = Debug|Win32
-		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|x64.ActiveCfg = Release|x64
-		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|x64.Build.0 = Release|x64
+		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|x64.ActiveCfg = Debug|x64
+		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Debug|x64.Build.0 = Debug|x64
 		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|Win32.ActiveCfg = Release|Win32
 		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|Win32.Build.0 = Release|Win32
-		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|x64.ActiveCfg = Debug|x64
-		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|x64.Build.0 = Debug|x64
+		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|x64.ActiveCfg = Release|x64
+		{212724F9-66FC-4BB6-97F5-975CA10EFFEB}.Release|x64.Build.0 = Release|x64
 		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|Win32.Build.0 = Debug|Win32
-		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|x64.ActiveCfg = Release|x64
-		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|x64.Build.0 = Release|x64
+		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|x64.ActiveCfg = Debug|x64
+		{E5EBFBA9-1617-412B-843E-682609C65100}.Debug|x64.Build.0 = Debug|x64
 		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|Win32.ActiveCfg = Release|Win32
 		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|Win32.Build.0 = Release|Win32
+		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|x64.ActiveCfg = Release|x64
+		{E5EBFBA9-1617-412B-843E-682609C65100}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {018160F0-A96F-4970-8FBE-DB91242E051A}
 	EndGlobalSection
 EndGlobal

--- a/Solutions/Tools.App/afg2dlgasc.vcxproj
+++ b/Solutions/Tools.App/afg2dlgasc.vcxproj
@@ -55,33 +55,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>agf2dlgasc</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.App/agfexport.vcxproj
+++ b/Solutions/Tools.App/agfexport.vcxproj
@@ -43,33 +43,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{776E38BA-D6A4-431E-8053-299310D85301}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>agfexport</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -121,7 +121,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\Tools;..\..\Common;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-	  <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -156,7 +156,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\Tools;..\..\Common;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-	  <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Solutions/Tools.App/agspak.vcxproj
+++ b/Solutions/Tools.App/agspak.vcxproj
@@ -40,33 +40,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{45BBD8B0-1FBB-4997-94D9-830461D56781}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>agspak</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.App/agsunpak.vcxproj
+++ b/Solutions/Tools.App/agsunpak.vcxproj
@@ -40,33 +40,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BED528B1-6BC6-4857-B78D-B70F672D8F23}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>agsunpak</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.App/crm2ash.vcxproj
+++ b/Solutions/Tools.App/crm2ash.vcxproj
@@ -42,33 +42,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>crm2ash</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.App/crmpak.vcxproj
+++ b/Solutions/Tools.App/crmpak.vcxproj
@@ -37,33 +37,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{20F0B521-1E8C-4F96-9C35-8CF244CA6947}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>crmpak</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.App/trac.vcxproj
+++ b/Solutions/Tools.App/trac.vcxproj
@@ -44,33 +44,33 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>trac</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "crm2ash", "Tools.App\crm2ash.vcxproj", "{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}"
 EndProject
@@ -84,5 +84,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {43E46631-8168-4C9F-A48F-53D9F1994333}
 	EndGlobalSection
 EndGlobal

--- a/Solutions/libogg.props
+++ b/Solutions/libogg.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_X64);$(AGS_LIBOGG_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19_X64);$(AGS_LIBOGG_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/libogg.props
+++ b/Solutions/libogg.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19);$(AGS_LIBOGG_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19_X64);$(AGS_LIBOGG_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBOGG_LIB_VS19_X64);$(AGS_LIBOGG_LIB_VS19)\..\x64;$(AGS_LIBOGG_LIB_X64);$(AGS_LIBOGG_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/libtheora.props
+++ b/Solutions/libtheora.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_X64);$(AGS_LIBTHEORA_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19_X64);$(AGS_LIBTHEORA_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/libtheora.props
+++ b/Solutions/libtheora.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19);$(AGS_LIBTHEORA_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19_X64);$(AGS_LIBTHEORA_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBTHEORA_LIB_VS19_X64);$(AGS_LIBTHEORA_LIB_VS19)\..\x64;$(AGS_LIBTHEORA_LIB_X64);$(AGS_LIBTHEORA_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/libvorbis.props
+++ b/Solutions/libvorbis.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_X64);$(AGS_LIBVORBIS_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19_X64);$(AGS_LIBVORBIS_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/libvorbis.props
+++ b/Solutions/libvorbis.props
@@ -5,12 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19);$(AGS_LIBVORBIS_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19_X64);$(AGS_LIBVORBIS_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_LIBVORBIS_LIB_VS19_X64);$(AGS_LIBVORBIS_LIB_VS19)\..\x64;$(AGS_LIBVORBIS_LIB_X64);$(AGS_LIBVORBIS_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/sdl2.props
+++ b/Solutions/sdl2.props
@@ -10,7 +10,7 @@
       <AdditionalIncludeDirectories>$(AGS_SDL_INCLUDE);$(AGS_SDL_SOUND_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_SDL_LIB);$(AGS_SDL_SOUND_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_SDL_LIB);$(AGS_SDL_SOUND_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>  
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
@@ -18,7 +18,7 @@
       <AdditionalIncludeDirectories>$(AGS_SDL_INCLUDE);$(AGS_SDL_SOUND_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_SDL_LIB_X64);$(AGS_SDL_SOUND_LIB_X64);$(AGS_SDL_LIB)\..\x64;$(AGS_SDL_SOUND_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_SDL_LIB_X64);$(AGS_SDL_SOUND_LIB_VS19_X64);$(AGS_SDL_LIB)\..\x64;$(AGS_SDL_SOUND_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Solutions/sdl2.props
+++ b/Solutions/sdl2.props
@@ -10,7 +10,7 @@
       <AdditionalIncludeDirectories>$(AGS_SDL_INCLUDE);$(AGS_SDL_SOUND_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_SDL_LIB);$(AGS_SDL_SOUND_LIB_VS19);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_SDL_LIB);$(AGS_SDL_SOUND_LIB_VS19);$(AGS_SDL_SOUND_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>  
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
@@ -18,7 +18,7 @@
       <AdditionalIncludeDirectories>$(AGS_SDL_INCLUDE);$(AGS_SDL_SOUND_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(AGS_SDL_LIB_X64);$(AGS_SDL_SOUND_LIB_VS19_X64);$(AGS_SDL_LIB)\..\x64;$(AGS_SDL_SOUND_LIB_VS19)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(AGS_SDL_LIB_X64);$(AGS_SDL_SOUND_LIB_VS19_X64);$(AGS_SDL_LIB)\..\x64;$(AGS_SDL_SOUND_LIB_VS19)\..\x64;$(AGS_SDL_SOUND_LIB_X64);$(AGS_SDL_SOUND_LIB)\..\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -2,7 +2,7 @@
 #define AgsName "Adventure Game Studio"
 #define AgsUrl "https://www.adventuregamestudio.co.uk/"
 #define VcRedistInstaller "vc_redist.x86.exe"
-#define VcRedistName "Microsoft Visual C++ 2015 Redistributable (x86)"
+#define VcRedistName "Microsoft Visual C++ 2015-2022 Redistributable (x86)"
 
 ; requires following macros to be passed by command line:
 ;   AgsAppId - a GUID identifying installed software
@@ -202,9 +202,9 @@ const
   PLATFORM_CHECK_ERROR_MESSAGE = 'This program is only supported on Windows Vista or newer.';
 
   // Visual C++ runtime
-  // https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe
-  VCPP_REDIST_MAJOR_VERSION = 14.0;
-  VCPP_REDIST_BUILD_VERSION = 24215;
+  // https://download.visualstudio.microsoft.com/download/pr/5319f718-2a84-4aff-86be-8dbdefd92ca1/DD1A8BE03398367745A87A5E35BEBDAB00FDAD080CF42AF0C3F20802D08C25D4/VC_redist.x86.exe
+  VCPP_REDIST_MAJOR_VERSION = 14.42;
+  VCPP_REDIST_BUILD_VERSION = 34433;
 
   // .NET Framework 4.6 or newer
   // in theory this is only needed for OS versions older than Windows 10

--- a/Windows/Installer/checksums.sha256
+++ b/Windows/Installer/checksums.sha256
@@ -1,1 +1,1 @@
-1acd8d5ea1cdc3eb2eb4c87be3ab28722d0825c15449e5c9ceef95d897de52fa  Source/Redist/vc_redist.x86.exe
+dd1a8be03398367745a87a5e35bebdab00fdad080cf42af0c3f20802d08c25d4  Source/Redist/vc_redist.x86.exe

--- a/Windows/Installer/checksums.sha256
+++ b/Windows/Installer/checksums.sha256
@@ -1,1 +1,1 @@
-12a69af8623d70026690ba14139bf3793cc76c865759cad301b207c1793063ed  Source/Redist/vc_redist.x86.exe
+1acd8d5ea1cdc3eb2eb4c87be3ab28722d0825c15449e5c9ceef95d897de52fa  Source/Redist/vc_redist.x86.exe

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -4,22 +4,22 @@ The following are instructions on how to build the Engine and Editor from the so
 
 ## Build Requirements
 
-* In common:
-  * Microsoft Visual Studio 2015 or higher - currently the only supported IDE for making Engine and Editor. The free Community edition is sufficient and is available for download at the Microsoft's site:
-    * https://visualstudio.microsoft.com/downloads/
-    * https://visualstudio.microsoft.com/vs/older-downloads/
-  * If you are using MSVS 2019 and higher you might need to manually download [Windows 10 SDK (10.0.10240)](https://go.microsoft.com/fwlink/p/?LinkId=619296) from the [SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/).
-* Specifically for the Engine:
-  * SDL 2.0.12 or higher (https://github.com/libsdl-org/SDL/tree/SDL2)
-  * SDL_Sound 2.0.* (https://github.com/icculus/sdl_sound)
-  * libogg-1.1.3 or higher ([Download](https://www.xiph.org/downloads/))
-  * libtheora-1.0 or higher ([Download](https://www.xiph.org/downloads/))
-  * libvorbis-1.2.0 or higher ([Download](https://www.xiph.org/downloads/))
-* Specifically for the Editor:
-  * irrKlang 1.6 (32-bit) assembly pack for .NET 4.5 ([Download](https://www.ambiera.com/irrklang/downloads.html)).
-* To build Windows installer:
-  * Inno Setup 6.0.2 or higher ([Download](http://www.jrsoftware.org/isdl.php))
-  * (optional) PowerShell ([Download](https://aka.ms/powershell-release?tag=stable))
+- In common:
+  - Microsoft Visual Studio 2019 or higher - currently the only supported IDE for making Engine and Editor. The free Community edition is sufficient and is available for download at the Microsoft's site:
+    - https://visualstudio.microsoft.com/downloads/
+    - https://visualstudio.microsoft.com/vs/older-downloads/
+  - You might need to manually download [Windows 10 SDK (10.0.10240)](https://go.microsoft.com/fwlink/p/?LinkId=619296) from the [SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/).
+- Specifically for the Engine:
+  - SDL 2.0.12 or higher (https://github.com/libsdl-org/SDL/tree/SDL2)
+  - SDL_Sound 2.0.* (https://github.com/icculus/sdl_sound)
+  - libogg-1.1.3 or higher ([Download](https://www.xiph.org/downloads/))
+  - libtheora-1.0 or higher ([Download](https://www.xiph.org/downloads/))
+  - libvorbis-1.2.0 or higher ([Download](https://www.xiph.org/downloads/))
+- Specifically for the Editor:
+  - irrKlang 1.6 (32-bit) assembly pack for .NET 4.6 ([Download](https://www.ambiera.com/irrklang/downloads.html)).
+- To build Windows installer:
+  - Inno Setup 6.2.2 or higher ([Download](http://www.jrsoftware.org/isdl.php))
+  - (optional) PowerShell ([Download](https://aka.ms/powershell-release?tag=stable))
 **IMPORTANT:** all libraries should match the Engine's architecture: e.g. if you are building engine using 32-bit (x86) configuration then link libraries for 32-bit (x86) too.
 
 **NOTE:** You may skip building libraries from the source completely by using prebuilt libs from the archive called "WinDevDependenciesVS.zip", which is attached to any [latest release of AGS](https://github.com/adventuregamestudio/ags/releases). If you go this way, then skip **"Building the libraries"** sections altogether.
@@ -42,8 +42,8 @@ If for some reason you'd like to build it yourself, take the one under "Source C
 
 AGS engine will need following files to link:
 
-* SDL2.lib
-* SDL2main.lib
+- `SDL2.lib`
+- `SDL2main.lib`
 
 and SDL2.dll to run.
 
@@ -71,11 +71,11 @@ All of these come with MSVC projects. You may need to make sure there are distin
 ## Building AGS Engine
 
 Engine requires following libraries:
-* SDL2
-* SDL_Sound
-* libogg
-* libtheora
-* libvorbis
+- SDL2
+- SDL_Sound
+- libogg
+- libtheora
+- libvorbis
 
 You may download the prebuilt libraries [here](https://github.com/adventuregamestudio/ags/releases/download/v.3.6.0.15/WinDevDependenciesVS.zip), although you'd still have to get library sources from their homepages because you need their headers for the engine compilation.
 
@@ -85,13 +85,19 @@ Engine MSVS solution is Solutions\Engine.sln. It contains two projects, the "Eng
 
 In order to direct Studio to necessary libraries and their headers setup following enviroment variables in your system by [creating user macros in the Property Pages](https://docs.microsoft.com/en-us/cpp/build/working-with-project-properties?view=msvc-160#user-defined-macros):
  
-* AGS_SDL_INCLUDE - pointing to the location of SDL2 headers;
-* AGS_SDL_LIB - pointing to the location of SDL2 library files;
-* AGS_SDL_SOUND_INCLUDE - pointing to the location of SDL Sound headers;
-* AGS_SDL_SOUND_LIB - pointing to the location of SDL Sound library files;
-* AGS_LIBOGG_LIB - pointing to the location of libogg library files;
-* AGS_LIBTHEORA_LIB - pointing to the location of libtheora library files;
-* AGS_LIBVORBIS_LIB - pointing to the location of libvorbis library files;
+- `AGS_SDL_INCLUDE` - pointing to the location of SDL2 headers;
+- `AGS_SDL_LIB` - pointing to the location of SDL2 library files;
+- `AGS_SDL_SOUND_INCLUDE` - pointing to the location of SDL Sound headers;
+- `AGS_SDL_SOUND_LIB` - pointing to the location of SDL Sound library files;
+- `AGS_LIBOGG_LIB` - pointing to the location of libogg library files;
+- `AGS_LIBTHEORA_LIB` - pointing to the location of libtheora library files;
+- `AGS_LIBVORBIS_LIB` - pointing to the location of libvorbis library files;
+
+**NOTE:** because libtheora, libvorbis, libogg and SDL Sound library used are statically built, if you need to alternate between branches using VS2019+ and VS2015 builds of the libraries, you can also specify the additional following environment variables:
+- `AGS_SDL_SOUND_LIB_VS19` - pointing to the location of VS2019+ builds of SDL Sound library files;
+- `AGS_LIBOGG_LIB_VS19` - pointing to the location of VS2019+ builds of libogg library files;
+- `AGS_LIBTHEORA_LIB_VS19` - pointing to the location of VS2019+ builds of libtheora library files;
+- `AGS_LIBVORBIS_LIB_VS19` - pointing to the location of VS2019+ builds of libvorbis library files;
 
 
 ## Building AGS Editor
@@ -136,7 +142,7 @@ There are two things to note here:
 
 In any case, there is a number of files that have to be prepared for installer to actually build. These files have to be placed in Windows\Installer\Source and subdirectories:
 
-- Redist\vc_redist.x86.exe - a [Visual C++ Redistributable for Visual Studio 2015](https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe) (or C++ Redist corresponding to the MSVS you were building AGS with).
+- Redist\vc_redist.x86.exe - a [Visual C++ Redistributable for Visual Studio 2015+, version 14.42.34433](https://download.visualstudio.microsoft.com/download/pr/5319f718-2a84-4aff-86be-8dbdefd92ca1/DD1A8BE03398367745A87A5E35BEBDAB00FDAD080CF42AF0C3F20802D08C25D4/VC_redist.x86.exe) (or C++ Redist corresponding to the MSVS you were building AGS with).
 - Editor\
   - AGSEditor.exe
   - AGS.Controls.dll

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -60,12 +60,12 @@ RUN mkdir Lib\irrKlang && \
   rd /s /q %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%
 
 # from
-# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x86/14.29.30133.0/Microsoft.VCRedist.2015%2B.x86.installer.yaml
-# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x64/14.29.30133.0/Microsoft.VCRedist.2015%2B.x64.installer.yaml
+# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x86/14.42.34433.0/Microsoft.VCRedist.2015%2B.x86.installer.yaml
+# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x64/14.42.34433.0/Microsoft.VCRedist.2015%2B.x64.installer.yaml
 RUN mkdir Redist && \
   cd Redist && \
-  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/221ed2ae-1269-497b-a962-e113045001fa/1ACD8D5EA1CDC3EB2EB4C87BE3AB28722D0825C15449E5C9CEEF95D897DE52FA/VC_redist.x86.exe -o vc_redist.x86.exe && \
-  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/7239cdc3-bd73-4f27-9943-22de059a6267/003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B/VC_redist.x64.exe -o vc_redist.x64.exe
+  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/5319f718-2a84-4aff-86be-8dbdefd92ca1/DD1A8BE03398367745A87A5E35BEBDAB00FDAD080CF42AF0C3F20802D08C25D4/VC_redist.x86.exe -o vc_redist.x86.exe && \
+  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe/1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940/VC_redist.x64.exe -o vc_redist.x64.exe
 
 ARG SDL_VERSION=release-2.28.5
 ARG SDL_VERSION_NUMBER=2.28.5

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -1,5 +1,5 @@
 # base will already have Chocolatey installed
-FROM ericoporto/min-ags-dev-env:1.0.0
+FROM ghcr.io/ericoporto/min-ags-dev-env:2.0.16
 
 # if no temp folder exists by default, create it
 RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
@@ -13,10 +13,10 @@ RUN pushd %TEMP% && \
   robocopy empty %TEMP% /MIR > nul & \
   rd /s /q empty
 
-ARG NUGET_VERSION=5.7.0
+ARG NUGET_VERSION=6.12.1
 ARG INNO_SETUP_VERSION=6.2.2
-RUN cinst nuget.commandline --version %NUGET_VERSION% -y && \
-  cinst innosetup --version %INNO_SETUP_VERSION% -y && \
+RUN choco install nuget.commandline --version %NUGET_VERSION% -y && \
+  choco install innosetup --version %INNO_SETUP_VERSION% -y && \
   mkdir empty && \
   robocopy empty %TEMP% /MIR > nul & \
   rd /s /q empty
@@ -59,10 +59,13 @@ RUN mkdir Lib\irrKlang && \
   move %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%\bin\dotnet-4-64\*.dll Lib\irrKlang\x64\ && \
   rd /s /q %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%
 
+# from
+# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x86/14.29.30133.0/Microsoft.VCRedist.2015%2B.x86.installer.yaml
+# https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2015%2B/x64/14.29.30133.0/Microsoft.VCRedist.2015%2B.x64.installer.yaml
 RUN mkdir Redist && \
   cd Redist && \
-  curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe && \
-  curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x64.exe
+  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/221ed2ae-1269-497b-a962-e113045001fa/1ACD8D5EA1CDC3EB2EB4C87BE3AB28722D0825C15449E5C9CEEF95D897DE52FA/VC_redist.x86.exe -o vc_redist.x86.exe && \
+  curl -fLJ https://download.visualstudio.microsoft.com/download/pr/7239cdc3-bd73-4f27-9943-22de059a6267/003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B/VC_redist.x64.exe -o vc_redist.x64.exe
 
 ARG SDL_VERSION=release-2.28.5
 ARG SDL_VERSION_NUMBER=2.28.5
@@ -81,16 +84,20 @@ RUN mkdir Lib\SDL2 && \
  
 ARG SDL2_SOUND_VERSION=474dbf755a1b67ebe7a55467b4f65e033f268aff
 RUN mkdir Lib\SDL_sound && \
-  echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 ^&^& pushd Lib\SDL_sound\build_x86 ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild_x86.bat && \
-  echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 ^&^& pushd Lib\SDL_sound\build_x64 ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild_x64.bat && \
   mkdir Lib\SDL_sound\build_x86  && \
   mkdir Lib\SDL_sound\build_x64  && \
   curl -fLSs "https://github.com/icculus/SDL_sound/archive/%SDL2_SOUND_VERSION%.tar.gz" | tar -f - -xvzC Lib\SDL_sound --strip-components 1 && \
   set SDL2_DIR=%cd%\Lib\SDL2 && \
-  cmake -DCMAKE_SYSTEM_VERSION=8.1 -S Lib\SDL_sound -B Lib\SDL_sound\build_x86 -G "Visual Studio 14 2015" -T"v140" -A"Win32" -DCMAKE_PREFIX_PATH=Lib\SDL2  -DSDLSOUND_DECODER_MIDI=1 && \
-  sdlsoundvcbuild_x86.bat && \
-  cmake -DCMAKE_SYSTEM_VERSION=8.1 -S Lib\SDL_sound -B Lib\SDL_sound\build_x64 -G "Visual Studio 14 2015" -T"v140" -A"x64" -DCMAKE_PREFIX_PATH=Lib\SDL2  -DSDLSOUND_DECODER_MIDI=1 && \
-  sdlsoundvcbuild_x64.bat && \
+  call "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" && \
+  cmake -S Lib\SDL_sound -B Lib\SDL_sound\build_x86 -G "Visual Studio 17 2022" -T"v142" -A"Win32" -DCMAKE_PREFIX_PATH=Lib\SDL2  -DSDLSOUND_DECODER_MIDI=1 && \
+  pushd Lib\SDL_sound\build_x86 && \
+  msbuild SDL_sound.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo && \
+  popd && \
+  call "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" && \
+  cmake -S Lib\SDL_sound -B Lib\SDL_sound\build_x64 -G "Visual Studio 17 2022" -T"v142" -A"x64" -DCMAKE_PREFIX_PATH=Lib\SDL2  -DSDLSOUND_DECODER_MIDI=1 && \
+  pushd Lib\SDL_sound\build_x64 && \
+  msbuild SDL_sound.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo && \
+  popd && \  
   mkdir Lib\SDL_sound\lib && \
   mkdir Lib\SDL_sound\lib\x86 && \
   mkdir Lib\SDL_sound\lib\x64 && \


### PR DESCRIPTION
fix #1508 

built on top of #2591

---

**Some notes:**

Visual Studio 2022 build tools image did not work with CMake. It seems the big issue is that Visual Studio 2022 Build Tools doesn't correctly installs all VC tools, the 142 (VS 2019, aka VC 14.29) vc tools seems to install most correctly but it doesn't seem to proper have the CLI/C++ tools working, and the VC 143 (VS 2022, aka VC 14.43) doesn't properly create the cl.exe in place.

I used VS 2022 community instead, which worked fine on the Windows container and properly install packages - though this means the image is slightly larger (21.96 GB in the base image). Here is the docker file for the base image

https://raw.githubusercontent.com/ericoporto/min-ags-dev-env/211537671e66f8e6df0c6fcd0826a529b535acd5/Dockerfile

I opted to build this package separately because installation of VS2022 takes a long time - a little more than an hour, enough to fail Cirrus CI. I built this image in my computer too, since the GHA that currently exists for docker fails with Windows Containers. 

I also kept the Windows Server 2019, in theory it could work with a newer windows (and move from the LTSC2019 base), but the cirrus ci official windows container images are still those, so I opted to keep with what is currently tested.

The resulting image has

- platform toolsets
  - v142 (14.29.30133)
  - v143 (14.42.34433)
- .NET Framework functionality to build 4.6.2 but also 4.8.1
- Should be possible to evolve to support newer .NET as needed (nom framework)

**TO-DO:**

- [x] test the windows binaries of editor in different Windows
  - [x] Windows 7
  - [x] Windows 10
  - [x] Windows 11
- [x] verify in a clear machine (VM?) that the selected VC redist is indeed correct and working with the installer
-  ~~maybe adding a `"windows-container"` repository right in the organization so that I can move the base image to there (using the GitHub Packages feature), this would also be an opportunity to document a how-to on windows containers to explain things~~ not now, maybe when GHA can push windows containers.