### PR TITLE
Update SDL_Sound to latest commit

### DIFF
--- a/CMake/FetchSDL_Sound.cmake
+++ b/CMake/FetchSDL_Sound.cmake
@@ -1,8 +1,8 @@
 FetchContent_Declare(
     sdlsound_content
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    URL https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.tar.gz
-    URL_HASH SHA1=2e9ab24fd861f61349b9386fd66c9851e9f03a60
+    URL https://github.com/icculus/SDL_sound/archive/16e626561f3b496e4a2da98c95d23359eeee3c01.tar.gz
+    URL_HASH SHA1=37d56d695f263bb35708a05131271f41a1d9c01d
 )
 
 FetchContent_GetProperties(sdlsound_content)
@@ -11,6 +11,7 @@ if(NOT sdlsound_content)
   set(SDLSOUND_BUILD_SHARED off CACHE BOOL "no shared")
   set(SDLSOUND_BUILD_TEST off CACHE BOOL "no tests")
   set(SDLSOUND_BUILD_STATIC on CACHE BOOL "static")
+  set(SDLSOUND_BUILD_DOCS off CACHE BOOOL "Build documentation")
 
   # see why we need to manually enable here: https://github.com/icculus/SDL_sound/issues/19#issuecomment-1079263491
   set(SDLSOUND_DECODER_MIDI on CACHE BOOL "")

--- a/OSX/README.md
+++ b/OSX/README.md
@@ -78,7 +78,7 @@ The Xcode project depends on the prebuilt SDL2 Framework and library sources.
 
 The project also requires sources of library dependencies, either using the `libsrc/download.sh` script or manually downloading them and extracting them as below.
 
-- Download [SDL_sound](https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.zip) source code and place it in `ags/libsrc/SDL_sound`
+- Download [SDL_sound](https://github.com/icculus/SDL_sound/archive/16e626561f3b496e4a2da98c95d23359eeee3c01.zip) source code and place it in `ags/libsrc/SDL_sound`
 - Download xiph [theora](https://github.com/xiph/theora/archive/7180717276af1ebc7da15c83162d6c5d6203aabf.tar.gz) source code, and place it in `ags/libsrc/theora`
 - Download xiph [ogg](https://github.com/xiph/ogg/archive/refs/tags/v1.3.5.tar.gz) source code, and place in `ags/libsrc/ogg`
 - Download xiph [vorbis](https://github.com/xiph/vorbis/archive/84c023699cdf023a32fa4ded32019f194afcdad0.tar.gz) source code, and place in `ags/libsrc/vorbis`
@@ -104,7 +104,7 @@ Make sure you have at least SDL 2.24.1 installed, if you have problems updating 
 
 The SDL_sound available in brew is not really well updated and it's a bit different from what's in the repository, using a different timidity and libmodplug. It's best to build it and install it from source. You will need CMake for this.
 
-    SDL2_SOUND_VERSION=c5639414c1bb24fb4eef5861c13adb42a4aab950
+    SDL2_SOUND_VERSION=16e626561f3b496e4a2da98c95d23359eeee3c01
     cd /tmp
     curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz
     tar -xvzf SDL_sound.tar.gz

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -52,7 +52,7 @@ and SDL2.dll to run.
 Official page for SDL_Sound library is https://www.icculus.org/SDL_sound/, but downloads are hosted on github: https://github.com/icculus/SDL_sound/releases.
 Any latest 2.0.X release should be good.
 
-For the reference, at the time of last update our build server is using following revision: https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.zip
+For the reference, at the time of last update our build server is using following revision: https://github.com/icculus/SDL_sound/archive/16e626561f3b496e4a2da98c95d23359eeee3c01.zip
 
 After you downloaded the source this way or another, you should use CMake to generate MSVS solution from their provided CMakeList.txt.
 Note that when doing this you may have to direct CMake to the SDL2's cmake config files. First go to the SDL2's sources location and find "cmake" directory inside. It should contain the file called "sdl2-config.cmake". If the file is not present, this means something is wrong with the SDL2's package, or maybe you've downloaded a way too old version of SDL2.

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -113,7 +113,7 @@ RUN curl -fLsS "https://github.com/xiph/theora/archive/refs/tags/v${LIBTHEORA_VE
   rm /tmp/libtheora-${LIBTHEORA_VERSION}.tar.gz 
 
 # Build and install SDL_sound
-ARG SDL2_SOUND_VERSION=c5639414c1bb24fb4eef5861c13adb42a4aab950
+ARG SDL2_SOUND_VERSION=16e626561f3b496e4a2da98c95d23359eeee3c01
 RUN cd /tmp && \
   curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz && \
   tar -xvzf SDL_sound.tar.gz && \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir Lib\SDL2 && \
   echo endif ^(^)  >> "Lib\SDL2\sdl2-config.cmake" && \
   echo string^(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES^) >> "Lib\SDL2\sdl2-config.cmake" 
  
-ARG SDL2_SOUND_VERSION=c5639414c1bb24fb4eef5861c13adb42a4aab950
+ARG SDL2_SOUND_VERSION=16e626561f3b496e4a2da98c95d23359eeee3c01
 RUN mkdir Lib\SDL_sound && \
   echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 ^&^& pushd Lib\SDL_sound\build_x86 ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild_x86.bat && \
   echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 ^&^& pushd Lib\SDL_sound\build_x64 ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild_x64.bat && \

--- a/debian/README.md
+++ b/debian/README.md
@@ -39,7 +39,7 @@ At the time of writing SDL_Sound `2.*` has just been released, but almost no lin
 Until that is resolved, we recommend to clone their repository from https://github.com/icculus/SDL_sound.
 Or download particular revision archive using following url:
 
-    https://github.com/icculus/SDL_sound/archive/c5639414c1bb24fb4eef5861c13adb42a4aab950.tar.gz
+    https://github.com/icculus/SDL_sound/archive/16e626561f3b496e4a2da98c95d23359eeee3c01.tar.gz
 
 then build and install using CMake (see instructions in the SDL_Sound's docs).
 

--- a/libsrc/download.sh
+++ b/libsrc/download.sh
@@ -35,7 +35,7 @@ get https://github.com/xiph/vorbis/archive/${LIBVORBIS_VERSION}.tar.gz vorbis.ta
 LIBTHEORA_VERSION=7180717276af1ebc7da15c83162d6c5d6203aabf
 get https://github.com/xiph/theora/archive/${LIBTHEORA_VERSION}.tar.gz theora.tar.gz
 
-SDLSOUND_VERSION=c5639414c1bb24fb4eef5861c13adb42a4aab950
+SDLSOUND_VERSION=16e626561f3b496e4a2da98c95d23359eeee3c01
 get https://github.com/icculus/SDL_sound/archive/${SDLSOUND_VERSION}.tar.gz SDL_sound.tar.gz
 
 SDL_VERSION=release-2.28.5

--- a/libsrc/sha1sums
+++ b/libsrc/sha1sums
@@ -1,5 +1,5 @@
 9dba2b579b7bfbd24cb302e4f4b27563cc8f1070  SDL.tar.gz
-2e9ab24fd861f61349b9386fd66c9851e9f03a60  SDL_sound.tar.gz
+37d56d695f263bb35708a05131271f41a1d9c01d  SDL_sound.tar.gz
 8085a94164c1eb6cfab245c5b4306c2d3ec847cd  ogg.tar.gz
 beaeae25bc7ace77007f42c33e0b0fa74acf4992  theora.tar.gz
 76f06629562d52a9539818f3b78722fbc9e19ddb  vorbis.tar.gz

--- a/version.json
+++ b/version.json
@@ -10,8 +10,8 @@
   
     "dependencies": {
         "sdlsound": {
-            "revision": "c5639414c1bb24fb4eef5861c13adb42a4aab950",
-            "urlHash": "2e9ab24fd861f61349b9386fd66c9851e9f03a60"
+            "revision": "16e626561f3b496e4a2da98c95d23359eeee3c01",
+            "urlHash": "37d56d695f263bb35708a05131271f41a1d9c01d"
         },
         "sdl": {
             "revision": "2.28.5",


### PR DESCRIPTION
https://github.com/icculus/SDL_sound/commit/16e626561f3b496e4a2da98c95d23359eeee3c01

SDL_sound now has a stable-2.0 branch, but it's still identical to main as SDL3 upgrade PR hasn't been merged yet.

Honestly not much changed there, this is more to guarantee things are kept in sync.