### PR TITLE
Emscripten: update to 3.1.74

### DIFF
--- a/Emscripten/install_dependencies.sh
+++ b/Emscripten/install_dependencies.sh
@@ -7,8 +7,8 @@ mkdir emscripten
 pushd emscripten
 git clone https://github.com/emscripten-core/emsdk.git
 pushd emsdk
-./emsdk install 3.1.55
-./emsdk activate 3.1.55
+./emsdk install 3.1.74
+./emsdk activate 3.1.74
 source ./emsdk_env.sh
 popd
 popd

--- a/ci/emscripten/Dockerfile
+++ b/ci/emscripten/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:jammy
 
 # The current used version of emsdk
-ARG EMSCRIPTEN_VERSION=3.1.55
+ARG EMSCRIPTEN_VERSION=3.1.74
 ENV EMSDK=/emsdk
 
 #fix TZ docker hang
@@ -91,7 +91,7 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
 # using `--entrypoint /bin/bash` in CLI).
 # This corresponds to the env variables set during: `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/16.20.0_64bit/bin:${PATH}"
+    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/20.18.0_64bit/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 # Create a 'standard` 1000:1000 user


### PR DESCRIPTION
More chore, upgrades emscripten version. This moves the sdl2 in emscripten to 2.30.9.

My plan is to later this week open a PR upgrading to latest SDL2 for ags itself, but first I need to test it,