### PR TITLE
Engine: refactor passing text_color into display_main()

### DIFF
--- a/Common/core/types.h
+++ b/Common/core/types.h
@@ -47,8 +47,8 @@
 // Stream offset type
 typedef int64_t soff_t;
 
-#define fixed_t int32_t // fixed point type
-#define color_t int32_t
+typedef int32_t fixed_t; // fixed point type
+typedef int32_t color_t; // AGS color number type (meaning depends on game's setting)
 
 // TODO: use distinct fixed point class
 enum

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2911,7 +2911,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         char_thinking = aschar;
 
     set_our_eip(155);
-    display_main(tdxp, tdyp, bwidth, texx, nullptr, DISPLAYTEXT_SPEECH, FONT_SPEECH, textcol, isThought, allowShrink, overlayPositionFixed);
+    display_main(tdxp, tdyp, bwidth, texx, nullptr, kDisplayText_Speech, 0 /* no overid */, FONT_SPEECH, textcol, isThought, allowShrink, overlayPositionFixed);
     set_our_eip(156);
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
         closeupface = nullptr;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2526,11 +2526,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         return;
     }
 
-    int textcol = speakingChar->talkcolor;
-
-    // if it's 0, it won't be recognised as speech
-    if (textcol == 0)
-        textcol = 16;
+    DisplayTextStyle disp_style = kDisplayTextStyle_Overchar;
+    const color_t text_color = speakingChar->talkcolor;
 
     Rect ui_view = play.GetUIViewport();
     int allowShrink = 0;
@@ -2843,7 +2840,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             facetalkchar = &game.chars[aschar];
             if (facetalkchar->blinktimer < 0)
                 facetalkchar->blinktimer = facetalkchar->blinkinterval;
-            textcol=-textcol;
+            disp_style = kDisplayTextStyle_TextWindow;
             overlayPositionFixed = true;
             // Process the first portrait view frame
             const int frame_vol = charextra[facetalkchar->index_id].GetFrameSoundVolume(facetalkchar);
@@ -2911,7 +2908,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         char_thinking = aschar;
 
     set_our_eip(155);
-    display_main(tdxp, tdyp, bwidth, texx, nullptr, kDisplayText_Speech, 0 /* no overid */, FONT_SPEECH, textcol, isThought, allowShrink, overlayPositionFixed);
+    display_main(tdxp, tdyp, bwidth, texx, nullptr, kDisplayText_Speech, 0 /* no overid */,
+        disp_style, FONT_SPEECH, text_color, isThought, allowShrink, overlayPositionFixed);
     set_our_eip(156);
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
         closeupface = nullptr;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2530,7 +2530,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     const color_t text_color = speakingChar->talkcolor;
 
     Rect ui_view = play.GetUIViewport();
-    int allowShrink = 0;
+    DisplayTextShrink allow_shrink = kDisplayTextShrink_None;
     int bwidth = widd;
     if (bwidth < 0)
         bwidth = ui_view.GetWidth()/2 + ui_view.GetWidth()/4;
@@ -2544,7 +2544,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         if (useview == 0)
             useview = -1;
         // speech bubble can shrink to fit
-        allowShrink = 1;
+        allow_shrink = kDisplayTextShrink_Left;
         if (speakingChar->room != displayed_room) {
             // not in room, centre it
             xx = -1;
@@ -2560,7 +2560,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     set_our_eip(1500);
 
     if (game.options[OPT_SPEECHTYPE] == 0)
-        allowShrink = 1;
+        allow_shrink = kDisplayTextShrink_Left;
 
     // If has a valid speech view, and idle anim in progress for the character, then stop it
     if (useview >= 0)
@@ -2799,7 +2799,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             }
 
             // allow the text box to be shrunk to fit the text
-            allowShrink = 1;
+            allow_shrink = kDisplayTextShrink_Left;
 
             // if the portrait's on the right, swap it round
             if (portrait_on_right) {
@@ -2823,7 +2823,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
                     tdxp = xx;
                 }
                 tdxp += get_textwindow_border_width(play.speech_textwindow_gui) / 2;
-                allowShrink = 2;
+                allow_shrink = kDisplayTextShrink_Right;
             }
             if (game.options[OPT_SPEECHTYPE] == 3)
                 overlay_x = 0;
@@ -2894,7 +2894,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         }
     }
     else
-        allowShrink = 1;
+        allow_shrink = kDisplayTextShrink_Left;
 
     // it wants the centred position, so make it so
     if ((xx >= 0) && (tdxp < 0))
@@ -2902,14 +2902,14 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
     // if they used DisplaySpeechAt, then use the supplied width
     if ((widd > 0) && (isThought == 0))
-        allowShrink = 0;
+        allow_shrink = kDisplayTextShrink_None;
 
     if (isThought)
         char_thinking = aschar;
 
     set_our_eip(155);
     display_main(tdxp, tdyp, bwidth, texx, nullptr, kDisplayText_Speech, 0 /* no overid */,
-        disp_style, FONT_SPEECH, text_color, isThought, allowShrink, overlayPositionFixed);
+        DisplayTextLooks(disp_style, isThought, allow_shrink), FONT_SPEECH, text_color, overlayPositionFixed);
     set_our_eip(156);
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
         closeupface = nullptr;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -139,16 +139,16 @@ private:
 
 
 // Generates a textual image and returns a disposable bitmap
-Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t text_color, int isThought,
-    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
+Bitmap *create_textual_image(const char *text, const DisplayTextLooks &look, color_t text_color,
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont,
     bool &alphaChannel, const TopBarSettings *topbar)
 {
     //
     // Configure the textual image
     //
 
-    const bool use_speech_textwindow = (style == kDisplayTextStyle_TextWindow) && (game.options[OPT_SPEECHTYPE] >= 2);
-    const bool use_thought_gui = (isThought) && (game.options[OPT_THOUGHTGUI] > 0);
+    const bool use_speech_textwindow = (look.Style == kDisplayTextStyle_TextWindow) && (game.options[OPT_SPEECHTYPE] >= 2);
+    const bool use_thought_gui = (look.AsThought) && (game.options[OPT_THOUGHTGUI] > 0);
 
     alphaChannel = false;
     int usingGui = -1;
@@ -186,7 +186,7 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
     // centre text in middle of screen
     else if (yy<0) yy = ui_view.GetHeight() / 2 - disp.FullTextHeight / 2 - padding;
     // speech, so it wants to be above the character's head
-    else if (style == kDisplayTextStyle_Overchar) {
+    else if (look.Style == kDisplayTextStyle_Overchar) {
         yy -= disp.FullTextHeight;
         if (yy < 5) yy = 5;
         yy = adjust_y_for_guis(yy);
@@ -196,11 +196,11 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
         // shrink the width of the dialog box to fit the text
         int oldWid = wii;
         // If it's not speech, or a shrink is allowed, then shrink it
-        if ((style == kDisplayTextStyle_MessageBox) || (allowShrink > 0))
+        if ((look.Style == kDisplayTextStyle_MessageBox) || (look.AllowShrink > 0))
             wii = longestline + paddingDoubledScaled;
 
         // shift the dialog box right to align it, if necessary
-        if ((allowShrink == 2) && (xx >= 0))
+        if ((look.AllowShrink == 2) && (xx >= 0))
             xx += (oldWid - wii);
     }
 
@@ -236,12 +236,13 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
     if ((strlen(todis) < 1) || (strcmp(todis, "  ") == 0) || (wii == 0))
         return text_window_ds;
 
-    if (style != kDisplayTextStyle_MessageBox)
+    if (look.Style != kDisplayTextStyle_MessageBox)
     {
         // Textual overlay purposed for character speech
         int ttxleft = 0, ttxtop = paddingScaled, oriwid = wii - padding * 2;
         int drawBackground = 0;
 
+        DisplayTextLooks fix_look = look;
         if (use_speech_textwindow)
         {
             drawBackground = 1;
@@ -249,7 +250,7 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
         else if (use_thought_gui)
         {
             // make it treat it as drawing inside a window now
-            style = kDisplayTextStyle_TextWindow;
+            fix_look.Style = kDisplayTextStyle_TextWindow;
             drawBackground = 1;
         }
 
@@ -269,10 +270,10 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
         }
 
         // Assign final text color, either use passed parameter, or TextWindow property
-        if (style == kDisplayTextStyle_TextWindow)
+        if (fix_look.Style == kDisplayTextStyle_TextWindow)
         {
             if ((usingGui >= 0) &&
-                    ((game.options[OPT_SPEECHTYPE] >= 2) || (isThought)))
+                    ((game.options[OPT_SPEECHTYPE] >= 2) || (fix_look.AsThought)))
                 text_color = text_window_ds->GetCompatibleColor(guis[usingGui].FgColor);
             else
                 text_color = text_window_ds->GetCompatibleColor(text_color);
@@ -287,7 +288,7 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
         {
             int ttyp = ttxtop + i * disp.Linespacing;
             // if it's inside a text box then don't centre the text
-            if (style == kDisplayTextStyle_TextWindow)
+            if (fix_look.Style == kDisplayTextStyle_TextWindow)
             {
                 wouttext_aligned(text_window_ds, ttxleft, ttyp, oriwid, usingfont, text_color, Lines[i].GetCStr(), play.text_align);
             }
@@ -368,8 +369,8 @@ bool display_check_user_input(int skip)
 // pass blocking=2 to create permanent overlay
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
     const TopBarSettings *topbar, DisplayTextType disp_type, int over_id,
-    DisplayTextStyle style, int usingfont, color_t text_color,
-    int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer)
+    const DisplayTextLooks &look, int usingfont, color_t text_color,
+    bool overlayPositionFixed, bool roomlayer)
 {
     //
     // Prepare for the message display
@@ -377,7 +378,7 @@ ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
 
     // AGS 2.x: If the screen is faded out, fade in again when displaying a message box.
     // FIXME: make conditions consistent, use disp_type when checking for MessageBox whenever possible
-    if ((style == kDisplayTextStyle_MessageBox) && (loaded_game_file_version <= kGameVersion_272))
+    if ((look.Style == kDisplayTextStyle_MessageBox) && (loaded_game_file_version <= kGameVersion_272))
         play.screen_is_faded_out = 0;
 
     // if it's a normal message box and the game was being skipped,
@@ -397,7 +398,7 @@ ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
         disp_type = kDisplayText_Speech;
     }
 
-    if ((style == kDisplayTextStyle_Overchar) && (disp_type < kDisplayText_NormalOverlay))
+    if ((look.Style == kDisplayTextStyle_Overchar) && (disp_type < kDisplayText_NormalOverlay))
     {
         // update the all_buttons_disabled variable in advance
         // of the adjust_x/y_for_guis calls
@@ -435,8 +436,8 @@ ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
 
     int adjustedXX, adjustedYY;
     bool alphaChannel;
-    Bitmap *text_window_ds = create_textual_image(text, style, text_color, isThought,
-        xx, yy, adjustedXX, adjustedYY, wii, usingfont, allowShrink, alphaChannel, topbar);
+    Bitmap *text_window_ds = create_textual_image(text, look, text_color,
+        xx, yy, adjustedXX, adjustedYY, wii, usingfont, alphaChannel, topbar);
 
     size_t nse = add_screen_overlay(roomlayer, xx, yy, over_id, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
     auto *over = get_overlay(nse); // FIXME: optimize return value
@@ -486,7 +487,8 @@ void display_at(int xx, int yy, int wii, const char *text, const TopBarSettings 
     try_auto_play_speech(text, text, play.narrator_speech);
 
     display_main(xx, yy, wii, text, topbar, kDisplayText_MessageBox, 0 /* no overid */,
-        kDisplayTextStyle_MessageBox, FONT_NORMAL, 0, 0 /* not thought */, 0 /* no shrink */, false /* no fixed pos */);
+        DisplayTextLooks(kDisplayTextStyle_MessageBox),
+        FONT_NORMAL, 0, false /* no fixed pos */);
 
     // Stop any blocking voice-over, if was started by this function
     if (play.IsBlockingVoiceSpeech())

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -264,26 +264,36 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
             }
         }
         else if ((ShouldAntiAliasText()) && (game.GetColorDepth() >= 24))
-            alphaChannel = true;
-
-        for (size_t ee = 0; ee<Lines.Count(); ee++)
         {
-            int ttyp = ttxtop + ee * disp.Linespacing;
+            alphaChannel = true;
+        }
+
+        // Assign final text color, either use passed parameter, or TextWindow property
+        if (style == kDisplayTextStyle_TextWindow)
+        {
+            if ((usingGui >= 0) &&
+                    ((game.options[OPT_SPEECHTYPE] >= 2) || (isThought)))
+                text_color = text_window_ds->GetCompatibleColor(guis[usingGui].FgColor);
+            else
+                text_color = text_window_ds->GetCompatibleColor(text_color);
+        }
+        else
+        {
+            text_color = text_window_ds->GetCompatibleColor(text_color);
+        }
+
+        // Print the lines of text
+        for (size_t i = 0; i < Lines.Count(); ++i)
+        {
+            int ttyp = ttxtop + i * disp.Linespacing;
             // if it's inside a text box then don't centre the text
             if (style == kDisplayTextStyle_TextWindow)
             {
-                if ((usingGui >= 0) &&
-                    ((game.options[OPT_SPEECHTYPE] >= 2) || (isThought)))
-                    text_color = text_window_ds->GetCompatibleColor(guis[usingGui].FgColor);
-                else
-                    text_color = text_window_ds->GetCompatibleColor(text_color);
-
-                wouttext_aligned(text_window_ds, ttxleft, ttyp, oriwid, usingfont, text_color, Lines[ee].GetCStr(), play.text_align);
+                wouttext_aligned(text_window_ds, ttxleft, ttyp, oriwid, usingfont, text_color, Lines[i].GetCStr(), play.text_align);
             }
             else
             {
-                text_color = text_window_ds->GetCompatibleColor(text_color);
-                wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, Lines[ee].GetCStr(), play.speech_text_align);
+                wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, Lines[i].GetCStr(), play.speech_text_align);
             }
         }
     }
@@ -301,8 +311,8 @@ Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t t
 
         adjust_y_coordinate_for_text(&yoffs, usingfont);
 
-        for (size_t ee = 0; ee<Lines.Count(); ee++)
-            wouttext_aligned(text_window_ds, xoffs, yoffs + ee * disp.Linespacing, oriwid, usingfont, text_color, Lines[ee].GetCStr(), play.text_align);
+        for (size_t i = 0; i < Lines.Count(); ++i)
+            wouttext_aligned(text_window_ds, xoffs, yoffs + i * disp.Linespacing, oriwid, usingfont, text_color, Lines[i].GetCStr(), play.text_align);
     }
     return text_window_ds;
 }

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -24,11 +24,20 @@
 
 using namespace AGS; // FIXME later
 
+// The general type and behavior of the displayed text
 enum DisplayTextType
 {
-    kDisplayText_MessageBox,
-    kDisplayText_Speech,
-    kDisplayText_NormalOverlay
+    kDisplayText_MessageBox,    // a super-blocking message box
+    kDisplayText_Speech,        // a blocking character speech
+    kDisplayText_NormalOverlay  // a custom text overlay
+};
+
+// More specific visual look of the displayed text
+enum DisplayTextStyle
+{
+    kDisplayTextStyle_MessageBox,   // standard message box
+    kDisplayTextStyle_TextWindow,   // use text window GUI, if applicable
+    kDisplayTextStyle_Overchar,     // display text above a character
 };
 
 struct TopBarSettings
@@ -59,7 +68,7 @@ struct ScreenOverlay;
 // see _display_main's comment below for parameters description.
 // NOTE: this function treats text as-is, not doing any processing over it.
 // TODO: refactor this collection of args into 1-2 structs with params.
-Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
+Common::Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t text_color, int isThought,
     int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
     bool &alphaChannel, const TopBarSettings *topbar);
 // Creates a textual overlay using the given parameters;
@@ -67,19 +76,16 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
 // * over_id - OVER_CUSTOM for auto overlay, but allows to pass actual overlay id
 //    to use, valid only if kDisplayText_NormalOverlay;
 //    FIXME: find a way to not pass over_id at all, this logic is bad
-// * pass yy = -1 to find Y co-ord automatically
-// * allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
-// * asspch has several meanings, which affect how the message is positioned
-//   == 0 - standard display box
-//   != 0 - text color for a speech or a regular textual overlay, where
-//     < 0 - use text window if applicable
-//     > 0 - suppose it's a classic LA-style speech above character's head
+// * style - more specific desired look (use text window, etc);
+// * pass yy = -1 to find Y co-ord automatically;
+// * allowShrink = 0 for none, 1 for leftwards, 2 for rightwards.
 // NOTE: this function treats the text as-is; it assumes that any processing
 // (translation, parsing voice token) was done prior to its call.
 // TODO: refactor this collection of args into few args + 1-2 structs with extended params.
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
-    const TopBarSettings *topbar, DisplayTextType disp_type, int over_id, int usingfont,
-    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
+    const TopBarSettings *topbar, DisplayTextType disp_type, int over_id,
+    DisplayTextStyle style, int usingfont, color_t text_color, int isThought,
+    int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
 // Displays a standard blocking message box at a given position
 void display_at(int xx, int yy, int wii, const char *text, const TopBarSettings *topbar);
 // Cleans up display message state

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -40,6 +40,29 @@ enum DisplayTextStyle
     kDisplayTextStyle_Overchar,     // display text above a character
 };
 
+// Whether displayed text is allowed to be shrinked
+enum DisplayTextShrink
+{
+    kDisplayTextShrink_None,
+    kDisplayTextShrink_Left,
+    kDisplayTextShrink_Right
+};
+
+struct DisplayTextLooks
+{
+    DisplayTextStyle Style = kDisplayTextStyle_TextWindow;
+    // Is this a character's thought; FIXME: merge with Style?
+    bool AsThought = false;
+    // Allow to make the resulting overlay smaller than requested
+    DisplayTextShrink AllowShrink = kDisplayTextShrink_None;
+
+    DisplayTextLooks() = default;
+    DisplayTextLooks(DisplayTextStyle style)
+        : Style(style) {}
+    DisplayTextLooks(DisplayTextStyle style, bool as_thought, DisplayTextShrink allow_shrink)
+        : Style(style), AsThought(as_thought), AllowShrink(allow_shrink) {}
+};
+
 struct TopBarSettings
 {
     Common::String Text;
@@ -68,8 +91,8 @@ struct ScreenOverlay;
 // see _display_main's comment below for parameters description.
 // NOTE: this function treats text as-is, not doing any processing over it.
 // TODO: refactor this collection of args into 1-2 structs with params.
-Common::Bitmap *create_textual_image(const char *text, DisplayTextStyle style, color_t text_color, int isThought,
-    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
+Common::Bitmap *create_textual_image(const char *text, const DisplayTextLooks &look, color_t text_color,
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont,
     bool &alphaChannel, const TopBarSettings *topbar);
 // Creates a textual overlay using the given parameters;
 // * disp_type tells the wanted type of overlay and behavior (blocking, etc);
@@ -78,14 +101,13 @@ Common::Bitmap *create_textual_image(const char *text, DisplayTextStyle style, c
 //    FIXME: find a way to not pass over_id at all, this logic is bad
 // * style - more specific desired look (use text window, etc);
 // * pass yy = -1 to find Y co-ord automatically;
-// * allowShrink = 0 for none, 1 for leftwards, 2 for rightwards.
 // NOTE: this function treats the text as-is; it assumes that any processing
 // (translation, parsing voice token) was done prior to its call.
 // TODO: refactor this collection of args into few args + 1-2 structs with extended params.
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
     const TopBarSettings *topbar, DisplayTextType disp_type, int over_id,
-    DisplayTextStyle style, int usingfont, color_t text_color, int isThought,
-    int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
+    const DisplayTextLooks &look, int usingfont, color_t text_color,
+    bool overlayPositionFixed, bool roomlayer = false);
 // Displays a standard blocking message box at a given position
 void display_at(int xx, int yy, int wii, const char *text, const TopBarSettings *topbar);
 // Cleans up display message state

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -24,20 +24,16 @@
 
 using namespace AGS; // FIXME later
 
-// options for 'disp_type' parameter
-// blocking speech
-#define DISPLAYTEXT_SPEECH        0
-// super-blocking message box
-#define DISPLAYTEXT_MESSAGEBOX    1
-// regular non-blocking overlay
-#define DISPLAYTEXT_NORMALOVERLAY 2
-// also accepts explicit overlay ID >= OVER_CUSTOM
-
-struct ScreenOverlay;
+enum DisplayTextType
+{
+    kDisplayText_MessageBox,
+    kDisplayText_Speech,
+    kDisplayText_NormalOverlay
+};
 
 struct TopBarSettings
 {
-    AGS::Common::String Text;
+    Common::String Text;
     int Font = 0;
     int Height = 0;
 
@@ -57,6 +53,8 @@ struct DisplayVars
         : Linespacing(linespacing), FullTextHeight(fulltxheight) {}
 };
 
+struct ScreenOverlay;
+
 // Generates a textual image from the given text and parameters;
 // see _display_main's comment below for parameters description.
 // NOTE: this function treats text as-is, not doing any processing over it.
@@ -65,10 +63,13 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
     int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
     bool &alphaChannel, const TopBarSettings *topbar);
 // Creates a textual overlay using the given parameters;
-// Pass yy = -1 to find Y co-ord automatically
-// allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
-// pass blocking=2 to create permanent overlay
-// asspch has several meanings, which affect how the message is positioned
+// * disp_type tells the wanted type of overlay and behavior (blocking, etc);
+// * over_id - OVER_CUSTOM for auto overlay, but allows to pass actual overlay id
+//    to use, valid only if kDisplayText_NormalOverlay;
+//    FIXME: find a way to not pass over_id at all, this logic is bad
+// * pass yy = -1 to find Y co-ord automatically
+// * allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
+// * asspch has several meanings, which affect how the message is positioned
 //   == 0 - standard display box
 //   != 0 - text color for a speech or a regular textual overlay, where
 //     < 0 - use text window if applicable
@@ -77,7 +78,7 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
 // (translation, parsing voice token) was done prior to its call.
 // TODO: refactor this collection of args into few args + 1-2 structs with extended params.
 ScreenOverlay *display_main(int xx, int yy, int wii, const char *text,
-    const TopBarSettings *topbar, int disp_type, int usingfont,
+    const TopBarSettings *topbar, DisplayTextType disp_type, int over_id, int usingfont,
     int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
 // Displays a standard blocking message box at a given position
 void display_at(int xx, int yy, int wii, const char *text, const TopBarSettings *topbar);

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -197,7 +197,7 @@ RuntimeScriptValue Sc_CreateTextOverlay(const RuntimeScriptValue *params, int32_
     API_SCALL_SCRIPT_SPRINTF(CreateTextOverlay, 6);
     return RuntimeScriptValue().SetInt32(
         CreateTextOverlay(params[0].IValue, params[1].IValue, params[2].IValue,
-            params[3].IValue, params[4].IValue, scsf_buffer, DISPLAYTEXT_NORMALOVERLAY));
+            params[3].IValue, params[4].IValue, scsf_buffer));
 }
 
 // void (int strt,int eend)
@@ -2277,7 +2277,7 @@ void ScPl_sc_AbortGame(const char *texx, ...)
 int ScPl_CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    return CreateTextOverlay(xx, yy, wii, fontid, clr, scsf_buffer, DISPLAYTEXT_NORMALOVERLAY);
+    return CreateTextOverlay(xx, yy, wii, fontid, clr, scsf_buffer);
 }
 
 void ScPl_Display(char *texx, ...)

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -561,7 +561,7 @@ int DisplaySpeechBackground(int charid, const char*speel) {
     }
 
     int ovrl=CreateTextOverlay(OVR_AUTOPLACE,charid,play.GetUIViewport().GetWidth()/2,FONT_SPEECH,
-        -game.chars[charid].talkcolor, get_translation(speel), DISPLAYTEXT_NORMALOVERLAY);
+        -game.chars[charid].talkcolor, get_translation(speel));
 
     auto *over = get_overlay(ovrl);
     over->bgSpeechForChar = charid;

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -561,7 +561,7 @@ int DisplaySpeechBackground(int charid, const char*speel) {
     }
 
     int ovrl=CreateTextOverlay(OVR_AUTOPLACE,charid,play.GetUIViewport().GetWidth()/2,FONT_SPEECH,
-        -game.chars[charid].talkcolor, get_translation(speel));
+        game.chars[charid].talkcolor, get_translation(speel), kDisplayTextStyle_Overchar);
 
     auto *over = get_overlay(ovrl);
     over->bgSpeechForChar = charid;

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -29,7 +29,7 @@ int CreateGraphicOverlay(int x, int y, int slott, int trans) {
     return over ? over->type : 0;
 }
 
-int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, int disp_type) {
+int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text) {
     int allowShrink = 0;
 
     if (xx != OVR_AUTOPLACE)
@@ -41,8 +41,7 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
     else  // allow DisplaySpeechBackground to be shrunk
         allowShrink = 1;
 
-    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, disp_type, allowShrink);
-    assert((disp_type < OVER_FIRSTFREE) || (disp_type == over->type));
+    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, OVER_CUSTOM, allowShrink);
     return over ? over->type : 0;
 }
 

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -30,6 +30,10 @@ int CreateGraphicOverlay(int x, int y, int slott, int trans) {
 }
 
 int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text) {
+    return CreateTextOverlay(xx, yy, wii, fontid, text_color, text, kDisplayTextStyle_TextWindow);
+}
+
+int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, DisplayTextStyle style) {
     int allowShrink = 0;
 
     if (xx != OVR_AUTOPLACE)
@@ -41,7 +45,7 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
     else  // allow DisplaySpeechBackground to be shrunk
         allowShrink = 1;
 
-    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, OVER_CUSTOM, allowShrink);
+    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, OVER_CUSTOM, style, allowShrink);
     return over ? over->type : 0;
 }
 

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -34,18 +34,21 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
 }
 
 int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, DisplayTextStyle style) {
-    int allowShrink = 0;
 
+    DisplayTextShrink allow_shrink = kDisplayTextShrink_None;
     if (xx != OVR_AUTOPLACE)
     {
         data_to_game_coords(&xx, &yy);
         // NOTE: this is ugly, but OVR_AUTOPLACE here suggests that width is already in game coords
         wii = data_to_game_coord(wii);
     }
-    else  // allow DisplaySpeechBackground to be shrunk
-        allowShrink = 1;
+    else
+    {
+        // allow DisplaySpeechBackground to be shrunk
+        allow_shrink = kDisplayTextShrink_Left;
+    }
 
-    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, OVER_CUSTOM, style, allowShrink);
+    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, OVER_CUSTOM, style, allow_shrink);
     return over ? over->type : 0;
 }
 

--- a/Engine/ac/global_overlay.h
+++ b/Engine/ac/global_overlay.h
@@ -18,7 +18,7 @@ struct ScreenOverlay;
 
 void RemoveOverlay(int ovrid);
 int  CreateGraphicOverlay(int xx, int yy, int slott, int trans);
-int  CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, const char* text, int disp_type);
+int  CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, const char* text);
 void SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int text_color, const char *text);
 void MoveOverlay(int ovrid, int newx, int newy);
 int  IsOverlayValid(int ovrid);

--- a/Engine/ac/global_overlay.h
+++ b/Engine/ac/global_overlay.h
@@ -14,11 +14,14 @@
 #ifndef __AGS_EE_AC__GLOBALOVERLAY_H
 #define __AGS_EE_AC__GLOBALOVERLAY_H
 
+#include "display.h"
+
 struct ScreenOverlay;
 
 void RemoveOverlay(int ovrid);
 int  CreateGraphicOverlay(int xx, int yy, int slott, int trans);
-int  CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, const char* text);
+int  CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text);
+int  CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, DisplayTextStyle style);
 void SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int text_color, const char *text);
 void MoveOverlay(int ovrid, int newx, int newy);
 int  IsOverlayValid(int ovrid);

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -237,7 +237,7 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
 }
 
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int over_type, int allow_shrink)
+    const char *text, int over_type, DisplayTextStyle style, int allow_shrink)
 {
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
     if (x < 0) x = play.GetUIViewport().GetWidth() / 2 - width / 2;
@@ -245,7 +245,7 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     // Skip a voice-over token, if present
     const char *draw_text = skip_voiceover_token(text);
     return display_main(x, y, width, draw_text, nullptr, kDisplayText_NormalOverlay, over_type,
-        kDisplayTextStyle_TextWindow, font, text_color, 0 /* not thought */, allow_shrink, false /* no fixed pos */, room_layer);
+        style, font, text_color, 0 /* not thought */, allow_shrink, false /* no fixed pos */, room_layer);
 }
 
 ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)
@@ -273,7 +273,7 @@ ScriptOverlay* Overlay_CreateTextualImpl(bool room_layer, int x, int y, int widt
 {
     data_to_game_coords(&x, &y);
     width = data_to_game_coord(width);
-    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, OVER_CUSTOM, 0);
+    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, OVER_CUSTOM, kDisplayTextStyle_TextWindow, 0);
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -77,7 +77,7 @@ void Overlay_SetText(ScreenOverlay &over, int x, int y, int width, int fontid, i
     // from CreateTextOverlay
     width = data_to_game_coord(width);
     // allow DisplaySpeechBackground to be shrunk
-    int allow_shrink = (x == OVR_AUTOPLACE) ? 1 : 0;
+    DisplayTextShrink allow_shrink = (x == OVR_AUTOPLACE) ? kDisplayTextShrink_Left : kDisplayTextShrink_None;
 
     // from Overlay_CreateTextCore
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
@@ -90,9 +90,10 @@ void Overlay_SetText(ScreenOverlay &over, int x, int y, int width, int fontid, i
     // Recreate overlay image
     int dummy_x = x, dummy_y = y, adj_x = x, adj_y = y;
     bool has_alpha = false;
-    Bitmap *image = create_textual_image(draw_text, kDisplayTextStyle_TextWindow, text_color,
-        0 /* not thought */, dummy_x, dummy_y, adj_x, adj_y,
-        width, fontid, allow_shrink, has_alpha, nullptr);
+    Bitmap *image = create_textual_image(draw_text,
+        DisplayTextLooks(kDisplayTextStyle_TextWindow, false /* not thought */, allow_shrink),
+        text_color, dummy_x, dummy_y, adj_x, adj_y,
+        width, fontid, has_alpha, nullptr);
 
     // Update overlay properties
     over.SetImage(std::unique_ptr<Bitmap>(image), has_alpha, adj_x - dummy_x, adj_y - dummy_y);
@@ -237,7 +238,7 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
 }
 
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int over_type, DisplayTextStyle style, int allow_shrink)
+    const char *text, int over_type, DisplayTextStyle style, DisplayTextShrink allow_shrink)
 {
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
     if (x < 0) x = play.GetUIViewport().GetWidth() / 2 - width / 2;
@@ -245,7 +246,7 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     // Skip a voice-over token, if present
     const char *draw_text = skip_voiceover_token(text);
     return display_main(x, y, width, draw_text, nullptr, kDisplayText_NormalOverlay, over_type,
-        style, font, text_color, 0 /* not thought */, allow_shrink, false /* no fixed pos */, room_layer);
+        DisplayTextLooks(style, false /* not thought */, allow_shrink), font, text_color, false /* no fixed pos */, room_layer);
 }
 
 ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)
@@ -273,7 +274,7 @@ ScriptOverlay* Overlay_CreateTextualImpl(bool room_layer, int x, int y, int widt
 {
     data_to_game_coords(&x, &y);
     width = data_to_game_coord(width);
-    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, OVER_CUSTOM, kDisplayTextStyle_TextWindow, 0);
+    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, OVER_CUSTOM, kDisplayTextStyle_TextWindow, kDisplayTextShrink_None);
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -238,14 +238,14 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
 }
 
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int disp_type, int allow_shrink)
+    const char *text, int over_type, int allow_shrink)
 {
     if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
     if (x < 0) x = play.GetUIViewport().GetWidth() / 2 - width / 2;
     if (text_color == 0) text_color = 16;
     // Skip a voice-over token, if present
     const char *draw_text = skip_voiceover_token(text);
-    return display_main(x, y, width, draw_text, nullptr, disp_type, font, -text_color, 0, allow_shrink, false, room_layer);
+    return display_main(x, y, width, draw_text, nullptr, kDisplayText_NormalOverlay, over_type, font, -text_color, 0, allow_shrink, false, room_layer);
 }
 
 ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)
@@ -273,7 +273,7 @@ ScriptOverlay* Overlay_CreateTextualImpl(bool room_layer, int x, int y, int widt
 {
     data_to_game_coords(&x, &y);
     width = data_to_game_coord(width);
-    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, DISPLAYTEXT_NORMALOVERLAY, 0);
+    auto *over = Overlay_CreateTextCore(room_layer, x, y, width, font, colour, text, OVER_CUSTOM, 0);
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -90,9 +90,8 @@ void Overlay_SetText(ScreenOverlay &over, int x, int y, int width, int fontid, i
     // Recreate overlay image
     int dummy_x = x, dummy_y = y, adj_x = x, adj_y = y;
     bool has_alpha = false;
-    // NOTE: we pass text_color negated to let optionally use textwindow (if applicable)
-    // this is a generic ugliness of _display_main args, need to refactor later.
-    Bitmap *image = create_textual_image(draw_text, -text_color, 0, dummy_x, dummy_y, adj_x, adj_y,
+    Bitmap *image = create_textual_image(draw_text, kDisplayTextStyle_TextWindow, text_color,
+        0 /* not thought */, dummy_x, dummy_y, adj_x, adj_y,
         width, fontid, allow_shrink, has_alpha, nullptr);
 
     // Update overlay properties
@@ -245,7 +244,8 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     if (text_color == 0) text_color = 16;
     // Skip a voice-over token, if present
     const char *draw_text = skip_voiceover_token(text);
-    return display_main(x, y, width, draw_text, nullptr, kDisplayText_NormalOverlay, over_type, font, -text_color, 0, allow_shrink, false, room_layer);
+    return display_main(x, y, width, draw_text, nullptr, kDisplayText_NormalOverlay, over_type,
+        kDisplayTextStyle_TextWindow, font, text_color, 0 /* not thought */, allow_shrink, false /* no fixed pos */, room_layer);
 }
 
 ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -38,7 +38,7 @@ ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool transparent 
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
 ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent = true, bool clone = false);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int over_type, DisplayTextStyle style, int allow_shrink);
+    const char *text, int over_type, DisplayTextStyle style, DisplayTextShrink allow_shrink);
 
 ScreenOverlay *get_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -37,7 +37,7 @@ ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool transparent 
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
 ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent = true, bool clone = false);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int disp_type, int allow_shrink);
+    const char *text, int over_type, int allow_shrink);
 
 ScreenOverlay *get_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__OVERLAY_H
 #define __AGS_EE_AC__OVERLAY_H
 #include <vector>
+#include "ac/display.h"
 #include "ac/screenoverlay.h"
 #include "ac/dynobj/scriptoverlay.h"
 #include "util/geometry.h"
@@ -37,7 +38,7 @@ ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool transparent 
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
 ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent = true, bool clone = false);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
-    const char *text, int over_type, int allow_shrink);
+    const char *text, int over_type, DisplayTextStyle style, int allow_shrink);
 
 ScreenOverlay *get_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)


### PR DESCRIPTION
* Replaced DISPLAYTEXT_x macros with DisplayTextType enum;
* Got rid of confusing `asspch` parameter which combines text color with the "text style" by applying a sign. Instead have separate `text_color` and a `style` parameter of DisplayTextStyle enum.
* Also added DisplayTextShrink enum for the `allow_shrink` parameter.
* Grouped them into `DisplayTextLooks` struct.

