### PR TITLE
Eliminate duplicate tests when function parameters are defined

### DIFF
--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -854,6 +854,43 @@ TEST_F(Compile0, LocalGlobalSeq2) {
     EXPECT_EQ(7u, mh.GetMessages()[0].Lineno);
 }
 
+TEST_F(Compile0, WarningParameterHides01)
+{
+    // A function parameter cannot hide anything unless the 
+    // function body follows
+
+    char const *inpl = R"%&/(
+        import int test();
+        import int func(float test);
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    ASSERT_EQ(0u, mh.WarningsCount());
+}
+
+TEST_F(Compile0, WarningParameterHides02)
+{
+    // A function parameter cannot hide anything unless the 
+    // function body follows
+
+    char const *inpl = R"%&/(
+        import int test();
+        void func(float test)
+        {
+            return;
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    ASSERT_EQ(1u, mh.WarningsCount());
+    std::string const warn_msg = mh.GetMessages().at(0u).Message;
+    EXPECT_NE(std::string::npos, warn_msg.find("hide"));
+}
+
 TEST_F(Compile0, VartypeLocalSeq1) {
 
     // Can't redefine a vartype as a local variable


### PR DESCRIPTION
Fixes #2647

When AGS code defines a parameter within a function header and a body follows then that parameter can hide or collide with global definitions. Code for these checks is already provided where the compiler processes local variable defns. So no need to duplicate the checks where the compiler processes parameter definitions – delete these checks.

This fixes a bug : These checks were even done when a function body doesn't even follow (i.e., for an import or forward declaration of a function), which is incorrect and makes for strange warnings.

Example code:
```
import void foo();
import void test(int foo); // Should NOT yield any warning or error
``` 

Provide googletests that demonstrate that the bug is fixed.