### PR TITLE
Editor: support loading 8-bit images with Alpha in palette

### DIFF
--- a/Common/gfx/image_file.cpp
+++ b/Common/gfx/image_file.cpp
@@ -883,7 +883,7 @@ PixelBuffer LoadPCX(Stream *in, RGB *pal) {
                     pal[i].r = static_cast<uint8_t>(in->ReadInt8()) / 4;
                     pal[i].g = static_cast<uint8_t>(in->ReadInt8()) / 4;
                     pal[i].b = static_cast<uint8_t>(in->ReadInt8()) / 4;
-                    pal[i].filler = 0;
+                    pal[i].a = 0; // filler
                 }
                 break;
             }

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -142,16 +142,16 @@ namespace AGS.Editor
             cmbFilenames.Items.Clear();
             imageLookup = new List<string>();
 
+            OneTimeControlSetup();
+
             foreach (string filename in filenames)
             {
                 imageLookup.Add(filename);
                 cmbFilenames.Items.Add(Path.GetFileName(filename));
             }
 
+            // NOTE: this also calls PostImageLoad()
             cmbFilenames.SelectedIndex = 0;
-
-            OneTimeControlSetup();
-            PostImageLoad();
         }
 
         public SpriteImportWindow(Bitmap bmp, SpriteFolder folder)
@@ -196,16 +196,16 @@ namespace AGS.Editor
             cmbFilenames.Items.Clear();
             imageLookup = new List<string>();
 
+            OneTimeControlSetup();
+
             foreach (string filename in filenames)
             {
                 imageLookup.Add(filename);
                 cmbFilenames.Items.Add(Path.GetFileName(filename));
             }
 
+            // NOTE: this also calls PostImageLoad()
             cmbFilenames.SelectedIndex = 0;
-
-            OneTimeControlSetup();
-            PostImageLoad();
         }
 
         public SpriteImportWindow(Bitmap bmp, Sprite replace)

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -264,8 +264,11 @@ namespace AGS.Editor
             }
 
             string format = image.PixelFormat.ToString().Substring(6).ToUpper().Replace("BPP", " bit ").Replace("INDEXED", "indexed");
-            string frametext = frames > 1 ? String.Format(", {0} frames", frames) : "";
-            lblImageDescription.Text = String.Format("{0} x {1}, {2}{3}", image.Width, image.Height, format, frametext);
+            string format_ex = string.Empty;
+            if (image.IsIndexed())
+                format_ex = image.HasAlpha() ? " (ARGB)" : " (RGB)";
+            string frametext = frames > 1 ? $", {frames} frames" : "";
+            lblImageDescription.Text = $"{image.Width} x {image.Height}, {format}{format_ex}{frametext}";
 
             // clear old labels to reset the scrollbars
             previewPanel.Controls.Clear();

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -216,6 +216,44 @@ namespace AGS.Editor.Utils
             bmp.PixelFormat == PixelFormat.Format8bppIndexed;
 
         /// <summary>
+        /// Check if Bitmap contains a valid alpha channel.
+        /// Returns positive for ARGB pixel format, and for bitmaps of Indexed
+        /// format which palette contains alpha component.
+        /// </summary>
+        public static bool HasAlpha(this Bitmap bmp)
+        {
+            if (Bitmap.IsAlphaPixelFormat(bmp.PixelFormat))
+                return true;
+
+            if ((bmp.PixelFormat & PixelFormat.Indexed) != 0)
+                return DoesPaletteHaveAlpha(bmp);
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if Bitmap's palette has alpha component.
+        /// Fails if there's no palette.
+        /// </summary>
+        public static bool DoesPaletteHaveAlpha(this Bitmap bmp)
+        {
+            if (bmp.Palette == null)
+                return false;
+
+            // First test if there is a "alpha" or "halftone" flags present
+            if ((bmp.Palette.Flags & (0x1 | 0x4)) == 0)
+                return false;
+
+            // Do a full scan of pal entries to see if they contain
+            // any non-opaque or non-fully-transparent colors.
+            for (int i = 0; i < bmp.Palette.Entries.Length; ++i)
+                if (bmp.Palette.Entries[i].A != 0 && bmp.Palette.Entries[i].A != 255)
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
         /// Loads a <see cref="Bitmap"/> from file that doesn't lock the original file.
         /// </summary>
         public static Bitmap LoadNonLockedBitmap(string path)

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -382,12 +382,17 @@ namespace AGS.Editor.Utils
             bool alpha, bool remapColours, bool useRoomBackground,
             SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
-            // ignore alpha channel if not 32 bit ARGB
-            bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
-                Factory.AGSEditor.CurrentGame.Settings.ColorDepth != GameColorDepth.TrueColor ? false : alpha;
+            // Use alpha channel if:
+            // * game is 32-bit
+            // * bitmap has valid alpha component
+            // * alpha requested by user;
+            bool useAlphaChannel = alpha
+                && Factory.AGSEditor.CurrentGame.Settings.ColorDepth == GameColorDepth.TrueColor
+                && bmp.HasAlpha();
 
             // ignore palette remap options if not using an indexed palette
-            if (bmp.PixelFormat != PixelFormat.Format8bppIndexed)
+            // and even then - if using alpha channel (remap won't work with alpha)
+            if (bmp.PixelFormat != PixelFormat.Format8bppIndexed && !useAlphaChannel)
             {
                 remapColours = false;
                 useRoomBackground = false;

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -260,31 +260,11 @@ namespace AGS.Editor.Utils
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
             SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
-            // ignore alpha channel if not 32 bit ARGB
-            bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
-                Factory.AGSEditor.CurrentGame.Settings.ColorDepth != GameColorDepth.TrueColor ? false : alpha;
-
-            // ignore palette remap options if not using an indexed palette
-            if (bmp.PixelFormat != PixelFormat.Format8bppIndexed)
-            {
-                remapColours = false;
-                useRoomBackground = false;
-            }
-
-            // do replacement
-            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp, transparency, remapColours, useRoomBackground, useAlphaChannel);
-
-            sprite.TransparentColour = transparency;
-            sprite.RemapToGamePalette = remapColours;
-            sprite.RemapToRoomPalette = useRoomBackground;
-            sprite.SourceFile = Utilities.GetRelativeToProjectPath(filename);
-            sprite.Frame = frame;
-            sprite.OffsetX = selection.Left;
-            sprite.OffsetY = selection.Top;
-            sprite.ImportWidth = selection.Width;
-            sprite.ImportHeight = selection.Height;
-            sprite.ImportAlphaChannel = alpha;
-            sprite.ImportAsTile = tile;
+            DoInsertSprite doInsert = (bmp_, useAlpha_, transparency_, remapColours_, useRoomBackground_) => {
+                Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp_, transparency_, remapColours_, useRoomBackground_, useAlpha_);
+                return sprite;
+            };
+            InsertNewSprite(bmp, doInsert, alpha, remapColours, useRoomBackground, transparency, filename, frame, selection, tile);
         }
 
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
@@ -327,33 +307,12 @@ namespace AGS.Editor.Utils
         public static void ImportNewSprite(SpriteFolder folder, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
             SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
-            // ignore alpha channel if not 32 bit ARGB
-            bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
-                Factory.AGSEditor.CurrentGame.Settings.ColorDepth != GameColorDepth.TrueColor ? false : alpha;
-
-            // ignore palette remap options if not using an indexed palette
-            if (bmp.PixelFormat != PixelFormat.Format8bppIndexed)
-            {
-                remapColours = false;
-                useRoomBackground = false;
-            } 
-
-            // do import
-            Sprite sprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, transparency, remapColours, useRoomBackground, useAlphaChannel);
-            
-            sprite.TransparentColour = transparency;
-            sprite.RemapToGamePalette = remapColours;
-            sprite.RemapToRoomPalette = useRoomBackground;
-            sprite.SourceFile = Utilities.GetRelativeToProjectPath(filename);
-            sprite.Frame = frame;
-            sprite.OffsetX = selection.Left;
-            sprite.OffsetY = selection.Top;
-            sprite.ImportWidth = selection.Width;
-            sprite.ImportHeight = selection.Height;
-            sprite.ImportAlphaChannel = alpha;
-            sprite.ImportAsTile = tile;
-
-            folder.Sprites.Add(sprite);
+            DoInsertSprite doInsert = (bmp_, useAlpha_, transparency_, remapColours_, useRoomBackground_) => {
+                return Factory.NativeProxy.CreateSpriteFromBitmap(bmp_, transparency_, remapColours_, useRoomBackground_, useAlpha_);
+            };
+            Sprite sprite = InsertNewSprite(bmp, doInsert, alpha, remapColours, useRoomBackground, transparency, filename, frame, selection, tile);
+            if (sprite != null)
+                folder.Sprites.Add(sprite);
         }
 
         public static void ImportNewSprites(SpriteFolder folder, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
@@ -410,6 +369,49 @@ namespace AGS.Editor.Utils
 
             progress.Hide();
             progress.Dispose();
+        }
+
+        private delegate Sprite DoInsertSprite(Bitmap bmp, bool useAlpha, SpriteImportTransparency transparency,
+            bool remapColours, bool useRoomBackground);
+
+        /// <summary>
+        /// Prepares new sprite and inserts it into the internal sprite set,
+        /// using provided delegate. Returns null on any failure.
+        /// </summary>
+        private static Sprite InsertNewSprite(Bitmap bmp, DoInsertSprite doInsert,
+            bool alpha, bool remapColours, bool useRoomBackground,
+            SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
+        {
+            // ignore alpha channel if not 32 bit ARGB
+            bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
+                Factory.AGSEditor.CurrentGame.Settings.ColorDepth != GameColorDepth.TrueColor ? false : alpha;
+
+            // ignore palette remap options if not using an indexed palette
+            if (bmp.PixelFormat != PixelFormat.Format8bppIndexed)
+            {
+                remapColours = false;
+                useRoomBackground = false;
+            }
+
+            // do import
+            Sprite sprite = doInsert(bmp, useAlphaChannel, transparency, remapColours, useRoomBackground);
+            if (sprite == null)
+                return null;
+
+            // Assign new sprite's properties
+            sprite.TransparentColour = transparency;
+            sprite.RemapToGamePalette = remapColours;
+            sprite.RemapToRoomPalette = useRoomBackground;
+            sprite.SourceFile = Utilities.GetRelativeToProjectPath(filename);
+            sprite.Frame = frame;
+            sprite.OffsetX = selection.Left;
+            sprite.OffsetY = selection.Top;
+            sprite.ImportWidth = selection.Width;
+            sprite.ImportHeight = selection.Height;
+            sprite.ImportAlphaChannel = alpha;
+            sprite.ImportAsTile = tile;
+
+            return sprite;
         }
 
         private static string ExpandExportPath(object obj, string path)

--- a/Editor/AGS.Native/SpriteFileWriter_NET.cpp
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.cpp
@@ -22,7 +22,7 @@ using AGSString = AGS::Common::String;
 using AGSStream = AGS::Common::Stream;
 
 extern AGSBitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, int *srcPalLen,
-    bool fixColourDepth, bool keepTransparency, int *originalColDepth);
+    bool fixColourDepth, bool importAlpha, bool keepTransparency, int *originalColDepth);
 extern AGSBitmap *CreateNativeBitmap(System::Drawing::Bitmap ^bmp, int spriteImportMethod, bool remapColours,
     bool useRoomBackgroundColours, bool alphaChannel, int *flags);
 
@@ -52,7 +52,7 @@ void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image)
 {
     RGB imgPalBuf[256];
     int importedColourDepth;
-    std::unique_ptr<AGSBitmap> native_bmp(CreateBlockFromBitmap(image, imgPalBuf, nullptr, true, true, &importedColourDepth));
+    std::unique_ptr<AGSBitmap> native_bmp(CreateBlockFromBitmap(image, imgPalBuf, nullptr, true, true /* FIXME */, true, &importedColourDepth));
     _nativeWriter->WriteBitmap(native_bmp.get());
 }
 

--- a/libsrc/allegro/include/allegro/palette.h
+++ b/libsrc/allegro/include/allegro/palette.h
@@ -26,7 +26,7 @@
 typedef struct RGB
 {
    unsigned char r, g, b;
-   unsigned char filler;
+   unsigned char a; /* alpha (if available, otherwise acts as a filler) */
 } RGB;
 
 #define PAL_SIZE     256


### PR DESCRIPTION
This lets Editor to correctly import 8-bit indexed PNGs that have valid alpha component in its palette.
The previous versions of AGS loaded all PNGs as 32-bit images, which solved this problem, but made it impossible to import 8-bit PNGs as actually 8-bit images.
AGS 3.6.2 imports 8-bit PNGs as 8-bit images, but now has opposite problem: if such image has to be converted to a 32-bit sprite (in 32-bit game), the alpha channel becomes lost. First it does not detect the presence of alpha, secondly the process of converting a 8-bit image to a final sprite does not use alpha component at all.
This PR solves these issues.

EDIT: I am not very good at graphic editors, and could not yet find a way to create or export such images.
So i am attaching a sprite provided by the user who got this problem:
[NE-01-SS-000.zip](https://github.com/user-attachments/files/18428839/NE-01-SS-000.zip)
