### PR TITLE
Refactor Character and Object Move functions, optimize WalkStraight

### DIFF
--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -75,8 +75,8 @@ void    Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int op
 void    Character_Think(CharacterInfo *chaa, const char *text);
 void    Character_UnlockView(CharacterInfo *chaa);
 void    Character_UnlockViewEx(CharacterInfo *chaa, int stopMoving);
-void    Character_Walk(CharacterInfo *chaa, int x, int y, int blocking, int direct);
-void    Character_Move(CharacterInfo *chaa, int x, int y, int blocking, int direct);
+void    Character_Walk(CharacterInfo *chaa, int x, int y, int blocking, int ignwal);
+void    Character_Move(CharacterInfo *chaa, int x, int y, int blocking, int ignwal);
 void    Character_WalkStraight(CharacterInfo *chaa, int xx, int yy, int blocking);
 
 void    Character_RunInteraction(CharacterInfo *chaa, int mood);
@@ -174,7 +174,6 @@ void animate_character(CharacterInfo *chap, int loopn, int sppd, int rept,
     int direction = 0, int sframe = 0, int volume = 100);
 // Clears up animation parameters
 void stop_character_anim(CharacterInfo *chap);
-void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims);
 int  find_looporder_index (int curloop);
 // returns 0 to use diagonal, 1 to not
 int  useDiagonal (CharacterInfo *char1);
@@ -189,12 +188,15 @@ int  doNextCharMoveStep(CharacterInfo *chi, CharacterExtras *chex);
 bool is_char_walking_ndirect(CharacterInfo *chi);
 int  find_nearest_walkable_area_within(int *xx, int *yy, int range, int step);
 void find_nearest_walkable_area (int *xx, int *yy);
-void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims);
 void FindReasonableLoopForCharacter(CharacterInfo *chap);
-// Start character walk or move
-void walk_or_move_character(CharacterInfo *chaa, int x, int y, int blocking, int direct, bool isWalk);
-// Start character walk or move along the straight line without pathfinding, until any non-passable area is met
-void walk_or_move_character_straight(CharacterInfo *chaa, int x, int y, int blocking, int direct, bool isWalk);
+// Start character walk or move; calculate path using destination and optionally "ignore walls" flag
+void move_character(CharacterInfo *chaa, int tox, int toy, bool ignwal, bool walk_anim);
+// Start character walk or move along the straight line until any non-passable area is met
+void move_character_straight(CharacterInfo *chaa, int x, int y, bool walk_anim);
+// Start character walk; calculate path using destination and optionally "ignore walls" flag
+void walk_character(CharacterInfo *chaa, int tox, int toy, bool ignwal);
+// Start character walk the straight line until any non-passable area is met
+void walk_character_straight(CharacterInfo *chaa, int tox, int toy);
 int  wantMoveNow (CharacterInfo *chi, CharacterExtras *chex);
 void setup_player_character(int charid);
 Common::Bitmap *GetCharacterImage(int charid, bool *is_original = nullptr);
@@ -229,6 +231,10 @@ Rect GetCharacterRoomBBox(int charid, bool use_frame_0 = false);
 // or the one that is least far away from its camera; calculated as a perpendicular distance between two AABBs.
 PViewport FindNearestViewport(int charid);
 
+// Character_DoMove converts and validates script parameters, and calls corresponding internal character move function
+void Character_DoMove(CharacterInfo *chaa, const char *api_name,
+    int x, int y, bool walk_straight, int blocking, int ignwal, bool walk_anim);
+
 //
 // Character update functions
 // TODO: move these into a runtime Character class, when there will be a proper one,
@@ -246,6 +252,6 @@ extern CharacterInfo*playerchar;
 extern int32_t _sc_PlayerCharPtr;
 
 // order of loops to turn character in circle from down to down
-extern int turnlooporder[8];
+extern const int turnlooporder[8];
 
 #endif // __AGS_EE_AC__CHARACTER_H

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -420,7 +420,7 @@ void UpdateCharacterFollower(CharacterInfo *chi, std::vector<int> &followingAsSh
             chi->room = -play.follow_change_room_timer;
           }
           if (chi->room >= 0) {
-            walk_character(chi->index_id, play.entered_at_x,play.entered_at_y,1, true);
+            walk_character(chi, play.entered_at_x, play.entered_at_y, true /* ignwal */);
             doing_nothing = 0;
           }
         }
@@ -437,8 +437,9 @@ void UpdateCharacterFollower(CharacterInfo *chi, std::vector<int> &followingAsSh
         // make sure he's not standing on top of the other man
         if (goxoffs < 0) goxoffs-=distaway;
         else goxoffs+=distaway;
-        walk_character(chi->index_id, game.chars[following].x + goxoffs,
-          game.chars[following].y + (Random(50)-25),0, true);
+        walk_character(chi, game.chars[following].x + goxoffs,
+          game.chars[following].y + (Random(50) - 25), false /* walk areas */);
+
         doing_nothing = 0;
       }
     }

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -202,24 +202,36 @@ void SetCharacterIgnoreLight (int who, int yesorno) {
     Character_SetIgnoreLighting(&game.chars[who], yesorno);
 }
 
+void MoveCharacter(int cc,int x, int y)
+{
+    if (!is_valid_character(cc))
+        quit("!MoveCharacter: invalid character specified");
 
-
-
-void MoveCharacter(int cc,int xx,int yy) {
-    walk_character(cc,xx,yy,0, true);
+    Character_DoMove(&game.chars[cc], "MoveCharacter", x, y,
+                     false /* not straight */, IN_BACKGROUND, WALKABLE_AREAS, true /* animate */);
 }
-void MoveCharacterDirect(int cc,int xx, int yy) {
-    walk_character(cc,xx,yy,1, true);
+
+void MoveCharacterDirect(int cc, int x, int y)
+{
+    if (!is_valid_character(cc))
+        quit("!MoveCharacterDirect: invalid character specified");
+
+    Character_DoMove(&game.chars[cc], "MoveCharacterDirect", x, y,
+                     false /* not straight */, IN_BACKGROUND, ANYWHERE, true /* animate */);
 }
-void MoveCharacterStraight(int cc,int xx, int yy) {
+
+void MoveCharacterStraight(int cc,int x, int y)
+{
     if (!is_valid_character(cc))
         quit("!MoveCharacterStraight: invalid character specified");
 
-    Character_WalkStraight(&game.chars[cc], xx, yy, IN_BACKGROUND);
+    Character_DoMove(&game.chars[cc], "MoveCharacterStraight", x, y,
+                     true /* straight */, IN_BACKGROUND, WALKABLE_AREAS, true /* animate */);
 }
 
 // Append to character path
-void MoveCharacterPath (int chac, int tox, int toy) {
+void MoveCharacterPath(int chac, int tox, int toy)
+{
     if (!is_valid_character(chac))
         quit("!MoveCharacterPath: invalid character specified");
 
@@ -313,44 +325,37 @@ void SetCharacterIgnoreWalkbehinds (int cha, int clik) {
 }
 
 
-void MoveCharacterToObject(int chaa,int obbj) {
+void MoveCharacterToObject(int chaa,int obbj)
+{
     // invalid object, do nothing
     // this allows MoveCharacterToObject(EGO, GetObjectAt(...));
     if (!is_valid_object(obbj))
         return;
 
-    walk_character(chaa,objs[obbj].x+5,objs[obbj].y+6,0, true);
-
-    GameLoopUntilNotMoving(&game.chars[chaa].walking);
+    // NOTE: yep, it was using a hardcoded +5,+6 relative position...
+    Character_DoMove(&game.chars[chaa], "MoveCharacterToObject", objs[obbj].x + 5, objs[obbj].y + 6,
+                     false /* not straight */, BLOCKING, WALKABLE_AREAS, true /* animate */);
 }
 
-void MoveCharacterToHotspot(int chaa,int hotsp) {
+void MoveCharacterToHotspot(int chaa, int hotsp)
+{
     if ((hotsp<0) || (hotsp>=MAX_ROOM_HOTSPOTS))
         quit("!MovecharacterToHotspot: invalid hotspot");
-    if (thisroom.Hotspots[hotsp].WalkTo.X<1) return;
-    walk_character(chaa,thisroom.Hotspots[hotsp].WalkTo.X,thisroom.Hotspots[hotsp].WalkTo.Y,0, true);
+    if (thisroom.Hotspots[hotsp].WalkTo.X < 1)
+        return;
 
-    GameLoopUntilNotMoving(&game.chars[chaa].walking);
+    Character_DoMove(&game.chars[chaa], "MoveCharacterToObject", thisroom.Hotspots[hotsp].WalkTo.X, thisroom.Hotspots[hotsp].WalkTo.Y,
+                     false /* not straight */, BLOCKING, WALKABLE_AREAS, true /* animate */);
 }
 
-int MoveCharacterBlocking(int chaa,int xx,int yy,int direct) {
+int MoveCharacterBlocking(int chaa, int x, int y, int ignwal)
+{
     if (!is_valid_character (chaa))
         quit("!MoveCharacterBlocking: invalid character");
 
-    // check if they try to move the player when Hide Player Char is
-    // ticked -- otherwise this will hang the game
-    if (game.chars[chaa].on != 1)
-    {
-        debug_script_warn("MoveCharacterBlocking: character is turned off (is Hide Player Character selected?) and cannot be moved");
-        return 0;
-    }
+    Character_DoMove(&game.chars[chaa], "MoveCharacterBlocking", x, y,
+                     false /* not straight */, BLOCKING, ignwal, true /* animate */);
 
-    if (direct)
-        MoveCharacterDirect(chaa,xx,yy);
-    else
-        MoveCharacter(chaa,xx,yy);
-
-    GameLoopUntilNotMoving(&game.chars[chaa].walking);
     return -1; // replicates legacy engine effect
 }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -890,7 +890,7 @@ void RoomProcessClick(int xx,int yy,int mood) {
             yy=thisroom.Hotspots[hsnum].WalkTo.Y;
             debug_script_log("Move to walk-to point hotspot %d", hsnum);
         }
-        walk_character(game.playercharacter,xx,yy,0, true);
+        walk_character(playerchar, xx, yy, false /* walk areas */);
         return;
     }
     play.usedmode=mood;

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -799,6 +799,30 @@ bool CycleViewAnim(int view, uint16_t &o_loop, uint16_t &o_frame, bool forwards,
     return !done; // have we finished animating?
 }
 
+void ValidateMoveParams(const char *apiname, int &blocking, int &ignwal)
+{
+    if (blocking == BLOCKING)
+        blocking = 1;
+    else if (blocking == IN_BACKGROUND)
+        blocking = 0;
+
+    if (ignwal == ANYWHERE)
+        ignwal = 1;
+    else if (ignwal == WALKABLE_AREAS)
+        ignwal = 0;
+
+    if ((blocking < 0) || (blocking > 1))
+    {
+        debug_script_warn("%s: invalid 'blocking' value %d, will treat as BLOCKING (1)", apiname, blocking);
+        blocking = 1;
+    }
+    if ((ignwal < 0) || (ignwal > 1))
+    {
+        debug_script_warn("%s: invalid 'walk where' value %d, will treat as ANYWHERE (1)", apiname, ignwal);
+        ignwal = 1;
+    }
+}
+
 //=============================================================================
 //
 // Script API Functions

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -306,20 +306,14 @@ bool Object_IsInteractionAvailable(ScriptObject *oobj, int mood) {
     return (ciwas == 2);
 }
 
-void Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int direct) {
-    if ((direct == ANYWHERE) || (direct == 1))
-        direct = 1;
-    else if ((direct == WALKABLE_AREAS) || (direct == 0))
-        direct = 0;
-    else
-        quit("Object.Move: invalid DIRECT parameter");
+void Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int ignwal)
+{
+    ValidateMoveParams("Object.Move", blocking, ignwal);
 
-    move_object(objj->id, x, y, speed, direct);
+    move_object(objj->id, x, y, speed, ignwal);
 
-    if ((blocking == BLOCKING) || (blocking == 1))
+    if (blocking)
         GameLoopUntilNotMoving(&objs[objj->id].moving);
-    else if ((blocking != IN_BACKGROUND) && (blocking != 0))
-        quit("Object.Move: invalid BLOCKING paramter");
 }
 
 void Object_SetClickable(ScriptObject *objj, int clik) {

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -61,7 +61,7 @@ void    Object_SetY(ScriptObject *objj, int yy);
 void    Object_GetName(ScriptObject *objj, char *buffer);
 const char* Object_GetName_New(ScriptObject *objj);
 bool    Object_IsInteractionAvailable(ScriptObject *oobj, int mood);
-void    Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int direct);
+void    Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int ignwal);
 void    Object_SetClickable(ScriptObject *objj, int clik);
 int     Object_GetClickable(ScriptObject *objj);
 void    Object_SetIgnoreScaling(ScriptObject *objj, int newval);

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -116,7 +116,10 @@ int     SetFirstAnimFrame(int view, int loop, int sframe, int direction);
 // loop and frame values are passed by reference and will be updated;
 // returns whether the animation should continue.
 bool    CycleViewAnim(int view, uint16_t &loop, uint16_t &frame, bool forwards, int repeat);
-void    CheckViewFrameForObject(RoomObject *obj);
+
+// Tests if the standard move/walk parameters are in valid range, if not then clamps them and
+// reports a script warning.
+void    ValidateMoveParams(const char *apiname, int &blocking, int &ignwal);
 
 #endif // __AGS_EE_AC__OBJECT_H
 


### PR DESCRIPTION
Fixes #1879, along the way.

This is a backport of a code refactor from ags4, that tidies up Character and Object Move and Walk functions, bringing them to consistency of parameter checking and delegating actual work to the internal implementation.
Except here I also did this for deprecated script functions.

The second change is, this optimizes WalkStraight function by not running a pathfinder with "anywhere" parameter. Instead makes it use result of previously called CanSeeFrom method, which is already supposed to tell a walkable path.

As a side effect, this makes WalkStraight also use the position fixup in StopMoving, where engine calls PlaceOnWalkableArea in case character ended up on a non-walkable area by mistake.

NOTE: I was considering writing a different algorithm to use here instead of PlaceOnWalkableArea, but decided to leave this for later. And there's a small concern about backwards compatibility, because it's known that changes in pathfinding may break some old games relying on exact character positions. Maybe we could still do that in AGS 4. I left a comment there about my idea.