### PR TITLE
New compiler: Initializers for global classic arrays and structs

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -215,7 +215,7 @@ bool AGS::Snippet::IsEmpty()
 
 void AGS::RestorePoint::Cut(Snippet &snippet, bool const keep_starting_linum)
 {
-    int32_t const orig_codesize = _scrip.Codesize_i32();
+    CodeLoc const orig_codesize = _scrip.Codesize_i32();
 
     // Reset the code to the remembered location.
     CodeLoc rcl = _rememberedCodeLocation;

--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -82,7 +82,7 @@ AGS::GlobalLoc AGS::ccCompiledScript::AddGlobal(size_t const value_size, void *v
 {
     assert(globaldata.size() + value_size <= INT32_MAX);
     if (0u == value_size)
-        return static_cast<int32_t>(globaldata.size()); // nothing to do
+        return static_cast<GlobalLoc>(globaldata.size()); // nothing to do
 
     // The new global variable will be moved to &(globaldata[offset])
     size_t const offset = globaldata.size();

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -787,12 +787,15 @@ bool AGS::SymbolTable::IsOldstring(Symbol s) const
     Vartype const s_without_const =
         VartypeWithout(VTT::kConst, s);
 
-    // string and const string are oldstrings
+    // 'string' and 'const string' are oldstrings
     if (kKW_String == s_without_const)
         return true;
 
-    // const char[..] and char[..] are considered oldstrings, too
-    return (IsArrayVartype(s) && kKW_Char == VartypeWithout(VTT::kArray, s_without_const));
+    // 'char'[..] considered oldstring, too
+    return
+        IsArrayVartype(s) &&
+        1u == ArrayDimensionsCount(s) &&
+        kKW_Char == VartypeWithout(VTT::kArray, s_without_const);
 }
 
 AGS::Symbol AGS::SymbolTable::Add(std::string const &name)

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -499,7 +499,9 @@ public:
 
     // Arrays and variables that are arrays
     // The "Array[...] of vartype" vartype
-    Vartype VartypeWithArray(std::vector<size_t> const &dims, AGS::Vartype vartype);
+    Vartype VartypeWithArray(std::vector<size_t> const &dims, Vartype vartype);
+    // The array without the first dimension 'a[3, 5]' -> 'a[5]'
+    Vartype ArrayVartypeWithoutFirstDim(Vartype vartype);
     // The "Const of vartype" vartype
     Vartype VartypeWithConst(AGS::Vartype vartype);
     // The "Dynarray of vartype" vartype

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -511,6 +511,8 @@ public:
 
     inline bool IsArrayVartype(Symbol s) const { return IsVTT(s, VTT::kArray); }
     size_t ArrayElementsCount(Symbol s) const;
+    size_t ArrayDimensionsCount(Symbol s) const
+        { return entries.at(s).VartypeD ? entries.at(s).VartypeD->Dims.size() : 0u; }
     inline bool IsDynarrayVartype(Symbol s) const { return IsVTT(s, VTT::kDynarray); }
     inline bool IsAnyArrayVartype(Symbol s) const { return IsArrayVartype(s) || IsDynarrayVartype(s); }
     

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -227,7 +227,7 @@ struct FuncParameterDesc
     AGS::Vartype Vartype = kKW_NoSymbol;
     Symbol Name = kKW_NoSymbol;
     Symbol Default = kKW_NoSymbol;
-    size_t Declared;
+    size_t Declared = SIZE_MAX;
 };
 
 struct SymbolTable;

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1723,7 +1723,7 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
         return false;
 
 
-    // Can convert null to dynpointer or dynarray
+    // Can convert 'null' to dynpointer or dynarray
     if (kKW_Null == vartype_is)
         return
             !_sym.IsDynpointerVartype(vartype_wants_to_be) &&
@@ -1733,14 +1733,14 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
     if (_sym.IsDynarrayVartype(vartype_is) != _sym.IsDynarrayVartype(vartype_wants_to_be))
         return true;
 
-    // can convert String * to const string
+    // Can convert 'String *' to 'const string'
     if (_sym.GetStringStructSym() == _sym.VartypeWithout(VTT::kDynpointer, vartype_is) &&
         kKW_String == _sym.VartypeWithout(VTT::kConst, vartype_wants_to_be))
     {
         return false;
     }
 
-    // can convert string or const string to String *
+    // Can convert 'string' or 'const string' to 'String *'
     if (kKW_String == _sym.VartypeWithout(VTT::kConst, vartype_is) &&
         _sym.GetStringStructSym() == _sym.VartypeWithout(VTT::kDynpointer, vartype_wants_to_be))
     {
@@ -1767,11 +1767,11 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
     vartype_is = _sym.VartypeWithout(VTT::kConst, vartype_is);
     vartype_wants_to_be = _sym.VartypeWithout(VTT::kConst, vartype_wants_to_be);
 
-    // floats cannot mingle with other types
+    // 'float's cannot mingle with other types
     if ((vartype_is == kKW_Float) != (vartype_wants_to_be == kKW_Float))
         return true;
 
-    // Can convert short, char etc. into int
+    // Can convert 'short', 'char' etc. into 'int'
     if (_sym.IsAnyIntegerVartype(vartype_is) && kKW_Int == vartype_wants_to_be)
         return false;
 
@@ -1783,7 +1783,7 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
             return false;
 
         // Array types must match exactly. We can't allow a 'child*[]' to be
-        // assigned to 'pareent[]' without additional dynamic type checking
+        // assigned to 'parent*[]' without additional dynamic type checking
         Symbol const core_wants_to_be = _sym.VartypeWithout(VTT::kDynarray, vartype_wants_to_be);
         Symbol const core_is = _sym.VartypeWithout(VTT::kDynarray, vartype_is);
         
@@ -3916,17 +3916,14 @@ void AGS::Parser::AccessData(VariableAccess access_type, SrcList &expression, Ev
     }
 }
 
-// Insert Bytecode for:
-// Copy at most OLDSTRING_LENGTH - 1 bytes from m[MAR...] to m[AX...]
-// Stop when encountering a 0
-void AGS::Parser::AccessData_StrCpy()
+void AGS::Parser::AccessData_StrCpy(size_t count)
 {
     BackwardJumpDest loop_start(_scrip);
     ForwardJump out_of_loop(_scrip);
 
     WriteCmd(SCMD_REGTOREG, SREG_AX, SREG_CX); // CX = dest
     WriteCmd(SCMD_REGTOREG, SREG_MAR, SREG_BX); // BX = src
-    WriteCmd(SCMD_LITTOREG, SREG_DX, STRINGBUFFER_LENGTH - 1); // DX = count
+    WriteCmd(SCMD_LITTOREG, SREG_DX, count - 1); // DX = counter
     loop_start.Set();   // Label LOOP_START
     WriteCmd(SCMD_REGTOREG, SREG_BX, SREG_MAR); // AX = m[BX]
     WriteCmd(SCMD_MEMREAD, SREG_AX);
@@ -3949,8 +3946,8 @@ void AGS::Parser::AccessData_StrCpy()
 
 void AGS::Parser::AccessData_AssignTo(SrcList &expression, EvaluationResult const &eres)
 {
-    // We'll evaluate expression later on which moves the cursor,
-    // so save it here and restore later on
+    // We'll evaluate 'expression' later on, which will
+    // move the cursor, so save it here and restore it later
     size_t const end_of_rhs_cursor = _src.GetCursor();
 
     EvaluationResult rhs_eres = eres;
@@ -4013,7 +4010,7 @@ void AGS::Parser::AccessData_AssignTo(SrcList &expression, EvaluationResult cons
     if (kKW_String == lhs_eres.Vartype && kKW_String == _sym.VartypeWithout(VTT::kConst, rhs_eres.Vartype))
     {
         // copy the string contents over.
-        AccessData_StrCpy();
+        AccessData_StrCpy(STRINGBUFFER_LENGTH);
         _src.SetCursor(end_of_rhs_cursor); // move cursor back to end of RHS
         return;
     }
@@ -4565,7 +4562,7 @@ void AGS::Parser::ParseVardecl_Local(Symbol var_name, Vartype vartype)
     WriteCmd(SCMD_LOADSPOFFS, 0);
     _reg_track.SetRegister(SREG_MAR);
     if (kKW_String == _sym.VartypeWithout(VTT::kConst, lhsvartype))
-        AccessData_StrCpy();
+        AccessData_StrCpy(STRINGBUFFER_LENGTH);
     else
         WriteCmd(
             is_dyn ? SCMD_MEMWRITEPTR : GetWriteCommandForSize(var_size),

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2702,7 +2702,7 @@ std::string const AGS::Parser::ReferenceMsgLoc(std::string const &msg, size_t de
     std::string const &section = _src.SectionId2Section(section_id);
 
     int const line = _src.GetLinenoAt(declared);
-    if (line <= 0 || (!section.empty() && '_' == section[0]))
+    if (line <= 0 || (!section.empty() && '_' == section[0u]))
         return msg;
 
     std::string tpl;
@@ -6898,19 +6898,19 @@ void AGS::Parser::Parse_BlankOutUnusedImports()
         if (_sym[entries_idx].Accessed)
             continue;
 
-        // Don't "compact" the entries in the _scrip.imports[] array. They are referenced by index, and if you
+        // Don't "compact" the entries in '_scrip.imports[]'. They are referenced by index, and if you
         // change the indexes of the entries then you get dangling "references". So the only thing allowed is
         // setting unused import entries to "".
         if (_sym.IsFunction(entries_idx))
         {
             if(_sym[entries_idx].FunctionD->TypeQualifiers[TQ::kImport])
-                _scrip.imports[_sym[entries_idx].FunctionD->Offset][0] = '\0';
+                _scrip.imports[_sym[entries_idx].FunctionD->Offset].clear();
             continue;
         }
         if (_sym.IsVariable(entries_idx))
         {
             if (_sym[entries_idx].VariableD->TypeQualifiers[TQ::kImport])
-                _scrip.imports[_sym[entries_idx].VariableD->Offset][0] = '\0';
+                _scrip.imports[_sym[entries_idx].VariableD->Offset].clear();
             continue;
         }
     }
@@ -7028,7 +7028,7 @@ void AGS::Parser::Parse_CheckFixupSanity()
                 fixup_idx,
                 code_idx);
         int const cv = _scrip.code[code_idx];
-        if (cv < 0 || static_cast<size_t>(cv) >= _scrip.imports.size() || '\0' == _scrip.imports[cv][0])
+        if (cv < 0 || static_cast<size_t>(cv) >= _scrip.imports.size() || _scrip.imports[cv].empty())
             InternalError(
                 "Fixup #%d references non-existent import #%d",
                 fixup_idx,

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2659,10 +2659,7 @@ void AGS::Parser::ParseExpression_Binary(size_t const op_idx, SrcList &expressio
     }
  
     if (ParseExpression_CompileTime(operator_sym, eres_lhs, eres_rhs, eres))
-        // Don't keep the starting LINUM:
-        // This code may run within the global data section, when a global is initialized,
-        // and that starting LINUM will be superfluous, outside of a function body.
-        start_of_term.Restore(false);
+        start_of_term.Restore();
 }
 
 void AGS::Parser::ParseExpression_CheckUsedUp(SrcList &expression)
@@ -4227,7 +4224,11 @@ void AGS::Parser::ParseAssignment_MAssign(Symbol const ass_symbol, SrcList &lhs)
 void AGS::Parser::ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype const wanted_vartype, std::vector<char> &initial_val)
 {
     EvaluationResult eres;
+    // Parse an expression making sure that no code is generated,
+    // not even LINUM directives (we are outside of a function body)
+    RestorePoint rp(_scrip);
     ParseExpression(_src, eres);
+    rp.Restore(false);
     
     if (eres.kTY_Literal != eres.Type)
         UserError("Cannot evaluate this expression at compile time, it cannot be used as initializer");
@@ -4236,7 +4237,7 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype co
 
     if ((kKW_Float == wanted_vartype) != (kKW_Float == eres.Vartype))
         UserError(
-            "Expected a '%s' value after '=' but found a '%s' value instead",
+            "Expected a '%s' value as an initializer but found a '%s' value instead",
             _sym.GetName(wanted_vartype).c_str(),
             _sym.GetName(eres.Vartype).c_str());
     
@@ -4251,10 +4252,10 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype co
         initial_val[0] = litval;
         return;
     case 2u:
-        (reinterpret_cast<int16_t *> (&initial_val[0]))[0] = litval;
+        (reinterpret_cast<int16_t *> (initial_val.data()))[0] = litval;
         return;
     case 4u:
-        (reinterpret_cast<int32_t *> (&initial_val[0]))[0] = litval;
+        (reinterpret_cast<int32_t *> (initial_val.data()))[0] = litval;
         return;
     }
 }
@@ -4281,14 +4282,14 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_Struct(Vartype const vartype
     // Data that we need to track for each (direct or indirect) component of 'vartype'
     struct ComponentFields
     {
-        Symbol Component; // without the qualifier
-        Symbol QualifiedName;
-        size_t Offset;
-        AGS::Vartype Vartype;
-        bool IsFunction;
-        bool IsAttribute;
-        std::vector<char> InitialVal;
-        size_t InitialValDeclared;
+        Symbol Component = kKW_NoSymbol; // without the qualifier
+        Symbol QualifiedName = kKW_NoSymbol;
+        size_t Offset = 0u;
+        AGS::Vartype Vartype = kKW_NoSymbol;
+        bool IsFunction = false;
+        bool IsAttribute = false;
+        std::vector<char> InitialVal = {};
+        size_t InitialValDeclared = SIZE_MAX;
     };
     std::vector<ComponentFields> fields = {};
 
@@ -4394,8 +4395,8 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_Array_Named(size_t const fir
 {
     struct init_record
     {
-        size_t Declared; // Where in _src the initial value was specified
-        std::vector<char> InitialVal;
+        size_t Declared = SIZE_MAX; // Where in _src the initial value was specified
+        std::vector<char> InitialVal = {};
     };
     std::unordered_map<size_t, init_record> inits;
 
@@ -4410,7 +4411,11 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_Array_Named(size_t const fir
                 _sym.GetName(bracket).c_str());
         EvaluationResult eres;
         size_t const array_index_start = _src.GetCursor();
+        // Parse an integer expression making sure that no code is generated
+        // not even LINUM directives (we are outside of a function body)
+        RestorePoint rp(_scrip);
         ParseIntegerExpression(_src, eres, "Expected an array index");
+        rp.Restore(false);
         if (EvaluationResult::kLOC_SymbolTable != eres.Location)
         {
             _src.SetCursor(array_index_start);
@@ -4755,7 +4760,7 @@ void AGS::Parser::ParseVardecl_Global(Symbol var_name, Vartype vartype)
     
     SymbolTableEntry &entry = _sym[var_name];
     entry.VariableD->Vartype = vartype;
-    int const global_offset = _scrip.AddGlobal(vartype_size, &initial_val[0]);
+    int const global_offset = _scrip.AddGlobal(vartype_size, initial_val.data());
     if (global_offset < 0)
         InternalError("Cannot allocate global variable");
 

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -767,14 +767,28 @@ private:
     void ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype var, std::vector<char> &initial_val);
 
     // Assign a string literal to a char array or a 'string'
-    void ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
+    // 'available_space' means the _total_ available space
+    // counting the string-terminating '\0'.
+    void ParseVardecl_InitialValAssignment_ArrayOrStringBuf_Literal(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
 
+    // Initial assignment to a global non-managed struct
+    void ParseVardecl_InitialValAssignment_Struct(Vartype vartype, std::vector<char> &initial_val);
+
+    // Initialize a static array by specifying named entries of the form '[idx]: value'
+    // Starting '{' has already been eaten
+    void ParseVardecl_InitialValAssignment_Array_Named(size_t first_dim_size, Vartype el_vartype, std::vector<char> &initial_val);
+
+    // Initialize a static array by specifying a sequence of (unnamed) entries
+    // Starting '{' has already been eaten
+    void ParseVardecl_InitialValAssignment_Array_Sequence(size_t first_dim_size, Vartype el_vartype, std::vector<char> &initial_val);
+
+    // Initial assignment to a global classic array
     void ParseVardecl_InitialValAssignment_Array(Vartype vartype, std::vector<char> &initial_val);
 
-    void ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val);
+    void ParseVardecl_InitialValAssignment_StringBuf(std::vector<char> &initial_val);
 
-    // Parse the assignment of an initial value to a variable. 
-    void ParseVardecl_InitialValAssignment(Symbol varname, std::vector<char> &initial_val);
+    // Parse the assignment of an initial value. 'vartype' is the vartype of the assigned entity.
+    void ParseVardecl_InitialValAssignment(Vartype vartype, std::vector<char> &initial_val);
 
     // Move variable information into the symbol table
     void ParseVardecl_Var2SymTable(Symbol var_name, Vartype vartype);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -737,9 +737,9 @@ private:
     void AccessData(VariableAccess access_type, SrcList &expression, EvaluationResult &eres);
 
     // Emit Bytecode for:
-    // Copy at most 'STRINGBUFFER_LENGT-1' bytes from 'm[MAR...]' to 'm[AX...]'
-    // Stop when encountering a 0
-    void AccessData_StrCpy();
+    // Copy at most 'count - 1' bytes from m[MAR...] to m[AX...],
+    // add '\0' at end of copy so 'count' bytes are processed in all
+    void AccessData_StrCpy(size_t count);
 
     // An optional '*' can follow at this point. If it is here, eat it.
     void EatDynpointerSymbolIfPresent(Vartype vartype);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -766,6 +766,11 @@ private:
 
     void ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype var, std::vector<char> &initial_val);
 
+    // Assign a string literal to a char array or a 'string'
+    void ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
+
+    void ParseVardecl_InitialValAssignment_Array(Vartype vartype, std::vector<char> &initial_val);
+
     void ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val);
 
     // Parse the assignment of an initial value to a variable. 

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -2921,8 +2921,8 @@ TEST_F(Bytecode0, Struct11_NoRTTI) {
 
     // WriteOutput("Struct11_NoRtti", scrip);
 
-    size_t const codesize = 75;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 75;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   19,   38,    0,           36,   20,   73,    3,    // 7
@@ -2936,30 +2936,32 @@ TEST_F(Bytecode0, Struct11_NoRTTI) {
        7,    3,   30,    4,           11,    4,    3,    3,    // 71
        4,    3,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 5;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 5;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      11,   18,   37,   47,         60,  -999
-    };
+      11,   18,   37,   47,         60, };
     char fixuptypes[] = {
-      4,   4,   4,   4,      4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       4,    4,    4,    4,          4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 1;
+    int const non_empty_imports_count = 1;
     std::string imports[] = {
-    "SS",           "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "SS", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct11_RTTI) {
@@ -3000,9 +3002,9 @@ TEST_F(Bytecode0, Struct11_RTTI) {
     std::string const &err_msg = mh.GetError().Message;
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
-    // WriteOutput("Struct11_NoRtti", scrip);
-    size_t const codesize = 76;
-    EXPECT_EQ(codesize, scrip.code.size());
+    // WriteOutput("Struct11_Rtti", scrip);
+    size_t const code_size = 76;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   19,   38,    0,           36,   20,   74,    3,    // 7
@@ -3016,30 +3018,32 @@ TEST_F(Bytecode0, Struct11_RTTI) {
        6,    7,    3,   30,            4,   11,    4,    3,    // 71
        3,    4,    3,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 5;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 5;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      12,   19,   38,   48,         61,  -999
-    };
+      12,   19,   38,   48,         61, };
     char fixuptypes[] = {
-      4,   4,   4,   4,      4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       4,    4,    4,    4,          4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 1;
+    int const non_empty_imports_count = 1;
     std::string imports[] = {
-    "SS",           "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "SS", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct12) {

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -13,13 +13,15 @@
 //=============================================================================
 #include <string>
 #include <fstream>
+#include <sstream>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "script2/cc_compiledscript.h"
 
 #include "cc_bytecode_test_lib.h"
 
-std::string Esc(const char ch)
+static std::string Esc(char const ch)
 {
     if (ch >= ' ' && ch <= 126)
     {
@@ -30,10 +32,11 @@ std::string Esc(const char ch)
     {
     default:
     {
-        static const char *tohex = "0123456789abcdef";
+        static char const *tohex = "0123456789abcdef";
+        unsigned char uch = static_cast<unsigned char>(ch);
         std::string ret = "\\x";
-        ret.push_back(tohex[ch / 16]);
-        ret.push_back(tohex[ch % 16]);
+        ret.push_back(tohex[uch / 16u]);
+        ret.push_back(tohex[uch % 16u]);
         return ret;
     }
     case '\a': return "\\a";
@@ -48,7 +51,7 @@ std::string Esc(const char ch)
     }
 }
 
-std::string EscapeString(const char *in)
+static std::string EscapeString(char const *in)
 {
     if (in == nullptr)
         return "0";
@@ -60,12 +63,12 @@ std::string EscapeString(const char *in)
     return "\"" + ret + "\"";
 }
 
-void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const codesize = " << scrip.code.size() << ";" << std::endl;
-    of << "EXPECT_EQ(codesize, scrip.code.size());" << std::endl << std::endl;
+    of << "size_t const code_size = " << scrip.code.size() << ";" << std::endl;
+    of << "EXPECT_EQ(code_size, scrip.code.size());" << std::endl << std::endl;
 
-    if (scrip.code.size() == 0)
+    if (scrip.code.empty())
         return;
 
     of << "int32_t code[] = {" << std::endl;
@@ -78,15 +81,14 @@ void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
     }
     of << " -999 " << std::endl << "};" << std::endl;
 
-    of << "CompareCode(&scrip, codesize, code);" << std::endl << std::endl;
+    of << "CompareCode(&scrip, code_size, code);" << std::endl << std::endl;
 }
 
-void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[])
+void CompareCode(AGS::ccCompiledScript *scrip, size_t code_size, int32_t code[])
 {
-    for (size_t idx = 0; idx < codesize; idx++)
+    code_size = std::min(code_size, scrip->code.size());
+    for (size_t idx = 0u; idx < code_size; idx++)
     {
-         if (idx >= scrip->code.size())
-             break;
          std::string prefix = "code[" + std::to_string(idx) + "] == ";
          std::string should_be_val = prefix + std::to_string(code[idx]);
          std::string is_val = prefix + std::to_string(scrip->code[idx]);
@@ -94,51 +96,53 @@ void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[])
     }
 }
 
-void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const numfixups = " << scrip.fixups.size() << ";" << std::endl;
-    of << "EXPECT_EQ(numfixups, scrip.fixups.size());" << std::endl << std::endl;
+    size_t const fixups_size = scrip.fixups.size();
+    of << "size_t const fixups_size = " << fixups_size << ";" << std::endl;
+    of << "ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());" << std::endl;
+    of << "EXPECT_EQ(fixups_size, scrip.fixups.size());" << std::endl << std::endl;
 
-    if (scrip.fixups.size() == 0)
+    if (scrip.fixups.empty())
         return;
 
     of << "int32_t fixups[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.fixups.size(); idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
         of.width(4);
         of << scrip.fixups[idx] << ", ";
-        if (idx % 8 == 3) of << "      ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "      ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
     of << " -999 " << std::endl << "};" << std::endl;
     
     of << "char fixuptypes[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.fixups.size(); idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
         of.width(3);
         of << static_cast<int>(scrip.fixuptypes[idx]) << ", ";
-        if (idx % 8 == 3) of << "   ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "   ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
     of << " '\\0' " << std::endl << "};" << std::endl;
 
-    of << "CompareFixups(&scrip, numfixups, fixups, fixuptypes);" << std::endl << std::endl;
+    of << "CompareFixups(&scrip, fixups_size, fixups, fixuptypes);" << std::endl << std::endl;
 }
 
-void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixups[], char fixuptypes[])
+void CompareFixups(AGS::ccCompiledScript *scrip, size_t fixups_size, int32_t fixups[], char fixuptypes[])
 {
-    for (size_t idx = 0; idx < numfixups; idx++)
+    fixups_size = std::min(fixups_size, scrip->fixups.size());
+
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-         if (idx >= scrip->fixups.size()) break;
          std::string const prefix = "fixups[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(fixups[idx]);
          std::string const is_val = prefix + std::to_string(scrip->fixups[idx]);
          ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
     }
 
-    for (size_t idx = 0; idx < numfixups; idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-         if (static_cast<int>(idx) >= scrip->fixups.size()) break;
          std::string const prefix = "fixuptypes[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(fixuptypes[idx]);
          std::string const is_val = prefix + std::to_string(scrip->fixuptypes[idx]);
@@ -146,94 +150,110 @@ void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixup
     }
 }
 
-void WriteOutputImports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputImports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    // Unfortunately, imports can contain empty strings that
-    // mustn't be counted. So we can't just believe numimports,
-    // and we can't check against scrip.numimports.
-    size_t realNumImports = 0;
-    for (size_t idx = 0; idx < scrip.imports.size(); idx++)
-        if (0 != strcmp(scrip.imports[idx].c_str(), ""))
-            ++realNumImports;
+    // Unfortunately, imports can contain empty strings that mustn't be counted. 
+    // So we can't believe 'imports.size()' and we may not check against it.
+    std::vector<std::string> imports;
+    for (size_t idx = 0u; idx < scrip.imports.size(); idx++)
+        if (!scrip.imports[idx].empty())
+            imports.push_back(scrip.imports[idx]);
 
-    of << "int const numimports = " << realNumImports << ";" << std::endl;
+    of << "int const non_empty_imports_count = " << imports.size() << ";" << std::endl;
 
-    of << "std::string imports[] = {" << std::endl;
-
-    size_t linelen = 0;
-    for (size_t idx = 0; idx < scrip.imports.size(); idx++)
+    if (imports.size())
     {
-        if (!strcmp(scrip.imports[idx].c_str(), ""))
+        of << "std::string imports[] = {" << std::endl;
+
+        size_t line_length = 0u;
+        for (size_t idx = 0u; idx < imports.size(); idx++)
+        {
+            std::string item = EscapeString(imports[idx].c_str());
+            item += ",";
+            item += std::string(15 - (item.length() % 15), ' ');
+            of << item;
+            line_length += item.length();
+            if (line_length >= 75u)
+            {
+                line_length = 0u;
+                of << "// " << idx << std::endl;
+            }
+        }
+        of << "};" << std::endl;
+        of << "CompareImports(&scrip, non_empty_imports_count, imports);" << std::endl << std::endl;
+    }
+    else
+    {
+        of << "CompareImports(&scrip, non_empty_imports_count, nullptr);" << std::endl << std::endl;
+    }
+}
+
+void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count, std::string imports[])
+{
+    size_t actual_non_empty_imports_count = 0u;
+    for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
+    {
+        if (!scrip->imports[scrip_idx].empty())
+            actual_non_empty_imports_count++;
+    }
+    size_t const should_be = non_empty_imports_count;
+    ASSERT_EQ(should_be, actual_non_empty_imports_count);
+
+    if (!imports)
+        return;
+
+    size_t array_idx = 0u; // index into 'imports[]'
+    for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
+    {
+        if (!scrip->imports[scrip_idx].empty())
             continue;
 
-        std::string item = EscapeString(scrip.imports[idx].c_str());
-        item += ",";
-        item += std::string(15 - (item.length() % 15), ' ');
-        of << item;
-        linelen += item.length();
-        if (linelen >= 75)
-        {
-            linelen = 0;
-            of << "// " << idx << std::endl;
-        }
-    }
-    of << " \"[[SENTINEL]]\" " << std::endl << "};" << std::endl;
-
-    of << "CompareImports(&scrip, numimports, imports);" << std::endl << std::endl;
-}
-
-void CompareImports(AGS::ccCompiledScript *scrip, size_t numimports, std::string imports[])
-{
-    int idx2 = -1;
-    for (size_t idx = 0; idx < scrip->imports.size(); idx++)
-    {
-         if (!strcmp(scrip->imports[idx].c_str(), ""))
-             continue;
-         idx2++;
-         ASSERT_LT(static_cast<size_t>(idx2), numimports); // idx2 is sure to be non-negative here
-         std::string const prefix = "imports[" + std::to_string(idx2) + "] == ";
-         std::string const should_be_val = prefix + "\"" + imports[idx2] + "\"";
-         std::string const is_val = prefix + "\"" + scrip->imports[idx] + "\"";
-         ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
+        std::string const prefix = "scrip.imports[" + std::to_string(scrip_idx) + "] == ";
+        std::string const should_be_val = prefix + "\"" + imports[array_idx] + "\"";
+        std::string const is_val = prefix + "\"" + scrip->imports[scrip_idx] + "\"";
+        ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
+        array_idx++;
     }
 }
 
-void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const numexports = " << scrip.exports.size() << ";" << std::endl;
-    of << "EXPECT_EQ(numexports, scrip.exports.size());" << std::endl << std::endl;
+    size_t const exports_size = scrip.exports.size();
+    of << "size_t const exports_size = " << scrip.exports.size() << ";" << std::endl;
+    of << "ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());" << std::endl;
+    of << "EXPECT_EQ(exports_size, scrip.exports.size());" << std::endl << std::endl;
 
-    if (scrip.exports.size() == 0)
+    if (scrip.exports.empty())
         return;
 
     of << "std::string exports[] = {" << std::endl;
 
-    size_t linelen = 0;
-    for (size_t idx = 0; idx < scrip.exports.size(); idx++)
+    size_t line_length = 0u;
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
         std::string item = EscapeString(scrip.exports[idx].c_str());
         item += ",";
-        item += std::string(6 - (item.length() % 6), ' ');
+        item += std::string(6u - (item.length() % 6u), ' ');
         of << item;
-        linelen += item.length();
-        if (linelen >= 50)
+        line_length += item.length();
+        if (line_length >= 50u)
         {
-            linelen = 0;
+            line_length = 0u;
             of << "// " << idx << std::endl;
         }
     }
-    of << " \"[[SENTINEL]]\" " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
     of << "int32_t export_addr[] = {" << std::endl;
 
-    for (size_t idx = 0; idx < scrip.exports.size(); idx++)
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
         of.setf(std::ios::hex, std::ios::basefield);
         of.setf(std::ios::showbase);
         of.width(4);
         of << scrip.export_addr[idx] << ", ";
-        if (idx % 4 == 1) of << "   ";
-        if (idx % 8 == 3)
+        if (idx % 4u == 1u) of << "   ";
+        if (idx % 8u == 3u)
         {
             of.setf(std::ios::dec, std::ios::basefield);
             of.unsetf(std::ios::showbase);
@@ -247,26 +267,29 @@ void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
     of.unsetf(std::ios::showbase);
     of.width(0);
 
-    of << " 0 " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
-    of << "CompareExports(&scrip, numexports, exports, export_addr);" << std::endl << std::endl;
+    of << "CompareExports(&scrip, exports_size, exports, export_addr);" << std::endl << std::endl;
 }
 
-void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string exports[],  int32_t export_addr[])
+void CompareExports(AGS::ccCompiledScript *scrip, size_t exports_size, std::string exports[], int32_t export_addr[])
 {
-    for (size_t idx = 0; idx < numexports; idx++)
+    exports_size = std::min(
+        std::min(exports_size, scrip->exports.size()),
+        exports_size);
+    exports_size = std::min(
+        std::min(exports_size, scrip->export_addr.size()),
+        exports_size);
+
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
-        if (idx >= scrip->exports.size())
-            break;
         std::string const prefix = "exports[" + std::to_string(idx) + "] == ";
         std::string const should_be_val = prefix + "\"" + exports[idx] + "\"";
         std::string const is_val = prefix + "\"" + scrip->exports[idx] + "\"";
         ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
     }
-    for (size_t idx = 0; idx < numexports; idx++)
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
-        if (idx >= scrip->exports.size())
-            break;
         std::string const prefix = "export_addr[" + std::to_string(idx) + "] == ";
         std::string const should_be_val = prefix + std::to_string(export_addr[idx]);
         std::string const is_val = prefix + std::to_string(scrip->export_addr[idx]);
@@ -275,16 +298,16 @@ void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string
 }
 
 
-void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const stringssize = " << scrip.strings.size() << ";" << std::endl;
-    of << "EXPECT_EQ(stringssize, scrip.strings.size());" << std::endl << std::endl;
+    of << "size_t const strings_size = " << scrip.strings.size() << ";" << std::endl;
+    of << "EXPECT_EQ(strings_size, scrip.strings.size());" << std::endl << std::endl;
 
-    if (scrip.strings.size() == 0)
+    if (scrip.strings.empty())
         return;
 
     of << "char strings[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.strings.size(); idx++)
+    for (size_t idx = 0u; idx < scrip.strings.size(); idx++)
     {
         std::string out = "";
         if (scrip.strings[idx] == 0)
@@ -292,20 +315,19 @@ void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
         else
             out += '\'' + Esc(scrip.strings[idx]) + '\'';
         of << out << ",  ";
-        if (idx % 8 == 3) of << "        ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "        ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << "'\\0'" << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
-    of << " CompareStrings(&scrip, stringssize, strings);" << std::endl << std::endl;
+    of << " CompareStrings(&scrip, strings_size, strings);" << std::endl << std::endl;
    }
 
-void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strings[])
+void CompareStrings(AGS::ccCompiledScript *scrip, size_t strings_size, char strings[])
 {
-    for (size_t idx = 0; idx < stringssize; idx++)
+    strings_size = std::min(strings_size, scrip->strings.size());
+    for (size_t idx = 0u; idx < strings_size; idx++)
     {
-         if (idx >= scrip->strings.size())
-             break;
          std::string const prefix = "strings[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(strings[idx]);
          std::string const is_val = prefix + std::to_string(scrip->strings[idx]);
@@ -313,17 +335,133 @@ void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strin
     }
 }
 
-void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip)
+static void WriteOutputGlobals(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    std::string path = WRITE_PATH;
-    std::ofstream of;
-    of.open(path.append(fname).append(".txt"));
+    size_t const globaldata_size = scrip.globaldata.size();
+    of << "size_t const globaldata_size = " << globaldata_size << ";" << std::endl;
+    of << "EXPECT_EQ(globaldata_size, scrip.globaldata.size());" << std::endl << std::endl;
 
-    WriteOutputCode(of, scrip);
-    WriteOutputFixups(of, scrip);
-    WriteOutputImports(of, scrip);
-    WriteOutputExports(of, scrip);
-    WriteOutputStrings(of, scrip);
+    if (scrip.globaldata.empty())
+        return;
 
-    of.close();
+    std::vector<CharRun> global_runs = {};
+
+    for (size_t idx = 0u; idx < globaldata_size;)
+    {
+        char const run_char = scrip.globaldata[idx];
+        size_t run_count = 0u;
+        while (idx < globaldata_size && run_char == scrip.globaldata[idx])
+        {
+            run_count++;
+            idx++;
+        }
+        global_runs.emplace_back(run_count, run_char);
+    }
+
+    if (global_runs.size() * 2u < scrip.globaldata.size())
+    {
+        // Write a run-length encoding of the globals to save space
+        // and for better comprehension
+        // A run '{ 7, 0xAA }' means:
+        // Expect 7 consecutive bytes that each have the value '0xAA'.
+        size_t cumulative = 0u;
+        of << "CharRun global_runs[] = {" << std::endl;
+        for (size_t idx = 0u; idx < global_runs.size(); idx++)
+        {
+            cumulative += global_runs[idx].count;
+            of << "{ " <<
+                std::dec << std::setfill(' ') << std::setw(3) <<
+                    global_runs[idx].count << ", 0x" <<
+                std::hex << std::setfill('0') << std::setw(2) <<
+                (0xFF & global_runs[idx].value) <<
+                "}, ";
+            if (idx % 4u == 3u)
+                of << "   // " << std::dec << std::setw(0) << cumulative << std::endl;
+        }
+        // Add a sentinel that has a count of '0' 
+        of << "{0, 0x00} };" << std::endl;
+        of << "CompareGlobalRuns(&scrip, global_runs);" <<
+            std::endl << std::endl;
+        return;
+    }
+
+    // Write the globals byte-by-byte
+    of << "unsigned char globaldata[] = {" << std::endl;
+    for (size_t idx = 0u; idx < scrip.globaldata.size(); idx++)
+    {
+        of << "0x" <<
+            std::hex << std::setfill('0') << std::setw(2) <<
+            (0xFF & scrip.globaldata[idx]) << ", ";
+        if (idx % 8u == 3u) of << "        ";
+        if (idx % 8u == 7u) of << "   // " << std::dec << std::setw(0) << idx << std::endl;
+    }
+    of << "};" << std::endl;
+    of << "CompareGlobalData(&scrip, globaldata_size, globaldata);" <<
+        std::endl << std::endl;
+}
+
+void CompareGlobalRuns(AGS::ccCompiledScript *scrip, CharRun global_runs[])
+{
+    size_t runs_idx = 0u;
+    // A run '{ 7, 0xAA }' means:
+    // Expect 7 consecutive bytes that each have the value '0xAA'.
+    size_t counter = global_runs[runs_idx].count;
+    unsigned char value = global_runs[runs_idx].value;
+    size_t data_idx = 0u;
+    do {
+        if (data_idx >= scrip->globaldata.size())
+            break;
+        if ((unsigned char) scrip->globaldata[data_idx] != value)
+        {
+            std::string const prefix = "globaldata[" + std::to_string(data_idx) + "] == 0x";
+            std::ostringstream should_be_val;
+            should_be_val << prefix << std::hex << std::setfill('0') <<
+                std::setw(2) << (0xFF & value);
+            std::ostringstream is_val;
+            is_val << prefix << std::hex << std::setfill('0') <<
+                std::setw(2) << (0xFF & scrip->globaldata[data_idx]);
+            ASSERT_STREQ(should_be_val.str().c_str(), is_val.str().c_str());
+        }
+        ++data_idx;
+        --counter;
+        if (!counter)
+        {
+            // Get next run
+            runs_idx++;
+            counter = global_runs[runs_idx].count;
+            value = global_runs[runs_idx].value;
+        }
+    } while (counter);
+}
+
+void CompareGlobalData(AGS::ccCompiledScript *scrip, size_t size, unsigned char gdata[])
+{
+    size = std::min(size, scrip->globaldata.size());
+    for (size_t idx = 0u; idx < size; idx++)
+    {
+        if ((unsigned char) scrip->globaldata[idx] == gdata[idx])
+            continue;
+
+        std::string const prefix = "globaldata[" + std::to_string(idx) + "] == 0x";
+        std::ostringstream should_be_val;
+        should_be_val << prefix << std::hex << std::setfill('0') <<
+            std::setw(2) << (0xFF & gdata[idx]);
+        std::ostringstream is_val;
+        is_val << prefix << std::hex << std::setfill('0') <<
+            std::setw(2) << (0xFF & scrip->globaldata[idx]);
+        ASSERT_STREQ(should_be_val.str().c_str(), is_val.str().c_str());
+    }
+}
+
+void WriteOutput(char const *fname, AGS::ccCompiledScript const &scrip)
+{
+    std::ofstream output { std::string(WRITE_PATH) + fname + ".txt" };
+    output.exceptions(std::ofstream::failbit);
+
+    WriteOutputCode(output, scrip);
+    WriteOutputFixups(output, scrip);
+    WriteOutputImports(output, scrip);
+    WriteOutputExports(output, scrip);
+    WriteOutputStrings(output, scrip);
+    WriteOutputGlobals(output, scrip);
 }

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -114,17 +114,17 @@ static void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &sc
         if (idx % 8u == 3u) of << "      ";
         if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << " -999 " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
     
     of << "char fixuptypes[] = {" << std::endl;
     for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-        of.width(3);
+        of.width(4);
         of << static_cast<int>(scrip.fixuptypes[idx]) << ", ";
-        if (idx % 8u == 3u) of << "   ";
+        if (idx % 8u == 3u) of << "      ";
         if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << " '\\0' " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
     of << "CompareFixups(&scrip, fixups_size, fixups, fixuptypes);" << std::endl << std::endl;
 }
@@ -205,7 +205,7 @@ void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count
     size_t array_idx = 0u; // index into 'imports[]'
     for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
     {
-        if (!scrip->imports[scrip_idx].empty())
+        if (scrip->imports[scrip_idx].empty())
             continue;
 
         std::string const prefix = "scrip.imports[" + std::to_string(scrip_idx) + "] == ";

--- a/Compiler/test2/cc_bytecode_test_lib.h
+++ b/Compiler/test2/cc_bytecode_test_lib.h
@@ -22,10 +22,19 @@ constexpr const char *WRITE_PATH = "C:/TEMP/";
 
 extern void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip);
 
-extern void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[]);
-extern void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixups[], char fixuptypes[]);
-extern void CompareImports(AGS::ccCompiledScript *scrip, size_t numimports, std::string imports[]);
-extern void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string exports[], int32_t export_addr[]);
-extern void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strings[]);
+struct CharRun
+{
+    size_t count;
+    unsigned char value;
+    CharRun(size_t c, unsigned char v) : count(c), value(v) {}
+};
+
+extern void CompareCode(AGS::ccCompiledScript *scrip, size_t code_size, int32_t code[]);
+extern void CompareFixups(AGS::ccCompiledScript *scrip, size_t fixups_size, int32_t fixups[], char fixuptypes[]);
+extern void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count, std::string imports[]);
+extern void CompareExports(AGS::ccCompiledScript *scrip, size_t exports_size, std::string exports[], int32_t export_addr[]);
+extern void CompareStrings(AGS::ccCompiledScript *scrip, size_t strings_size, char strings[]);
+extern void CompareGlobalRuns(AGS::ccCompiledScript *scrip, struct CharRun global_runs[]);
+extern void CompareGlobalData(AGS::ccCompiledScript *scrip, size_t size, unsigned char gdata[]);
 
 #endif

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -1155,10 +1155,8 @@ TEST_F(Compile0, StructForwardDeclareNew) {
 
 TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
 {
-    // NO SCOPT_RTTIOPS:
-    // Cannot have managed components in managed struct.
-    // This is an Engine restriction.
-    ccSetOption(SCOPT_RTTIOPS, 0);
+    // Cannot have managed components in managed struct
+    // when RTTIOPT is unset. This is an Engine restriction.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1169,11 +1167,13 @@ TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
         };                      \n\
         ";
 
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
+
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
-
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_EQ(std::string::npos, err_msg.find("xception"));
@@ -1181,10 +1181,8 @@ TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
 
 TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
 {
-    // NO SCOPT_RTTIOPS:
-    // Cannot have managed components in managed struct.
-    // This is an Engine restriction.
-    ccSetOption(SCOPT_RTTIOPS, 0);
+    // Cannot have managed components in managed struct
+    // when RTTIOPS is unset. This is an Engine restriction.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1194,6 +1192,9 @@ TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
             Managed1 compo[];   \n\
         };                      \n\
         ";
+
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
@@ -1206,8 +1207,8 @@ TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
 
 TEST_F(Compile0, StructManaged2a_RTTIOPS)
 {
-    // + SCOPT_RTTIOPS:
-    // Can have managed components in managed struct.
+    // Can have managed components in managed struct
+    // when RTTIOPS is set.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1228,7 +1229,8 @@ TEST_F(Compile0, StructManaged2a_RTTIOPS)
 
 TEST_F(Compile0, StructManaged2b_RTTIOPS)
 {
-    // Can have managed components in managed struct.
+    // Can have managed components in managed struct
+    // when RTTIOPS is set.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1434,9 +1436,9 @@ TEST_F(Compile0, ImportOverride2) {
         }                       \n\
         ";
 
-    ccSetOption(SCOPT_NOIMPORTOVERRIDE, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -1454,8 +1456,9 @@ TEST_F(Compile0, ImportOverride3) {
     import int Func(int i = 5);     \n\
     ";
 
-    ccSetOption(SCOPT_NOIMPORTOVERRIDE, true);
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    // Note: Don't use 'ccSetOption()' in Googletests.
+
+    int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2435,7 +2438,8 @@ TEST_F(Compile0, StringOldstyle01) {
 
 TEST_F(Compile0, StringOldstyle02) {
 
-    // If a function expects a non-const string, it mustn't be passed a const string
+    // If a function expects a non-const string,
+    // it mustn't be passed a const string
 
     char const *inpl = "\
         void Func(string s)         \n\
@@ -2444,9 +2448,9 @@ TEST_F(Compile0, StringOldstyle02) {
         }                           \n\
         ";
 
-    ccSetOption(SCOPT_OLDSTRINGS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2457,8 +2461,8 @@ TEST_F(Compile0, StringOldstyle02) {
 
 TEST_F(Compile0, StringOldstyle03) {
 
-    // A string literal is a constant string, so you should not be able to
-    // return it as a string.
+    // A string literal is a constant string,
+    // so you can't return it as a string.
 
     char const *inpl = "\
         string Func()                   \n\
@@ -2467,9 +2471,9 @@ TEST_F(Compile0, StringOldstyle03) {
         }                               \n\
         ";
 
-    ccSetOption(SCOPT_OLDSTRINGS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -1457,7 +1457,7 @@ TEST_F(Compile0, ImportOverride3) {
     ";
 
     // Note: Don't use 'ccSetOption()' in Googletests.
-
+    
     int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
@@ -2480,6 +2480,43 @@ TEST_F(Compile0, StringOldstyle03) {
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("ype mismatch"));
+}
+
+TEST_F(Compile0, StringOldstyle04) {
+    // Initializing constant is too long
+    // (the terminating '\0' MUST fit into 'Global2')
+
+    char const *inpl = R"%&/(
+        char Global2[4] = "Lamm"; 
+        )%&/";
+
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("oo long"));
+}
+
+TEST_F(Compile0, StringOldstyle05) {
+    // Initializing constant is too long
+
+    char const *inpl = R"%&/(
+        string Global = "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d";
+        )%&/";
+
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("oo long"));
 }
 
 TEST_F(Compile0, ConstOldstringReturn)

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1652,9 +1652,9 @@ TEST_F(Compile1, FixupMismatch) {
         }                                       \n\
         ";
 
-    ccSetOption(SCOPT_LINENUMBERS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_LINENUMBERS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2935,7 +2935,9 @@ TEST_F(Compile1, DynarrayOfArray) {
         }                               \n\
         ";
 
-    ccSetOption(SCOPT_RTTIOPS, false);
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
+
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -904,3 +904,33 @@ TEST_F(Compile2, ArrayInitNamedDouble) {
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("[3]"));
 }
+
+TEST_F(Compile2, InitManaged01)
+{
+    
+    char const *inpl = R"%&/(
+        managed struct Foo
+        {
+            int Payload;
+        } Var = new Foo;
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'null'"));
+}
+TEST_F(Compile2, InitManaged02)
+{
+    
+    char const *inpl = R"%&/(
+        int List[] = new int;
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'null'"));
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -773,3 +773,22 @@ TEST_F(Compile2, CTEvalLogicalOps) {
     EXPECT_NE(std::string::npos, err_msg.find("'101577700 /"));
 }
 
+TEST_F(Compile2, MultiDimCharArrayToString) {
+
+    // A character array with more than 1 dimension cannot be
+    // converted to 'const string'.
+
+    char const *inpl = R"%&/(
+        int test(const string s)
+        {
+            char arr[5][7];
+            return test(arr);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("convert"));
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -792,3 +792,115 @@ TEST_F(Compile2, MultiDimCharArrayToString) {
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("convert"));
 }
+
+TEST_F(Compile2, ArrayInitLiteralOverflow) {
+
+    // Can't initialize the array because the literal
+    // including the terminal '\0' is too long
+
+    char const *inpl = R"%&/(
+        char arr[5] = "Super";
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too long"));
+}
+
+TEST_F(Compile2, ArrayInitSequenceTooLong) {
+
+    // Too many values to initialize an array of 5 elements
+
+    char const *inpl = R"%&/(
+        short arr[5] = { 1, 2, 3, 4, 5, 6 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("at most 5"));
+}
+
+TEST_F(Compile2, ArrayInitNamedUnnamedMix01) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { 1, [2]: 5 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'['"));
+}
+
+TEST_F(Compile2, ArrayInitNamedUnnamedMix02) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [0]: 1, 2, };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'2'"));
+}
+
+TEST_F(Compile2, ArrayInitNamedOutOfRange01) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [(3 - 5) / 2]: 1 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too low"));
+}
+
+TEST_F(Compile2, ArrayInitNamedOutOfRange02) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [5]: 1 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too high"));
+}
+
+TEST_F(Compile2, ArrayInitNamedDouble) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [3]: 1,
+                         [3]: 2, };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("[3]"));
+}

--- a/Compiler/test2/cc_symboltable_test.cpp
+++ b/Compiler/test2/cc_symboltable_test.cpp
@@ -237,3 +237,16 @@ TEST_F(SymbolTable, IsAnyIntegerVartype)
     EXPECT_TRUE(symt.IsAnyIntegerVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsAnyIntegerVartype(AGS::kKW_Float));
 }
+
+TEST_F(SymbolTable, ArrayWithoutFirstDim)
+{
+    std::vector<size_t> const dims = { 3, 5, };
+    AGS::Vartype vartype35 = symt.VartypeWithArray(dims, AGS::kKW_Short);
+    EXPECT_STREQ("short[3, 5]", symt.GetName(vartype35).c_str());
+    AGS::Vartype vartype5 = symt.ArrayVartypeWithoutFirstDim(vartype35);
+    EXPECT_STREQ("short[5]", symt.GetName(vartype5).c_str());
+    AGS::Vartype vartype = symt.ArrayVartypeWithoutFirstDim(vartype5);
+    EXPECT_STREQ("short", symt.GetName(vartype).c_str());
+    AGS::Vartype vartype0 = symt.ArrayVartypeWithoutFirstDim(vartype);
+    EXPECT_STREQ("short", symt.GetName(vartype0).c_str());
+}

--- a/Compiler/test2/cc_symboltable_test.cpp
+++ b/Compiler/test2/cc_symboltable_test.cpp
@@ -14,10 +14,22 @@
 #include "gtest/gtest.h"
 #include "script2/cc_symboltable.h"
 
-TEST(SymbolTable, GetNameNonExistent)
+class SymbolTable : public ::testing::Test
 {
+public:
+    // Constant definitions etc.
+
+protected:
     AGS::SymbolTable symt;
 
+    SymbolTable()
+    {
+        // Initializations, will be done at the start of each test
+    }
+};
+
+TEST_F(SymbolTable, GetNameNonExistent)
+{
     EXPECT_STREQ("(invalid symbol)", symt.GetName(100).c_str());
     EXPECT_STREQ("(invalid symbol)", symt.GetName(200).c_str());
 
@@ -28,10 +40,8 @@ TEST(SymbolTable, GetNameNonExistent)
     EXPECT_STREQ("(invalid symbol)", symt.GetName(c_sym + 1).c_str());
 }
 
-TEST(SymbolTable, GetNameNormal)
+TEST_F(SymbolTable, GetNameNormal)
 {
-    AGS::SymbolTable symt;
-
     // Read out the name that was put in
 
     int const foo_sym = symt.Add("foo");
@@ -39,17 +49,13 @@ TEST(SymbolTable, GetNameNormal)
     EXPECT_STREQ("foo", symt.GetName(foo_sym).c_str());
 }
 
-TEST(SymbolTable, GetNamePredefined)
+TEST_F(SymbolTable, GetNamePredefined)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_STREQ("return", symt.GetName(AGS::kKW_Return).c_str());
 }
 
-TEST(SymbolTable, GetVartypeName)
+TEST_F(SymbolTable, GetVartypeName)
 {
-    AGS::SymbolTable symt;
-
     AGS::Vartype const foo_vartype = symt.Add("foo");
     symt.MakeEntryVartype(foo_vartype);
     symt[foo_vartype].VartypeD->Type = AGS::VTT::kAtomic;
@@ -67,10 +73,8 @@ TEST(SymbolTable, GetVartypeName)
         symt.GetName(symt.VartypeWithArray(dims, foo_vartype)).c_str());
 }
 
-TEST(SymbolTable, VartypeWithWithout)
+TEST_F(SymbolTable, VartypeWithWithout)
 {
-    AGS::SymbolTable symt;
-
     AGS::Vartype const foo_vartype = symt.Add("foo");
     symt.MakeEntryVartype(foo_vartype);
     symt[foo_vartype].VartypeD->Type = AGS::VTT::kAtomic;
@@ -83,37 +87,29 @@ TEST(SymbolTable, VartypeWithWithout)
     EXPECT_EQ(foo_converted, symt.VartypeWithout(AGS::VTT::kDynarray, foo_converted));
 }
 
-TEST(SymbolTable, AddSymbolAlreadyExists)
+TEST_F(SymbolTable, AddSymbolAlreadyExists)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     ASSERT_EQ(AGS::kKW_NoSymbol, symt.Add("a"));
 }
 
-TEST(SymbolTable, AddSymbolUnique)
+TEST_F(SymbolTable, AddSymbolUnique)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     int const b_sym = symt.Add("b");
     ASSERT_NE(a_sym, b_sym);
 }
 
-TEST(SymbolTable, FindOrAdd)
+TEST_F(SymbolTable, FindOrAdd)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     int const b_sym = symt.Add("b");
     int const a2_sym = symt.FindOrAdd("a");
     EXPECT_EQ(a_sym, a2_sym);
 }
 
-TEST(SymbolTable, FindResetCaches)
+TEST_F(SymbolTable, FindResetCaches)
 {
-    AGS::SymbolTable symt;
-
     // Even after caches are reset, Find() must work
 
     EXPECT_EQ(AGS::kKW_NoSymbol, symt.Find("Llanfair­pwllgwyngyll­gogery­chwyrn­drobwll­llan­tysilio­gogo­goch"));
@@ -124,10 +120,8 @@ TEST(SymbolTable, FindResetCaches)
     // BTW those names really exist
 }
 
-TEST(SymbolTable, EntriesEnsureModifiable)
+TEST_F(SymbolTable, EntriesEnsureModifiable)
 {
-    AGS::SymbolTable symt;
-
     // ensure reading and writing to entries actually works
 
     int const a_sym = symt.Add("x");
@@ -138,10 +132,8 @@ TEST(SymbolTable, EntriesEnsureModifiable)
     EXPECT_EQ(11, symt[a_sym].Declared);
 }
 
-TEST(SymbolTable, StringStruct)
+TEST_F(SymbolTable, StringStruct)
 {
-    AGS::SymbolTable symt;
-
     // set/get a stringstruct symbol
 
     AGS::Symbol const str_set = symt.Add("String");
@@ -155,20 +147,16 @@ TEST(SymbolTable, StringStruct)
     EXPECT_TRUE(symt.IsDynpointerVartype(strptr_get));
 }
 
-TEST(SymbolTable, IsInBounds)
+TEST_F(SymbolTable, IsInBounds)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_FALSE(symt.IsInBounds(-1));
     EXPECT_FALSE(symt.IsInBounds(0));
     EXPECT_FALSE(symt.IsInBounds(symt.GetLastAllocated() + 1));
     EXPECT_TRUE(symt.IsInBounds(AGS::kKW_New));
 }
 
-TEST(SymbolTable, CanBePartOfAnExpression)
+TEST_F(SymbolTable, CanBePartOfAnExpression)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_FALSE(symt.CanBePartOfAnExpression(AGS::kKW_Float));     // typical vartype
     EXPECT_FALSE(symt.CanBePartOfAnExpression(AGS::kKW_Return));    // typical keyword
     EXPECT_TRUE(symt.CanBePartOfAnExpression(AGS::kKW_And));        // typical bool operator
@@ -198,10 +186,8 @@ TEST(SymbolTable, CanBePartOfAnExpression)
     EXPECT_TRUE(symt.CanBePartOfAnExpression(var_sym));
 }
 
-TEST(SymbolTable, IsPrimitiveAtomic)
+TEST_F(SymbolTable, IsPrimitiveAtomic)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_TRUE(symt.IsPrimitiveVartype(AGS::kKW_Long));
     EXPECT_TRUE(symt.IsAtomicVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsPrimitiveVartype(AGS::kKW_Return));
@@ -217,10 +203,8 @@ TEST(SymbolTable, IsPrimitiveAtomic)
     EXPECT_FALSE(symt.IsAtomicVartype(structy_ptr_sym));
 }
 
-TEST(SymbolTable, ArrayClassic)
+TEST_F(SymbolTable, ArrayClassic)
 {
-    AGS::SymbolTable symt;
-
     AGS::Symbol const array_sym = symt.Add("HArry");
     symt.MakeEntryVartype(array_sym);
     symt[array_sym].VartypeD->BaseVartype = AGS::kKW_Int;
@@ -236,10 +220,8 @@ TEST(SymbolTable, ArrayClassic)
     EXPECT_EQ(2 * 3 * 5 * 7, symt.ArrayElementsCount(array_sym));
 }
 
-TEST(SymbolTable, OperatorPrio)
+TEST_F(SymbolTable, OperatorPrio)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_EQ(symt.kNoPrio, symt.BinaryOrPostfixOpPrio(AGS::kKW_BitNeg));
     EXPECT_NE(symt.kNoPrio, symt.PrefixOpPrio(AGS::kKW_BitNeg));
 
@@ -250,10 +232,8 @@ TEST(SymbolTable, OperatorPrio)
     EXPECT_NE(symt.kNoPrio, symt.PrefixOpPrio(AGS::kKW_Minus));
 }
 
-TEST(SymbolTable, IsAnyIntegerVartype)
+TEST_F(SymbolTable, IsAnyIntegerVartype)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_TRUE(symt.IsAnyIntegerVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsAnyIntegerVartype(AGS::kKW_Float));
 }


### PR DESCRIPTION
Fixes #2152

I've implemented the possibility to initialize global structs and global classic arrays, using a similar syntax as we (now) have for parameters.

## Background 
Global variables can be initialized at compile time: The compiler essentially prepares in a byte buffer an image of all the global variables with the initial values already set so that the variables can be used at run time without any further processing. (Managed variables can only be initialized to `null` this way.) 

Of course, this can only work when the compiler knows what initial values those global variables should have.  Previously, there was no way of specifying the initial values for `struct` variables and for classic arrays. Now there is a way.

I've implemented the following initializations:
## Initializer for non-managed `struct` variables 

```
struct Car
{
    bool HasAirbags;
    float MaxSpeed;
    float MaxAcceleration;
};
Car OldBugatti = { MaxAcceleration: 50.0, MaxSpeed: 199.8, }; // ← Comma in front of '}' is allowed but optional
```
Notes: 
- The ordering of the fields is immaterial. What matters is how the fields are named in the list.
- All the fields are set to binary zeros where the init value isn't specified. In, e.g., the above example, `HasAirbags` is set to binary zeros, i.e., to `false`
- The `struct` __may__ have managed fields such as `String`s, but the only value that you can initialize them to is `null`.
- If a `struct A` extends a `struct B` and you initialize a variable of type `A`, then you can initialize all the fields from `A` and `B` by just naming them:
```
struct Vehicle 
{
    float MaxSpeed, MaxAcceleration;
};
struct Car extends Vehicle
{
    bool HasAirbags;
};
Car OldBugatti = { MaxAcceleration: 50.0, HasAirbags: false, }; 
```
- You __must__ use the notation `fieldname : value`. You cannot simply list the values without the fieldnames in some sequential order (I haven't implemented that for now).
- A `struct` variable can have a field that is another `struct`. In this case, the initializers are nested:
```
struct Location 
{ 
    float Longitude, Latitude; 
};
struct PointOfInterest
{
    int AdmissionFee;
    Location WhereItIs;
};

PointOfInterest EiffelTower = {
        WhereItIs: { Longitude: 48.8584, Latitude: 2.2945 }, 
        AdmissionFee: 20 + 3,    // ← Simple 'int' or 'float' expressions are possible
};
```

## Initializers for classic (i.e., non-dynamic) array variables
I provide several ways:

### Sequence initialization
```
int Primes[10] = { 2, 3, 5, 7 };
```
Notes:
- If your list contains fewer values than the dimension of the array, then the rest will be filled up with binary zeros. If your list contains more values, then the compiler will balk.
- You may use simple `int` and `float` expressions that can be evaluated at compile time
- You may not mix Sequence initialization and Named initialization (cf. below, including examples) within the same list
- You may not initialize multi-dimensional arrays (cf 'multi-dimensional arrays' below) by just listing all the values without inner braces (cf. below for an example)

### Named initialization
```
bool IsPrime[10] = {
    [2]: true,     // ← means, IsPrime[2] is 'true'
    [3]: true,     // ← means, IsPrime[3] is 'true' etc.
    [5]: true,
    [7]: true,
};
```
Notes:
- All the non-mentioned indices are set to binary zeros
- The compiler will balk if you attempt to set an index more than once
- The sequence in the list is immaterial. 
- This variant is useful if most of the values in your array are zero and only a few values are different from zero (so-called sparse arrays)
- You may not mix Named initialization and Sequence initialization within the same list. For instance, the compiler will balk at `{ 1, 2, [5]: 99 }` or `{ [0]: 2, [1]: 3, 5, 7, }`

### Multi-dimensional classic arrays
An `int Foo[2][3]` is treated as `2` arrays, each of which has `3` values. So this is how the array is initialized:

```
int Spreadsheet[2][3] = {
    { 1, 2, 3, },
    { 4, 5, 6  }
};
```

Notes:
- `C++` offers the possibility to omit all the inner braces and simply list all the values. I have __not__ implemented that. For instance, you __cannot__ define `int Spreadsheet[2][3] = { 1, 2, 3, 4, 5, 6);`
- You can use both Named and Sequence initialization for multi-dimensional arrays, but you may not mix them within the same list. So you __can__ do, e.g.,
```
// The outer list is Named, both the inner lists are Sequence
int Spreadsheet[2][3] = {
    [0]: { 1, 2, 3, },
    [1]: { 4, 5, 6  },
};
```

### Special case: Classic one-dimensional `char` arrays

These can also be initialized by a string literal. 
```
char SafeCode[10] = "AABAACAAD";
```
Notes:
- The string literal __including the terminating `\0`__ must be at most as long as the array, otherwise the compiler will balk. This is a safeguard attempt for when this array is passed as an argument to a function (e.g., `Display(SafeCode);`)
- If the string literal is shorter than the array, then the rest of the array is filled up with binary zeros.

## Local `struct`s and local classic arrays

Unfortunately, not supported for now. If you define an array within a function, you'll have to initialize its values the old-fashioned way. These initializations need to happen at runtime, anyway. 


