### PR TITLE
New compiler: incorrect compile time left bitshift overflow

### DIFF
--- a/Compiler/script2/cs_compile_time.cpp
+++ b/Compiler/script2/cs_compile_time.cpp
@@ -177,8 +177,8 @@ void AGS::CTF_IntShiftLeft::Evaluate(Symbol arg1, Symbol arg2, Symbol &result)
             std::to_string(i2).c_str());
 
     // The Engine calculates shifts by using signed values, so overflow is possible. 
-    size_t const digitnum = std::numeric_limits<CodeCell>::digits - 1;
-    if (0 != abs(i1) >> (digitnum - i2))
+    size_t const digitnum = std::numeric_limits<CodeCell>::digits + 1;
+    if (0 != i2 && 0 != abs(i1) >> (digitnum - i2))
         UserError(
             "Overflow when calculating '%s << %s'",
             std::to_string(i1).c_str(),

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -514,7 +514,7 @@ TEST_F(Compile2, CTEvalIntShiftLeft2) {
     char const *inpl = "\
         int main()                              \n\
         {                                       \n\
-            return 536870912 << 2;              \n\
+            return 536870912 << 3;              \n\
         }                                       \n\
         ";
 
@@ -582,6 +582,25 @@ TEST_F(Compile2, CTEvalIntShiftLeft5) {
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("egative shift"));
+}
+
+TEST_F(Compile2, CTEvalIntShiftLeft6) {
+
+
+    char const* inpl = "\
+        int main()                              \n\
+        {                                       \n\
+            return (0xFF << 24) / 0;            \n\
+        }                                       \n\
+        ";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const& err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("-16777216"));
 }
 
 TEST_F(Compile2, CTEvalIntShiftRight1) {


### PR DESCRIPTION
During compile time, attempting to left shift with `int a = 0xFF << 24;` was causing an overflow error where none is expected. 

One test was catching a bogus overflow for `536870912 << 2` but that's just `0x80000000` which is valid, so I amended it to `<< 3` to cause a real overflow.
I also added an extra test to make sure it can shift to the highest bit unimpeded.

Was this "overflow" done on purpose to avoid touching the sign bit? If that's the case I don't agree, as it's a too big departure from runtime, and prevents from filling valid bit positions.