### PR TITLE
AGS 4: Add BlendMode to DrawingSurface

### DIFF
--- a/Common/gfx/blender.cpp
+++ b/Common/gfx/blender.cpp
@@ -286,3 +286,39 @@ uint32_t _blender_masked_multiply32(uint32_t x, uint32_t y, uint32_t n)
     return _blender_mask_alpha24(_blender_multiply24(x, y, n), x, y, n);
 }
 // ===============================
+
+#include "gfx/gfx_def.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+// Array of blender descriptions
+// NOTE: set NULL function pointer to fallback to common image blitting
+typedef BLENDER_FUNC PfnBlenderCb;
+static const PfnBlenderCb BlendModeSets[kNumBlendModes] =
+{
+    _argb2argb_blender,             // kBlend_Alpha
+    _blender_masked_add32,          // kBlend_Add
+    _blender_masked_darken32,       // kBlend_Darken
+    _blender_masked_lighten32,      // kBlend_Lighten
+    _blender_masked_multiply32,     // kBlend_Multiply
+    _blender_masked_screen32,       // kBlend_Screen
+    _blender_masked_burn32,         // kBlend_Burn
+    _blender_masked_subtract32,     // kBlend_Subtract
+    _blender_masked_exclusion32,    // kBlend_Exclusion
+    _blender_masked_dodge32,        // kBlend_Dodge
+};
+
+bool SetBlender(BlendMode blend_mode, int alpha)
+{
+    if (blend_mode < 0 || blend_mode >= kNumBlendModes)
+        return false;
+    const auto &blender = BlendModeSets[blend_mode];
+    set_blender_mode(nullptr, nullptr, blender, 0, 0, 0, alpha);
+    return true;
+}
+
+} // namespace Common
+} // namespace AGS

--- a/Common/gfx/blender.cpp
+++ b/Common/gfx/blender.cpp
@@ -196,14 +196,17 @@ void set_argb2any_blender()
 #define _BLENDOP_EXCLUSION(B,L) (B + L - 2 * B * L / 255)
 #define _BLENDOP_SUBTRACT(B,L) (L - B < 0) ? 0:(L - B)
 
-uint32_t _blender_mask_alpha24(uint32_t blender_result, uint32_t x, uint32_t y, uint32_t n)
+uint32_t _blender_mask_alpha32(uint32_t blender_result, uint32_t x, uint32_t y, uint32_t n)
 {
+    // TODO: there may be ways to optimize following, reducing amount of division ops
     const uint32_t src_alpha = geta32(x);
-    const uint32_t alphainv = 255 - src_alpha;
-    const uint32_t r = (getr24(blender_result)*src_alpha + alphainv*getr24(y)) / 255;
-    const uint32_t g = (getg24(blender_result)*src_alpha + alphainv*getg24(y)) / 255;
-    const uint32_t b = (getb24(blender_result)*src_alpha + alphainv*getb24(y)) / 255;
-    return r | g << 8 | b << 16;
+    const uint32_t dst_alpha = geta32(y);
+    const uint32_t inv_src_a = 255 - src_alpha;
+    const uint32_t fin_a = 255 - (255 - src_alpha) * (255 - dst_alpha) / 255;
+    const uint32_t r = getr24(blender_result) * src_alpha / fin_a + inv_src_a * getr24(y) / fin_a / 255;
+    const uint32_t g = getg24(blender_result) * src_alpha / fin_a + inv_src_a * getg24(y) / fin_a / 255;
+    const uint32_t b = getb24(blender_result) * src_alpha / fin_a + inv_src_a * getb24(y) / fin_a / 255;
+    return makeacol32(r, g, b, fin_a);
 }
 // alegro's dodge blend was wrong, mine is not perfect either
 uint32_t _my_blender_dodge24(uint32_t x, uint32_t y, uint32_t n)
@@ -251,39 +254,39 @@ uint32_t _my_blender_subtract24(uint32_t x, uint32_t y, uint32_t n)
 
 uint32_t _blender_masked_add32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_blender_add24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_blender_add24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_dodge32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_dodge24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_dodge24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_burn32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_burn24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_burn24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_lighten32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_lighten24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_lighten24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_darken32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_darken24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_darken24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_exclusion32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_exclusion24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_exclusion24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_subtract32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_my_blender_subtract24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_my_blender_subtract24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_screen32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_blender_screen24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_blender_screen24(x, y, n), x, y, n);
 }
 uint32_t _blender_masked_multiply32(uint32_t x, uint32_t y, uint32_t n)
 {
-    return _blender_mask_alpha24(_blender_multiply24(x, y, n), x, y, n);
+    return _blender_mask_alpha32(_blender_multiply24(x, y, n), x, y, n);
 }
 // ===============================
 

--- a/Common/gfx/blender.h
+++ b/Common/gfx/blender.h
@@ -58,9 +58,7 @@ void set_argb2any_blender();
 
 // ===============================
 // [AVD] Custom blenders for software BlendMode implementation
-// If we ditch software rendering we can remove this whole section
-// not very pretty but forces the original alpha of "x" to "blender_result"
-uint32_t _blender_mask_alpha24(uint32_t blender_result, uint32_t x, uint32_t y, uint32_t n);
+uint32_t _blender_mask_alpha32(uint32_t blender_result, uint32_t x, uint32_t y, uint32_t n);
 uint32_t _my_blender_dodge24(uint32_t x, uint32_t y, uint32_t n);
 uint32_t _my_blender_burn24(uint32_t x, uint32_t y, uint32_t n);
 uint32_t _my_blender_lighten24(uint32_t x, uint32_t y, uint32_t n);

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -40,9 +40,10 @@ enum GraphicFlip
 };
 
 // Blend modes for object sprites
+// This matches the blend modes in script API
 enum BlendMode
 {
-    kBlend_Normal,        // alpha-blend src to dest, combining src & dest alphas
+    kBlend_Normal       = 0, // alpha-blend src to dest, combining src & dest alphas
     kBlend_Add,
     kBlend_Darken,
     kBlend_Lighten,
@@ -278,6 +279,9 @@ namespace GfxDef
         }
     }
 } // namespace GfxDef
+
+// Sets current blending mode, which will affect any further drawing
+bool SetBlender(Common::BlendMode blend_mode, int alpha);
 
 } // namespace Common
 } // namespace AGS

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -793,6 +793,8 @@ builtin managed struct DrawingSurface {
   /// Gets the width of the surface.
   readonly import attribute int Width;
 #ifdef SCRIPT_API_v400
+  /// Gets/sets the current BlendMode that will be used for drawing onto this surface.
+  import attribute BlendMode BlendMode;
   /// Gets the colour depth of this surface.
   readonly import attribute int ColorDepth;
 #endif // SCRIPT_API_v400

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -80,7 +80,7 @@ void DrawingSurface_Release(ScriptDrawingSurface* sds)
         dynamicallyCreatedSurfaces[sds->dynamicSurfaceNumber] = nullptr;
         sds->dynamicSurfaceNumber = -1;
     }
-    sds->modified = 0;
+    sds->modified = false;
 }
 
 ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
@@ -212,6 +212,16 @@ int DrawingSurface_GetDrawingColor(ScriptDrawingSurface *sds)
     return sds->GetScriptDrawingColor();
 }
 
+void DrawingSurface_SetBlendMode(ScriptDrawingSurface *sds, int blend_mode)
+{
+    sds->SetBlendMode(static_cast<BlendMode>(blend_mode));
+}
+
+int DrawingSurface_GetBlendMode(ScriptDrawingSurface *sds)
+{
+    return sds->GetBlendMode();
+}
+
 int DrawingSurface_GetHeight(ScriptDrawingSurface *sds) 
 {
     Bitmap *ds = sds->GetBitmapSurface();
@@ -313,7 +323,7 @@ void DrawingSurface_DrawLine(ScriptDrawingSurface *sds, int fromx, int fromy, in
 }
 
 void DrawingSurface_DrawPixel(ScriptDrawingSurface *sds, int x, int y) {
-    Bitmap *ds = sds->StartDrawing();
+    Bitmap *ds = sds->StartDrawingWithBrush();
     if (sds->IsAlphaBlending())
     {
         ds->BlendPixel(x, y, sds->GetRealDrawingColor());
@@ -476,6 +486,16 @@ RuntimeScriptValue Sc_DrawingSurface_SetDrawingColor(void *self, const RuntimeSc
     API_OBJCALL_VOID_PINT(ScriptDrawingSurface, DrawingSurface_SetDrawingColor);
 }
 
+RuntimeScriptValue Sc_DrawingSurface_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptDrawingSurface, DrawingSurface_GetBlendMode);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptDrawingSurface, DrawingSurface_SetBlendMode);
+}
+
 // int (ScriptDrawingSurface *sds)
 RuntimeScriptValue Sc_DrawingSurface_GetHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -531,6 +551,8 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /
         { "DrawingSurface::Release^0",            API_FN_PAIR(DrawingSurface_Release) },
         { "DrawingSurface::get_DrawingColor",     API_FN_PAIR(DrawingSurface_GetDrawingColor) },
         { "DrawingSurface::set_DrawingColor",     API_FN_PAIR(DrawingSurface_SetDrawingColor) },
+        { "DrawingSurface::get_BlendMode",        API_FN_PAIR(DrawingSurface_GetBlendMode) },
+        { "DrawingSurface::set_BlendMode",        API_FN_PAIR(DrawingSurface_SetBlendMode) },
         { "DrawingSurface::get_ColorDepth",       API_FN_PAIR(DrawingSurface_GetColorDepth) },
         { "DrawingSurface::get_Height",           API_FN_PAIR(DrawingSurface_GetHeight) },
         { "DrawingSurface::get_Width",            API_FN_PAIR(DrawingSurface_GetWidth) },

--- a/Engine/ac/dynobj/scriptdrawingsurface.h
+++ b/Engine/ac/dynobj/scriptdrawingsurface.h
@@ -17,11 +17,13 @@
 #include "ac/dynobj/cc_agsdynamicobject.h"
 #include "game/roomstruct.h"
 #include "gfx/bitmap.h"
+#include "gfx/gfx_def.h"
 #include "util/stream.h"
 
 struct ScriptDrawingSurface final : AGSCCDynamicObject
 {
     using Bitmap = AGS::Common::Bitmap;
+    using BlendMode = AGS::Common::BlendMode;
 public:
     // These numbers and types are used to determine the source of this drawing surface;
     // only one of them can be valid for this surface.
@@ -33,7 +35,7 @@ public:
     int dynamicSurfaceNumber;
     bool isLinkedBitmapOnly;
     Bitmap *linkedBitmapOnly;
-    int modified;
+    bool modified;
 
     int Dispose(void *address, bool force) override;
     const char *GetType() override;
@@ -43,6 +45,8 @@ public:
     int GetRealDrawingColor() const { return _currentColor; }
     int GetScriptDrawingColor() const { return _currentScriptColor; }
     void SetDrawingColor(int color_number);
+    BlendMode GetBlendMode() const { return _currentBlendMode; }
+    void SetBlendMode(BlendMode);
 
     // TODO: review this, may need to hide GetBitmapSurface and use StartDrawingReadOnly instead;
     // the reason is that the bitmap may have to be "locked" for the duration of use, as it is
@@ -68,6 +72,7 @@ private:
     bool _alphaBlending = false;
     int _currentColor = 0;
     int _currentScriptColor = 0;
+    BlendMode _currentBlendMode = AGS::Common::kBlend_Normal;
 };
 
 #endif // __AC_SCRIPTDRAWINGSURFACE_H

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -42,33 +42,6 @@ Bitmap *ConvertBitmap(Bitmap *src, int dst_color_depth, bool keep_mask)
     return src;
 }
 
-
-// Array of blender descriptions
-// NOTE: set NULL function pointer to fallback to common image blitting
-typedef BLENDER_FUNC PfnBlenderCb;
-static const PfnBlenderCb BlendModeSets[kNumBlendModes] =
-{
-    _argb2argb_blender,             // kBlend_Alpha
-    _blender_masked_add32,          // kBlend_Add
-    _blender_masked_darken32,       // kBlend_Darken
-    _blender_masked_lighten32,      // kBlend_Lighten
-    _blender_masked_multiply32,     // kBlend_Multiply
-    _blender_masked_screen32,       // kBlend_Screen
-    _blender_masked_burn32,         // kBlend_Burn
-    _blender_masked_subtract32,     // kBlend_Subtract
-    _blender_masked_exclusion32,    // kBlend_Exclusion
-    _blender_masked_dodge32,        // kBlend_Dodge
-};
-
-static bool SetBlender(BlendMode blend_mode, int alpha)
-{
-    if (blend_mode < 0 || blend_mode >= kNumBlendModes)
-        return false;
-    const auto &blender = BlendModeSets[blend_mode];
-    set_blender_mode(nullptr, nullptr, blender, 0, 0, 0, alpha);
-    return true;
-}
-
 void DrawSpriteBlend(Bitmap *ds, const Point &ds_at, Bitmap *sprite,
                        BlendMode blend_mode, int alpha)
 {

--- a/Engine/gfx/gfx_util.h
+++ b/Engine/gfx/gfx_util.h
@@ -44,7 +44,7 @@ namespace GfxUtil
     Bitmap *ConvertBitmap(Bitmap *src, int dst_color_depth, bool keep_mask = true);
 
     // Considers the given information about source and destination surfaces,
-    // then draws a bimtap over another either using requested blending mode,
+    // then draws a bitmap over another either using requested blending mode,
     // or fallbacks to common "magic pink" transparency mode;
     // optionally uses blending alpha (overall image transparency).
     void DrawSpriteBlend(Bitmap *ds, const Point &ds_at, Bitmap *sprite,


### PR DESCRIPTION
This adds DrawingSurface.BlendMode property, that is used by all operations that also use DrawingColor.

Adjusts custom blenders to work with 32-bit ARGB colors, and fixes the incorrect color shifts in them, which switched R and B parts. This change might affect how the object blend mode work in software mode, so that has to be tested too.

NOTE: not working for DrawString & DrawStringWrapper atm, because I need to figure out how to pass blend mode parameter into the internal font renderers.
