### PR TITLE
Editor: update properties referencing GUIs on GUI removal or id change

### DIFF
--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -86,6 +86,7 @@ namespace AGS.Editor.Components
                         GUI newGUI = ImportExport.ImportGUIFromFile(fileName, _agsEditor.CurrentGame);
                         newGUI.ID = _agsEditor.CurrentGame.RootGUIFolder.GetAllItemsCount();
                         AddSingleItem(newGUI);
+                        GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
                         _agsEditor.CurrentGame.NotifyClientsGUIAddedOrRemoved(newGUI);
                     }
                     catch (Exception ex)
@@ -120,6 +121,7 @@ namespace AGS.Editor.Components
                 {
                     _agsEditor.CurrentGame.NotifyClientsGUIAddedOrRemoved(_guiRightClicked);
                     DeleteSingleItem(_guiRightClicked);
+                    GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
                 }
             }
             else if (controlID == COMMAND_CHANGE_ID)
@@ -235,6 +237,8 @@ namespace AGS.Editor.Components
             else
                 RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
+            GUIIndexTypeConverter.RefreshGUIList();
+
             foreach (ContentDocument doc in _documents.Values)
             {
                 var docItem = ((GUIEditor)doc.Control).GuiToEdit;
@@ -295,6 +299,7 @@ namespace AGS.Editor.Components
             _documents.Clear();
 
             RePopulateTreeView();
+            GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
         }
 
         public override void GameSettingsChanged()
@@ -324,6 +329,7 @@ namespace AGS.Editor.Components
             newGui.ID = _agsEditor.CurrentGame.RootGUIFolder.GetAllItemsCount();
             newGui.Name = _agsEditor.GetFirstAvailableScriptName("gGui");
             string newNodeId = AddSingleItem(newGui);
+            GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
             _guiController.ProjectTree.SelectNode(this, newNodeId);
 			ShowOrAddPane(newGui);
         }
@@ -336,6 +342,7 @@ namespace AGS.Editor.Components
         {
             GUI itemBeingEdited = ((GUIEditor)_guiController.ActivePane.Control).GuiToEdit;
             RePopulateTreeView(GetNodeID(itemBeingEdited));
+            GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
         }
 
         private string GetNodeID(GUI item)

--- a/Editor/AGS.Editor/Components/SettingsComponent.cs
+++ b/Editor/AGS.Editor/Components/SettingsComponent.cs
@@ -53,6 +53,48 @@ namespace AGS.Editor.Components
 			{
 				_guiController.AddOrShowPane(_document);
 			}
+
+            GuiComponent guiComponent = ComponentController.Instance.FindComponent<GuiComponent>();
+            // FIXME: following delegate rem/add is a nasty hack, but we do not have proper
+            // callbacks like "after all components attached", "on game loaded", "on game unloaded",
+            // so have to use RefreshDataFromGame which may be called multiple times.
+            if (guiComponent != null)
+            {
+                guiComponent.GUIChangedID -= GuiComponent_GUIChangedID;
+                guiComponent.GUIChangedID += GuiComponent_GUIChangedID;
+            }
+            Factory.AGSEditor.CurrentGame.GUIAddedOrRemoved -= CurrentGame_GUIRemoved;
+            Factory.AGSEditor.CurrentGame.GUIAddedOrRemoved += CurrentGame_GUIRemoved;
+        }
+
+        private int UpdatePropertyOnGuiMove(int propertyValue, int guiOldID, int guiNewID, bool wasRemoved)
+        {
+            if (propertyValue == guiOldID)
+            {
+                return guiNewID;
+            }
+            else if (wasRemoved && (propertyValue > guiOldID))
+            {
+                return propertyValue - 1;
+            }
+            return propertyValue;
+        }
+
+        private void CurrentGame_GUIRemoved(GUI gui)
+        {
+            // Pass 0 as a "new id", since 0 is used as "no gui"
+            _agsEditor.CurrentGame.Settings.TextWindowGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.TextWindowGUI, gui.ID, 0, true);
+            _agsEditor.CurrentGame.Settings.DialogOptionsGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.DialogOptionsGUI, gui.ID, 0, true);
+            _agsEditor.CurrentGame.Settings.ThoughtGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.ThoughtGUI, gui.ID, 0, true);
+            _settingsPane.RefreshData();
+        }
+
+        private void GuiComponent_GUIChangedID(GUI gui, int oldID)
+        {
+            _agsEditor.CurrentGame.Settings.TextWindowGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.TextWindowGUI, oldID, gui.ID, false);
+            _agsEditor.CurrentGame.Settings.DialogOptionsGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.DialogOptionsGUI, oldID, gui.ID, false);
+            _agsEditor.CurrentGame.Settings.ThoughtGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.ThoughtGUI, oldID, gui.ID, false);
+            _settingsPane.RefreshData();
         }
     }
 }

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -223,6 +223,7 @@
     <Compile Include="PropertyGridExtras\FontFileUIEditor.cs" />
     <Compile Include="PropertyGridExtras\FontSizeTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\FontSizeUIEditor.cs" />
+    <Compile Include="PropertyGridExtras\GUIIndexTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\InteractionEventPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\MultilineStringUIEditor.cs" />

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -24,6 +24,12 @@ namespace AGS.Types
         public const int MAX_SOUND_CHANNELS = 16;
         public const int MAX_USER_SOUND_CHANNELS = MAX_SOUND_CHANNELS - 1; // 1 reserved for Speech
 
+        // TODO: these events are unfortunately a hack. They are not even fired by the
+        // Game class itself, and instead require for some external manager to call
+        // Game.Notify** methods.
+        // We need some sort of a global interface, preferably in AGS.Types, that would
+        // contain all the game changing events and Notify methods, e.g. IGameListener,
+        // provided by the Editor API.
         public delegate void GUIAddedOrRemovedHandler(GUI theGUI);
         public delegate void GUIControlAddedOrRemovedHandler(GUI owningGUI, GUIControl control);
         public delegate void ViewListUpdatedHandler();

--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
@@ -20,7 +20,7 @@ namespace AGS.Types
 
         public static void SetAudioClipList(IList<AudioClip> audioClips)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _AudioClips = audioClips;
             RefreshAudioClipList();
         }

--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeTypeConverter.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
 
         public static void SetAudioClipTypeList(IList<AudioClipType> audioClipTypes)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _AudioClipTypes = audioClipTypes;
             RefreshAudioClipTypeList();
         }

--- a/Editor/AGS.Types/PropertyGridExtras/FontTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/FontTypeConverter.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
 
         public static void SetFontList(IList<Font> fonts)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _Fonts = fonts;
             RefreshFontList();
         }

--- a/Editor/AGS.Types/PropertyGridExtras/GUIIndexTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/GUIIndexTypeConverter.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace AGS.Types
+{
+    public class GUIIndexTypeConverter : BaseListSelectTypeConverter<int, string>
+    {
+        protected static Dictionary<int, string> _allGUIs = new Dictionary<int, string>();
+        protected static Dictionary<int, string> _normalGUIs = new Dictionary<int, string>();
+        protected static Dictionary<int, string> _textWindowGUIs = new Dictionary<int, string>();
+        private static IList<GUI> _GUIs = null;
+
+        protected override Dictionary<int, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _allGUIs;
+        }
+
+        public static void SetGUIList(IList<GUI> guis)
+        {
+            // Keep a reference to the list so it can be updated whenever we need to
+            _GUIs = guis;
+            RefreshGUIList();
+        }
+
+        public static void RefreshGUIList()
+        {
+            if (_GUIs == null)
+            {
+                throw new InvalidOperationException("Static collection has not been set");
+            }
+
+            _allGUIs.Clear();
+            _normalGUIs.Clear();
+            _textWindowGUIs.Clear();
+            _allGUIs.Add(0, "(None)");
+            _normalGUIs.Add(0, "(None)");
+            _textWindowGUIs.Add(0, "(None)");
+
+            foreach (GUI gui in _GUIs.OrderBy(a => a.Name))
+            {
+                // Skip gui 0, because 0 is used as "no selection" in properties
+                if (gui.ID == 0)
+                    continue;
+
+                _allGUIs.Add(gui.ID, gui.Name);
+                if (gui is NormalGUI)
+                    _normalGUIs.Add(gui.ID, gui.Name);
+                else if (gui is TextWindowGUI)
+                    _textWindowGUIs.Add(gui.ID, gui.Name);
+            }
+        }
+    }
+
+    public class GUINormalIndexTypeConverter : GUIIndexTypeConverter
+    {
+        protected override Dictionary<int, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _normalGUIs;
+        }
+    }
+
+    public class GUITextWindowIndexTypeConverter : GUIIndexTypeConverter
+    {
+        protected override Dictionary<int, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _textWindowGUIs;
+        }
+    }
+}

--- a/Editor/AGS.Types/PropertyGridExtras/RoomListTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/RoomListTypeConverter.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
 
         public static void SetRoomList(IList<IRoom> rooms)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _Rooms = rooms;
             RefreshRoomList();
         }

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptListTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptListTypeConverter.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
 
         public static void SetScriptList(ScriptsAndHeaders scripts)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _scripts = scripts;
             RefreshScriptList();
         }

--- a/Editor/AGS.Types/PropertyGridExtras/TranslationListTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/TranslationListTypeConverter.cs
@@ -17,7 +17,7 @@ namespace AGS.Types
 
         public static void SetTranslationsList(IList<Translation> trans)
         {
-            // Keep a refernce to the list so it can be updated whenever we need to
+            // Keep a reference to the list so it can be updated whenever we need to
             _Translations = trans;
             RefreshTranslationsList();
         }

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -834,9 +834,10 @@ namespace AGS.Types
         public CrossfadeSpeed CrossfadeMusic { get; set; }
 
         [DisplayName("Use GUI for dialog options")]
-        [Description("Dialog options can be drawn on a textwindow GUI (0 to just draw at bottom of screen instead)")]
+        [Description("Dialog options can be drawn on a normal or textwindow GUI (0 to just draw at bottom of screen instead)")]
         [Category("Dialog")]
         [DefaultValue(0)]
+        [TypeConverter(typeof(GUIIndexTypeConverter))]
         public int DialogOptionsGUI
         {
             get { return _dialogOptionsGUI; }
@@ -974,6 +975,7 @@ namespace AGS.Types
         [Description("Sets which text-window GUI is used for normal text in the game. You must use the GUI number, not name. You can't use GUI 0 for this, because 0 means that AGS will use its built-in text window instead.")]
         [Category("Text output")]
         [DefaultValue(0)]
+        [TypeConverter(typeof(GUITextWindowIndexTypeConverter))]
         public int TextWindowGUI
         {
             get { return _textWindowGUI; }
@@ -1035,6 +1037,7 @@ namespace AGS.Types
         [Description("Character.Think will use this custom text-window GUI")]
         [Category("Text output")]
         [DefaultValue(0)]
+        [TypeConverter(typeof(GUITextWindowIndexTypeConverter))]
         public int ThoughtGUI
         {
             get { return _thoughtGUI; }


### PR DESCRIPTION
Fix #2542

1. Properties that let select GUI display a dropdown list of gui script names instead of being raw number fields. The displayed names are mapped to GUI number internally, so no data upgrade is necessary.
2. Whenever a GUI is removed, or has ID changed by command, SettingsComponent class updates all of its properties and fixes GUI selection. If selected GUI got removed, property is changed to 0 ("None").

The feature is purely in UI and does not change data format.