### PR TITLE
Editor: implement "Replace source paths" operation for sprites and audio clips

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -232,6 +232,12 @@
     <Compile Include="GUI\Progress.Designer.cs">
       <DependentUpon>Progress.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\ReplaceFolderDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\ReplaceFolderDialog.Designer.cs">
+      <DependentUpon>ReplaceFolderDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\SplashScreen.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -471,6 +477,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\Progress.resx">
       <DependentUpon>Progress.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\ReplaceFolderDialog.resx">
+      <DependentUpon>ReplaceFolderDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\SpriteExportDialog.resx">
       <DependentUpon>SpriteExportDialog.cs</DependentUpon>

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Linq;
 using AGS.Types;
+using System.Windows.Forms;
 
 namespace AGS.Editor.Components
 {
@@ -13,6 +14,7 @@ namespace AGS.Editor.Components
         private const string COMPILED_AUDIO_FILENAME_PREFIX = "au";
         private const string COMMAND_ADD_AUDIO = "AddAudioClipCmd";
         private const string COMMAND_REIMPORT_ALL = "ReimportAllAudioClipCmd";
+        private const string COMMAND_REPLACE_AUDIO_SOURCE_FOLDER = "ReplaceAudioClipSourceFolderCmd";
         private const string COMMAND_PROPERTIES = "PropertiesAudioClip";
         private const string COMMAND_RENAME = "RenameAudioClip";
         private const string COMMAND_REIMPORT = "ReimportAudioClip";
@@ -113,6 +115,10 @@ namespace AGS.Editor.Components
             else if (controlID == COMMAND_REIMPORT_ALL)
             {
                 CommandForceReimportOfAllAudioClips();
+            }
+            else if (controlID == COMMAND_REPLACE_AUDIO_SOURCE_FOLDER)
+            {
+                CommandReplaceSourceFolderForAudioClips();
             }
             else if (controlID == COMMAND_RENAME)
             {
@@ -508,7 +514,7 @@ namespace AGS.Editor.Components
 
         private void UpdateViewFrameSounds(IList<AudioClip> allAudio, ViewFolder views)
         {
-            foreach (View view in views.Views)
+            foreach (AGS.Types.View view in views.Views)
             {
                 foreach (ViewLoop loop in view.Loops)
                 {
@@ -699,6 +705,53 @@ namespace AGS.Editor.Components
                     _editor.SelectedItem = clip;
                     Factory.GUIController.RefreshPropertyGrid();
                 }
+            }
+        }
+
+        private void CommandReplaceSourceFolderForAudioClips()
+        {
+            var allAudioClips = _agsEditor.CurrentGame.RootAudioClipFolder.AllItemsFlat;
+            string firstFoundSourceFile = null;
+            AudioClip foundClip = allAudioClips.Where(s => !string.IsNullOrEmpty(s.SourceFileName)).FirstOrDefault();
+            if (foundClip != null)
+                firstFoundSourceFile = foundClip.SourceFileName;
+
+            if (string.IsNullOrEmpty(firstFoundSourceFile))
+            {
+                Factory.GUIController.ShowMessage("None of the audio clips has a source filename.", MessageBoxIcon.Warning);
+                return;
+            }
+
+            string parentDir = Path.GetDirectoryName(firstFoundSourceFile);
+            var replaceDirs = ReplaceFolderDialog.Show("Replace audio clip(s) source path",
+                "Please choose which part of the parent path should be replaced and provide a replacement. Relative paths will be assumed relative to your game's project folder.",
+                parentDir, parentDir, Factory.AGSEditor.CurrentGame.DirectoryPath);
+
+            if (replaceDirs == null || replaceDirs.Item1 == replaceDirs.Item2)
+                return;
+
+            int itemCount = 0;
+            foreach (var clip in allAudioClips)
+            {
+                if (string.IsNullOrEmpty(clip.SourceFileName))
+                    continue;
+
+                string newPath;
+                if (Utilities.ReplacePathBaseProjectRelative(clip.SourceFileName, replaceDirs.Item1, replaceDirs.Item2, out newPath))
+                {
+                    clip.SourceFileName = newPath;
+                    itemCount++;
+                }
+            }
+
+            if (itemCount > 0)
+            {
+                Factory.GUIController.ShowMessage($"{itemCount} audio clip(s) had their source paths updated.", MessageBoxIcon.Information);
+                Factory.GUIController.RefreshPropertyGrid();
+            }
+            else
+            {
+                Factory.GUIController.ShowMessage($"No audio clips with the matching old paths found, no changes were made.", MessageBoxIcon.Information);
             }
         }
 
@@ -908,11 +961,13 @@ namespace AGS.Editor.Components
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
             menu.Add(new MenuCommand(COMMAND_ADD_AUDIO, "Add audio file(s)...", null));
-            menu.Add(new MenuCommand(COMMAND_REIMPORT_ALL, "Force reimport all file(s)", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
+            menu.Add(MenuCommand.Separator);
+            menu.Add(new MenuCommand(COMMAND_REPLACE_AUDIO_SOURCE_FOLDER, "Replace source paths for audio clips...", null));
+            menu.Add(new MenuCommand(COMMAND_REIMPORT_ALL, "Force reimport all file(s)", null));
             menu.Add(MenuCommand.Separator);
             menu.Add(new MenuCommand(COMMAND_PROPERTIES, "Properties", null));
         }

--- a/Editor/AGS.Editor/GUI/ReplaceFolderDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ReplaceFolderDialog.Designer.cs
@@ -1,0 +1,165 @@
+﻿
+namespace AGS.Editor
+{
+    partial class ReplaceFolderDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblOperationDescription = new System.Windows.Forms.Label();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.tbOldPath = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.tbNewPath = new System.Windows.Forms.TextBox();
+            this.btnBrowseOldPath = new System.Windows.Forms.Button();
+            this.btnBrowseNewPath = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // lblOperationDescription
+            // 
+            this.lblOperationDescription.Location = new System.Drawing.Point(13, 13);
+            this.lblOperationDescription.Name = "lblOperationDescription";
+            this.lblOperationDescription.Size = new System.Drawing.Size(392, 52);
+            this.lblOperationDescription.TabIndex = 0;
+            this.lblOperationDescription.Text = "label1";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(346, 145);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(92, 26);
+            this.btnCancel.TabIndex = 11;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOK.Location = new System.Drawing.Point(248, 145);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(92, 26);
+            this.btnOK.TabIndex = 10;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // tbOldPath
+            // 
+            this.tbOldPath.Location = new System.Drawing.Point(77, 80);
+            this.tbOldPath.Name = "tbOldPath";
+            this.tbOldPath.Size = new System.Drawing.Size(321, 20);
+            this.tbOldPath.TabIndex = 12;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 83);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(50, 13);
+            this.label1.TabIndex = 13;
+            this.label1.Text = "Old path:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(13, 109);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(56, 13);
+            this.label2.TabIndex = 15;
+            this.label2.Text = "New path:";
+            // 
+            // tbNewPath
+            // 
+            this.tbNewPath.Location = new System.Drawing.Point(77, 106);
+            this.tbNewPath.Name = "tbNewPath";
+            this.tbNewPath.Size = new System.Drawing.Size(321, 20);
+            this.tbNewPath.TabIndex = 14;
+            // 
+            // btnBrowseOldPath
+            // 
+            this.btnBrowseOldPath.Location = new System.Drawing.Point(404, 80);
+            this.btnBrowseOldPath.Name = "btnBrowseOldPath";
+            this.btnBrowseOldPath.Size = new System.Drawing.Size(33, 20);
+            this.btnBrowseOldPath.TabIndex = 16;
+            this.btnBrowseOldPath.Text = "...";
+            this.btnBrowseOldPath.UseVisualStyleBackColor = true;
+            this.btnBrowseOldPath.Click += new System.EventHandler(this.btnBrowseOldPath_Click);
+            // 
+            // btnBrowseNewPath
+            // 
+            this.btnBrowseNewPath.Location = new System.Drawing.Point(404, 105);
+            this.btnBrowseNewPath.Name = "btnBrowseNewPath";
+            this.btnBrowseNewPath.Size = new System.Drawing.Size(33, 20);
+            this.btnBrowseNewPath.TabIndex = 17;
+            this.btnBrowseNewPath.Text = "...";
+            this.btnBrowseNewPath.UseVisualStyleBackColor = true;
+            this.btnBrowseNewPath.Click += new System.EventHandler(this.btnBrowseNewPath_Click);
+            // 
+            // ReplaceFolderDialog
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(450, 183);
+            this.Controls.Add(this.btnBrowseNewPath);
+            this.Controls.Add(this.btnBrowseOldPath);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.tbNewPath);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tbOldPath);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.lblOperationDescription);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ReplaceFolderDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ReplaceFolderDialog";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblOperationDescription;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.TextBox tbOldPath;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox tbNewPath;
+        private System.Windows.Forms.Button btnBrowseOldPath;
+        private System.Windows.Forms.Button btnBrowseNewPath;
+    }
+}

--- a/Editor/AGS.Editor/GUI/ReplaceFolderDialog.cs
+++ b/Editor/AGS.Editor/GUI/ReplaceFolderDialog.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public partial class ReplaceFolderDialog : Form
+    {
+        private string _makeRelativeToThisDir;
+
+        public ReplaceFolderDialog()
+        {
+            InitializeComponent();
+        }
+
+        private ReplaceFolderDialog(string titleBar, string headerText, string oldPath, string newPath, string makeRelativeToThisDir = null)
+        {
+            InitializeComponent();
+            Text = titleBar;
+            lblOperationDescription.Text = headerText;
+            _makeRelativeToThisDir = makeRelativeToThisDir;
+            OldPath = oldPath;
+            NewPath = newPath;
+        }
+
+        public string OldPath
+        {
+            get { return tbOldPath.Text; }
+            set
+            {
+                string path = value;
+                if (!string.IsNullOrEmpty(_makeRelativeToThisDir))
+                    path = Utilities.GetRelativeToBasePath(path, _makeRelativeToThisDir);
+                tbOldPath.Text = path;
+            }
+        }
+
+        public string NewPath
+        {
+            get { return tbNewPath.Text; }
+            set
+            {
+                string path = value;
+                if (!string.IsNullOrEmpty(_makeRelativeToThisDir))
+                    path = Utilities.GetRelativeToBasePath(path, _makeRelativeToThisDir);
+                tbNewPath.Text = path;
+            }
+        }
+
+        public static Tuple<string, string> Show(string titleBar, string headerText, string oldPath, string newPath, string makeRelativeToThisDir = null)
+        {
+            ReplaceFolderDialog dialog = new ReplaceFolderDialog(titleBar, headerText, oldPath, newPath, makeRelativeToThisDir);
+            Tuple<string, string> result = null;
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                result = new Tuple<string, string>(dialog.OldPath, dialog.NewPath);
+            }
+            dialog.Dispose();
+            return result;
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+
+        private void btnBrowseOldPath_Click(object sender, EventArgs e)
+        {
+            OldPath = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Select folder", tbOldPath.Text);
+        }
+
+        private void btnBrowseNewPath_Click(object sender, EventArgs e)
+        {
+            NewPath = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Select folder", tbNewPath.Text);
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/ReplaceFolderDialog.resx
+++ b/Editor/AGS.Editor/GUI/ReplaceFolderDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Resolve #2520

This implements an operation that replaces parent part of the source file path for sprites and audio clips. In other words, it lets to replace the folder in the source path. This may be useful if a user wants to move game assets elsewhere.

There are two new menu commands.
1. "Replace source paths for sprites..." command in the Sprite Manager's context menu.
2. "Replace source paths for audio clips..." command in the Audio node context menu (in the project explorer).

Both act similarly: open a dialog that lets choose old and new parent folder, then runs all the respective items (sprites or audio clips), and replaces the parent folder in each one of them whose base path matches the "old" path selection.

For example, if you set
old path: "C:/My Documents/Sprites"
new path "D:/MyAGSGame/Sprites"
then it will replace a "C:/My Documents/Sprites/image.png" with "D:/MyAGSGame/Sprites/image.png".