### PR TITLE
AGS 4: Script API: add eRound options and new Maths.Random()

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -140,7 +140,11 @@ enum MouseButton {
 enum RoundDirection {
   eRoundDown = 0,
   eRoundNearest = 1,
-  eRoundUp = 2
+  eRoundUp = 2,
+#ifdef SCRIPT_API_v400
+  eRoundTowardsZero = 3,
+  eRoundAwayFromZero = 4
+#endif // SCRIPT_API_v400
 };
 
 enum RepeatStyle {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2022,6 +2022,9 @@ builtin struct Maths {
   import static float Tanh(float radians);
   /// Gets the value of PI
   readonly import static attribute float Pi;
+#ifdef SCRIPT_API_v400
+  import static float Round(float value, RoundDirection);
+#endif
 };
 
 builtin managed struct DateTime {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2023,6 +2023,11 @@ builtin struct Maths {
   /// Gets the value of PI
   readonly import static attribute float Pi;
 #ifdef SCRIPT_API_v400
+  /// Returns a random number in the range of 0 to LIMIT-1.
+  import static int Random(int limit);
+  /// Returns a random float in the range of [0.0, 1.0) (including 0 but excluding 1).
+  import static float RandomFloat();
+  /// Rounds the given float towards chosen direction, and returns a result as a new float.
   import static float Round(float value, RoundDirection);
 #endif
 };

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -35,8 +35,6 @@ extern RoomStruct thisroom;
 extern unsigned int loopcounter;
 extern int char_speaking_anim;
 
-#define Random __Rand
-
 int CharacterInfo::get_baseline() const {
     if (baseline < 1)
         return y;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -396,9 +396,9 @@ RuntimeScriptValue Sc_QuitGame(const RuntimeScriptValue *params, int32_t param_c
 }
 
 // int (int upto)
-RuntimeScriptValue Sc_Rand(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Random(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT(__Rand);
+    API_SCALL_INT_PINT(Random);
 }
 
 // void (int areanum)
@@ -779,7 +779,7 @@ void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*
         { "PlayFlic",                 API_FN_PAIR(PlayFlic) },
         { "PlayVideo",                API_FN_PAIR(PlayVideo) },
         { "QuitGame",                 API_FN_PAIR(QuitGame) },
-        { "Random",                   Sc_Rand, __Rand },
+        { "Random",                   API_FN_PAIR(Random) },
         { "RemoveWalkableArea",       API_FN_PAIR(RemoveWalkableArea) },
         { "ResetRoom",                API_FN_PAIR(ResetRoom) },
         { "RestartGame",              API_FN_PAIR(restart_game) },

--- a/Engine/ac/math.cpp
+++ b/Engine/ac/math.cpp
@@ -14,6 +14,7 @@
 #include "ac/math.h"
 #include <cmath>
 #include "ac/common.h" // quit
+#include "debug/debug_log.h"
 #include "util/math.h"
 
 using namespace AGS::Common;
@@ -28,8 +29,13 @@ int FloatToInt(float value, int roundDirection)
         return static_cast<int>(std::ceil(value));
     case eRoundNearest:
         return static_cast<int>(std::round(value));
+    case eRoundTowardsZero:
+        return static_cast<int>(std::trunc(value));
+    case eRoundAwayFromZero:
+        return static_cast<int>(value < 0.f ? std::floor(value) : std::ceil(value));
     default:
-        quit("!FloatToInt: invalid round direction");
+        debug_script_warn("!FloatToInt: invalid round direction %d", roundDirection);
+        return static_cast<int>(value);
     }
     return 0;
 }

--- a/Engine/ac/math.cpp
+++ b/Engine/ac/math.cpp
@@ -19,25 +19,30 @@
 
 using namespace AGS::Common;
 
-int FloatToInt(float value, int roundDirection)
+float RoundImpl(const char *apiname, float value, int roundDirection)
 {
     switch (roundDirection)
     {
     case eRoundDown:
-        return static_cast<int>(std::floor(value));
+        return std::floor(value);
     case eRoundUp:
-        return static_cast<int>(std::ceil(value));
+        return std::ceil(value);
     case eRoundNearest:
-        return static_cast<int>(std::round(value));
+        return std::round(value);
     case eRoundTowardsZero:
-        return static_cast<int>(std::trunc(value));
+        return std::trunc(value);
     case eRoundAwayFromZero:
-        return static_cast<int>(value < 0.f ? std::floor(value) : std::ceil(value));
+        return value < 0.f ? std::floor(value) : std::ceil(value);
     default:
-        debug_script_warn("!FloatToInt: invalid round direction %d", roundDirection);
-        return static_cast<int>(value);
+        debug_script_warn("!%s: invalid round direction %d", apiname, roundDirection);
+        return value;
     }
-    return 0;
+    return 0.f;
+}
+
+int FloatToInt(float value, int roundDirection)
+{
+    return static_cast<int>(RoundImpl("FloatToInt", value, roundDirection));
 }
 
 float IntToFloat(int value)
@@ -123,6 +128,11 @@ float Math_DegreesToRadians(float value)
 float Math_RadiansToDegrees(float value)
 {
     return static_cast<float>(Math::RadiansToDegrees(value));
+}
+
+float Math_Round(float value, int roundDirection)
+{
+    return RoundImpl("Math.Round", value, roundDirection);
 }
 
 float Math_GetPi()
@@ -229,6 +239,11 @@ RuntimeScriptValue Sc_Math_RaiseToPower(const RuntimeScriptValue *params, int32_
     API_SCALL_FLOAT_PFLOAT2(Math_RaiseToPower);
 }
 
+RuntimeScriptValue Sc_Math_Round(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_FLOAT_PFLOAT_PINT(Math_Round);
+}
+
 // float (float value)
 RuntimeScriptValue Sc_Math_Sin(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -281,6 +296,7 @@ void RegisterMathAPI()
         { "Maths::Log10^1",               API_FN_PAIR(Math_Log10) },
         { "Maths::RadiansToDegrees^1",    API_FN_PAIR(Math_RadiansToDegrees) },
         { "Maths::RaiseToPower^2",        API_FN_PAIR(Math_RaiseToPower) },
+        { "Maths::Round^2",               API_FN_PAIR(Math_Round) },
         { "Maths::Sin^1",                 API_FN_PAIR(Math_Sin) },
         { "Maths::Sinh^1",                API_FN_PAIR(Math_Sinh) },
         { "Maths::Sqrt^1",                API_FN_PAIR(Math_Sqrt) },

--- a/Engine/ac/math.cpp
+++ b/Engine/ac/math.cpp
@@ -130,6 +130,22 @@ float Math_RadiansToDegrees(float value)
     return static_cast<float>(Math::RadiansToDegrees(value));
 }
 
+int Math_Random(int limit)
+{
+    if (limit <= 0 || limit > (RAND_MAX + 1))
+    {
+        debug_script_warn("!Maths.Random: invalid parameter %d -- must be in range (1..%d)", limit, (RAND_MAX + 1));
+        return 0;
+    }
+
+    return rand() % (limit);
+}
+
+float Math_RandomFloat()
+{
+    return static_cast<float>(rand()) / static_cast<float>(RAND_MAX + 1);
+}
+
 float Math_Round(float value, int roundDirection)
 {
     return RoundImpl("Math.Round", value, roundDirection);
@@ -148,12 +164,15 @@ float Math_Sqrt(float value)
     return ::sqrt(value);
 }
 
-int __Rand(int upto)
+int Random(int upto)
 {
-    upto++;
-    if (upto < 1)
-        quit("!Random: invalid parameter passed -- must be at least 0.");
-    return rand()%upto;
+    if (upto < 0 || upto > RAND_MAX)
+    {
+        debug_script_warn("!Random: invalid parameter %d -- must be in range (0..%d)", upto, RAND_MAX);
+        return 0;
+    }
+
+    return rand() % (++upto);
 }
 
 
@@ -239,6 +258,16 @@ RuntimeScriptValue Sc_Math_RaiseToPower(const RuntimeScriptValue *params, int32_
     API_SCALL_FLOAT_PFLOAT2(Math_RaiseToPower);
 }
 
+RuntimeScriptValue Sc_Math_Random(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(Math_Random);
+}
+
+RuntimeScriptValue Sc_Math_RandomFloat(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_FLOAT(Math_RandomFloat);
+}
+
 RuntimeScriptValue Sc_Math_Round(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_FLOAT_PFLOAT_PINT(Math_Round);
@@ -296,6 +325,8 @@ void RegisterMathAPI()
         { "Maths::Log10^1",               API_FN_PAIR(Math_Log10) },
         { "Maths::RadiansToDegrees^1",    API_FN_PAIR(Math_RadiansToDegrees) },
         { "Maths::RaiseToPower^2",        API_FN_PAIR(Math_RaiseToPower) },
+        { "Maths::Random^1",              API_FN_PAIR(Math_Random) },
+        { "Maths::RandomFloat^0",         API_FN_PAIR(Math_RandomFloat) },
         { "Maths::Round^2",               API_FN_PAIR(Math_Round) },
         { "Maths::Sin^1",                 API_FN_PAIR(Math_Sin) },
         { "Maths::Sinh^1",                API_FN_PAIR(Math_Sinh) },

--- a/Engine/ac/math.h
+++ b/Engine/ac/math.h
@@ -49,6 +49,7 @@ float Math_DegreesToRadians(float value);
 float Math_RadiansToDegrees(float value);
 float Math_GetPi();
 float Math_Sqrt(float value);
+float Math_Round(float value, int roundDirection);
 
 int __Rand(int upto);
 #define Random __Rand

--- a/Engine/ac/math.h
+++ b/Engine/ac/math.h
@@ -23,7 +23,9 @@
 enum RoundDirections {
     eRoundDown = 0,
     eRoundNearest = 1,
-    eRoundUp = 2
+    eRoundUp = 2,
+    eRoundTowardsZero = 3,
+    eRoundAwayFromZero = 4
 };
 
 

--- a/Engine/ac/math.h
+++ b/Engine/ac/math.h
@@ -50,8 +50,7 @@ float Math_RadiansToDegrees(float value);
 float Math_GetPi();
 float Math_Sqrt(float value);
 float Math_Round(float value, int roundDirection);
-
-int __Rand(int upto);
-#define Random __Rand
+// Returns a random number from 0 to upto *inclusive*
+int   Random(int upto);
 
 #endif // __AGS_EE_AC__MATH_H

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -305,6 +305,10 @@ inline const char *ScriptVSprintf(std::vector<char> &buf, const char *format, va
     ASSERT_PARAM_COUNT(FUNCTION, 1); \
     return RuntimeScriptValue().SetFloat(FUNCTION(params[0].FValue))
 
+#define API_SCALL_FLOAT_PFLOAT_PINT(FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 2); \
+    return RuntimeScriptValue().SetFloat(FUNCTION(params[0].FValue, params[1].IValue))
+
 #define API_SCALL_FLOAT_PFLOAT2(FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 2); \
     return RuntimeScriptValue().SetFloat(FUNCTION(params[0].FValue, params[1].FValue))


### PR DESCRIPTION
Resolve #1983, #2683

Contents:
1. Expands eRound option with 2 new modes:
    * `eRoundTowardsZero` - rounds towards a closest integer *less by magnitude* (absolute value);
    * `eRoundAwayFromZero` - rounds towards a closest integer *larger by magnitude* (absolute value);

2. Add `float Maths.Round(float, RoundDirection)` - which rounds a float value to another float value (without making it int).

3. Add `Maths.Random(limit)`, a proper variant of `Random`, which treats limit as an upper exclusive boundary. So `Maths.Random(10)` would choose a number between 0 and 9, but never 10.

4. Add `Maths.RandomFloat()` which produces a float in range [0.0, 1.0) (excluding 1.0).
