### PR TITLE
AGS 4: implement CopyX BlendModes

### DIFF
--- a/Common/gfx/blender.cpp
+++ b/Common/gfx/blender.cpp
@@ -182,6 +182,24 @@ void set_argb2any_blender()
         0, 0, 0, 0xff);
 }
 
+// Copy blender: copy src, ignore dest
+uint32_t blender_src_copy(uint32_t x, uint32_t /*y*/, uint32_t /*n*/)
+{
+    return x;
+}
+
+// Copy RGB blender: mix source RGB with dest alpha
+uint32_t blender_src_copyrgb(uint32_t x, uint32_t y, uint32_t /*n*/)
+{
+    return x & 0xFFFFFF | y & 0xFF000000;
+}
+
+// Copy alpha blender: mix source alpha with dest RGB
+uint32_t blender_src_copyalpha(uint32_t x, uint32_t y, uint32_t /*n*/)
+{
+    return x & 0xFF000000 | y & 0xFFFFFF;
+}
+
 // ===============================
 // [AVD] Custom blenders for software BlendMode implementation
 // If we ditch software rendering we can remove this whole section
@@ -311,6 +329,9 @@ static const PfnBlenderCb BlendModeSets[kNumBlendModes] =
     _blender_masked_subtract32,     // kBlend_Subtract
     _blender_masked_exclusion32,    // kBlend_Exclusion
     _blender_masked_dodge32,        // kBlend_Dodge
+    blender_src_copy,               // kBlend_Copy
+    blender_src_copyrgb,            // kBlend_CopyRGB
+    blender_src_copyalpha,          // kBlend_CopyAlpha
 };
 
 bool SetBlender(BlendMode blend_mode, int alpha)

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -53,6 +53,9 @@ enum BlendMode
     kBlend_Subtract,
     kBlend_Exclusion,
     kBlend_Dodge,
+    kBlend_Copy,
+    kBlend_CopyRGB,
+    kBlend_CopyAlpha,
     kNumBlendModes
 };
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -609,7 +609,15 @@ enum BlendMode {
     eBlendBurn,
     eBlendSubtract,
     eBlendExclusion,
-    eBlendDodge
+    eBlendDodge,
+#ifdef SCRIPT_API_v400
+    /// copy source color to destination
+    eBlendCopy,
+    /// copy source rgb to destination (keep destination alpha)
+    eBlendCopyRGB,
+    /// copy source alpha to destination (keep destination rgb)
+    eBlendCopyAlpha
+#endif // #ifdef SCRIPT_API_v400
 };
 #endif // SCRIPT_API_v399
 

--- a/Editor/AGS.Types/Enums/BlendMode.cs
+++ b/Editor/AGS.Types/Enums/BlendMode.cs
@@ -13,6 +13,9 @@ namespace AGS.Types
         Burn,
         Subtract,
         Exclusion,
-        Dodge
+        Dodge,
+        Copy,
+        CopyRGB,
+        CopyAlpha
     }
 }

--- a/Engine/ac/dynobj/scriptdrawingsurface.cpp
+++ b/Engine/ac/dynobj/scriptdrawingsurface.cpp
@@ -74,7 +74,7 @@ Bitmap *ScriptDrawingSurface::StartDrawing()
 Bitmap *ScriptDrawingSurface::StartDrawingWithBrush()
 {
     Bitmap *ds = GetBitmapSurface();
-    _alphaBlending = (ds->GetColorDepth() == 32)
+    _alphaBlending = (ds->GetColorDepth() == 32) && (_currentBlendMode != kBlend_Copy)
         && ((geta32(_currentColor) != 0xFF) || (_currentBlendMode != kBlend_Normal));
     if (_alphaBlending)
     {

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1203,6 +1203,19 @@ void OGLGraphicsDriver::RenderTexture(OGLBitmap *bmpToDraw, int draw_x, int draw
         // APPROXIMATIONS (need pixel shaders)
         case kBlend_Burn: SetBlendOpRGB(GL_FUNC_SUBTRACT, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR); break; // LINEAR BURN (approximation)
         case kBlend_Dodge: SetBlendOpRGB(GL_FUNC_ADD, GL_DST_COLOR, GL_ONE); break; // fake color dodge (half strength of the real thing)
+        case kBlend_Copy:
+            SetBlendOpRGBAlpha(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ZERO,
+                               GL_FUNC_ADD, GL_ONE, GL_ZERO);
+            break;
+        case kBlend_CopyRGB:
+            SetBlendOpRGBAlpha(GL_FUNC_ADD, GL_DST_ALPHA, GL_ZERO,
+                               GL_FUNC_ADD, GL_ZERO, GL_ONE);
+            break;
+        case kBlend_CopyAlpha:
+            SetBlendOpRGBAlpha(GL_FUNC_ADD, GL_ZERO, GL_SRC_ALPHA,
+                               GL_FUNC_ADD, GL_ONE, GL_ZERO);
+            break;
+        default: break;
     }
 
     // WORKAROUNDS - BEGIN

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -338,11 +338,20 @@ private:
     OGLSpriteBatches _backupBatches;
     std::vector<OGLDrawListEntry> _backupSpriteList;
 
-    // Saved blend settings exclusive for alpha channel; for convenience,
+    // Saved blend settings
+    struct BlendOpState
+    {
+        GLenum Op{}, Src{}, Dst{};
+        BlendOpState() = default;
+        BlendOpState(GLenum op, GLenum src, GLenum dst)
+            : Op(op), Src(src), Dst(dst) {}
+    };
+
+    // Saved alpha channel blend settings for the current render target
+    BlendOpState _rtBlendAlpha{};
+    // Saved current blend settings exclusive for alpha channel; for convenience,
     // because GL does not have functions for setting ONLY RGB or ONLY alpha ops.
-    GLenum _blendOpAlpha{};
-    GLenum _blendSrcAlpha{};
-    GLenum _blendDstAlpha{};
+    BlendOpState _blendAlpha{};
 
 
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
@@ -376,11 +385,11 @@ private:
         const SpriteColorTransform &color, const Size &rend_sz);
     void SetupViewport();
 
-    // Sets uniform GL blend settings, same for both RGB and alpha component
+    // Sets uniform blend settings, same for both RGB and alpha component
     void SetBlendOpUniform(GLenum blend_op, GLenum src_factor, GLenum dst_factor);
-    // Sets GL blend settings for RGB only, and keeps saved alpha blend settings
+    // Sets blend settings for RGB only, and keeps previously set alpha blend settings
     void SetBlendOpRGB(GLenum rgb_op, GLenum srgb_factor, GLenum drgb_factor);
-    // Sets GL blend settings with separate op for alpha, and saves used alpha params
+    // Sets blend settings with separate op for alpha, and saves used alpha params
     void SetBlendOpRGBAlpha(GLenum rgb_op, GLenum srgb_factor, GLenum drgb_factor,
         GLenum alpha_op, GLenum sa_factor, GLenum da_factor);
 

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -48,9 +48,13 @@ void DrawSpriteBlend(Bitmap *ds, const Point &ds_at, Bitmap *sprite,
     if (alpha <= 0)
         return; // do not draw 100% transparent image
 
+    if (blend_mode == kBlend_Copy)
+    {
+        // optimized variant for Copy "blend mode"
+        ds->Blit(sprite, ds_at.X, ds_at.Y);
+    }
     // support only 32-bit blending at the moment
-    if ((ds->GetColorDepth() == 32) && (sprite->GetColorDepth() == 32) &&
-        // set blenders if applicable and tell if succeeded
+    else if ((ds->GetColorDepth() == 32) && (sprite->GetColorDepth() == 32) &&
         SetBlender(blend_mode, alpha))
     {
         ds->TransBlendBlt(sprite, ds_at.X, ds_at.Y);

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1298,6 +1298,24 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
         // APPROXIMATIONS (need pixel shaders)
         case kBlend_Burn: SetBlendOpRGB(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
         case kBlend_Dodge: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
+        case kBlend_Copy:
+            SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ZERO);
+            SetBlendOpAlpha(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_ZERO);
+            // Disabling alpha test seems to be required, because Direct3D
+            // skips source zero alpha completely otherwise
+            direct3ddevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+            break;
+        case kBlend_CopyRGB:
+            SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_DESTALPHA, D3DBLEND_ZERO);
+            SetBlendOpAlpha(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_ONE);
+            direct3ddevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+            break;
+        case kBlend_CopyAlpha:
+            SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCALPHA);
+            SetBlendOpAlpha(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_ZERO);
+            direct3ddevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+            break;
+        default: break;
     }
 
     // BLENDMODES WORKAROUNDS - BEGIN
@@ -1353,6 +1371,7 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
     // FIXME: set everything prior to a texture drawing instead?
     SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
     SetBlendOpAlpha(_rtBlendAlpha.Op, _rtBlendAlpha.Src, _rtBlendAlpha.Dst);
+    direct3ddevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
   }
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -32,10 +32,6 @@
 #include "platform/base/sys_main.h"
 #include "util/matrix.h"
 
-#define AGS_D3DBLENDOP(blend_op, src_blend, dest_blend) \
-  direct3ddevice->SetRenderState(D3DRS_BLENDOP, blend_op); \
-  direct3ddevice->SetRenderState(D3DRS_SRCBLEND, src_blend); \
-  direct3ddevice->SetRenderState(D3DRS_DESTBLEND, dest_blend); \
 
 using namespace AGS::Common;
 
@@ -587,7 +583,13 @@ bool D3DGraphicsDriver::CreateDisplayMode(const DisplayMode &mode)
   return true;
 }
 
-void D3DGraphicsDriver::SetBlendOp(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor)
+void D3DGraphicsDriver::SetBlendOpUniform(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor)
+{
+    SetBlendOpRGB(blend_op, src_factor, dst_factor);
+    SetBlendOpAlpha(blend_op, src_factor, dst_factor);
+}
+
+void D3DGraphicsDriver::SetBlendOpRGB(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor)
 {
     direct3ddevice->SetRenderState(D3DRS_BLENDOP, blend_op);
     direct3ddevice->SetRenderState(D3DRS_SRCBLEND, src_factor);
@@ -612,7 +614,9 @@ void D3DGraphicsDriver::InitializeD3DState()
   direct3ddevice->SetRenderState(D3DRS_ZENABLE, FALSE);
 
   direct3ddevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-  SetBlendOp(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+  direct3ddevice->SetRenderState(D3DRS_SEPARATEALPHABLENDENABLE, TRUE);
+  SetBlendOpUniform(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+  _rtBlendAlpha = BlendOpState(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
 
   direct3ddevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
   direct3ddevice->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATER); 
@@ -1270,7 +1274,7 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
     {
     case kTxHint_PremulAlpha:
         direct3ddevice->SetRenderState(D3DRS_BLENDFACTOR, D3DCOLOR_RGBA(alpha, alpha, alpha, 255));
-        SetBlendOp(D3DBLENDOP_ADD, D3DBLEND_BLENDFACTOR, D3DBLEND_INVSRCALPHA);
+        SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_BLENDFACTOR, D3DBLEND_INVSRCALPHA);
         break;
     default:
         break;
@@ -1278,29 +1282,34 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
 
     // FIXME: user blend modes break the above special blend for RT textures
     // Blend modes
-    switch (bmpToDraw->_blendMode) {
-        // blend mode is always NORMAL at this point
-        //case kBlend_Alpha: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA); break; // ALPHA
-        case kBlend_Add: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // ADD (transparency = strength)
-        case kBlend_Darken: AGS_D3DBLENDOP(D3DBLENDOP_MIN, D3DBLEND_ONE, D3DBLEND_ONE); break; // DARKEN
-        case kBlend_Lighten: AGS_D3DBLENDOP(D3DBLENDOP_MAX, D3DBLEND_ONE, D3DBLEND_ONE); break; // LIGHTEN
-        case kBlend_Multiply: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCCOLOR); break; // MULTIPLY
-        case kBlend_Screen: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_INVSRCCOLOR); break; // SCREEN
-        case kBlend_Subtract: AGS_D3DBLENDOP(D3DBLENDOP_REVSUBTRACT, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // SUBTRACT (transparency = strength)
-        case kBlend_Exclusion: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_INVDESTCOLOR, D3DBLEND_INVSRCCOLOR); break; // EXCLUSION
+    switch (bmpToDraw->_blendMode)
+    {
+        case kBlend_Normal:
+            // blend mode is always NORMAL at this point
+            // SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA); // ALPHA
+            break;
+        case kBlend_Add: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // ADD (transparency = strength)
+        case kBlend_Darken: SetBlendOpRGB(D3DBLENDOP_MIN, D3DBLEND_ONE, D3DBLEND_ONE); break; // DARKEN
+        case kBlend_Lighten: SetBlendOpRGB(D3DBLENDOP_MAX, D3DBLEND_ONE, D3DBLEND_ONE); break; // LIGHTEN
+        case kBlend_Multiply: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCCOLOR); break; // MULTIPLY
+        case kBlend_Screen: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_INVSRCCOLOR); break; // SCREEN
+        case kBlend_Subtract: SetBlendOpRGB(D3DBLENDOP_REVSUBTRACT, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // SUBTRACT (transparency = strength)
+        case kBlend_Exclusion: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_INVDESTCOLOR, D3DBLEND_INVSRCCOLOR); break; // EXCLUSION
         // APPROXIMATIONS (need pixel shaders)
-        case kBlend_Burn: AGS_D3DBLENDOP(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
-        case kBlend_Dodge: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
+        case kBlend_Burn: SetBlendOpRGB(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
+        case kBlend_Dodge: SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
     }
 
     // BLENDMODES WORKAROUNDS - BEGIN
 
     // allow transparency with blending modes
     // darken/lighten the base sprite so a higher transparency value makes it trasparent
-    if (bmpToDraw->_blendMode > 0) {
+    if (bmpToDraw->_blendMode > 0)
+    {
         const int alpha = bmpToDraw->_alpha;
         const int invalpha = 255 - alpha;
-        switch (bmpToDraw->_blendMode) {
+        switch (bmpToDraw->_blendMode)
+        {
         case kBlend_Darken:
         case kBlend_Multiply:
         case kBlend_Burn: // FIXME burn is imperfect due to blend mode, darker than normal even when trasparent
@@ -1315,6 +1324,8 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
             // fade to black
             direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
             direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(alpha, alpha, alpha, alpha));
+            break;
+        default:
             break;
         }
         direct3ddevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
@@ -1338,8 +1349,10 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
       throw Ali3DException("IDirect3DDevice9::DrawPrimitive failed");
     }
 
-    // Restore default blending mode
-    SetBlendOp(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+    // Restore default blending mode, using render target's settings
+    // FIXME: set everything prior to a texture drawing instead?
+    SetBlendOpRGB(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+    SetBlendOpAlpha(_rtBlendAlpha.Op, _rtBlendAlpha.Src, _rtBlendAlpha.Dst);
   }
 }
 
@@ -1458,8 +1471,8 @@ void D3DGraphicsDriver::SetRenderTarget(const D3DSpriteBatch *batch, Size &rend_
         direct3ddevice->SetTransform(D3DTS_PROJECTION, (D3DMATRIX*)glm::value_ptr(mat_ortho));
         // Configure rules for merging sprite alpha values onto a
         // render target, which also contains alpha channel.
-        direct3ddevice->SetRenderState(D3DRS_SEPARATEALPHABLENDENABLE, TRUE);
         SetBlendOpAlpha(D3DBLENDOP_ADD, D3DBLEND_INVDESTALPHA, D3DBLEND_ONE);
+        _rtBlendAlpha = BlendOpState(D3DBLENDOP_ADD, D3DBLEND_INVDESTALPHA, D3DBLEND_ONE);
     }
     else
     {
@@ -1469,8 +1482,9 @@ void D3DGraphicsDriver::SetRenderTarget(const D3DSpriteBatch *batch, Size &rend_
         rend_sz = _currentBackbuffer->RendSize;
         SetD3DViewport(_currentBackbuffer->Viewport);
         direct3ddevice->SetTransform(D3DTS_PROJECTION, (D3DMATRIX*)glm::value_ptr(_currentBackbuffer->Projection));
-        // Disable alpha merging rules, return back to default settings
-        direct3ddevice->SetRenderState(D3DRS_SEPARATEALPHABLENDENABLE, FALSE);
+        // Return back to default alpha merging rules
+        SetBlendOpAlpha(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+        _rtBlendAlpha = BlendOpState(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
     }
 
     if (clear)

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -331,6 +331,19 @@ private:
     D3DSpriteBatches _backupBatches;
     std::vector<D3DDrawListEntry> _backupSpriteList;
 
+    // Saved blend settings
+    struct BlendOpState
+    {
+        D3DBLENDOP Op{};
+        D3DBLEND   Src{}, Dst{};
+        BlendOpState() = default;
+        BlendOpState(D3DBLENDOP op, D3DBLEND src, D3DBLEND dst)
+            : Op(op), Src(src), Dst(dst) {}
+    };
+
+    // Saved alpha channel blend settings for the current render target
+    BlendOpState _rtBlendAlpha{};
+
     // Called after new mode was successfully initialized
     void OnModeSet(const DisplayMode &mode) override;
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
@@ -386,9 +399,11 @@ private:
     // Renders given texture onto the current render target
     void RenderTexture(D3DBitmap *bitmap, int draw_x, int draw_y, const glm::mat4 &matGlobal,
         const SpriteColorTransform &color, const Size &rend_sz);
-    // Helper method for setting blending parameters
-    void SetBlendOp(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
-    // Helper method for setting exclusive alpha blending parameters
+    // Sets uniform blend settings, same for both RGB and alpha component
+    void SetBlendOpUniform(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
+    // Sets blend settings for RGB only, and keeps previously set alpha blend settings
+    void SetBlendOpRGB(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
+    // Sets blend settings for alpha channel
     void SetBlendOpAlpha(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
 };
 


### PR DESCRIPTION
This implements 3 new BlendModes:
* Copy - copies full color from src to dest, fully discards dest;
* CopyRGB - copies rgb color component from src to dest, mixing with dest alpha;
* CopyAlpha - copies src alpha to dest, mixing with dest rgb.

```
    /// copy source color to destination
    eBlendCopy,
    /// copy source rgb to destination (keep destination alpha)
    eBlendCopyRGB,
    /// copy source alpha to destination (keep destination rgb)
    eBlendCopyAlpha
```

Initially my intention was to implement only Copy, meant for drawing transparent primitives on DrawingSurface. This should replace an ability to draw with transparent color, which does not exactly work now after implemented alpha support (#2661).

After adding this mode to object rendering as well, it came to me that having a mode which copies only alpha might complement (if not replace in some circumstances) DynamicSprite.CopyTransparencyMask() function. That's why I added CopyAlpha, and then CopyRGB just to have all 3 variants.

CopyAlpha blend mode allows to copy transparency when using DrawingSurface.BlendImage() method.
But it also in theory might allow to "cut holes" in underlying surface for composite objects such as GUIs. I.e. if you have a GUI and a button with a mask sprite assigned to it, then you could assign eBlendCopyAlpha to such button and have it produce a transparent whole of any arbitrary shape in GUI background.

I say in theory above, because somehow we still do not have GUIControls support BlendMode property. I might just address this next. In order to test the OpenGL and Direct3D renderers with the new modes I had to hardcode BlendMode for GUI controls right into the engine.

Note that any other object won't benefit from these Copy modes much, because copying transparency will replace it on final screen image rather than, say, only an object immediately below, that's how rendering works. In order to "cut holes" only in selected objects we'll have to implement a special feature which combines two textures separately prior to rendering the final one.