### PR TITLE
OGL: Fixed blendmodes not respecting transparency

### DIFF
--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -281,6 +281,8 @@ private:
     ShaderProgram _tintShader;
     ShaderProgram _lightShader;
     ShaderProgram _transparencyShader;
+    ShaderProgram _darkenbyAlphaShader;
+    ShaderProgram _lightenByAlphaShader;
 
     int device_screen_physical_width;
     int device_screen_physical_height;


### PR DESCRIPTION
Solved the OpenGL renderer not respecting alpha transparency on several blend modes.

It was broken since SDL2 was merged, because the hacks that darken/lighten the textures don't work along the _transparencyShader shader. 

Unlike D3D, there's always a shader enabled for rendering sprites, so I rewrote those texture ops into two new shaders to match D3D output (which is not perfect, but at least it's consistent again).