### PR TITLE
Editor: let select palette index for the sprite's transparent color

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -112,7 +112,8 @@ namespace AGS.Editor
          *                  GlobalVariable may be of array type.
          * 3.6.2.2        - Button.WrapText, TextPadding.
          * 3.6.2.6        - Settings.GameFPS.
-         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton
+         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton,
+         *                  Imported sprites can select transparent palette index.
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060300;
         /*

--- a/Editor/AGS.Editor/AGSEditorController.cs
+++ b/Editor/AGS.Editor/AGSEditorController.cs
@@ -82,7 +82,7 @@ namespace AGS.Editor
                 throw new AGSEditorException("Unable to find sprite " + spriteNumber + " in any sprite folders");
             }
 
-            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newImage, (SpriteImportTransparency)((int)transparencyType), true, false, useAlphaChannel);
+            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newImage, (SpriteImportTransparency)((int)transparencyType), 0, true, false, useAlphaChannel);
             if (sprite.ColorDepth < 32)
             {
                 sprite.AlphaChannel = false;
@@ -93,7 +93,7 @@ namespace AGS.Editor
 
         Sprite IAGSEditor.CreateNewSprite(ISpriteFolder inFolder, Bitmap newImage, SpriteImportTransparency transparencyType, bool useAlphaChannel)
         {
-            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(newImage, (SpriteImportTransparency)((int)transparencyType), true, false, useAlphaChannel);
+            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(newImage, (SpriteImportTransparency)((int)transparencyType), 0, true, false, useAlphaChannel);
             if (newSprite.ColorDepth < 32)
             {
                 newSprite.AlphaChannel = false;

--- a/Editor/AGS.Editor/GIFLoader/GifDecoder.cs
+++ b/Editor/AGS.Editor/GIFLoader/GifDecoder.cs
@@ -35,6 +35,15 @@ namespace AGS.Editor
             }
         }
 
+        public Color[] GetOriginalPalette()
+        {
+            var image = collection[0];
+            Color[] cols = new Color[image.ColormapSize];
+            for (int i = 0; i < image.ColormapSize; ++i)
+                cols[i] = image.GetColormap(i).ToColor();
+            return cols;
+        }
+
         public int GetFrameCount()
         {
             return collection.Count;

--- a/Editor/AGS.Editor/ImportExport.cs
+++ b/Editor/AGS.Editor/ImportExport.cs
@@ -1413,7 +1413,7 @@ namespace AGS.Editor
                 bmp.Palette = pal;
             }
 
-            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, SpriteImportTransparency.LeaveAsIs, true, false, hasAlpha);
+            Sprite newSprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, SpriteImportTransparency.LeaveAsIs, 0, true, false, hasAlpha);
             bmp.Dispose();
             return newSprite;
         }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -136,20 +136,20 @@ namespace AGS.Editor
 			}
         }
 
-        public Sprite CreateSpriteFromBitmap(Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        public Sprite CreateSpriteFromBitmap(Bitmap bmp, SpriteImportTransparency transparency, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
             int spriteSlot = _native.GetFreeSpriteSlot();
             lock (_spriteSetLock)
             {
-                return _native.SetSpriteFromBitmap(spriteSlot, bmp, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+                return _native.SetSpriteFromBitmap(spriteSlot, bmp, (int)transparency, transColour, remapColours, useRoomBackgroundColours, alphaChannel);
             }
         }
 
-        public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, SpriteImportTransparency transparency, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        public void ReplaceSpriteWithBitmap(Sprite spr, Bitmap bmp, SpriteImportTransparency transparency, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
         {
             lock (_spriteSetLock)
             {
-                _native.ReplaceSpriteWithBitmap(spr, bmp, (int)transparency, remapColours, useRoomBackgroundColours, alphaChannel);
+                _native.ReplaceSpriteWithBitmap(spr, bmp, (int)transparency, transColour, remapColours, useRoomBackgroundColours, alphaChannel);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.Designer.cs
@@ -35,7 +35,9 @@ namespace AGS.Editor
             this.chkRoomBackground = new System.Windows.Forms.CheckBox();
             this.chkRemapCols = new System.Windows.Forms.CheckBox();
             this.groupTransColour = new System.Windows.Forms.GroupBox();
+            this.udTransColorIndex = new System.Windows.Forms.NumericUpDown();
             this.panelBottomRight = new System.Windows.Forms.Panel();
+            this.panelTopRight = new System.Windows.Forms.Panel();
             this.panelBottomLeft = new System.Windows.Forms.Panel();
             this.panelIndex0 = new System.Windows.Forms.Panel();
             this.panelTopLeft = new System.Windows.Forms.Panel();
@@ -45,7 +47,7 @@ namespace AGS.Editor
             this.radTransColourTopRightPixel = new System.Windows.Forms.RadioButton();
             this.radTransColourBottomLeftPixel = new System.Windows.Forms.RadioButton();
             this.radTransColourTopLeftPixel = new System.Windows.Forms.RadioButton();
-            this.radTransColourIndex0 = new System.Windows.Forms.RadioButton();
+            this.radTransColourIndex = new System.Windows.Forms.RadioButton();
             this.btnClose = new System.Windows.Forms.Button();
             this.btnImport = new System.Windows.Forms.Button();
             this.chkTiled = new System.Windows.Forms.CheckBox();
@@ -71,9 +73,9 @@ namespace AGS.Editor
             this.numOffsetY = new System.Windows.Forms.NumericUpDown();
             this.previewPanel = new AGS.Editor.BufferedPanel();
             this.btnImportAll = new System.Windows.Forms.Button();
-            this.panelTopRight = new System.Windows.Forms.Panel();
             this.groupImportOptions.SuspendLayout();
             this.groupTransColour.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udTransColorIndex)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.zoomSlider)).BeginInit();
             this.groupSelection.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numMaxTiles)).BeginInit();
@@ -133,6 +135,7 @@ namespace AGS.Editor
             // 
             // groupTransColour
             // 
+            this.groupTransColour.Controls.Add(this.udTransColorIndex);
             this.groupTransColour.Controls.Add(this.panelBottomRight);
             this.groupTransColour.Controls.Add(this.panelTopRight);
             this.groupTransColour.Controls.Add(this.panelBottomLeft);
@@ -144,7 +147,7 @@ namespace AGS.Editor
             this.groupTransColour.Controls.Add(this.radTransColourTopRightPixel);
             this.groupTransColour.Controls.Add(this.radTransColourBottomLeftPixel);
             this.groupTransColour.Controls.Add(this.radTransColourTopLeftPixel);
-            this.groupTransColour.Controls.Add(this.radTransColourIndex0);
+            this.groupTransColour.Controls.Add(this.radTransColourIndex);
             this.groupTransColour.Location = new System.Drawing.Point(12, 108);
             this.groupTransColour.Name = "groupTransColour";
             this.groupTransColour.Size = new System.Drawing.Size(224, 192);
@@ -152,36 +155,57 @@ namespace AGS.Editor
             this.groupTransColour.TabStop = false;
             this.groupTransColour.Text = "Transparent colour";
             // 
+            // udTransColorIndex
+            // 
+            this.udTransColorIndex.Location = new System.Drawing.Point(99, 64);
+            this.udTransColorIndex.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+            this.udTransColorIndex.Name = "udTransColorIndex";
+            this.udTransColorIndex.Size = new System.Drawing.Size(48, 21);
+            this.udTransColorIndex.TabIndex = 13;
+            this.udTransColorIndex.ValueChanged += new System.EventHandler(this.udTransColorIndex_ValueChanged);
+            // 
             // panelBottomRight
             // 
             this.panelBottomRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelBottomRight.Location = new System.Drawing.Point(136, 158);
+            this.panelBottomRight.Location = new System.Drawing.Point(152, 158);
             this.panelBottomRight.Name = "panelBottomRight";
-            this.panelBottomRight.Size = new System.Drawing.Size(78, 17);
+            this.panelBottomRight.Size = new System.Drawing.Size(62, 17);
             this.panelBottomRight.TabIndex = 12;
+            // 
+            // panelTopRight
+            // 
+            this.panelTopRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelTopRight.Location = new System.Drawing.Point(152, 135);
+            this.panelTopRight.Name = "panelTopRight";
+            this.panelTopRight.Size = new System.Drawing.Size(62, 17);
+            this.panelTopRight.TabIndex = 11;
             // 
             // panelBottomLeft
             // 
             this.panelBottomLeft.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelBottomLeft.Location = new System.Drawing.Point(136, 112);
+            this.panelBottomLeft.Location = new System.Drawing.Point(152, 112);
             this.panelBottomLeft.Name = "panelBottomLeft";
-            this.panelBottomLeft.Size = new System.Drawing.Size(78, 17);
+            this.panelBottomLeft.Size = new System.Drawing.Size(62, 17);
             this.panelBottomLeft.TabIndex = 10;
             // 
             // panelIndex0
             // 
             this.panelIndex0.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelIndex0.Location = new System.Drawing.Point(136, 66);
+            this.panelIndex0.Location = new System.Drawing.Point(152, 66);
             this.panelIndex0.Name = "panelIndex0";
-            this.panelIndex0.Size = new System.Drawing.Size(78, 17);
+            this.panelIndex0.Size = new System.Drawing.Size(62, 17);
             this.panelIndex0.TabIndex = 8;
             // 
             // panelTopLeft
             // 
             this.panelTopLeft.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelTopLeft.Location = new System.Drawing.Point(136, 89);
+            this.panelTopLeft.Location = new System.Drawing.Point(152, 89);
             this.panelTopLeft.Name = "panelTopLeft";
-            this.panelTopLeft.Size = new System.Drawing.Size(78, 17);
+            this.panelTopLeft.Size = new System.Drawing.Size(62, 17);
             this.panelTopLeft.TabIndex = 9;
             // 
             // radTransColourNone
@@ -246,18 +270,19 @@ namespace AGS.Editor
             this.radTransColourTopLeftPixel.Text = "Top-left pixel";
             this.radTransColourTopLeftPixel.UseVisualStyleBackColor = true;
             // 
-            // radTransColourIndex0
+            // radTransColourIndex
             // 
-            this.radTransColourIndex0.AutoSize = true;
-            this.radTransColourIndex0.Location = new System.Drawing.Point(5, 66);
-            this.radTransColourIndex0.Name = "radTransColourIndex0";
-            this.radTransColourIndex0.Size = new System.Drawing.Size(97, 17);
-            this.radTransColourIndex0.TabIndex = 8;
-            this.radTransColourIndex0.Text = "Palette index 0";
-            this.radTransColourIndex0.UseVisualStyleBackColor = true;
+            this.radTransColourIndex.AutoSize = true;
+            this.radTransColourIndex.Location = new System.Drawing.Point(5, 66);
+            this.radTransColourIndex.Name = "radTransColourIndex";
+            this.radTransColourIndex.Size = new System.Drawing.Size(92, 17);
+            this.radTransColourIndex.TabIndex = 8;
+            this.radTransColourIndex.Text = "Palette index:";
+            this.radTransColourIndex.UseVisualStyleBackColor = true;
             // 
             // btnClose
             // 
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnClose.Location = new System.Drawing.Point(12, 569);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(70, 30);
@@ -315,7 +340,7 @@ namespace AGS.Editor
             this.zoomSlider.Maximum = 20;
             this.zoomSlider.Minimum = 1;
             this.zoomSlider.Name = "zoomSlider";
-            this.zoomSlider.Size = new System.Drawing.Size(567, 45);
+            this.zoomSlider.Size = new System.Drawing.Size(567, 42);
             this.zoomSlider.TabIndex = 2;
             this.zoomSlider.Value = 1;
             this.zoomSlider.Scroll += new System.EventHandler(this.zoomSlider_Scroll);
@@ -573,20 +598,12 @@ namespace AGS.Editor
             this.btnImportAll.UseVisualStyleBackColor = true;
             this.btnImportAll.Click += new System.EventHandler(this.btnImportAll_Click);
             // 
-            // panelTopRight
-            // 
-            this.panelTopRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelTopRight.Location = new System.Drawing.Point(136, 135);
-            this.panelTopRight.Name = "panelTopRight";
-            this.panelTopRight.Size = new System.Drawing.Size(78, 17);
-            this.panelTopRight.TabIndex = 11;
-            // 
             // SpriteImportWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnClose;
-            this.ClientSize = new System.Drawing.Size(824, 611);
+            this.ClientSize = new System.Drawing.Size(832, 618);
             this.Controls.Add(this.lblZoom);
             this.Controls.Add(this.zoomSlider);
             this.Controls.Add(this.btnImportAll);
@@ -609,6 +626,7 @@ namespace AGS.Editor
             this.groupImportOptions.PerformLayout();
             this.groupTransColour.ResumeLayout(false);
             this.groupTransColour.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udTransColorIndex)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.zoomSlider)).EndInit();
             this.groupSelection.ResumeLayout(false);
             this.groupSelection.PerformLayout();
@@ -645,7 +663,7 @@ namespace AGS.Editor
         private System.Windows.Forms.RadioButton radTransColourTopRightPixel;
         private System.Windows.Forms.RadioButton radTransColourBottomLeftPixel;
         private System.Windows.Forms.RadioButton radTransColourTopLeftPixel;
-        private System.Windows.Forms.RadioButton radTransColourIndex0;
+        private System.Windows.Forms.RadioButton radTransColourIndex;
         private System.Windows.Forms.Panel panelBottomRight;
         private System.Windows.Forms.Panel panelBottomLeft;
         private System.Windows.Forms.Panel panelIndex0;
@@ -668,5 +686,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblY;
         private System.Windows.Forms.Button btnImportAll;
         private System.Windows.Forms.Panel panelTopRight;
+        private System.Windows.Forms.NumericUpDown udTransColorIndex;
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -89,7 +89,7 @@ namespace AGS.Editor
         {
             get
             {
-                if (radTransColourIndex0.Checked) { return SpriteImportTransparency.PaletteIndex0; };
+                if (radTransColourIndex.Checked) { return SpriteImportTransparency.PaletteIndex; };
                 if (radTransColourTopLeftPixel.Checked) { return SpriteImportTransparency.TopLeft; };
                 if (radTransColourBottomLeftPixel.Checked) { return SpriteImportTransparency.BottomLeft; };
                 if (radTransColourTopRightPixel.Checked) { return SpriteImportTransparency.TopRight; };
@@ -103,7 +103,11 @@ namespace AGS.Editor
                 switch(value)
                 {
                     case SpriteImportTransparency.PaletteIndex0:
-                        radTransColourIndex0.Checked = true;
+                        radTransColourIndex.Checked = true;
+                        udTransColorIndex.Value = 0;
+                        break;
+                    case SpriteImportTransparency.PaletteIndex:
+                        radTransColourIndex.Checked = true;
                         break;
                     case SpriteImportTransparency.TopLeft:
                         radTransColourTopLeftPixel.Checked = true;
@@ -125,6 +129,12 @@ namespace AGS.Editor
                         break;
                 }
             }
+        }
+
+        public int TransparentColourIndex
+        {
+            get { return (int)udTransColorIndex.Value; }
+            set { udTransColorIndex.Value = value; }
         }
 
         public SpriteImportWindow(string[] filenames, SpriteFolder folder)
@@ -179,6 +189,7 @@ namespace AGS.Editor
 
             // set defaults from the old sprite
             SpriteImportMethod = replace.TransparentColour;
+            TransparentColourIndex = replace.TransparentColourIndex;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
             UseAlphaChannel = replace.ImportAlphaChannel;
@@ -214,6 +225,7 @@ namespace AGS.Editor
 
             // set defaults from the old sprite
             SpriteImportMethod = replace.TransparentColour;
+            TransparentColourIndex = replace.TransparentColourIndex;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
             UseAlphaChannel = replace.ImportAlphaChannel;
@@ -282,13 +294,13 @@ namespace AGS.Editor
             previewPanel.Controls.Add(scrollWindowSizer);
 
             // update colour preview
-            try
+            if (image.Palette.Entries.Length > this.TransparentColourIndex)
             {
-                panelIndex0.BackColor = image.Palette.Entries[0];
+                panelIndex0.BackColor = image.Palette.Entries[this.TransparentColourIndex];
             }
-            catch (IndexOutOfRangeException)
+            else
             {
-                // not an indexed palette
+                panelIndex0.BackColor = Color.Transparent;
             }
 
             previewPanel.Refresh();
@@ -408,7 +420,7 @@ namespace AGS.Editor
             try
             {
                 SpriteTools.ReplaceSprite(replace, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
-                    UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
+                    UseBackgroundSlots, SpriteImportMethod, TransparentColourIndex, filename, 0), spritesheet);
             }
             catch (AGSEditorException ex)
             {
@@ -438,12 +450,12 @@ namespace AGS.Editor
                 {
                     // in the interest of speed, import the existing bitmap if the file has a single frame
                     SpriteTools.ImportNewSprites(folder, image, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
-                        UseBackgroundSlots, SpriteImportMethod, filename, 0), spritesheet);
+                        UseBackgroundSlots, SpriteImportMethod, TransparentColourIndex, filename, 0), spritesheet);
                 }
                 else
                 {
                     SpriteTools.ImportNewSprites(folder, new SpriteImportOptions(UseAlphaChannel, RemapToGamePalette,
-                        UseBackgroundSlots, SpriteImportMethod, filename), spritesheet);
+                        UseBackgroundSlots, SpriteImportMethod, TransparentColourIndex, filename), spritesheet);
                 }
             }
             catch (AGSEditorException ex)
@@ -637,6 +649,19 @@ namespace AGS.Editor
         private void InvalidateOn_ValueChanged(object sender, EventArgs e)
         {
             previewPanel.Invalidate();
+        }
+
+        private void udTransColorIndex_ValueChanged(object sender, EventArgs e)
+        {
+            if (image != null && image.Palette != null && image.Palette.Entries.Length > this.TransparentColourIndex)
+            {
+                panelIndex0.BackColor = image.Palette.Entries[this.TransparentColourIndex];
+            }
+            else
+            {
+                panelIndex0.BackColor = Color.Transparent;
+            }
+            radTransColourIndex.Checked = true;
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -923,7 +923,7 @@ namespace AGS.Editor
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)
-                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.SourceFile, spr.Frame), spritesheet);
+                    SpriteTools.ReplaceSprite(spr, new SpriteImportOptions(spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spr.TransparentColourIndex, spr.SourceFile, spr.Frame), spritesheet);
                 }
                 catch (Exception ex)
                 {
@@ -1011,7 +1011,7 @@ namespace AGS.Editor
                 else
                 {
                     Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, newBmp, sprite.TransparentColour,
-                        sprite.RemapToGamePalette, sprite.RemapToRoomPalette, sprite.AlphaChannel);
+                        sprite.TransparentColourIndex, sprite.RemapToGamePalette, sprite.RemapToRoomPalette, sprite.AlphaChannel);
                     RefreshSpriteDisplay();
                 }
                 newBmp.Dispose();

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -18,18 +18,20 @@ namespace AGS.Editor.Utils
         public bool RemapColours;
         public bool UseRoomBackground;
         public SpriteImportTransparency Transparency;
+        public int TransparentColourIndex;
         public string Filename;
         public int Frame;
         public Rectangle Selection;
         public bool Tile;
 
         public SpriteImportOptions(bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
+            SpriteImportTransparency transparency, int transIndex, string filename, int frame, Rectangle selection, bool tile)
         {
             ImportAlpha = alpha;
             RemapColours = remapColours;
             UseRoomBackground = useRoomBackground;
             Transparency = transparency;
+            TransparentColourIndex = transIndex;
             Filename = filename;
             Frame = frame;
             Selection = selection;
@@ -39,8 +41,8 @@ namespace AGS.Editor.Utils
         /// <summary>
         /// Initializes only most basic options.
         /// </summary>
-        public SpriteImportOptions(bool alpha, bool remapColours, bool useRoomBackground, SpriteImportTransparency transparency)
-            : this(alpha, remapColours, useRoomBackground, transparency, "", 0, Rectangle.Empty, false)
+        public SpriteImportOptions(bool alpha, bool remapColours, bool useRoomBackground, SpriteImportTransparency transparency, int transIndex)
+            : this(alpha, remapColours, useRoomBackground, transparency, transIndex, "", 0, Rectangle.Empty, false)
         {
         }
 
@@ -48,8 +50,8 @@ namespace AGS.Editor.Utils
         /// Initializes options with a filename and optional frame (for multi-frame image formats).
         /// </summary>
         public SpriteImportOptions(bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, string filename, int frame = 0)
-            : this(alpha, remapColours, useRoomBackground, transparency, filename, frame, Rectangle.Empty, false)
+            SpriteImportTransparency transparency, int transIndex, string filename, int frame = 0)
+            : this(alpha, remapColours, useRoomBackground, transparency, transIndex, filename, frame, Rectangle.Empty, false)
         {
         }
 
@@ -58,7 +60,7 @@ namespace AGS.Editor.Utils
         /// </summary>
         public SpriteImportOptions(SpriteImportOptions baseOptions, string filename, int frame = 0)
             : this(baseOptions.ImportAlpha, baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
-                  filename, frame, Rectangle.Empty, false)
+                  baseOptions.TransparentColourIndex, filename, frame, Rectangle.Empty, false)
         {
         }
 
@@ -67,7 +69,7 @@ namespace AGS.Editor.Utils
         /// </summary>
         public SpriteImportOptions(SpriteImportOptions baseOptions, Rectangle selection, bool tile)
             : this(baseOptions.ImportAlpha, baseOptions.RemapColours, baseOptions.UseRoomBackground, baseOptions.Transparency,
-                  baseOptions.Filename, baseOptions.Frame, selection, tile)
+                  baseOptions.TransparentColourIndex, baseOptions.Filename, baseOptions.Frame, selection, tile)
         {
         }
     }
@@ -320,6 +322,7 @@ namespace AGS.Editor.Utils
         private static void SetSpriteImportOptions(Sprite sprite, SpriteImportOptions options)
         {
             sprite.TransparentColour = options.Transparency;
+            sprite.TransparentColourIndex = options.TransparentColourIndex;
             sprite.RemapToGamePalette = options.RemapColours;
             sprite.RemapToRoomPalette = options.UseRoomBackground;
             sprite.SourceFile = Utilities.GetRelativeToProjectPath(options.Filename);
@@ -362,7 +365,8 @@ namespace AGS.Editor.Utils
             bool useAlphaChannel, remapColours, useRoomBackground;
             AdjustImportParams(bmp, options, out useAlphaChannel, out remapColours, out useRoomBackground);
 
-            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
+            Factory.NativeProxy.ReplaceSpriteWithBitmap(sprite, bmp, options.Transparency, options.TransparentColourIndex,
+                remapColours, useRoomBackground, useAlphaChannel);
             SetSpriteImportOptions(sprite, options);
         }
 
@@ -405,7 +409,8 @@ namespace AGS.Editor.Utils
             bool useAlphaChannel, remapColours, useRoomBackground;
             AdjustImportParams(bmp, options, out useAlphaChannel, out remapColours, out useRoomBackground);
 
-            Sprite sprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, options.Transparency, remapColours, useRoomBackground, useAlphaChannel);
+            Sprite sprite = Factory.NativeProxy.CreateSpriteFromBitmap(bmp, options.Transparency, options.TransparentColourIndex,
+                remapColours, useRoomBackground, useAlphaChannel);
             if (sprite != null)
             {
                 SetSpriteImportOptions(sprite, options);
@@ -764,8 +769,8 @@ namespace AGS.Editor.Utils
             var bmp = LoadBitmapFromSource(sprite);
             if (bmp != null)
             {
-                writer.WriteBitmap(bmp, sprite.TransparentColour, sprite.RemapToGamePalette,
-                    sprite.RemapToRoomPalette, sprite.AlphaChannel);
+                writer.WriteBitmap(bmp, sprite.TransparentColour, sprite.TransparentColourIndex,
+                    sprite.RemapToGamePalette, sprite.RemapToRoomPalette, sprite.AlphaChannel);
                 bmp.Dispose();
                 return;
             }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -64,7 +64,8 @@ extern void drawSprite(HDC hdc, int x,int y, int spriteNum, bool flipImage);
 extern void drawSpriteStretch(HDC hdc, int x,int y, int width, int height, int spriteNum, bool flipImage);
 extern void drawBlockOfColour(HDC hdc, int x,int y, int width, int height, int colNum);
 extern void drawViewLoop (HDC hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
-extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitmap^ bmp, int spriteImportMethod,
+    int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 extern Bitmap^ getSpriteAsBitmap(int spriteNum);
 extern Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height);
 extern Bitmap^ getBackgroundAsBitmap(Room ^room, int backgroundNumber);
@@ -443,34 +444,34 @@ namespace AGS
 			}
 		}
 
-		Sprite^ NativeMethods::SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
-		{
-            SpriteImportResolution spriteRes = SetNewSpriteFromBitmap(spriteSlot, bmp, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
-      int colDepth = GetSpriteColorDepth(spriteSlot);
-			Sprite^ newSprite = gcnew Sprite(spriteSlot, bmp->Width, bmp->Height, colDepth, spriteRes, alphaChannel);
-      int roomNumber = GetCurrentlyLoadedRoomNumber();
-      if ((colDepth == 8) && (useRoomBackgroundColours) && (roomNumber >= 0))
-      {
-        newSprite->ColoursLockedToRoom = roomNumber;
-      }
-      return newSprite;
-		}
+        Sprite^ NativeMethods::SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        {
+            SpriteImportResolution spriteRes = SetNewSpriteFromBitmap(spriteSlot, bmp, spriteImportMethod, transColour, remapColours, useRoomBackgroundColours, alphaChannel);
+            int colDepth = GetSpriteColorDepth(spriteSlot);
+            Sprite^ newSprite = gcnew Sprite(spriteSlot, bmp->Width, bmp->Height, colDepth, spriteRes, alphaChannel);
+            int roomNumber = GetCurrentlyLoadedRoomNumber();
+            if ((colDepth == 8) && (useRoomBackgroundColours) && (roomNumber >= 0))
+            {
+                newSprite->ColoursLockedToRoom = roomNumber;
+            }
+            return newSprite;
+        }
 
-		void NativeMethods::ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
-		{
-            SpriteImportResolution spriteRes = SetNewSpriteFromBitmap(spr->Number, bmp, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
-			spr->Resolution = spriteRes;
-			spr->ColorDepth = GetSpriteColorDepth(spr->Number);
-			spr->Width = bmp->Width;
-			spr->Height = bmp->Height;
-			spr->AlphaChannel = alphaChannel;
-      spr->ColoursLockedToRoom = System::Nullable<int>();
-      int roomNumber = GetCurrentlyLoadedRoomNumber();
-      if ((spr->ColorDepth == 8) && (useRoomBackgroundColours) && (roomNumber >= 0))
-      {
-        spr->ColoursLockedToRoom = roomNumber;
-      }
-		}
+        void NativeMethods::ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+        {
+            SpriteImportResolution spriteRes = SetNewSpriteFromBitmap(spr->Number, bmp, spriteImportMethod, transColour, remapColours, useRoomBackgroundColours, alphaChannel);
+            spr->Resolution = spriteRes;
+            spr->ColorDepth = GetSpriteColorDepth(spr->Number);
+            spr->Width = bmp->Width;
+            spr->Height = bmp->Height;
+            spr->AlphaChannel = alphaChannel;
+            spr->ColoursLockedToRoom = System::Nullable<int>();
+            int roomNumber = GetCurrentlyLoadedRoomNumber();
+            if ((spr->ColorDepth == 8) && (useRoomBackgroundColours) && (roomNumber >= 0))
+            {
+                spr->ColoursLockedToRoom = roomNumber;
+            }
+        }
 
         Bitmap^ NativeMethods::GetSpriteBitmap(int spriteSlot)
         {

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -56,8 +56,8 @@ namespace AGS
 			int  DrawFont(int hDC, int fontNum, int draw_atx, int draw_aty, int width, int height, int scroll_y);
 			void DrawBlockOfColour(int hDC, int x, int y, int width, int height, int colourNum);
 			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
-			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
-			void ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+			void ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
             Bitmap^ GetSpriteBitmap(int spriteSlot);
             Bitmap^ GetSpriteBitmapAs32Bit(int spriteSlot, int width, int height);
 			void DeleteSprite(int spriteSlot);

--- a/Editor/AGS.Native/SpriteFileWriter_NET.cpp
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.cpp
@@ -23,7 +23,8 @@ using AGSStream = AGS::Common::Stream;
 
 extern AGSBitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, int *srcPalLen,
     bool fixColourDepth, bool importAlpha, bool keepTransparency, int *originalColDepth);
-extern AGSBitmap *CreateNativeBitmap(System::Drawing::Bitmap ^bmp, int spriteImportMethod, bool remapColours,
+extern AGSBitmap *CreateNativeBitmap(System::Drawing::Bitmap ^bmp, int spriteImportMethod,
+    int transColour, bool remapColours,
     bool useRoomBackgroundColours, bool alphaChannel, int *flags);
 
 namespace AGS
@@ -57,10 +58,10 @@ void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image)
 }
 
 void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::SpriteImportTransparency transparency,
-    bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+    int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
 {
-    std::unique_ptr<AGSBitmap> native_bmp(CreateNativeBitmap(image, (int)transparency, remapColours,
-        useRoomBackgroundColours, alphaChannel, nullptr));
+    std::unique_ptr<AGSBitmap> native_bmp(CreateNativeBitmap(image, (int)transparency, transColour,
+        remapColours, useRoomBackgroundColours, alphaChannel, nullptr));
     _nativeWriter->WriteBitmap(native_bmp.get());
 }
 

--- a/Editor/AGS.Native/SpriteFileWriter_NET.h
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.h
@@ -35,7 +35,7 @@ public:
     void WriteBitmap(System::Drawing::Bitmap ^image);
     // Converts bitmap according to the sprite's properties, and writes into the file
     void WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::SpriteImportTransparency transparency,
-        bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+        int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
     // Writes a native bitmap into the file without any additional convertions
     void WriteNativeBitmap(NativeBitmap ^bitmap);
     // Writes a raw sprite data presented in internal spritefile format

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1285,75 +1285,98 @@ void drawGUIAt(HDC hdc, int x, int y, int x1, int y1, int x2, int y2, int resolu
     drawBlockScaledAt(hdc, final_gui, x, y, scale);
 }
 
-#define SIMP_INDEX0  0
-#define SIMP_TOPLEFT 1
-#define SIMP_BOTLEFT 2
-#define SIMP_TOPRIGHT 3
-#define SIMP_BOTRIGHT 4
+#define SIMP_INDEX0     0
+#define SIMP_TOPLEFT    1
+#define SIMP_BOTLEFT    2
+#define SIMP_TOPRIGHT   3
+#define SIMP_BOTRIGHT   4
 #define SIMP_LEAVEALONE 5
-#define SIMP_NONE     6
+#define SIMP_NONE       6
 
-// Adjusts sprite's transparency using the chosen method
-void sort_out_transparency(Common::Bitmap *toimp, int sprite_import_method, RGB*itspal, int importedColourDepth,
-    int &transcol)
+// Removes all transparency pixels (change them to a close non-trnasparent colour)
+void remove_transparency(AGSBitmap *toimp, const int transcol)
 {
-  if (sprite_import_method == SIMP_LEAVEALONE)
-  {
-    transcol = 0;
-    return;
-  }
-
-  set_palette_range(palette, 0, 255, 0);
-  transcol=toimp->GetMaskColor();
-  // NOTE: This takes the pixel from the corner of the overall import
-  // graphic, NOT just the image to be imported
-  if (sprite_import_method == SIMP_TOPLEFT)
-    transcol=toimp->GetPixel(0,0);
-  else if (sprite_import_method==SIMP_BOTLEFT)
-    transcol=toimp->GetPixel(0,(toimp->GetHeight())-1);
-  else if (sprite_import_method == SIMP_TOPRIGHT)
-    transcol = toimp->GetPixel((toimp->GetWidth())-1, 0);
-  else if (sprite_import_method == SIMP_BOTRIGHT)
-    transcol = toimp->GetPixel((toimp->GetWidth())-1, (toimp->GetHeight())-1);
-
-  if (sprite_import_method == SIMP_NONE)
-  {
-    // remove all transparency pixels (change them to
-    // a close non-trnasparent colour)
     int changeTransparencyTo;
     if (transcol == 0)
-      changeTransparencyTo = 16;
+        changeTransparencyTo = 16;
     else
-      changeTransparencyTo = transcol - 1;
+        changeTransparencyTo = transcol - 1;
 
-    for (int tt=0;tt<toimp->GetWidth();tt++) {
-      for (int uu=0;uu<toimp->GetHeight();uu++) {
-        if (toimp->GetPixel(tt,uu) == transcol)
-          toimp->PutPixel(tt,uu, changeTransparencyTo);
-      }
+    for (int tt = 0; tt < toimp->GetWidth(); tt++)
+    {
+        for (int uu = 0; uu < toimp->GetHeight(); uu++)
+        {
+            if (toimp->GetPixel(tt, uu) == transcol)
+                toimp->PutPixel(tt, uu, changeTransparencyTo);
+        }
     }
-  }
-  else
-  {
-	  int bitmapMaskColor = toimp->GetMaskColor();
+}
+
+void make_color_transparent(AGSBitmap *toimp, const RGB *itspal, int importedColourDepth, const int transcol)
+{
+    int bitmapMaskColor = toimp->GetMaskColor();
     int replaceWithCol = 16;
-	  if (toimp->GetColorDepth() > 8)
-	  {
-      if (importedColourDepth == 8)
-        replaceWithCol = makecol_depth(toimp->GetColorDepth(), itspal[0].r * 4, itspal[0].g * 4, itspal[0].b * 4);
-      else
-		    replaceWithCol = 0;
-	  }
-    // swap all transparent pixels with index 0 pixels
-    for (int tt=0;tt<toimp->GetWidth();tt++) {
-      for (int uu=0;uu<toimp->GetHeight();uu++) {
-        if (toimp->GetPixel(tt,uu)==transcol)
-          toimp->PutPixel(tt,uu, bitmapMaskColor);
-        else if (toimp->GetPixel(tt,uu) == bitmapMaskColor)
-          toimp->PutPixel(tt,uu, replaceWithCol);
-      }
+    if (toimp->GetColorDepth() > 8)
+    {
+        if (importedColourDepth == 8)
+            replaceWithCol = makecol_depth(toimp->GetColorDepth(), itspal[0].r, itspal[0].g, itspal[0].b);
+        else
+            replaceWithCol = 0;
     }
-  }
+    // swap all transparent pixels with index 0 pixels
+    for (int uu = 0; uu < toimp->GetHeight(); ++uu)
+    {
+        for (int tt = 0; tt < toimp->GetWidth(); ++tt)
+        {
+            if (toimp->GetPixel(tt, uu) == transcol)
+                toimp->PutPixel(tt, uu, bitmapMaskColor);
+            else if (toimp->GetPixel(tt, uu) == bitmapMaskColor)
+                toimp->PutPixel(tt, uu, replaceWithCol);
+        }
+    }
+}
+
+// Adjusts sprite's transparency using the chosen method
+void sort_out_transparency(AGSBitmap *toimp, int sprite_import_method, const RGB *itspal, int importedColourDepth,
+    int &transcol)
+{
+    if (sprite_import_method == SIMP_LEAVEALONE)
+    {
+        transcol = toimp->GetMaskColor();
+        return;
+    }
+
+    set_palette_range(palette, 0, 255, 0);
+
+    if (sprite_import_method == SIMP_NONE)
+    {
+        transcol = toimp->GetMaskColor();
+        remove_transparency(toimp, transcol);
+        return;
+    }
+
+    // NOTE: This takes the pixel from the corner of the overall import
+    // graphic, NOT just the image to be imported
+    switch (sprite_import_method)
+    {
+    case SIMP_TOPLEFT:
+        transcol = toimp->GetPixel(0, 0);
+        break;
+    case SIMP_BOTLEFT:
+        transcol = toimp->GetPixel(0, (toimp->GetHeight()) - 1);
+        break;
+    case SIMP_TOPRIGHT:
+        transcol = toimp->GetPixel((toimp->GetWidth()) - 1, 0);
+        break;
+    case SIMP_BOTRIGHT:
+        transcol = toimp->GetPixel((toimp->GetWidth()) - 1, (toimp->GetHeight()) - 1);
+        break;
+    default:
+        transcol = toimp->GetMaskColor();
+        break;
+    }
+
+    make_color_transparent(toimp, itspal, importedColourDepth, transcol);
 }
 
 // Adjusts 8-bit sprite's palette
@@ -2541,7 +2564,7 @@ Common::Bitmap *CreateNativeBitmap(System::Drawing::Bitmap^ bmp, int spriteImpor
 
     RGB imgPalBuf[256];
     int importedColourDepth;
-    Common::Bitmap *tempsprite = CreateBlockFromBitmap(bmp, imgPalBuf, nullptr, true,
+    AGSBitmap *tempsprite = CreateBlockFromBitmap(bmp, imgPalBuf, nullptr, true,
         alphaChannel, (spriteImportMethod != SIMP_NONE), &importedColourDepth);
 
     int transcol;

--- a/Editor/AGS.Types/Enums/SpriteImportTransparency.cs
+++ b/Editor/AGS.Types/Enums/SpriteImportTransparency.cs
@@ -4,7 +4,7 @@ namespace AGS.Types
 {
     public enum SpriteImportTransparency
     {
-        [Description("Pixels of index 0 will be transparent (256-colour games only)")]
+        [Description("Pixels of palette index 0 will be transparent (256-colour games only)")]
         PaletteIndex0,
         [Description("The top-left pixel will be the transparent colour for this sprite")]
         TopLeft,
@@ -17,6 +17,8 @@ namespace AGS.Types
         [Description("AGS will leave the sprite's pixels as they are. Any pixels that match the AGS Transparent Colour will be invisible.")]
         LeaveAsIs,
         [Description("AGS will remove all transparent pixels by changing them to a very similar non-transparent colour")]
-        NoTransparency
+        NoTransparency,
+        [Description("Pixels of chosen palette index will be transparent (256-colour games only)")]
+        PaletteIndex
     }
 }

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -22,6 +22,7 @@ namespace AGS.Types
         private int? _coloursLockedToRoom = null;
         private int _frame = 0;
         private SpriteImportTransparency _tranparentColour = SpriteImportTransparency.LeaveAsIs;
+        private int _transparentColourIndex = 0;
         private int _offsetX;
         private int _offsetY;
         private int _importWidth;
@@ -210,6 +211,14 @@ namespace AGS.Types
             set { _tranparentColour = value; }
         }
 
+        [Description("Palette index treated as a transparent colour")]
+        [Category("Import")]
+        public int TransparentColourIndex
+        {
+            get { return _transparentColourIndex; }
+            set { _transparentColourIndex = value; }
+        }
+
         [Description("Remap colours to game palette")]
         [Category("Import")]
         public bool RemapToGamePalette
@@ -296,6 +305,16 @@ namespace AGS.Types
                 {
                     _importAsTile = false;
                 }
+
+                // added in XML Version 3060300
+                try
+                {
+                    _transparentColourIndex = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "TransparentColorIndex"));
+                }
+                catch (InvalidDataException)
+                {
+                    _transparentColourIndex = 0;
+                }
             }
         }
 
@@ -325,6 +344,7 @@ namespace AGS.Types
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());
             writer.WriteElementString("RemapToRoomPalette", _remapToRoomPalette.ToString());
             writer.WriteElementString("ImportMethod", _tranparentColour.ToString());
+            writer.WriteElementString("TransparentColorIndex", _transparentColourIndex.ToString());
             writer.WriteElementString("ImportAlphaChannel", _importAlphaChannel.ToString());
             writer.WriteEndElement(); // end source
 


### PR DESCRIPTION
Long overdue, resolves #805

In the sprite import dialog replaces "Palette index 0" with "Palette index" selection and a numeric input field (default to value 0). This allows user to select exact palette index to use as a transparent color, in case the sprite source has it on other index than 0.
"Palette index 0" is still available in the sprite's properties for backwards compatibility.

Images for the test:
8-bit PNG: 
![Bar_Door1](https://github.com/user-attachments/assets/81fd9cfb-708b-4d42-b718-da1c80cf6691)
8-bit GIF (multiframe):
![Bar Door](https://github.com/user-attachments/assets/7db69d49-0333-4fb1-b0da-3960cfab2e60)

