### PR TITLE
CMake compatibility

### DIFF
--- a/CMake/FetchGoogleTest.cmake
+++ b/CMake/FetchGoogleTest.cmake
@@ -11,8 +11,8 @@ else()
     FetchContent_Declare(
         googletest_content
         DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-        URL https://github.com/google/googletest/archive/4ec4cd23f486bf70efcc5d2caa40f24368f752e3.tar.gz
-        URL_HASH MD5=b907483a9045a2edda15ee7d2a68aaa5
+        URL https://github.com/google/googletest/archive/52204f78f94d7512df1f0f3bea1d47437a2c3a58.tar.gz
+        URL_HASH MD5=9512a106bb006ab84e0a822ec363c6c7
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.13..3.14)
 
+# keep fetch content working on CMake 3.X versions, but won't work in CMake 4.X
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/CMake/c_flag_overrides.cmake)
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/CMake/cxx_flag_overrides.cmake)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")


### PR DESCRIPTION
It seems GitHub Actions builder had an update in CMake that broke building in PR #2712. Made a quick fix that worked in the pipeline in my fork.

I will need to joing together the fetch content scripts as now it's expected to do a single MakeAvailable call later that contains all libraries in it - so, I can't separately call to build SDL2 and then SDL Sound anymore, I need to tell cmake to build SDL2 and SDL_Sound in sequence, so it figures the link between then, when fetching them. This will take a little more time to figure it out.