### PR TITLE
[Remake] New compiler: Initializers for global classic arrays and structs

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -215,7 +215,7 @@ bool AGS::Snippet::IsEmpty()
 
 void AGS::RestorePoint::Cut(Snippet &snippet, bool const keep_starting_linum)
 {
-    int32_t const orig_codesize = _scrip.Codesize_i32();
+    CodeLoc const orig_codesize = _scrip.Codesize_i32();
 
     // Reset the code to the remembered location.
     CodeLoc rcl = _rememberedCodeLocation;

--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -82,7 +82,7 @@ AGS::GlobalLoc AGS::ccCompiledScript::AddGlobal(size_t const value_size, void *v
 {
     assert(globaldata.size() + value_size <= INT32_MAX);
     if (0u == value_size)
-        return static_cast<int32_t>(globaldata.size()); // nothing to do
+        return static_cast<GlobalLoc>(globaldata.size()); // nothing to do
 
     // The new global variable will be moved to &(globaldata[offset])
     size_t const offset = globaldata.size();

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -788,12 +788,15 @@ bool AGS::SymbolTable::IsOldstring(Symbol s) const
     Vartype const s_without_const =
         VartypeWithout(VTT::kConst, s);
 
-    // string and const string are oldstrings
+    // 'string' and 'const string' are oldstrings
     if (kKW_String == s_without_const)
         return true;
 
-    // const char[..] and char[..] are considered oldstrings, too
-    return (IsArrayVartype(s) && kKW_Char == VartypeWithout(VTT::kArray, s_without_const));
+    // 'char'[..] considered oldstring, too
+    return
+        IsArrayVartype(s) &&
+        1u == ArrayDimensionsCount(s) &&
+        kKW_Char == VartypeWithout(VTT::kArray, s_without_const);
 }
 
 AGS::Symbol AGS::SymbolTable::Add(std::string const &name)

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -552,6 +552,10 @@ std::string const AGS::SymbolTable::GetName(AGS::Symbol symbl) const
 
 AGS::Vartype AGS::SymbolTable::VartypeWithArray(std::vector<size_t> const &dims, AGS::Vartype vartype)
 {
+    if (dims.empty())
+        // A zero-dimensional array is a "no-op".
+        return vartype;
+
     // If 'vartype' is an array, the new array index must be spliced into the vartype name
     // in front of the first '['
     std::string pre = GetName(vartype);
@@ -599,6 +603,24 @@ AGS::Vartype AGS::SymbolTable::VartypeWithArray(std::vector<size_t> const &dims,
         entries[array_vartype].VartypeD->Dims = dims_to_use;
     }
     return array_vartype;
+}
+
+AGS::Vartype AGS::SymbolTable::ArrayVartypeWithoutFirstDim(Vartype const vartype)
+{
+    if (!IsVartype(vartype))
+        return kKW_NoSymbol;
+
+    auto &dims = entries[vartype].VartypeD->Dims;
+    size_t const dims_count = dims.size();
+    if (0u == dims_count)
+        return vartype;
+
+    Vartype const base_vartype = entries[vartype].VartypeD->BaseVartype;
+    if (1u == dims_count)
+        return base_vartype;
+
+    std::vector<size_t> const new_dims{ dims.cbegin() + 1u, dims.cend() };
+    return VartypeWithArray(new_dims, base_vartype);
 }
 
 AGS::Vartype AGS::SymbolTable::VartypeWithConst(AGS::Vartype vartype)
@@ -754,7 +776,8 @@ AGS::Vartype AGS::SymbolTable::GetFirstBaseVartype(AGS::Vartype vartype) const
 {
     // TODO: extra safety checks?
     for (const auto *ste = &entries[vartype]; ste->VartypeD && (ste->VartypeD->BaseVartype > 0);
-        vartype = ste->VartypeD->BaseVartype, ste = &entries[vartype]) { }
+        vartype = ste->VartypeD->BaseVartype, ste = &entries[vartype])
+    { }
     return vartype;
 }
 

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -500,7 +500,9 @@ public:
 
     // Arrays and variables that are arrays
     // The "Array[...] of vartype" vartype
-    Vartype VartypeWithArray(std::vector<size_t> const &dims, AGS::Vartype vartype);
+    Vartype VartypeWithArray(std::vector<size_t> const &dims, Vartype vartype);
+    // The array without the first dimension 'a[3, 5]' -> 'a[5]'
+    Vartype ArrayVartypeWithoutFirstDim(Vartype vartype);
     // The "Const of vartype" vartype
     Vartype VartypeWithConst(AGS::Vartype vartype);
     // The "Dynarray of vartype" vartype

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -228,7 +228,7 @@ struct FuncParameterDesc
     AGS::Vartype Vartype = kKW_NoSymbol;
     Symbol Name = kKW_NoSymbol;
     Symbol Default = kKW_NoSymbol;
-    size_t Declared;
+    size_t Declared = SIZE_MAX;
 };
 
 struct SymbolTable;

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -512,6 +512,8 @@ public:
 
     inline bool IsArrayVartype(Symbol s) const { return IsVTT(s, VTT::kArray); }
     size_t ArrayElementsCount(Symbol s) const;
+    size_t ArrayDimensionsCount(Symbol s) const
+        { return entries.at(s).VartypeD ? entries.at(s).VartypeD->Dims.size() : 0u; }
     inline bool IsDynarrayVartype(Symbol s) const { return IsVTT(s, VTT::kDynarray); }
     inline bool IsAnyArrayVartype(Symbol s) const { return IsArrayVartype(s) || IsDynarrayVartype(s); }
     

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -6961,19 +6961,19 @@ void AGS::Parser::Parse_BlankOutUnusedImports()
         if (_sym[entries_idx].Accessed)
             continue;
 
-        // Don't "compact" the entries in the _scrip.imports[] array. They are referenced by index, and if you
+        // Don't "compact" the entries in '_scrip.imports[]'. They are referenced by index, and if you
         // change the indexes of the entries then you get dangling "references". So the only thing allowed is
         // setting unused import entries to "".
         if (_sym.IsFunction(entries_idx))
         {
             if(_sym[entries_idx].FunctionD->TypeQualifiers[TQ::kImport])
-                _scrip.imports[_sym[entries_idx].FunctionD->Offset][0u] = '\0';
+                _scrip.imports[_sym[entries_idx].FunctionD->Offset].clear();
             continue;
         }
         if (_sym.IsVariable(entries_idx))
         {
             if (_sym[entries_idx].VariableD->TypeQualifiers[TQ::kImport])
-                _scrip.imports[_sym[entries_idx].VariableD->Offset][0u] = '\0';
+                _scrip.imports[_sym[entries_idx].VariableD->Offset].clear();
             continue;
         }
     }
@@ -7091,7 +7091,7 @@ void AGS::Parser::Parse_CheckFixupSanity()
                 fixup_idx,
                 code_idx);
         int const cv = _scrip.code[code_idx];
-        if (cv < 0 || static_cast<size_t>(cv) >= _scrip.imports.size() || '\0' == _scrip.imports[cv][0u])
+        if (cv < 0 || static_cast<size_t>(cv) >= _scrip.imports.size() || _scrip.imports[cv].empty())
             InternalError(
                 "Fixup #%d references non-existent import #%d",
                 fixup_idx,

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4320,6 +4320,49 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype co
     }
 }
 
+void AGS::Parser::ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t const available_space, std::vector<char> &initial_val)
+{
+    // Get the relevant characters from the strings table
+    std::string const lit_value = &(_scrip.strings[_sym[string_lit].LiteralD->Value]);
+
+    if (lit_value.length() >= available_space)
+        UserError(
+            "Initializing string literal has %u chars and is too long (available space: %u chars)",
+            lit_value.length(),
+            available_space - 1u);
+
+    initial_val.assign(lit_value.begin(), lit_value.end());
+    initial_val.push_back('\0');
+}
+
+void AGS::Parser::ParseVardecl_InitialValAssignment_Array(Vartype const vartype, std::vector<char> &initial_val)
+{
+    Symbol const next_sym = _src.GetNext();
+    if (_sym.IsLiteral(next_sym) && _sym.VartypeWithConst(kKW_String) == _sym[next_sym].LiteralD->Vartype)
+    {
+        Vartype const base_vartype = _sym[vartype].VartypeD->BaseVartype;
+        if (kKW_Char != base_vartype)
+            UserError(
+                "Cannot initialize an array of '%s' with a string literal",
+                _sym.GetName(base_vartype).c_str());
+        size_t const dims_count = _sym.ArrayDimensionsCount(vartype);
+        if (dims_count > 1u)
+            UserError(
+                "Cannot initialize a multi-dimensional array with a string literal");
+
+        ParseVardecl_InitialValAssignment_AssignStringLit(
+            next_sym,
+            _sym.ArrayElementsCount(vartype),
+            initial_val);
+        return;
+    }
+    // TODO: Check that the array can be initialized.
+    // It must consist of non-managed arrays or non-managed structs
+    // or 'float's or integer types or 'string'.
+    Expect(kKW_OpenBrace, next_sym);
+    InternalError("Array initializers aren't implemented yet (except for string literals)");
+}
+
 void AGS::Parser::ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val)
 {
     Symbol string_lit = _src.GetNext();
@@ -4330,16 +4373,7 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_OldString(std::vector<char> 
         _sym.VartypeWithConst(kKW_String) != _sym[string_lit].LiteralD->Vartype)
         UserError("Expected a string literal after '=', found '%s' instead", _sym.GetName(_src.PeekNext()).c_str());
 
-    // The scanner has put the constant string into the strings table. That's where we must find and get it.
-    std::string const lit_value = &(_scrip.strings[_sym[string_lit].LiteralD->Value]);
-    
-    if (lit_value.length() >= STRINGBUFFER_LENGTH)
-        UserError(
-            "Initializer string is too long (max. chars allowed: %u)",
-            STRINGBUFFER_LENGTH - 1u);
-
-    initial_val.assign(lit_value.begin(), lit_value.end());
-    initial_val.push_back('\0');
+    ParseVardecl_InitialValAssignment_AssignStringLit(string_lit, STRINGBUFFER_LENGTH, initial_val);
 }
 
 void AGS::Parser::ParseVardecl_InitialValAssignment(Symbol varname, std::vector<char> &initial_val)
@@ -4352,8 +4386,9 @@ void AGS::Parser::ParseVardecl_InitialValAssignment(Symbol varname, std::vector<
 
     if (_sym.IsStructVartype(vartype))
         UserError("'%s' is a struct and cannot be initialized here", _sym.GetName(varname).c_str());
+
     if (_sym.IsArrayVartype(vartype))
-        UserError("'%s' is an array and cannot be initialized here", _sym.GetName(varname).c_str());
+        return ParseVardecl_InitialValAssignment_Array(vartype, initial_val);
 
     if (kKW_String == vartype)
         return ParseVardecl_InitialValAssignment_OldString(initial_val);

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4612,12 +4612,26 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_StringBuf(std::vector<char> 
 
 void AGS::Parser::ParseVardecl_InitialValAssignment(Vartype vartype, std::vector<char> &initial_val)
 {
-    if (_sym.IsManagedVartype(vartype))
+    if (_sym.IsDynarrayVartype(vartype))
     {
         // We only reserve the space for the pointer.
         // The space for the actual object will be reserved with an AGS 'new' expression.
         initial_val.resize (SIZE_OF_DYNPOINTER);
-        return Expect(kKW_Null, _src.GetNext());
+
+        if (kKW_Null != _src.GetNext())
+            UserError("Can only initialize this global dynamic array as 'null'");
+        return;
+    }
+
+    if (_sym.IsDynpointerVartype(vartype))
+    {
+        // We only reserve the space for the pointer.
+        // The space for the actual object will be reserved with an AGS 'new' expression.
+        initial_val.resize (SIZE_OF_DYNPOINTER);
+
+        if (kKW_Null != _src.GetNext())
+            UserError("Can only initialize this global managed variable as 'null'");
+        return;
     }
 
     if (_sym.IsStructVartype(vartype))
@@ -7201,7 +7215,7 @@ void AGS::Parser::ParseInput()
         // Command clauses
 
         if (kKW_NoSymbol == name_of_current_func)
-            UserError("'%s' is illegal outside a function", _sym.GetName(leading_sym).c_str());
+            UserError("Cannot start a definition or declaration with '%s'", _sym.GetName(leading_sym).c_str());
 
         Parse_CheckTQSIsEmpty(tqs);
         ParseCommand(leading_sym, struct_of_current_func, name_of_current_func);
@@ -7276,11 +7290,11 @@ void AGS::Parser::UserError(char const *msg, ...)
     va_copy(vlist2, vlist1);
     size_t const needed_len = vsnprintf(nullptr, 0u, msg, vlist1) + 1u;
     std::vector<char> message(needed_len);
-    vsprintf(&message[0u], msg, vlist2);
+    vsprintf(message.data(), msg, vlist2);
     va_end(vlist2);
     va_end(vlist1);
 
-    Error(false, &message[0u]);
+    Error(false, message.data());
 }
 
 void AGS::Parser::InternalError(char const *descr, ...)
@@ -7289,14 +7303,14 @@ void AGS::Parser::InternalError(char const *descr, ...)
     va_list vlist1, vlist2;
     va_start(vlist1, descr);
     va_copy(vlist2, vlist1);
-    // '+ 1' for the trailing '\0'
+    // '+ 1u' for the trailing '\0'
     size_t const needed_len = vsnprintf(nullptr, 0u, descr, vlist1) + 1u;
     std::vector<char> message(needed_len);
-    vsprintf(&message[0u], descr, vlist2);
+    vsprintf(message.data(), descr, vlist2);
     va_end(vlist2);
     va_end(vlist1);
 
-    Error(true, &message[0u]);
+    Error(true, message.data());
 }
 
 void AGS::Parser::Warning(char const *descr, ...)
@@ -7305,10 +7319,10 @@ void AGS::Parser::Warning(char const *descr, ...)
     va_list vlist1, vlist2;
     va_start(vlist1, descr);
     va_copy(vlist2, vlist1);
-    // '+ 1' for the trailing '\0'
+    // '+ 1u' for the trailing '\0'
     size_t const needed_len = vsnprintf(nullptr, 0u, descr, vlist1) + 1u;
     std::vector<char> message(needed_len);
-    vsprintf(&message[0u], descr, vlist2);
+    vsprintf(message.data(), descr, vlist2);
     va_end(vlist2);
     va_end(vlist1);
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -235,6 +235,7 @@ Classic arrays and Dynarrays, pointers and managed structs:
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <algorithm>
 
 #include "util/string.h"
 
@@ -292,15 +293,14 @@ void AGS::Parser::SkipNextSymbol(SrcList &src, Symbol expected)
             _sym.GetName(act).c_str());
 }
 
-
-void AGS::Parser::Expect(SymbolList const &expected, Symbol actual, std::string const &custom_msg)
+void AGS::Parser::Expect(SymbolList const &expected, Symbol const actual, std::string const &custom_msg)
 {
-    for (size_t expected_idx = 0u; expected_idx < expected.size(); expected_idx++)
-        if (actual == expected[expected_idx])
-            return;
+    auto found_it = std::find(expected.cbegin(), expected.cend(), actual);
+    if (expected.cend() != found_it) // found 'actual' in the list
+        return;
 
     std::string errmsg = custom_msg;
-    if (errmsg == "")
+    if (errmsg.empty())
     {
         // Provide a default message
         errmsg = "Expected ";
@@ -310,7 +310,7 @@ void AGS::Parser::Expect(SymbolList const &expected, Symbol actual, std::string 
             if (expected_idx + 2u < expected.size())
                 errmsg += ", ";
             else if (expected_idx + 2u == expected.size())
-                errmsg += " or ";
+                errmsg += ", or ";
         }
     }
     errmsg += ", found '%s' instead";
@@ -2721,7 +2721,10 @@ void AGS::Parser::ParseExpression_Binary(size_t const op_idx, SrcList &expressio
     }
  
     if (ParseExpression_CompileTime(operator_sym, eres_lhs, eres_rhs, eres))
-        start_of_term.Restore();
+        // Don't keep the starting LINUM:
+        // This code may run within the global data section, when a global is initialized,
+        // and that starting LINUM will be superfluous, outside of a function body.
+        start_of_term.Restore(false);
 }
 
 void AGS::Parser::ParseExpression_CheckUsedUp(SrcList &expression)
@@ -4320,19 +4323,241 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype co
     }
 }
 
-void AGS::Parser::ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t const available_space, std::vector<char> &initial_val)
+void AGS::Parser::ParseVardecl_InitialValAssignment_ArrayOrStringBuf_Literal(Symbol string_lit, size_t const available_space, std::vector<char> &initial_val)
 {
     // Get the relevant characters from the strings table
     std::string const lit_value = &(_scrip.strings[_sym[string_lit].LiteralD->Value]);
 
-    if (lit_value.length() >= available_space)
+    // '- 1u' to leave space for the terminating '\0'
+    if (lit_value.length() > available_space - 1u)
         UserError(
-            "Initializing string literal has %u chars and is too long (available space: %u chars)",
+            "Initializing string literal has %u chars and is too long "
+            "(available space: %u chars)",
             lit_value.length(),
             available_space - 1u);
 
     initial_val.assign(lit_value.begin(), lit_value.end());
-    initial_val.push_back('\0');
+    initial_val.resize(available_space);
+}
+
+void AGS::Parser::ParseVardecl_InitialValAssignment_Struct(Vartype const vartype, std::vector<char> &initial_val)
+{
+    // Data that we need to track for each (direct or indirect) component of 'vartype'
+    struct ComponentFields
+    {
+        Symbol Component; // without the qualifier
+        Symbol QualifiedName;
+        size_t Offset;
+        AGS::Vartype Vartype;
+        bool IsFunction;
+        bool IsAttribute;
+        std::vector<char> InitialVal;
+        size_t InitialValDeclared;
+    };
+    std::vector<ComponentFields> fields = {};
+
+    SymbolList components;
+    _sym.GetComponentsOfStruct(vartype, components);
+
+    for (size_t idx = 0u; idx < components.size(); idx++)
+    {
+        auto &compo = components[idx];
+        ComponentFields cf;
+        cf.Component = _sym[compo].ComponentD->Component;
+        cf.QualifiedName = compo;
+        cf.Offset = _sym[compo].ComponentD->Offset;
+        cf.Vartype = _sym[compo].VariableD ? _sym[compo].VariableD->Vartype : kKW_NoSymbol;
+        cf.InitialVal = {};
+        cf.InitialValDeclared = 0u;
+        cf.IsAttribute = (nullptr != _sym[compo].AttributeD);
+        cf.IsFunction = (nullptr != _sym[compo].FunctionD);
+        fields.push_back(cf);
+    }
+
+    Expect(kKW_OpenBrace, _src.GetNext());
+    Symbol sym = _src.GetNext();
+    while (sym != kKW_CloseBrace)
+    {
+        // Find the entry in 'fields' where 'Component' equals 'sym'
+        auto found_it = std::find_if(
+            fields.begin(),
+            fields.end(),
+            [&](ComponentFields const &cf) { return cf.Component == sym; });
+
+        if (fields.end() == found_it) // didn't find in the list
+        {
+            if (!_sym.IsIdentifier(sym))
+                UserError(
+                    "Expected an identifier as a component of '%s' but found '%s",
+                    _sym.GetName(vartype).c_str(),
+                    _sym.GetName(sym).c_str());
+            UserError(
+                ReferenceMsgSym(
+                    "Cannot find '%s' in struct '%s'", vartype).c_str(),
+                _sym.GetName(sym).c_str(),
+                _sym.GetName(vartype).c_str());
+        }
+        if (found_it->IsAttribute)
+            UserError(
+                ReferenceMsgSym(
+                    "Cannot initialize the attribute '%s'", vartype).c_str(),
+                _sym.GetName(vartype).c_str(),
+                _sym.GetName(found_it->QualifiedName).c_str());
+        if (found_it->IsFunction)
+            UserError(
+                ReferenceMsgSym(
+                    "Cannot initialize the function '%s'", vartype).c_str(),
+                _sym.GetName(vartype).c_str(),
+                _sym.GetName(found_it->QualifiedName).c_str());
+        if (!found_it->InitialVal.empty())
+            UserError(
+                ReferenceMsgLoc(
+                    "Component '%s' has already been initialized",
+                    found_it->InitialValDeclared).c_str(),
+                _sym.GetName(found_it->QualifiedName).c_str());
+
+        Expect(kKW_Colon, _src.GetNext());
+        found_it->InitialValDeclared = _src.GetCursor();
+        ParseVardecl_InitialValAssignment(found_it->Vartype, found_it->InitialVal);
+        sym = _src.GetNext();
+        Expect(SymbolList{ kKW_Comma, kKW_CloseBrace }, sym);
+        if (kKW_Comma == sym)
+            sym = _src.GetNext();
+    }
+
+    // Sort the fields in ascending order of 'Offset'
+    std::sort(
+        fields.begin(),
+        fields.end(),
+        [](ComponentFields const &cf1, ComponentFields const &cf2) { return cf1.Offset < cf2.Offset; });
+
+    initial_val.clear();
+
+    for (auto it = fields.begin(); it != fields.end(); it++)
+    {
+        if (it->IsAttribute || it->IsFunction)
+            continue; // Nothing to initialize
+        if (it->InitialVal.empty())
+            continue; // Skip fields that don't have an initialization
+        // Everything between the end of the preceding initialization and the current offset
+        // hasn't been specified, so set it to zeros.
+        initial_val.resize(it->Offset);
+        
+        // Append the current initial value here
+        initial_val.insert(
+            initial_val.end(),
+            it->InitialVal.begin(),
+            it->InitialVal.end());
+    }
+    // Fields at the end of this struct might not be initialized yet,
+    // so fill up to the size of this struct.
+    initial_val.resize(_sym.GetSize(vartype));
+}
+
+void AGS::Parser::ParseVardecl_InitialValAssignment_Array_Named(size_t const first_dim_size, Vartype const el_vartype, std::vector<char> &initial_val)
+{
+    struct init_record
+    {
+        size_t Declared; // Where in _src the initial value was specified
+        std::vector<char> InitialVal;
+    };
+    std::unordered_map<size_t, init_record> inits;
+
+    while (kKW_CloseBrace != _src.PeekNext())
+    {
+        // Get the index '[...]:'
+        Symbol const bracket = _src.GetNext();
+        if (kKW_OpenBracket != bracket)
+            UserError(
+                "Expected '}' or '[', found '%s' instead "
+                "(cannot mix named and unnamed array fields within the same '{...}')",
+                _sym.GetName(bracket).c_str());
+        EvaluationResult eres;
+        size_t const array_index_start = _src.GetCursor();
+        ParseIntegerExpression(_src, eres, "Expected an array index");
+        if (EvaluationResult::kLOC_SymbolTable != eres.Location)
+        {
+            _src.SetCursor(array_index_start);
+            UserError(
+                "Cannot evaluate the array index expression at compile time that starts with '[%s'",
+                _sym.GetName(_src.PeekNext()).c_str());
+        }
+        if (!_sym.IsLiteral(eres.Symbol))
+            InternalError("Cannot retrieve literal '%s'", _sym.GetName(eres.Symbol).c_str());
+        int const idx_as_int = _sym[eres.Symbol].LiteralD->Value;
+        if (idx_as_int < 0)
+            UserError("Array index '[%d]' is too low (minimum is '[0]')", idx_as_int);
+        size_t const idx = static_cast<size_t>(idx_as_int);
+        if (idx >= first_dim_size)
+            UserError("Array index '[%u]' is too high (maximum is '[%u]')", idx, first_dim_size - 1u);
+        if (inits.count(idx))
+            UserError(
+                ReferenceMsgLoc(
+                    "The value of field '[%u]' has already been specified",
+                    inits[idx].Declared).c_str(),
+                idx);
+        
+        Expect(kKW_CloseBracket, _src.GetNext());
+        Expect(kKW_Colon, _src.GetNext());
+
+        // Get the value and write a record to 'inits'
+        init_record current_record;
+        current_record.Declared = array_index_start;
+        ParseVardecl_InitialValAssignment(el_vartype, current_record.InitialVal);
+        inits[idx] = current_record;
+
+        // Handle the separators
+        Symbol const comma_or_close = _src.PeekNext();
+        Expect(SymbolList{ kKW_Comma, kKW_CloseBrace, }, comma_or_close);
+        if (kKW_Comma == comma_or_close)
+            SkipNextSymbol(_src, kKW_Comma);
+    }
+    SkipNextSymbol(_src, kKW_CloseBrace);
+
+    // Stitch together the fields,
+    // using binary zeros wherever a field hasn't been specified.
+    size_t const el_size = _sym.GetSize(el_vartype);
+    auto const all_binary_zeros = std::vector<char>(el_size, '\0');
+    initial_val.clear();
+    initial_val.reserve(el_size * first_dim_size);
+    for (size_t dim_idx = 0u; dim_idx < first_dim_size; ++dim_idx)
+    {
+        auto const &the_field_to_append =
+            inits.count(dim_idx) ? inits[dim_idx].InitialVal : all_binary_zeros;
+        initial_val.insert(
+            initial_val.end(), 
+            the_field_to_append.cbegin(), the_field_to_append.cend());
+    }
+}
+
+void AGS::Parser::ParseVardecl_InitialValAssignment_Array_Sequence(size_t const first_dim_size, Vartype const el_vartype, std::vector<char> &initial_val)
+{
+    initial_val.clear();
+
+    for (size_t dim_idx = 0u; kKW_CloseBrace != _src.PeekNext(); ++dim_idx)
+    {
+        if (first_dim_size == dim_idx)
+            UserError("Expected at most %u array fields, found more", first_dim_size);
+
+        if (kKW_OpenBracket == _src.PeekNext())
+            UserError(
+                "Expected a value, found '[' instead "
+                "(cannot mix named and unnamed array fields within the same '{...}'");
+        std::vector<char> el_initial_val;
+        ParseVardecl_InitialValAssignment(el_vartype, el_initial_val);
+        initial_val.insert(
+            initial_val.end(),
+            el_initial_val.begin(), el_initial_val.end());
+
+        Symbol const comma_or_close = _src.PeekNext();
+        Expect(SymbolList{ kKW_Comma, kKW_CloseBrace, }, comma_or_close);
+        if (kKW_Comma == comma_or_close)
+            SkipNextSymbol(_src, kKW_Comma);
+    }
+    SkipNextSymbol(_src, kKW_CloseBrace);
+
+    // Initialize all following elements with binary zeros
+    initial_val.resize(first_dim_size * _sym.GetSize(el_vartype));
 }
 
 void AGS::Parser::ParseVardecl_InitialValAssignment_Array(Vartype const vartype, std::vector<char> &initial_val)
@@ -4350,20 +4575,24 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_Array(Vartype const vartype,
             UserError(
                 "Cannot initialize a multi-dimensional array with a string literal");
 
-        ParseVardecl_InitialValAssignment_AssignStringLit(
+        ParseVardecl_InitialValAssignment_ArrayOrStringBuf_Literal(
             next_sym,
             _sym.ArrayElementsCount(vartype),
             initial_val);
         return;
     }
-    // TODO: Check that the array can be initialized.
-    // It must consist of non-managed arrays or non-managed structs
-    // or 'float's or integer types or 'string'.
-    Expect(kKW_OpenBrace, next_sym);
-    InternalError("Array initializers aren't implemented yet (except for string literals)");
+    Expect(kKW_OpenBrace, next_sym, "Expected '{' or a string literal");
+
+    // Split the first dimension off the array vartype
+    size_t const first_dim_size = _sym[vartype].VartypeD->Dims.at(0u);
+    Vartype const el_vartype = _sym.ArrayVartypeWithoutFirstDim(vartype);
+
+    if (kKW_OpenBracket == _src.PeekNext())
+        return ParseVardecl_InitialValAssignment_Array_Named(first_dim_size, el_vartype, initial_val);
+    return ParseVardecl_InitialValAssignment_Array_Sequence(first_dim_size, el_vartype, initial_val);
 }
 
-void AGS::Parser::ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val)
+void AGS::Parser::ParseVardecl_InitialValAssignment_StringBuf(std::vector<char> &initial_val)
 {
     Symbol string_lit = _src.GetNext();
     if (_sym.IsConstant(string_lit))
@@ -4373,32 +4602,33 @@ void AGS::Parser::ParseVardecl_InitialValAssignment_OldString(std::vector<char> 
         _sym.VartypeWithConst(kKW_String) != _sym[string_lit].LiteralD->Vartype)
         UserError("Expected a string literal after '=', found '%s' instead", _sym.GetName(_src.PeekNext()).c_str());
 
-    ParseVardecl_InitialValAssignment_AssignStringLit(string_lit, STRINGBUFFER_LENGTH, initial_val);
+    ParseVardecl_InitialValAssignment_ArrayOrStringBuf_Literal(string_lit, STRINGBUFFER_LENGTH, initial_val);
 }
 
-void AGS::Parser::ParseVardecl_InitialValAssignment(Symbol varname, std::vector<char> &initial_val)
+void AGS::Parser::ParseVardecl_InitialValAssignment(Vartype vartype, std::vector<char> &initial_val)
 {
-    SkipNextSymbol(_src, kKW_Assign);
-
-    Vartype const vartype = _sym.GetVartype(varname);
     if (_sym.IsManagedVartype(vartype))
+    {
+        // We only reserve the space for the pointer.
+        // The space for the actual object will be reserved with an AGS 'new' expression.
+        initial_val.resize (SIZE_OF_DYNPOINTER);
         return Expect(kKW_Null, _src.GetNext());
+    }
 
     if (_sym.IsStructVartype(vartype))
-        UserError("'%s' is a struct and cannot be initialized here", _sym.GetName(varname).c_str());
+        return ParseVardecl_InitialValAssignment_Struct(vartype, initial_val);
 
     if (_sym.IsArrayVartype(vartype))
         return ParseVardecl_InitialValAssignment_Array(vartype, initial_val);
 
     if (kKW_String == vartype)
-        return ParseVardecl_InitialValAssignment_OldString(initial_val);
+        return ParseVardecl_InitialValAssignment_StringBuf(initial_val);
 
     if (_sym.IsAnyIntegerVartype(vartype) || kKW_Float == vartype)
         return ParseVardecl_InitialValAssignment_IntOrFloatVartype(vartype, initial_val);
 
     UserError(
-        "Variable '%s' has type '%s' and cannot be initialized here",
-        _sym.GetName(varname).c_str(),
+        "Type '%s' cannot be initialized",
         _sym.GetName(vartype).c_str());
 }
 
@@ -4575,10 +4805,17 @@ void AGS::Parser::ParseVardecl_Import(Symbol var_name)
 void AGS::Parser::ParseVardecl_Global(Symbol var_name, Vartype vartype)
 {
     size_t const vartype_size = _sym.GetSize(vartype);
-    std::vector<char> initial_val(vartype_size + 1u, '\0');
+    std::vector<char> initial_val;
 
     if (kKW_Assign == _src.PeekNext())
-        ParseVardecl_InitialValAssignment(var_name, initial_val);
+    {
+        SkipNextSymbol(_src, kKW_Assign);
+        ParseVardecl_InitialValAssignment(vartype, initial_val);
+    }
+    else
+    {
+        initial_val.insert(initial_val.begin(), _sym.GetSize(vartype), '\0');
+    }
     
     SymbolTableEntry &entry = _sym[var_name];
     entry.VariableD->Vartype = vartype;

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -763,14 +763,28 @@ private:
     void ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype var, std::vector<char> &initial_val);
 
     // Assign a string literal to a char array or a 'string'
-    void ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
+    // 'available_space' means the _total_ available space
+    // counting the string-terminating '\0'.
+    void ParseVardecl_InitialValAssignment_ArrayOrStringBuf_Literal(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
 
+    // Initial assignment to a global non-managed struct
+    void ParseVardecl_InitialValAssignment_Struct(Vartype vartype, std::vector<char> &initial_val);
+
+    // Initialize a static array by specifying named entries of the form '[idx]: value'
+    // Starting '{' has already been eaten
+    void ParseVardecl_InitialValAssignment_Array_Named(size_t first_dim_size, Vartype el_vartype, std::vector<char> &initial_val);
+
+    // Initialize a static array by specifying a sequence of (unnamed) entries
+    // Starting '{' has already been eaten
+    void ParseVardecl_InitialValAssignment_Array_Sequence(size_t first_dim_size, Vartype el_vartype, std::vector<char> &initial_val);
+
+    // Initial assignment to a global classic array
     void ParseVardecl_InitialValAssignment_Array(Vartype vartype, std::vector<char> &initial_val);
 
-    void ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val);
+    void ParseVardecl_InitialValAssignment_StringBuf(std::vector<char> &initial_val);
 
-    // Parse the assignment of an initial value to a variable. 
-    void ParseVardecl_InitialValAssignment(Symbol varname, std::vector<char> &initial_val);
+    // Parse the assignment of an initial value. 'vartype' is the vartype of the assigned entity.
+    void ParseVardecl_InitialValAssignment(Vartype vartype, std::vector<char> &initial_val);
 
     // Move variable information into the symbol table
     void ParseVardecl_Var2SymTable(Vartype vartype, Symbol var_name);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -733,9 +733,9 @@ private:
     void AccessData(VariableAccess access_type, SrcList &expression, EvaluationResult &eres);
 
     // Emit Bytecode for:
-    // Copy at most 'STRINGBUFFER_LENGT-1' bytes from 'm[MAR...]' to 'm[AX...]'
-    // Stop when encountering a 0
-    void AccessData_StrCpy();
+    // Copy at most 'count - 1' bytes from m[MAR...] to m[AX...],
+    // add '\0' at end of copy so 'count' bytes are processed in all
+    void AccessData_StrCpy(size_t count);
 
     // An optional '*' can follow at this point. If it is here, eat it.
     void EatDynpointerSymbolIfPresent(SrcList src, Vartype vartype);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -762,6 +762,11 @@ private:
 
     void ParseVardecl_InitialValAssignment_IntOrFloatVartype(Vartype var, std::vector<char> &initial_val);
 
+    // Assign a string literal to a char array or a 'string'
+    void ParseVardecl_InitialValAssignment_AssignStringLit(Symbol string_lit, size_t available_space, std::vector<char> &initial_val);
+
+    void ParseVardecl_InitialValAssignment_Array(Vartype vartype, std::vector<char> &initial_val);
+
     void ParseVardecl_InitialValAssignment_OldString(std::vector<char> &initial_val);
 
     // Parse the assignment of an initial value to a variable. 

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -770,7 +770,10 @@ private:
     // Initial assignment to a global non-managed struct
     void ParseVardecl_InitialValAssignment_Struct(Vartype vartype, std::vector<char> &initial_val);
 
-    // Initialize a static array by specifying named entries of the form '[idx]: value'
+    // Peeks into a static array initialization and checks whether the first entry has
+    // a form of 'idx: value'.
+    bool ParseVardecl_InitialValAssignment_PeekArrayNamed();
+    // Initialize a static array by specifying named entries of the form 'idx: value'
     // Starting '{' has already been eaten
     void ParseVardecl_InitialValAssignment_Array_Named(size_t first_dim_size, Vartype el_vartype, std::vector<char> &initial_val);
 

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -2921,8 +2921,8 @@ TEST_F(Bytecode0, Struct11_NoRTTI) {
 
     // WriteOutput("Struct11_NoRtti", scrip);
 
-    size_t const codesize = 75;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 75;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   19,   38,    0,           36,   20,   73,    3,    // 7
@@ -2936,30 +2936,32 @@ TEST_F(Bytecode0, Struct11_NoRTTI) {
        7,    3,   30,    4,           11,    4,    3,    3,    // 71
        4,    3,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 5;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 5;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      11,   18,   37,   47,         60,  -999
-    };
+      11,   18,   37,   47,         60, };
     char fixuptypes[] = {
-      4,   4,   4,   4,      4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       4,    4,    4,    4,          4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 1;
+    int const non_empty_imports_count = 1;
     std::string imports[] = {
-    "SS",           "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "SS", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct11_RTTI) {
@@ -3000,9 +3002,9 @@ TEST_F(Bytecode0, Struct11_RTTI) {
     std::string const &err_msg = mh.GetError().Message;
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
-    // WriteOutput("Struct11_NoRtti", scrip);
-    size_t const codesize = 76;
-    EXPECT_EQ(codesize, scrip.code.size());
+    // WriteOutput("Struct11_Rtti", scrip);
+    size_t const code_size = 76;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   19,   38,    0,           36,   20,   74,    3,    // 7
@@ -3016,30 +3018,32 @@ TEST_F(Bytecode0, Struct11_RTTI) {
        6,    7,    3,   30,            4,   11,    4,    3,    // 71
        3,    4,    3,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 5;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 5;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      12,   19,   38,   48,         61,  -999
-    };
+      12,   19,   38,   48,         61, };
     char fixuptypes[] = {
-      4,   4,   4,   4,      4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       4,    4,    4,    4,          4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 1;
+    int const non_empty_imports_count = 1;
     std::string imports[] = {
-    "SS",           "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "SS", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct12) {

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2908,8 +2908,8 @@ TEST_F(Bytecode1, ArrayInit01) {
             "SATOR",
             { 'A', 'R', 'E', 'P', 'O', },
             "TENET",
-            { [4]: 'S', [3]: 'A', [2]: 'T', [1]: 'O',
-              [0]: 'R', [5]: '\xFF' & '\x0F' & '\xF0', },
+            { 4: 'S', 3: 'A', 2: 'T', 1: 'O',
+              0: 'R', 5: '\xFF' & '\x0F' & '\xF0', },
         };
         )%&/";
 
@@ -2958,9 +2958,9 @@ TEST_F(Bytecode1, ArrayInit02) {
     char const *inpl = R"%&/(
         const int two = 2;
         int matrix[3][3] = {
-            [0]:     { 1, },
-            [4 / 4]: { 0, 1, },
-            [two]:   { [2]: 1, },
+            0:     { 1, },
+            4 / 4: { 0, 1, },
+            two:   { 2: 1, },
         };
         )%&/";
 

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -13,13 +13,15 @@
 //=============================================================================
 #include <string>
 #include <fstream>
+#include <sstream>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "script2/cc_compiledscript.h"
 
 #include "cc_bytecode_test_lib.h"
 
-std::string Esc(const char ch)
+static std::string Esc(char const ch)
 {
     if (ch >= ' ' && ch <= 126)
     {
@@ -30,10 +32,11 @@ std::string Esc(const char ch)
     {
     default:
     {
-        static const char *tohex = "0123456789abcdef";
+        static char const *tohex = "0123456789abcdef";
+        unsigned char uch = static_cast<unsigned char>(ch);
         std::string ret = "\\x";
-        ret.push_back(tohex[ch / 16]);
-        ret.push_back(tohex[ch % 16]);
+        ret.push_back(tohex[uch / 16u]);
+        ret.push_back(tohex[uch % 16u]);
         return ret;
     }
     case '\a': return "\\a";
@@ -48,7 +51,7 @@ std::string Esc(const char ch)
     }
 }
 
-std::string EscapeString(const char *in)
+static std::string EscapeString(char const *in)
 {
     if (in == nullptr)
         return "0";
@@ -60,12 +63,12 @@ std::string EscapeString(const char *in)
     return "\"" + ret + "\"";
 }
 
-void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const codesize = " << scrip.code.size() << ";" << std::endl;
-    of << "EXPECT_EQ(codesize, scrip.code.size());" << std::endl << std::endl;
+    of << "size_t const code_size = " << scrip.code.size() << ";" << std::endl;
+    of << "EXPECT_EQ(code_size, scrip.code.size());" << std::endl << std::endl;
 
-    if (scrip.code.size() == 0)
+    if (scrip.code.empty())
         return;
 
     of << "int32_t code[] = {" << std::endl;
@@ -78,15 +81,14 @@ void WriteOutputCode(std::ofstream &of, AGS::ccCompiledScript const &scrip)
     }
     of << " -999 " << std::endl << "};" << std::endl;
 
-    of << "CompareCode(&scrip, codesize, code);" << std::endl << std::endl;
+    of << "CompareCode(&scrip, code_size, code);" << std::endl << std::endl;
 }
 
-void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[])
+void CompareCode(AGS::ccCompiledScript *scrip, size_t code_size, int32_t code[])
 {
-    for (size_t idx = 0; idx < codesize; idx++)
+    code_size = std::min(code_size, scrip->code.size());
+    for (size_t idx = 0u; idx < code_size; idx++)
     {
-         if (idx >= scrip->code.size())
-             break;
          std::string prefix = "code[" + std::to_string(idx) + "] == ";
          std::string should_be_val = prefix + std::to_string(code[idx]);
          std::string is_val = prefix + std::to_string(scrip->code[idx]);
@@ -94,51 +96,53 @@ void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[])
     }
 }
 
-void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const numfixups = " << scrip.fixups.size() << ";" << std::endl;
-    of << "EXPECT_EQ(numfixups, scrip.fixups.size());" << std::endl << std::endl;
+    size_t const fixups_size = scrip.fixups.size();
+    of << "size_t const fixups_size = " << fixups_size << ";" << std::endl;
+    of << "ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());" << std::endl;
+    of << "EXPECT_EQ(fixups_size, scrip.fixups.size());" << std::endl << std::endl;
 
-    if (scrip.fixups.size() == 0)
+    if (scrip.fixups.empty())
         return;
 
     of << "int32_t fixups[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.fixups.size(); idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
         of.width(4);
         of << scrip.fixups[idx] << ", ";
-        if (idx % 8 == 3) of << "      ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "      ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
     of << " -999 " << std::endl << "};" << std::endl;
     
     of << "char fixuptypes[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.fixups.size(); idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
         of.width(3);
         of << static_cast<int>(scrip.fixuptypes[idx]) << ", ";
-        if (idx % 8 == 3) of << "   ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "   ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
     of << " '\\0' " << std::endl << "};" << std::endl;
 
-    of << "CompareFixups(&scrip, numfixups, fixups, fixuptypes);" << std::endl << std::endl;
+    of << "CompareFixups(&scrip, fixups_size, fixups, fixuptypes);" << std::endl << std::endl;
 }
 
-void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixups[], char fixuptypes[])
+void CompareFixups(AGS::ccCompiledScript *scrip, size_t fixups_size, int32_t fixups[], char fixuptypes[])
 {
-    for (size_t idx = 0; idx < numfixups; idx++)
+    fixups_size = std::min(fixups_size, scrip->fixups.size());
+
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-         if (idx >= scrip->fixups.size()) break;
          std::string const prefix = "fixups[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(fixups[idx]);
          std::string const is_val = prefix + std::to_string(scrip->fixups[idx]);
          ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
     }
 
-    for (size_t idx = 0; idx < numfixups; idx++)
+    for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-         if (static_cast<int>(idx) >= scrip->fixups.size()) break;
          std::string const prefix = "fixuptypes[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(fixuptypes[idx]);
          std::string const is_val = prefix + std::to_string(scrip->fixuptypes[idx]);
@@ -146,94 +150,110 @@ void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixup
     }
 }
 
-void WriteOutputImports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputImports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    // Unfortunately, imports can contain empty strings that
-    // mustn't be counted. So we can't just believe numimports,
-    // and we can't check against scrip.numimports.
-    size_t realNumImports = 0;
-    for (size_t idx = 0; idx < scrip.imports.size(); idx++)
-        if (0 != strcmp(scrip.imports[idx].c_str(), ""))
-            ++realNumImports;
+    // Unfortunately, imports can contain empty strings that mustn't be counted. 
+    // So we can't believe 'imports.size()' and we may not check against it.
+    std::vector<std::string> imports;
+    for (size_t idx = 0u; idx < scrip.imports.size(); idx++)
+        if (!scrip.imports[idx].empty())
+            imports.push_back(scrip.imports[idx]);
 
-    of << "int const numimports = " << realNumImports << ";" << std::endl;
+    of << "int const non_empty_imports_count = " << imports.size() << ";" << std::endl;
 
-    of << "std::string imports[] = {" << std::endl;
-
-    size_t linelen = 0;
-    for (size_t idx = 0; idx < scrip.imports.size(); idx++)
+    if (imports.size())
     {
-        if (!strcmp(scrip.imports[idx].c_str(), ""))
+        of << "std::string imports[] = {" << std::endl;
+
+        size_t line_length = 0u;
+        for (size_t idx = 0u; idx < imports.size(); idx++)
+        {
+            std::string item = EscapeString(imports[idx].c_str());
+            item += ",";
+            item += std::string(15 - (item.length() % 15), ' ');
+            of << item;
+            line_length += item.length();
+            if (line_length >= 75u)
+            {
+                line_length = 0u;
+                of << "// " << idx << std::endl;
+            }
+        }
+        of << "};" << std::endl;
+        of << "CompareImports(&scrip, non_empty_imports_count, imports);" << std::endl << std::endl;
+    }
+    else
+    {
+        of << "CompareImports(&scrip, non_empty_imports_count, nullptr);" << std::endl << std::endl;
+    }
+}
+
+void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count, std::string imports[])
+{
+    size_t actual_non_empty_imports_count = 0u;
+    for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
+    {
+        if (!scrip->imports[scrip_idx].empty())
+            actual_non_empty_imports_count++;
+    }
+    size_t const should_be = non_empty_imports_count;
+    ASSERT_EQ(should_be, actual_non_empty_imports_count);
+
+    if (!imports)
+        return;
+
+    size_t array_idx = 0u; // index into 'imports[]'
+    for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
+    {
+        if (!scrip->imports[scrip_idx].empty())
             continue;
 
-        std::string item = EscapeString(scrip.imports[idx].c_str());
-        item += ",";
-        item += std::string(15 - (item.length() % 15), ' ');
-        of << item;
-        linelen += item.length();
-        if (linelen >= 75)
-        {
-            linelen = 0;
-            of << "// " << idx << std::endl;
-        }
-    }
-    of << " \"[[SENTINEL]]\" " << std::endl << "};" << std::endl;
-
-    of << "CompareImports(&scrip, numimports, imports);" << std::endl << std::endl;
-}
-
-void CompareImports(AGS::ccCompiledScript *scrip, size_t numimports, std::string imports[])
-{
-    int idx2 = -1;
-    for (size_t idx = 0; idx < scrip->imports.size(); idx++)
-    {
-         if (!strcmp(scrip->imports[idx].c_str(), ""))
-             continue;
-         idx2++;
-         ASSERT_LT(static_cast<size_t>(idx2), numimports); // idx2 is sure to be non-negative here
-         std::string const prefix = "imports[" + std::to_string(idx2) + "] == ";
-         std::string const should_be_val = prefix + "\"" + imports[idx2] + "\"";
-         std::string const is_val = prefix + "\"" + scrip->imports[idx] + "\"";
-         ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
+        std::string const prefix = "scrip.imports[" + std::to_string(scrip_idx) + "] == ";
+        std::string const should_be_val = prefix + "\"" + imports[array_idx] + "\"";
+        std::string const is_val = prefix + "\"" + scrip->imports[scrip_idx] + "\"";
+        ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
+        array_idx++;
     }
 }
 
-void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const numexports = " << scrip.exports.size() << ";" << std::endl;
-    of << "EXPECT_EQ(numexports, scrip.exports.size());" << std::endl << std::endl;
+    size_t const exports_size = scrip.exports.size();
+    of << "size_t const exports_size = " << scrip.exports.size() << ";" << std::endl;
+    of << "ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());" << std::endl;
+    of << "EXPECT_EQ(exports_size, scrip.exports.size());" << std::endl << std::endl;
 
-    if (scrip.exports.size() == 0)
+    if (scrip.exports.empty())
         return;
 
     of << "std::string exports[] = {" << std::endl;
 
-    size_t linelen = 0;
-    for (size_t idx = 0; idx < scrip.exports.size(); idx++)
+    size_t line_length = 0u;
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
         std::string item = EscapeString(scrip.exports[idx].c_str());
         item += ",";
-        item += std::string(6 - (item.length() % 6), ' ');
+        item += std::string(6u - (item.length() % 6u), ' ');
         of << item;
-        linelen += item.length();
-        if (linelen >= 50)
+        line_length += item.length();
+        if (line_length >= 50u)
         {
-            linelen = 0;
+            line_length = 0u;
             of << "// " << idx << std::endl;
         }
     }
-    of << " \"[[SENTINEL]]\" " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
     of << "int32_t export_addr[] = {" << std::endl;
 
-    for (size_t idx = 0; idx < scrip.exports.size(); idx++)
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
         of.setf(std::ios::hex, std::ios::basefield);
         of.setf(std::ios::showbase);
         of.width(4);
         of << scrip.export_addr[idx] << ", ";
-        if (idx % 4 == 1) of << "   ";
-        if (idx % 8 == 3)
+        if (idx % 4u == 1u) of << "   ";
+        if (idx % 8u == 3u)
         {
             of.setf(std::ios::dec, std::ios::basefield);
             of.unsetf(std::ios::showbase);
@@ -247,26 +267,29 @@ void WriteOutputExports(std::ofstream &of, AGS::ccCompiledScript const &scrip)
     of.unsetf(std::ios::showbase);
     of.width(0);
 
-    of << " 0 " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
-    of << "CompareExports(&scrip, numexports, exports, export_addr);" << std::endl << std::endl;
+    of << "CompareExports(&scrip, exports_size, exports, export_addr);" << std::endl << std::endl;
 }
 
-void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string exports[],  int32_t export_addr[])
+void CompareExports(AGS::ccCompiledScript *scrip, size_t exports_size, std::string exports[], int32_t export_addr[])
 {
-    for (size_t idx = 0; idx < numexports; idx++)
+    exports_size = std::min(
+        std::min(exports_size, scrip->exports.size()),
+        exports_size);
+    exports_size = std::min(
+        std::min(exports_size, scrip->export_addr.size()),
+        exports_size);
+
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
-        if (idx >= scrip->exports.size())
-            break;
         std::string const prefix = "exports[" + std::to_string(idx) + "] == ";
         std::string const should_be_val = prefix + "\"" + exports[idx] + "\"";
         std::string const is_val = prefix + "\"" + scrip->exports[idx] + "\"";
         ASSERT_STREQ(should_be_val.c_str(), is_val.c_str());
     }
-    for (size_t idx = 0; idx < numexports; idx++)
+    for (size_t idx = 0u; idx < exports_size; idx++)
     {
-        if (idx >= scrip->exports.size())
-            break;
         std::string const prefix = "export_addr[" + std::to_string(idx) + "] == ";
         std::string const should_be_val = prefix + std::to_string(export_addr[idx]);
         std::string const is_val = prefix + std::to_string(scrip->export_addr[idx]);
@@ -275,16 +298,16 @@ void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string
 }
 
 
-void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
+static void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    of << "size_t const stringssize = " << scrip.strings.size() << ";" << std::endl;
-    of << "EXPECT_EQ(stringssize, scrip.strings.size());" << std::endl << std::endl;
+    of << "size_t const strings_size = " << scrip.strings.size() << ";" << std::endl;
+    of << "EXPECT_EQ(strings_size, scrip.strings.size());" << std::endl << std::endl;
 
-    if (scrip.strings.size() == 0)
+    if (scrip.strings.empty())
         return;
 
     of << "char strings[] = {" << std::endl;
-    for (size_t idx = 0; idx < scrip.strings.size(); idx++)
+    for (size_t idx = 0u; idx < scrip.strings.size(); idx++)
     {
         std::string out = "";
         if (scrip.strings[idx] == 0)
@@ -292,20 +315,19 @@ void WriteOutputStrings(std::ofstream &of, AGS::ccCompiledScript const &scrip)
         else
             out += '\'' + Esc(scrip.strings[idx]) + '\'';
         of << out << ",  ";
-        if (idx % 8 == 3) of << "        ";
-        if (idx % 8 == 7) of << "   // " << idx << std::endl;
+        if (idx % 8u == 3u) of << "        ";
+        if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << "'\\0'" << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
-    of << " CompareStrings(&scrip, stringssize, strings);" << std::endl << std::endl;
+    of << " CompareStrings(&scrip, strings_size, strings);" << std::endl << std::endl;
    }
 
-void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strings[])
+void CompareStrings(AGS::ccCompiledScript *scrip, size_t strings_size, char strings[])
 {
-    for (size_t idx = 0; idx < stringssize; idx++)
+    strings_size = std::min(strings_size, scrip->strings.size());
+    for (size_t idx = 0u; idx < strings_size; idx++)
     {
-         if (idx >= scrip->strings.size())
-             break;
          std::string const prefix = "strings[" + std::to_string(idx) + "] == ";
          std::string const should_be_val = prefix + std::to_string(strings[idx]);
          std::string const is_val = prefix + std::to_string(scrip->strings[idx]);
@@ -313,17 +335,133 @@ void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strin
     }
 }
 
-void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip)
+static void WriteOutputGlobals(std::ofstream &of, AGS::ccCompiledScript const &scrip)
 {
-    std::string path = WRITE_PATH;
-    std::ofstream of;
-    of.open(path.append(fname).append(".txt"));
+    size_t const globaldata_size = scrip.globaldata.size();
+    of << "size_t const globaldata_size = " << globaldata_size << ";" << std::endl;
+    of << "EXPECT_EQ(globaldata_size, scrip.globaldata.size());" << std::endl << std::endl;
 
-    WriteOutputCode(of, scrip);
-    WriteOutputFixups(of, scrip);
-    WriteOutputImports(of, scrip);
-    WriteOutputExports(of, scrip);
-    WriteOutputStrings(of, scrip);
+    if (scrip.globaldata.empty())
+        return;
 
-    of.close();
+    std::vector<CharRun> global_runs = {};
+
+    for (size_t idx = 0u; idx < globaldata_size;)
+    {
+        char const run_char = scrip.globaldata[idx];
+        size_t run_count = 0u;
+        while (idx < globaldata_size && run_char == scrip.globaldata[idx])
+        {
+            run_count++;
+            idx++;
+        }
+        global_runs.emplace_back(run_count, run_char);
+    }
+
+    if (global_runs.size() * 2u < scrip.globaldata.size())
+    {
+        // Write a run-length encoding of the globals to save space
+        // and for better comprehension
+        // A run '{ 7, 0xAA }' means:
+        // Expect 7 consecutive bytes that each have the value '0xAA'.
+        size_t cumulative = 0u;
+        of << "CharRun global_runs[] = {" << std::endl;
+        for (size_t idx = 0u; idx < global_runs.size(); idx++)
+        {
+            cumulative += global_runs[idx].count;
+            of << "{ " <<
+                std::dec << std::setfill(' ') << std::setw(3) <<
+                    global_runs[idx].count << ", 0x" <<
+                std::hex << std::setfill('0') << std::setw(2) <<
+                (0xFF & global_runs[idx].value) <<
+                "}, ";
+            if (idx % 4u == 3u)
+                of << "   // " << std::dec << std::setw(0) << cumulative << std::endl;
+        }
+        // Add a sentinel that has a count of '0' 
+        of << "{0, 0x00} };" << std::endl;
+        of << "CompareGlobalRuns(&scrip, global_runs);" <<
+            std::endl << std::endl;
+        return;
+    }
+
+    // Write the globals byte-by-byte
+    of << "unsigned char globaldata[] = {" << std::endl;
+    for (size_t idx = 0u; idx < scrip.globaldata.size(); idx++)
+    {
+        of << "0x" <<
+            std::hex << std::setfill('0') << std::setw(2) <<
+            (0xFF & scrip.globaldata[idx]) << ", ";
+        if (idx % 8u == 3u) of << "        ";
+        if (idx % 8u == 7u) of << "   // " << std::dec << std::setw(0) << idx << std::endl;
+    }
+    of << "};" << std::endl;
+    of << "CompareGlobalData(&scrip, globaldata_size, globaldata);" <<
+        std::endl << std::endl;
+}
+
+void CompareGlobalRuns(AGS::ccCompiledScript *scrip, CharRun global_runs[])
+{
+    size_t runs_idx = 0u;
+    // A run '{ 7, 0xAA }' means:
+    // Expect 7 consecutive bytes that each have the value '0xAA'.
+    size_t counter = global_runs[runs_idx].count;
+    unsigned char value = global_runs[runs_idx].value;
+    size_t data_idx = 0u;
+    do {
+        if (data_idx >= scrip->globaldata.size())
+            break;
+        if ((unsigned char) scrip->globaldata[data_idx] != value)
+        {
+            std::string const prefix = "globaldata[" + std::to_string(data_idx) + "] == 0x";
+            std::ostringstream should_be_val;
+            should_be_val << prefix << std::hex << std::setfill('0') <<
+                std::setw(2) << (0xFF & value);
+            std::ostringstream is_val;
+            is_val << prefix << std::hex << std::setfill('0') <<
+                std::setw(2) << (0xFF & scrip->globaldata[data_idx]);
+            ASSERT_STREQ(should_be_val.str().c_str(), is_val.str().c_str());
+        }
+        ++data_idx;
+        --counter;
+        if (!counter)
+        {
+            // Get next run
+            runs_idx++;
+            counter = global_runs[runs_idx].count;
+            value = global_runs[runs_idx].value;
+        }
+    } while (counter);
+}
+
+void CompareGlobalData(AGS::ccCompiledScript *scrip, size_t size, unsigned char gdata[])
+{
+    size = std::min(size, scrip->globaldata.size());
+    for (size_t idx = 0u; idx < size; idx++)
+    {
+        if ((unsigned char) scrip->globaldata[idx] == gdata[idx])
+            continue;
+
+        std::string const prefix = "globaldata[" + std::to_string(idx) + "] == 0x";
+        std::ostringstream should_be_val;
+        should_be_val << prefix << std::hex << std::setfill('0') <<
+            std::setw(2) << (0xFF & gdata[idx]);
+        std::ostringstream is_val;
+        is_val << prefix << std::hex << std::setfill('0') <<
+            std::setw(2) << (0xFF & scrip->globaldata[idx]);
+        ASSERT_STREQ(should_be_val.str().c_str(), is_val.str().c_str());
+    }
+}
+
+void WriteOutput(char const *fname, AGS::ccCompiledScript const &scrip)
+{
+    std::ofstream output { std::string(WRITE_PATH) + fname + ".txt" };
+    output.exceptions(std::ofstream::failbit);
+
+    WriteOutputCode(output, scrip);
+    WriteOutputFixups(output, scrip);
+    WriteOutputImports(output, scrip);
+    WriteOutputExports(output, scrip);
+    WriteOutputStrings(output, scrip);
+    WriteOutputGlobals(output, scrip);
 }

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <iomanip>
 
 #include "gtest/gtest.h"
 #include "script2/cc_compiledscript.h"

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -114,17 +114,17 @@ static void WriteOutputFixups(std::ofstream &of, AGS::ccCompiledScript const &sc
         if (idx % 8u == 3u) of << "      ";
         if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << " -999 " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
     
     of << "char fixuptypes[] = {" << std::endl;
     for (size_t idx = 0u; idx < fixups_size; idx++)
     {
-        of.width(3);
+        of.width(4);
         of << static_cast<int>(scrip.fixuptypes[idx]) << ", ";
-        if (idx % 8u == 3u) of << "   ";
+        if (idx % 8u == 3u) of << "      ";
         if (idx % 8u == 7u) of << "   // " << idx << std::endl;
     }
-    of << " '\\0' " << std::endl << "};" << std::endl;
+    of << "};" << std::endl;
 
     of << "CompareFixups(&scrip, fixups_size, fixups, fixuptypes);" << std::endl << std::endl;
 }
@@ -205,7 +205,7 @@ void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count
     size_t array_idx = 0u; // index into 'imports[]'
     for (size_t scrip_idx = 0u; scrip_idx < scrip->imports.size(); scrip_idx++)
     {
-        if (!scrip->imports[scrip_idx].empty())
+        if (scrip->imports[scrip_idx].empty())
             continue;
 
         std::string const prefix = "scrip.imports[" + std::to_string(scrip_idx) + "] == ";

--- a/Compiler/test2/cc_bytecode_test_lib.h
+++ b/Compiler/test2/cc_bytecode_test_lib.h
@@ -22,10 +22,19 @@ constexpr const char *WRITE_PATH = "C:/TEMP/";
 
 extern void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip);
 
-extern void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[]);
-extern void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixups[], char fixuptypes[]);
-extern void CompareImports(AGS::ccCompiledScript *scrip, size_t numimports, std::string imports[]);
-extern void CompareExports(AGS::ccCompiledScript *scrip, size_t numexports, std::string exports[], int32_t export_addr[]);
-extern void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strings[]);
+struct CharRun
+{
+    size_t count;
+    unsigned char value;
+    CharRun(size_t c, unsigned char v) : count(c), value(v) {}
+};
+
+extern void CompareCode(AGS::ccCompiledScript *scrip, size_t code_size, int32_t code[]);
+extern void CompareFixups(AGS::ccCompiledScript *scrip, size_t fixups_size, int32_t fixups[], char fixuptypes[]);
+extern void CompareImports(AGS::ccCompiledScript *scrip, size_t non_empty_imports_count, std::string imports[]);
+extern void CompareExports(AGS::ccCompiledScript *scrip, size_t exports_size, std::string exports[], int32_t export_addr[]);
+extern void CompareStrings(AGS::ccCompiledScript *scrip, size_t strings_size, char strings[]);
+extern void CompareGlobalRuns(AGS::ccCompiledScript *scrip, struct CharRun global_runs[]);
+extern void CompareGlobalData(AGS::ccCompiledScript *scrip, size_t size, unsigned char gdata[]);
 
 #endif

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -1155,10 +1155,8 @@ TEST_F(Compile0, StructForwardDeclareNew) {
 
 TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
 {
-    // NO SCOPT_RTTIOPS:
-    // Cannot have managed components in managed struct.
-    // This is an Engine restriction.
-    ccSetOption(SCOPT_RTTIOPS, 0);
+    // Cannot have managed components in managed struct
+    // when RTTIOPT is unset. This is an Engine restriction.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1169,11 +1167,13 @@ TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
         };                      \n\
         ";
 
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
+
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
-
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_EQ(std::string::npos, err_msg.find("xception"));
@@ -1181,10 +1181,8 @@ TEST_F(Compile0, StructManaged1a_NoRTTIOPS)
 
 TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
 {
-    // NO SCOPT_RTTIOPS:
-    // Cannot have managed components in managed struct.
-    // This is an Engine restriction.
-    ccSetOption(SCOPT_RTTIOPS, 0);
+    // Cannot have managed components in managed struct
+    // when RTTIOPS is unset. This is an Engine restriction.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1194,6 +1192,9 @@ TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
             Managed1 compo[];   \n\
         };                      \n\
         ";
+
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
@@ -1206,8 +1207,8 @@ TEST_F(Compile0, StructManaged1b_NoRTTIOPS)
 
 TEST_F(Compile0, StructManaged2a_RTTIOPS)
 {
-    // + SCOPT_RTTIOPS:
-    // Can have managed components in managed struct.
+    // Can have managed components in managed struct
+    // when RTTIOPS is set.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1228,7 +1229,8 @@ TEST_F(Compile0, StructManaged2a_RTTIOPS)
 
 TEST_F(Compile0, StructManaged2b_RTTIOPS)
 {
-    // Can have managed components in managed struct.
+    // Can have managed components in managed struct
+    // when RTTIOPS is set.
 
     char const *inpl = "\
         managed struct Managed1 \n\
@@ -1434,9 +1436,9 @@ TEST_F(Compile0, ImportOverride2) {
         }                       \n\
         ";
 
-    ccSetOption(SCOPT_NOIMPORTOVERRIDE, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -1454,8 +1456,9 @@ TEST_F(Compile0, ImportOverride3) {
     import int Func(int i = 5);     \n\
     ";
 
-    ccSetOption(SCOPT_NOIMPORTOVERRIDE, true);
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    // Note: Don't use 'ccSetOption()' in Googletests.
+
+    int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2435,7 +2438,8 @@ TEST_F(Compile0, StringOldstyle01) {
 
 TEST_F(Compile0, StringOldstyle02) {
 
-    // If a function expects a non-const string, it mustn't be passed a const string
+    // If a function expects a non-const string,
+    // it mustn't be passed a const string
 
     char const *inpl = "\
         void Func(string s)         \n\
@@ -2444,9 +2448,9 @@ TEST_F(Compile0, StringOldstyle02) {
         }                           \n\
         ";
 
-    ccSetOption(SCOPT_OLDSTRINGS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2457,8 +2461,8 @@ TEST_F(Compile0, StringOldstyle02) {
 
 TEST_F(Compile0, StringOldstyle03) {
 
-    // A string literal is a constant string, so you should not be able to
-    // return it as a string.
+    // A string literal is a constant string,
+    // so you can't return it as a string.
 
     char const *inpl = "\
         string Func()                   \n\
@@ -2467,9 +2471,9 @@ TEST_F(Compile0, StringOldstyle03) {
         }                               \n\
         ";
 
-    ccSetOption(SCOPT_OLDSTRINGS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -1457,7 +1457,7 @@ TEST_F(Compile0, ImportOverride3) {
     ";
 
     // Note: Don't use 'ccSetOption()' in Googletests.
-
+    
     int compile_result = cc_compile(inpl, SCOPT_NOIMPORTOVERRIDE, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
@@ -2480,6 +2480,43 @@ TEST_F(Compile0, StringOldstyle03) {
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("ype mismatch"));
+}
+
+TEST_F(Compile0, StringOldstyle04) {
+    // Initializing constant is too long
+    // (the terminating '\0' MUST fit into 'Global2')
+
+    char const *inpl = R"%&/(
+        char Global2[4] = "Lamm"; 
+        )%&/";
+
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("oo long"));
+}
+
+TEST_F(Compile0, StringOldstyle05) {
+    // Initializing constant is too long
+
+    char const *inpl = R"%&/(
+        string Global = "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d"
+                        "123456789a123456789b123456789c123456789d";
+        )%&/";
+
+    int compile_result = cc_compile(inpl, SCOPT_OLDSTRINGS, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    size_t err_line = mh.GetError().Lineno;
+    EXPECT_EQ(0u, mh.WarningsCount());
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("oo long"));
 }
 
 TEST_F(Compile0, ConstOldstringReturn)

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1652,9 +1652,9 @@ TEST_F(Compile1, FixupMismatch) {
         }                                       \n\
         ";
 
-    ccSetOption(SCOPT_LINENUMBERS, true);
+    // Note: Don't use 'ccSetOption()' in Googletests.
 
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    int compile_result = cc_compile(inpl, SCOPT_LINENUMBERS, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -2935,7 +2935,9 @@ TEST_F(Compile1, DynarrayOfArray) {
         }                               \n\
         ";
 
-    ccSetOption(SCOPT_RTTIOPS, false);
+    // Note: Don't use 'ccSetOption()' in Googletests.
+    // 'kNoOptions' is 0, so in particular, SCOPT_RTTIOPS is 0.
+
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -792,7 +792,6 @@ TEST_F(Compile2, CTEvalLogicalOps) {
     EXPECT_NE(std::string::npos, err_msg.find("'101577700 /"));
 }
 
-
 TEST_F(Compile2, ParamIsFunc) {
 
     char const *inpl = R"&/(
@@ -807,4 +806,24 @@ TEST_F(Compile2, ParamIsFunc) {
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("'crash'"));
+}
+
+TEST_F(Compile2, MultiDimCharArrayToString) {
+
+    // A character array with more than 1 dimension cannot be
+    // converted to 'const string'.
+
+    char const *inpl = R"%&/(
+        int test(const string s)
+        {
+            char arr[5][7];
+            return test(arr);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("convert"));
 }

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -939,3 +939,33 @@ TEST_F(Compile2, ArrayInitNamedDouble) {
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("[3]"));
 }
+
+TEST_F(Compile2, InitManaged01)
+{
+    
+    char const *inpl = R"%&/(
+        managed struct Foo
+        {
+            int Payload;
+        } Var = new Foo;
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'null'"));
+}
+TEST_F(Compile2, InitManaged02)
+{
+    
+    char const *inpl = R"%&/(
+        int List[] = new int;
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'null'"));
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -827,3 +827,115 @@ TEST_F(Compile2, MultiDimCharArrayToString) {
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("convert"));
 }
+
+TEST_F(Compile2, ArrayInitLiteralOverflow) {
+
+    // Can't initialize the array because the literal
+    // including the terminal '\0' is too long
+
+    char const *inpl = R"%&/(
+        char arr[5] = "Super";
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too long"));
+}
+
+TEST_F(Compile2, ArrayInitSequenceTooLong) {
+
+    // Too many values to initialize an array of 5 elements
+
+    char const *inpl = R"%&/(
+        short arr[5] = { 1, 2, 3, 4, 5, 6 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("at most 5"));
+}
+
+TEST_F(Compile2, ArrayInitNamedUnnamedMix01) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { 1, [2]: 5 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'['"));
+}
+
+TEST_F(Compile2, ArrayInitNamedUnnamedMix02) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [0]: 1, 2, };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("'2'"));
+}
+
+TEST_F(Compile2, ArrayInitNamedOutOfRange01) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [(3 - 5) / 2]: 1 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too low"));
+}
+
+TEST_F(Compile2, ArrayInitNamedOutOfRange02) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [5]: 1 };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("too high"));
+}
+
+TEST_F(Compile2, ArrayInitNamedDouble) {
+
+    // Can't mix unnamed and named entries in
+    // array initialization sequence
+
+    char const *inpl = R"%&/(
+        short arr[5] = { [3]: 1,
+                         [3]: 2, };
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+    EXPECT_NE(std::string::npos, err_msg.find("[3]"));
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -865,14 +865,14 @@ TEST_F(Compile2, ArrayInitNamedUnnamedMix01) {
     // array initialization sequence
 
     char const *inpl = R"%&/(
-        short arr[5] = { 1, [2]: 5 };
+        short arr[5] = { 1, 2: 5 };
         )%&/";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-    EXPECT_NE(std::string::npos, err_msg.find("'['"));
+    EXPECT_NE(std::string::npos, err_msg.find("':'"));
 }
 
 TEST_F(Compile2, ArrayInitNamedUnnamedMix02) {
@@ -881,23 +881,22 @@ TEST_F(Compile2, ArrayInitNamedUnnamedMix02) {
     // array initialization sequence
 
     char const *inpl = R"%&/(
-        short arr[5] = { [0]: 1, 2, };
+        short arr[5] = { 0: 1, 2, };
         )%&/";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-    EXPECT_NE(std::string::npos, err_msg.find("'2'"));
+    EXPECT_NE(std::string::npos, err_msg.find("':'"));
 }
 
 TEST_F(Compile2, ArrayInitNamedOutOfRange01) {
 
-    // Can't mix unnamed and named entries in
-    // array initialization sequence
+    // Element's "name" must be a valid array index
 
     char const *inpl = R"%&/(
-        short arr[5] = { [(3 - 5) / 2]: 1 };
+        short arr[5] = { (3 - 5) / 2: 1 };
         )%&/";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
@@ -909,11 +908,10 @@ TEST_F(Compile2, ArrayInitNamedOutOfRange01) {
 
 TEST_F(Compile2, ArrayInitNamedOutOfRange02) {
 
-    // Can't mix unnamed and named entries in
-    // array initialization sequence
+    // Element's "name" must be a valid array index
 
     char const *inpl = R"%&/(
-        short arr[5] = { [5]: 1 };
+        short arr[5] = { 5: 1 };
         )%&/";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
@@ -925,19 +923,18 @@ TEST_F(Compile2, ArrayInitNamedOutOfRange02) {
 
 TEST_F(Compile2, ArrayInitNamedDouble) {
 
-    // Can't mix unnamed and named entries in
-    // array initialization sequence
+    // Can't initialize same element twice
 
     char const *inpl = R"%&/(
-        short arr[5] = { [3]: 1,
-                         [3]: 2, };
+        short arr[5] = { 3: 1,
+                         3: 2, };
         )%&/";
 
     int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
     std::string const &err_msg = mh.GetError().Message;
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-    EXPECT_NE(std::string::npos, err_msg.find("[3]"));
+    EXPECT_NE(std::string::npos, err_msg.find("3"));
 }
 
 TEST_F(Compile2, InitManaged01)

--- a/Compiler/test2/cc_symboltable_test.cpp
+++ b/Compiler/test2/cc_symboltable_test.cpp
@@ -237,3 +237,16 @@ TEST_F(SymbolTable, IsAnyIntegerVartype)
     EXPECT_TRUE(symt.IsAnyIntegerVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsAnyIntegerVartype(AGS::kKW_Float));
 }
+
+TEST_F(SymbolTable, ArrayWithoutFirstDim)
+{
+    std::vector<size_t> const dims = { 3, 5, };
+    AGS::Vartype vartype35 = symt.VartypeWithArray(dims, AGS::kKW_Short);
+    EXPECT_STREQ("short[3, 5]", symt.GetName(vartype35).c_str());
+    AGS::Vartype vartype5 = symt.ArrayVartypeWithoutFirstDim(vartype35);
+    EXPECT_STREQ("short[5]", symt.GetName(vartype5).c_str());
+    AGS::Vartype vartype = symt.ArrayVartypeWithoutFirstDim(vartype5);
+    EXPECT_STREQ("short", symt.GetName(vartype).c_str());
+    AGS::Vartype vartype0 = symt.ArrayVartypeWithoutFirstDim(vartype);
+    EXPECT_STREQ("short", symt.GetName(vartype0).c_str());
+}

--- a/Compiler/test2/cc_symboltable_test.cpp
+++ b/Compiler/test2/cc_symboltable_test.cpp
@@ -14,10 +14,22 @@
 #include "gtest/gtest.h"
 #include "script2/cc_symboltable.h"
 
-TEST(SymbolTable, GetNameNonExistent)
+class SymbolTable : public ::testing::Test
 {
+public:
+    // Constant definitions etc.
+
+protected:
     AGS::SymbolTable symt;
 
+    SymbolTable()
+    {
+        // Initializations, will be done at the start of each test
+    }
+};
+
+TEST_F(SymbolTable, GetNameNonExistent)
+{
     EXPECT_STREQ("(invalid symbol)", symt.GetName(100).c_str());
     EXPECT_STREQ("(invalid symbol)", symt.GetName(200).c_str());
 
@@ -28,10 +40,8 @@ TEST(SymbolTable, GetNameNonExistent)
     EXPECT_STREQ("(invalid symbol)", symt.GetName(c_sym + 1).c_str());
 }
 
-TEST(SymbolTable, GetNameNormal)
+TEST_F(SymbolTable, GetNameNormal)
 {
-    AGS::SymbolTable symt;
-
     // Read out the name that was put in
 
     int const foo_sym = symt.Add("foo");
@@ -39,17 +49,13 @@ TEST(SymbolTable, GetNameNormal)
     EXPECT_STREQ("foo", symt.GetName(foo_sym).c_str());
 }
 
-TEST(SymbolTable, GetNamePredefined)
+TEST_F(SymbolTable, GetNamePredefined)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_STREQ("return", symt.GetName(AGS::kKW_Return).c_str());
 }
 
-TEST(SymbolTable, GetVartypeName)
+TEST_F(SymbolTable, GetVartypeName)
 {
-    AGS::SymbolTable symt;
-
     AGS::Vartype const foo_vartype = symt.Add("foo");
     symt.MakeEntryVartype(foo_vartype);
     symt[foo_vartype].VartypeD->Type = AGS::VTT::kAtomic;
@@ -67,10 +73,8 @@ TEST(SymbolTable, GetVartypeName)
         symt.GetName(symt.VartypeWithArray(dims, foo_vartype)).c_str());
 }
 
-TEST(SymbolTable, VartypeWithWithout)
+TEST_F(SymbolTable, VartypeWithWithout)
 {
-    AGS::SymbolTable symt;
-
     AGS::Vartype const foo_vartype = symt.Add("foo");
     symt.MakeEntryVartype(foo_vartype);
     symt[foo_vartype].VartypeD->Type = AGS::VTT::kAtomic;
@@ -83,37 +87,29 @@ TEST(SymbolTable, VartypeWithWithout)
     EXPECT_EQ(foo_converted, symt.VartypeWithout(AGS::VTT::kDynarray, foo_converted));
 }
 
-TEST(SymbolTable, AddSymbolAlreadyExists)
+TEST_F(SymbolTable, AddSymbolAlreadyExists)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     ASSERT_EQ(AGS::kKW_NoSymbol, symt.Add("a"));
 }
 
-TEST(SymbolTable, AddSymbolUnique)
+TEST_F(SymbolTable, AddSymbolUnique)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     int const b_sym = symt.Add("b");
     ASSERT_NE(a_sym, b_sym);
 }
 
-TEST(SymbolTable, FindOrAdd)
+TEST_F(SymbolTable, FindOrAdd)
 {
-    AGS::SymbolTable symt;
-
     int const a_sym = symt.Add("a");
     int const b_sym = symt.Add("b");
     int const a2_sym = symt.FindOrAdd("a");
     EXPECT_EQ(a_sym, a2_sym);
 }
 
-TEST(SymbolTable, FindResetCaches)
+TEST_F(SymbolTable, FindResetCaches)
 {
-    AGS::SymbolTable symt;
-
     // Even after caches are reset, Find() must work
 
     EXPECT_EQ(AGS::kKW_NoSymbol, symt.Find("Llanfair­pwllgwyngyll­gogery­chwyrn­drobwll­llan­tysilio­gogo­goch"));
@@ -124,10 +120,8 @@ TEST(SymbolTable, FindResetCaches)
     // BTW those names really exist
 }
 
-TEST(SymbolTable, EntriesEnsureModifiable)
+TEST_F(SymbolTable, EntriesEnsureModifiable)
 {
-    AGS::SymbolTable symt;
-
     // ensure reading and writing to entries actually works
 
     int const a_sym = symt.Add("x");
@@ -138,10 +132,8 @@ TEST(SymbolTable, EntriesEnsureModifiable)
     EXPECT_EQ(11, symt[a_sym].Declared);
 }
 
-TEST(SymbolTable, StringStruct)
+TEST_F(SymbolTable, StringStruct)
 {
-    AGS::SymbolTable symt;
-
     // set/get a stringstruct symbol
 
     AGS::Symbol const str_set = symt.Add("String");
@@ -155,20 +147,16 @@ TEST(SymbolTable, StringStruct)
     EXPECT_TRUE(symt.IsDynpointerVartype(strptr_get));
 }
 
-TEST(SymbolTable, IsInBounds)
+TEST_F(SymbolTable, IsInBounds)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_FALSE(symt.IsInBounds(-1));
     EXPECT_FALSE(symt.IsInBounds(0));
     EXPECT_FALSE(symt.IsInBounds(symt.GetLastAllocated() + 1));
     EXPECT_TRUE(symt.IsInBounds(AGS::kKW_New));
 }
 
-TEST(SymbolTable, CanBePartOfAnExpression)
+TEST_F(SymbolTable, CanBePartOfAnExpression)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_FALSE(symt.CanBePartOfAnExpression(AGS::kKW_Float));     // typical vartype
     EXPECT_FALSE(symt.CanBePartOfAnExpression(AGS::kKW_Return));    // typical keyword
     EXPECT_TRUE(symt.CanBePartOfAnExpression(AGS::kKW_And));        // typical bool operator
@@ -198,10 +186,8 @@ TEST(SymbolTable, CanBePartOfAnExpression)
     EXPECT_TRUE(symt.CanBePartOfAnExpression(var_sym));
 }
 
-TEST(SymbolTable, IsPrimitiveAtomic)
+TEST_F(SymbolTable, IsPrimitiveAtomic)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_TRUE(symt.IsPrimitiveVartype(AGS::kKW_Long));
     EXPECT_TRUE(symt.IsAtomicVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsPrimitiveVartype(AGS::kKW_Return));
@@ -217,10 +203,8 @@ TEST(SymbolTable, IsPrimitiveAtomic)
     EXPECT_FALSE(symt.IsAtomicVartype(structy_ptr_sym));
 }
 
-TEST(SymbolTable, ArrayClassic)
+TEST_F(SymbolTable, ArrayClassic)
 {
-    AGS::SymbolTable symt;
-
     AGS::Symbol const array_sym = symt.Add("HArry");
     symt.MakeEntryVartype(array_sym);
     symt[array_sym].VartypeD->BaseVartype = AGS::kKW_Int;
@@ -236,10 +220,8 @@ TEST(SymbolTable, ArrayClassic)
     EXPECT_EQ(2 * 3 * 5 * 7, symt.ArrayElementsCount(array_sym));
 }
 
-TEST(SymbolTable, OperatorPrio)
+TEST_F(SymbolTable, OperatorPrio)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_EQ(symt.kNoPrio, symt.BinaryOrPostfixOpPrio(AGS::kKW_BitNeg));
     EXPECT_NE(symt.kNoPrio, symt.PrefixOpPrio(AGS::kKW_BitNeg));
 
@@ -250,10 +232,8 @@ TEST(SymbolTable, OperatorPrio)
     EXPECT_NE(symt.kNoPrio, symt.PrefixOpPrio(AGS::kKW_Minus));
 }
 
-TEST(SymbolTable, IsAnyIntegerVartype)
+TEST_F(SymbolTable, IsAnyIntegerVartype)
 {
-    AGS::SymbolTable symt;
-
     EXPECT_TRUE(symt.IsAnyIntegerVartype(AGS::kKW_Long));
     EXPECT_FALSE(symt.IsAnyIntegerVartype(AGS::kKW_Float));
 }


### PR DESCRIPTION
This is a rebased version of @fernewelten 's #2662 PR, which has a applied change to the initialization syntax, as suggested in the previous PR discussion: when we use "named" initialization for array elements we don't need to use `[N]:` syntax, but `N:` syntax instead.

Example:
```
bool IsPrime[10] = {
    2: true,
    3: true,
    5: true,
    7: true,
};
```

Everything else should stay as stated in #2662 description, so please refer to it.