### PR TITLE
Custom pixel shaders support + Shaders script API

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -161,6 +161,7 @@ target_sources(common
     util/smart_ptr.h
     util/stdio_compat.c
     util/stdio_compat.h
+    util/stl_utils.h
     util/stream.cpp
     util/stream.h
     util/string.cpp

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -110,6 +110,7 @@ enum CharacterSvgVersion
     kCharSvgVersion_400_13  = 4000013, // compat with kCharSvgVersion_36205
     kCharSvgVersion_400_14  = 4000014, // proper ARGB color properties
     kCharSvgVersion_400_16  = 4000016, // motion path exposed to script, separate runtime flags, turns
+    kCharSvgVersion_400_18  = 4000018, // shaders
 };
 
 

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -146,6 +146,8 @@ const char *GetScriptAPIName(ScriptAPIVersion v)
     case kScriptAPI_v400: return "4.0.0-alpha8";
     case kScriptAPI_v400_07: return "4.0.0-alpha12";
     case kScriptAPI_v400_14: return "4.0.0-alpha18";
+    case kScriptAPI_v400_16: return "4.0.0-alpha20";
+    case kScriptAPI_v400_18: return "4.0.0-alpha22";
     default: return "unknown";
     }
 }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -197,7 +197,8 @@ enum ScriptAPIVersion
     kScriptAPI_v400_07 = 4000007,
     kScriptAPI_v400_14 = 4000014,
     kScriptAPI_v400_16 = 4000016,
-    kScriptAPI_Current = kScriptAPI_v400_16
+    kScriptAPI_v400_18 = 4000018,
+    kScriptAPI_Current = kScriptAPI_v400_18
 };
 
 const char *GetScriptAPIName(ScriptAPIVersion v);

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -160,6 +160,7 @@ enum GuiSvgVersion
     kGuiSvgVersion_40010    = 4000010, // compat with kGuiSvgVersion_36200-36202
     kGuiSvgVersion_40014    = 4000014, // proper ARGB color properties
     kGuiSvgVersion_40016    = 4000016, // extended graphic properties for controls
+    kGuiSvgVersion_40018    = 4000018, // shaders
 };
 
 // Style of GUI drawing in disabled state

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -792,6 +792,19 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version, st
             _scale.Y = 1.f;
     }
 
+    if (svg_version >= kGuiSvgVersion_40018)
+    {
+        _shaderID = in->ReadInt32();
+        _shaderHandle = in->ReadInt32();
+        in->ReadInt32(); // reserved
+        in->ReadInt32();
+    }
+    else
+    {
+        _shaderID = -1;
+        _shaderHandle = 0;
+    }
+
     MarkChanged();
     UpdateGraphicSpace();
 }
@@ -824,6 +837,10 @@ void GUIMain::SkipSavestate(Stream *in, GuiSvgVersion svg_version, std::vector<C
     if (svg_version >= kGuiSvgVersion_400)
     {
         in->Seek(15 * sizeof(int32_t));
+    }
+    if (svg_version >= kGuiSvgVersion_40018)
+    {
+        in->Seek(4 * sizeof(int32_t));
     }
 }
 
@@ -875,6 +892,11 @@ void GUIMain::WriteToSavegame(Common::Stream *out) const
     out->WriteInt32(0); // sprite pivot y
     out->WriteInt32(0); // sprite anchor x
     out->WriteInt32(0); // sprite anchor y
+    // kGuiSvgVersion_40018
+    out->WriteInt32(_shaderID);
+    out->WriteInt32(_shaderHandle);
+    out->WriteInt32(0); // reserved
+    out->WriteInt32(0);
 }
 
 

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -132,9 +132,10 @@ void GUIMain::SetBlendMode(BlendMode blend_mode)
     _blendMode = blend_mode;
 }
 
-void GUIMain::SetShader(int shader_id)
+void GUIMain::SetShader(int shader_id, int shader_handle)
 {
     _shaderID = shader_id;
+    _shaderHandle = shader_handle;
 }
 
 void GUIMain::SetScale(float sx, float sy)

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -801,7 +801,7 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version, st
     }
     else
     {
-        _shaderID = -1;
+        _shaderID = 0;
         _shaderHandle = 0;
     }
 

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -132,6 +132,11 @@ void GUIMain::SetBlendMode(BlendMode blend_mode)
     _blendMode = blend_mode;
 }
 
+void GUIMain::SetShader(int shader_id)
+{
+    _shaderID = shader_id;
+}
+
 void GUIMain::SetScale(float sx, float sy)
 {
     _scale = Pointf(sx, sy);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -141,7 +141,7 @@ public:
     void    SetTransparencyAsPercentage(int percent);
     BlendMode GetBlendMode() const { return _blendMode; }
     void    SetBlendMode(BlendMode blend_mode);
-    int     GetShader() const { return _shaderID; }
+    int     GetShaderID() const { return _shaderID; }
     int     GetShaderHandle() const { return _shaderHandle; }
     void    SetShader(int shader_id, int shader_handle);
     Pointf  GetScale() const { return _scale; }
@@ -273,7 +273,7 @@ private:
     int     _popupAtMouseY = -1; // popup when mousey < this
     int     _transparency = 0;  // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal; // render blend mode
-    int     _shaderID = -1;
+    int     _shaderID = 0;
     int     _shaderHandle = 0; // // runtime script shader handle
     Pointf  _scale = Pointf(1.f, 1.f);; // x,y scale
     float   _rotation = 0.f;    // rotation, in degrees

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -141,6 +141,8 @@ public:
     void    SetTransparencyAsPercentage(int percent);
     BlendMode GetBlendMode() const { return _blendMode; }
     void    SetBlendMode(BlendMode blend_mode);
+    int     GetShader() const { return _shaderID; }
+    void    SetShader(int shader_id);
     Pointf  GetScale() const { return _scale; }
     void    SetScale(const Pointf &scale) { SetScale(scale.X, scale.Y); }
     void    SetScale(float sx, float sy);
@@ -270,6 +272,7 @@ private:
     int     _popupAtMouseY = -1; // popup when mousey < this
     int     _transparency = 0;  // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal; // render blend mode
+    int     _shaderID = 0;
     Pointf  _scale = Pointf(1.f, 1.f);; // x,y scale
     float   _rotation = 0.f;    // rotation, in degrees
     int     _zOrder = 0;

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -142,7 +142,8 @@ public:
     BlendMode GetBlendMode() const { return _blendMode; }
     void    SetBlendMode(BlendMode blend_mode);
     int     GetShader() const { return _shaderID; }
-    void    SetShader(int shader_id);
+    int     GetShaderHandle() const { return _shaderHandle; }
+    void    SetShader(int shader_id, int shader_handle);
     Pointf  GetScale() const { return _scale; }
     void    SetScale(const Pointf &scale) { SetScale(scale.X, scale.Y); }
     void    SetScale(float sx, float sy);
@@ -273,6 +274,7 @@ private:
     int     _transparency = 0;  // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal; // render blend mode
     int     _shaderID = -1;
+    int     _shaderHandle = 0; // // runtime script shader handle
     Pointf  _scale = Pointf(1.f, 1.f);; // x,y scale
     float   _rotation = 0.f;    // rotation, in degrees
     int     _zOrder = 0;

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -272,7 +272,7 @@ private:
     int     _popupAtMouseY = -1; // popup when mousey < this
     int     _transparency = 0;  // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal; // render blend mode
-    int     _shaderID = 0;
+    int     _shaderID = -1;
     Pointf  _scale = Pointf(1.f, 1.f);; // x,y scale
     float   _rotation = 0.f;    // rotation, in degrees
     int     _zOrder = 0;

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -165,9 +165,10 @@ void GUIObject::SetBlendMode(BlendMode blend_mode)
     }
 }
 
-void GUIObject::SetShader(int shader_id)
+void GUIObject::SetShader(int shader_id, int shader_handle)
 {
     _shaderID = shader_id;
+    _shaderHandle = shader_handle;
 }
 
 void GUIObject::SetVisible(bool on)

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -165,6 +165,11 @@ void GUIObject::SetBlendMode(BlendMode blend_mode)
     }
 }
 
+void GUIObject::SetShader(int shader_id)
+{
+    _shaderID = shader_id;
+}
+
 void GUIObject::SetVisible(bool on)
 {
     if (on != ((_flags & kGUICtrl_Visible) != 0))

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -239,6 +239,7 @@ void GUIObject::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
     _zOrder = in->ReadInt32();
     // Dynamic state
     _isActivated = in->ReadBool() ? 1 : 0;
+
     if (svg_ver >= kGuiSvgVersion_36023)
     {
         _transparency = in->ReadInt32();
@@ -246,6 +247,7 @@ void GUIObject::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
         in->ReadInt32();
         in->ReadInt32();
     }
+
     if (svg_ver >= kGuiSvgVersion_40016)
     {
         _blendMode = static_cast<BlendMode>(in->ReadInt32());
@@ -265,6 +267,19 @@ void GUIObject::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
         in->ReadInt32(); // sprite pivot y
         in->ReadInt32(); // sprite anchor x
         in->ReadInt32(); // sprite anchor y
+    }
+
+    if (svg_ver >= kGuiSvgVersion_40018)
+    {
+        _shaderID = in->ReadInt32();
+        _shaderHandle = in->ReadInt32();
+        in->ReadInt32(); // reserved
+        in->ReadInt32();
+    }
+    else
+    {
+        _shaderID = -1;
+        _shaderHandle = 0;
     }
 
     MarkChanged();
@@ -304,6 +319,11 @@ void GUIObject::WriteToSavegame(Stream *out) const
     out->WriteInt32(0); // sprite pivot y
     out->WriteInt32(0); // sprite anchor x
     out->WriteInt32(0); // sprite anchor y
+    // kGuiSvgVersion_40018
+    out->WriteInt32(_shaderID);
+    out->WriteInt32(_shaderHandle);
+    out->WriteInt32(0); // reserved
+    out->WriteInt32(0);
 }
 
 } // namespace Common

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -278,7 +278,7 @@ void GUIObject::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
     }
     else
     {
-        _shaderID = -1;
+        _shaderID = 0;
         _shaderHandle = 0;
     }
 

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -72,7 +72,9 @@ public:
     void            SetTransparencyAsPercentage(int percent);
     BlendMode       GetBlendMode() const { return _blendMode; }
     void            SetBlendMode(BlendMode blend_mode);
-    int             GetShader() const { return _shaderID; }
+    int             GetShaderID() const { return _shaderID; }
+    int             GetShaderHandle() const { return _shaderHandle; }
+    void            SetShader(int shader_id, int shader_handle);
     int             GetZOrder() const { return _zOrder; }
     void            SetZOrder(int zorder);
     void            SetClickable(bool on);
@@ -97,7 +99,6 @@ public:
     // in *relative* coordinates, optionally clipped by the logical size
     virtual Rect    CalcGraphicRect(bool /*clipped*/) { return RectWH(0, 0, _width, _height); }
     virtual void    Draw(Bitmap *ds, int x = 0, int y = 0) { (void)ds; (void)x; (void)y; }
-    void            SetShader(int shader_id);
 
     // Events
     // Key pressed for control; returns if handled
@@ -150,6 +151,7 @@ protected:
     int      _transparency = 0; // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal;
     int      _shaderID = -1;
+    int      _shaderHandle = 0; // runtime script shader handle
     bool     _hasChanged = false;
 
     // TODO: explicit event names & handlers for every event

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -149,7 +149,7 @@ protected:
     int      _height = 0;
     int      _transparency = 0; // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal;
-    int      _shaderID = 0;
+    int      _shaderID = -1;
     bool     _hasChanged = false;
 
     // TODO: explicit event names & handlers for every event

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -72,6 +72,7 @@ public:
     void            SetTransparencyAsPercentage(int percent);
     BlendMode       GetBlendMode() const { return _blendMode; }
     void            SetBlendMode(BlendMode blend_mode);
+    int             GetShader() const { return _shaderID; }
     int             GetZOrder() const { return _zOrder; }
     void            SetZOrder(int zorder);
     void            SetClickable(bool on);
@@ -96,6 +97,7 @@ public:
     // in *relative* coordinates, optionally clipped by the logical size
     virtual Rect    CalcGraphicRect(bool /*clipped*/) { return RectWH(0, 0, _width, _height); }
     virtual void    Draw(Bitmap *ds, int x = 0, int y = 0) { (void)ds; (void)x; (void)y; }
+    void            SetShader(int shader_id);
 
     // Events
     // Key pressed for control; returns if handled
@@ -147,6 +149,7 @@ protected:
     int      _height = 0;
     int      _transparency = 0; // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal;
+    int      _shaderID = 0;
     bool     _hasChanged = false;
 
     // TODO: explicit event names & handlers for every event

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -150,7 +150,7 @@ protected:
     int      _height = 0;
     int      _transparency = 0; // "incorrect" alpha (in legacy 255-range units)
     BlendMode _blendMode = kBlend_Normal;
-    int      _shaderID = -1;
+    int      _shaderID = 0;
     int      _shaderHandle = 0; // runtime script shader handle
     bool     _hasChanged = false;
 

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -51,6 +51,22 @@ String GetFilename(const String &path)
     return path;
 }
 
+String GetFilenameNoExt(const String &path)
+{
+    const char *cstr = path.GetCStr();
+    const char *ptr_end = cstr + path.GetLength();
+    const char *cstr_end_at = nullptr;
+    for (const char *ptr = ptr_end; ptr >= cstr; --ptr)
+    {
+        if (*ptr == '.' && !cstr_end_at)
+            cstr_end_at = ptr;
+
+        if (*ptr == '/' || *ptr == PATH_ALT_SEPARATOR)
+            return String(ptr + 1, cstr_end_at ? (cstr_end_at - ptr - 1) : SIZE_MAX);
+    }
+    return path;
+}
+
 String GetFileExtension(const String &path)
 {
     const char *cstr = path.GetCStr();

--- a/Common/util/path.h
+++ b/Common/util/path.h
@@ -40,6 +40,8 @@ namespace Path
     String  GetParent(const String &path);
     // Returns filename part out of the longer path
     String  GetFilename(const String &path);
+    // Returns filename without extension
+    String  GetFilenameNoExt(const String &path);
     // Returns file's extension; file may be a fully qualified path too
     String  GetFileExtension(const String &path);
     // Returns part of the filename without extension

--- a/Common/util/stl_utils.h
+++ b/Common/util/stl_utils.h
@@ -1,0 +1,57 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Utility helpers around STL containers.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__STLUTILS_H
+#define __AGS_CN_UTIL__STLUTILS_H
+
+#include <queue>
+
+namespace AGS
+{
+namespace Common
+{
+
+namespace StlUtil
+{
+    // Move elements from one queue to another
+    template <typename T>
+    void MoveQueue(std::queue<T> &dst, std::queue<T> &src)
+    {
+        for (; !src.empty(); src.pop())
+            dst.push(src.front());
+    }
+
+    // A dirty solution for removing an element of queue from the middle;
+    // to be used as a quick hack or temporary fix only.
+    template <typename T>
+    void EraseFromQueue(std::queue<T> &q, const T &elem)
+    {
+        std::queue<T> t;
+        for (; !q.empty(); q.pop())
+        {
+            if (q.front() != elem)
+                t.push(q.front());
+        }
+        MoveQueue(q, t);
+    }
+
+} // namespace STLUtil
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__STLUTILS_H

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3022,6 +3022,10 @@ builtin managed struct Camera {
   /// Gets/sets the camera rotation in degrees.
   import attribute float Rotation;
 #endif // SCRIPT_API_v399
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this camera.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 
   /// Gets/sets whether this camera will follow the player character automatically.
   import attribute bool AutoTracking;
@@ -3084,6 +3088,10 @@ builtin struct Screen {
   import static readonly attribute Viewport *Viewports[];
   /// Gets the number of viewports.
   import static readonly attribute int ViewportCount;
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader applied to the whole game screen.
+  import static attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 
 #ifdef SCRIPT_API_v36026
   /// Returns the point in room which is displayed at the given screen coordinates.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3341,6 +3341,8 @@ builtin managed struct ShaderInstance {
   import void SetConstantF3(const string name, float x, float y, float z);
   /// Sets a shader's constant value as 4 floats
   import void SetConstantF4(const string name, float x, float y, float z, float w);
+
+  import readonly attribute ShaderProgram* Shader;
 };
 #endif // SCRIPT_API_v400_18
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1290,6 +1290,9 @@ builtin managed struct Overlay {
   readonly import attribute int  TintLuminance;
   /// Gets/sets the flip direction of this overlay.
   import attribute eFlipDirection Flip;
+
+  ///
+  import attribute int Shader;
 #endif // SCRIPT_API_v400
 };
 
@@ -1565,6 +1568,9 @@ builtin managed struct GUIControl {
 
   /// Gets/sets the blending mode of this control.
   import attribute BlendMode BlendMode;
+
+  ///
+  import attribute int Shader;
 #endif // SCRIPT_API_v400
 };
 
@@ -1820,6 +1826,9 @@ builtin managed struct GUI {
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this GUI.
   import bool SetTextProperty(const string property, const string value);
+
+  ///
+  import attribute int Shader;
 #endif // SCRIPT_API_v400
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
@@ -2447,6 +2456,9 @@ builtin managed struct Object {
   import attribute bool Enabled;
   /// Gets this object's current MotionPath, or null if it's not moving.
   import attribute MotionPath* MotionPath;
+
+  ///
+  import attribute int Shader;
 #endif // SCRIPT_API_v400
   readonly int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
@@ -2714,6 +2726,9 @@ builtin managed struct Character {
   import attribute float FaceDirectionRatio;
   /// Gets this character's current MotionPath, or null if it's not moving.
   import attribute MotionPath* MotionPath;
+
+  ///
+  import attribute int Shader;
 #endif // SCRIPT_API_v400
 #ifdef SCRIPT_COMPAT_v399
   char  on;
@@ -3041,6 +3056,11 @@ builtin managed struct Viewport {
   import Point *ScreenToRoomPoint(int scrx, int scry, bool clipViewport = true);
   /// Returns the point on screen corresponding to the given room coordinates if seen through this viewport.
   import Point *RoomToScreenPoint(int roomx, int roomy, bool clipViewport = true);
+
+#ifdef SCRIPT_API_v400
+  ///
+  import attribute int Shader;
+#endif // SCRIPT_API_v400
 };
 
 builtin struct Screen {
@@ -3291,6 +3311,13 @@ builtin managed struct MotionPath {
   import readonly attribute float VelocityX;
   /// Gets the current Y magnitude of an object's velocity.
   import readonly attribute float VelocityY;
+};
+
+builtin managed struct ShaderProgram {
+  ///
+  import static ShaderProgram* CreateFromFile(const string filename);
+  ///
+  import readonly attribute int ShaderID;
 };
 #endif // SCRIPT_API_v400
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -908,6 +908,10 @@ builtin struct Room {
   /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character in the current room.
   import static attribute float FaceDirectionRatio;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the current Room's background shader.
+  import static attribute ShaderInstance* BackgroundShader;
+#endif // SCRIPT_API_v400_18
 };
 
 builtin struct Parser {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -845,6 +845,9 @@ builtin managed struct Walkbehind;
 builtin managed struct Pathfinder;
 builtin managed struct MotionPath;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+builtin managed struct ShaderInstance;
+#endif // SCRIPT_API_v400_18
 
 builtin struct Room {
   /// Gets a custom text property associated with this room.
@@ -1290,10 +1293,11 @@ builtin managed struct Overlay {
   readonly import attribute int  TintLuminance;
   /// Gets/sets the flip direction of this overlay.
   import attribute eFlipDirection Flip;
-
-  ///
-  import attribute int Shader;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this overlay.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 };
 
 #ifdef SCRIPT_API_v400
@@ -1557,21 +1561,22 @@ builtin managed struct GUIControl {
   import readonly attribute String ScriptName;
 #endif // SCRIPT_API_v361
 #ifdef SCRIPT_API_v400
-  /// Gets an integer custom property for this GUI.
+  /// Gets an integer custom property for this control.
   import int  GetProperty(const string property);
-  /// Gets a text custom property for this GUI.
+  /// Gets a text custom property for this control.
   import String GetTextProperty(const string property);
-  /// Sets an integer custom property for this GUI.
+  /// Sets an integer custom property for this control.
   import bool SetProperty(const string property, int value);
-  /// Sets a text custom property for this GUI.
+  /// Sets a text custom property for this control.
   import bool SetTextProperty(const string property, const string value);
 
   /// Gets/sets the blending mode of this control.
   import attribute BlendMode BlendMode;
-
-  ///
-  import attribute int Shader;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this control.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 };
 
 builtin managed struct Label extends GUIControl {
@@ -1826,10 +1831,11 @@ builtin managed struct GUI {
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this GUI.
   import bool SetTextProperty(const string property, const string value);
-
-  ///
-  import attribute int Shader;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this GUI.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
@@ -2456,10 +2462,11 @@ builtin managed struct Object {
   import attribute bool Enabled;
   /// Gets this object's current MotionPath, or null if it's not moving.
   import attribute MotionPath* MotionPath;
-
-  ///
-  import attribute int Shader;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this object.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
   readonly int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
 
@@ -2726,10 +2733,11 @@ builtin managed struct Character {
   import attribute float FaceDirectionRatio;
   /// Gets this character's current MotionPath, or null if it's not moving.
   import attribute MotionPath* MotionPath;
-
-  ///
-  import attribute int Shader;
 #endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this character.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 #ifdef SCRIPT_COMPAT_v399
   char  on;
 #endif // SCRIPT_COMPAT_v399
@@ -3057,10 +3065,10 @@ builtin managed struct Viewport {
   /// Returns the point on screen corresponding to the given room coordinates if seen through this viewport.
   import Point *RoomToScreenPoint(int roomx, int roomy, bool clipViewport = true);
 
-#ifdef SCRIPT_API_v400
-  ///
-  import attribute int Shader;
-#endif // SCRIPT_API_v400
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader of this viewport.
+  import attribute ShaderInstance* Shader;
+#endif // SCRIPT_API_v400_18
 };
 
 builtin struct Screen {
@@ -3312,19 +3320,29 @@ builtin managed struct MotionPath {
   /// Gets the current Y magnitude of an object's velocity.
   import readonly attribute float VelocityY;
 };
+#endif // SCRIPT_API_v400
 
+#ifdef SCRIPT_API_v400_18
 builtin managed struct ShaderProgram {
-  ///
-  import static ShaderProgram* CreateFromFile(const string filename);
-  ///
-  import readonly attribute int ShaderID;
-  ///
+  /// Creates a new ShaderProgram by either loading a precompiled shader, or reading source code and compiling one.
+  import static ShaderProgram* CreateFromFile(const string filename); // $AUTOCOMPLETESTATICONLY$
+  /// Creates a new shader instance of this shader program.
+  import ShaderInstance* CreateInstance();
+  /// Gets the default shader instance of this shader program.
+  import readonly attribute ShaderInstance* Default;
+};
+
+builtin managed struct ShaderInstance {
+  /// Sets a shader's constant value as 1 float
   import void SetConstantF(const string name, float value);
+  /// Sets a shader's constant value as 2 floats
   import void SetConstantF2(const string name, float x, float y);
+  /// Sets a shader's constant value as 3 floats
   import void SetConstantF3(const string name, float x, float y, float z);
+  /// Sets a shader's constant value as 4 floats
   import void SetConstantF4(const string name, float x, float y, float z, float w);
 };
-#endif // SCRIPT_API_v400
+#endif // SCRIPT_API_v400_18
 
 
 import ColorType palette[PALETTE_SIZE];

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1059,6 +1059,10 @@ builtin struct Mouse {
   /// Gets/sets whether the mouse cursor will be automatically locked in the game window.
   import static attribute bool AutoLock;
 #endif // SCRIPT_API_v36026
+#ifdef SCRIPT_API_v400_18
+  /// Gets/sets the shader applied to the mouse cursor.
+  import static attribute ShaderInstance* CursorShader;
+#endif // SCRIPT_API_v400_18
   /// Gets the current mouse position.
   readonly int  x,y;
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3318,6 +3318,11 @@ builtin managed struct ShaderProgram {
   import static ShaderProgram* CreateFromFile(const string filename);
   ///
   import readonly attribute int ShaderID;
+  ///
+  import void SetConstantF(const string name, float value);
+  import void SetConstantF2(const string name, float x, float y);
+  import void SetConstantF3(const string name, float x, float y, float z);
+  import void SetConstantF4(const string name, float x, float y, float z, float w);
 };
 #endif // SCRIPT_API_v400
 

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -53,6 +53,8 @@ namespace AGS.Types
         v400_14 = 4000014,
         [Description("4.0.0 Alpha 20")]
         v400_16 = 4000016,
+        [Description("4.0.0 Alpha 22")]
+        v400_18 = 4000018,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -224,6 +224,7 @@ target_sources(engine
     ac/screenoverlay.h
     ac/scriptcontainers.cpp
     ac/shader_script.cpp
+    ac/shader_script.h
     ac/slider.cpp
     ac/slider.h
     ac/speech.cpp

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -115,6 +115,8 @@ target_sources(engine
     ac/dynobj/scriptrestoredsaveinfo.h
     ac/dynobj/scriptset.cpp
     ac/dynobj/scriptset.h
+    ac/dynobj/scriptshader.cpp
+    ac/dynobj/scriptshader.h
     ac/dynobj/scriptstring.cpp
     ac/dynobj/scriptstring.h
     ac/dynobj/scriptsystem.cpp
@@ -221,6 +223,7 @@ target_sources(engine
     ac/screenoverlay.cpp
     ac/screenoverlay.h
     ac/scriptcontainers.cpp
+    ac/shader_script.cpp
     ac/slider.cpp
     ac/slider.h
     ac/speech.cpp

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -550,6 +550,7 @@ endif()
 
 if (WIN32)
     target_link_libraries(engine PUBLIC shlwapi)
+    target_link_libraries(engine PUBLIC D3DCompiler.lib)
 endif()
 
 if(ANDROID)

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1796,7 +1796,7 @@ void Character_SetShader(CharacterInfo *chaa, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(chex.shader_handle);
 
     ccAddObjectReference(new_inst_ref);
-    chex.shader_id = shader_inst->GetShaderInstanceID();
+    chex.shader_id = shader_inst->GetID();
     chex.shader_handle = new_inst_ref;
 }
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1786,18 +1786,9 @@ ScriptShaderInstance *Character_GetShader(CharacterInfo *chaa)
 
 void Character_SetShader(CharacterInfo *chaa, ScriptShaderInstance *shader_inst)
 {
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
     auto &chex = charextra[chaa->index_id];
-    if (chex.shader_handle == new_inst_ref)
-        return;
-
-    if (chex.shader_handle > 0)
-        ccReleaseObjectReference(chex.shader_handle);
-
-    ccAddObjectReference(new_inst_ref);
     chex.shader_id = shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID;
-    chex.shader_handle = new_inst_ref;
+    chex.shader_handle = ccReplaceObjectHandle(chex.shader_handle, shader_inst);
 }
 
 float Character_GetRotation(CharacterInfo *chaa) {

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1778,6 +1778,16 @@ void Character_SetBlendMode(CharacterInfo *chaa, int blend_mode) {
     charextra[chaa->index_id].blend_mode = ValidateBlendMode("Character.BlendMode", blend_mode);
 }
 
+int Character_GetShader(CharacterInfo *chaa)
+{
+    return charextra[chaa->index_id].shader_id;
+}
+
+void Character_SetShader(CharacterInfo *chaa, int shader_id)
+{
+    charextra[chaa->index_id].shader_id = shader_id;
+}
+
 float Character_GetRotation(CharacterInfo *chaa) {
     return charextra[chaa->index_id].rotation;
 }
@@ -4214,6 +4224,16 @@ RuntimeScriptValue Sc_Character_SetBlendMode(void *self, const RuntimeScriptValu
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_Character_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetShader);
+}
+
+RuntimeScriptValue Sc_Character_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetShader);
+}
+
 // bool (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetUseRegionTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -4456,6 +4476,9 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::get_FaceDirectionRatio",    API_FN_PAIR(Character_GetFaceDirectionRatio) },
         { "Character::set_FaceDirectionRatio",    API_FN_PAIR(Character_SetFaceDirectionRatio) },
         { "Character::get_MotionPath",            API_FN_PAIR(Character_GetMotionPath) },
+
+        { "Character::get_Shader",                API_FN_PAIR(Character_GetShader) },
+        { "Character::set_Shader",                API_FN_PAIR(Character_SetShader) },
     };
 
     ccAddExternalFunctions(character_api);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1796,7 +1796,7 @@ void Character_SetShader(CharacterInfo *chaa, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(chex.shader_handle);
 
     ccAddObjectReference(new_inst_ref);
-    chex.shader_id = shader_inst->GetID();
+    chex.shader_id = shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID;
     chex.shader_handle = new_inst_ref;
 }
 

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -147,6 +147,19 @@ void CharacterExtras::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
         flags = 0;
         turns = 0;
     }
+
+    if (save_ver >= kCharSvgVersion_400_18)
+    {
+        shader_id = in->ReadInt32();
+        shader_handle = in->ReadInt32();
+        in->ReadInt32(); // reserved
+        in->ReadInt32();
+    }
+    else
+    {
+        shader_id = -1;
+        shader_handle = 0;
+    }
 }
 
 void CharacterExtras::WriteToSavegame(Stream *out) const
@@ -196,4 +209,9 @@ void CharacterExtras::WriteToSavegame(Stream *out) const
     out->WriteInt32(movelist_handle);
     out->WriteInt32(flags);
     out->WriteInt32(turns);
+    // -- kCharSvgVersion_400_18
+    out->WriteInt32(shader_id);
+    out->WriteInt32(shader_handle);
+    out->WriteInt32(0); // reserved
+    out->WriteInt32(0);
 }

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -157,7 +157,7 @@ void CharacterExtras::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
     }
     else
     {
-        shader_id = -1;
+        shader_id = 0;
         shader_handle = 0;
     }
 }

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -72,7 +72,7 @@ struct CharacterExtras
     int   follow_dist = 0; // follow distance, in pixels
     int   follow_eagerness = 0; // follow reaction
     Common::BlendMode blend_mode = Common::kBlend_Normal;
-    int   shader_id = 0;
+    int   shader_id = -1;
     float rotation = 0.f;
     // Optional character face direction ratio, 0 = ignore
     float face_dir_ratio = 0.f;

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -72,7 +72,7 @@ struct CharacterExtras
     int   follow_dist = 0; // follow distance, in pixels
     int   follow_eagerness = 0; // follow reaction
     Common::BlendMode blend_mode = Common::kBlend_Normal;
-    int   shader_id = -1;
+    int   shader_id = 0;
     int   shader_handle = 0; // script shader handle
     float rotation = 0.f;
     // Optional character face direction ratio, 0 = ignore

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -73,6 +73,7 @@ struct CharacterExtras
     int   follow_eagerness = 0; // follow reaction
     Common::BlendMode blend_mode = Common::kBlend_Normal;
     int   shader_id = -1;
+    int   shader_handle = 0; // script shader handle
     float rotation = 0.f;
     // Optional character face direction ratio, 0 = ignore
     float face_dir_ratio = 0.f;

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -72,6 +72,7 @@ struct CharacterExtras
     int   follow_dist = 0; // follow distance, in pixels
     int   follow_eagerness = 0; // follow reaction
     Common::BlendMode blend_mode = Common::kBlend_Normal;
+    int   shader_id = 0;
     float rotation = 0.f;
     // Optional character face direction ratio, 0 = ignore
     float face_dir_ratio = 0.f;

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -24,6 +24,7 @@
 #include "ac/viewframe.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
+#include "main/game_run.h"
 #include "main/update.h"
 #include "media/audio/audio_system.h"
 
@@ -33,7 +34,6 @@ extern std::vector<ViewStruct> views;
 extern GameSetupStruct game;
 extern int displayed_room;
 extern RoomStruct thisroom;
-extern unsigned int loopcounter;
 extern int char_speaking_anim;
 
 int CharacterInfo::get_baseline() const {
@@ -465,7 +465,7 @@ void UpdateCharacterIdle(CharacterInfo *chi, CharacterExtras *chex, int &doing_n
     else if ((doing_nothing == 0) || ((chi->flags & CHF_FIXVIEW) != 0))
       chi->idleleft = chi->idletime;
     // count idle time
-    else if ((loopcounter % GetGameSpeed()==0) || (chex->process_idle_this_time == 1)) {
+    else if ((get_loop_counter() % GetGameSpeed()==0) || (chex->process_idle_this_time == 1)) {
       chi->idleleft--;
       if (chi->idleleft == -1) {
         int useloop=chi->loop;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2427,7 +2427,7 @@ static void draw_gui_controls_batch(int gui_id)
         if (!obj_ddb) continue;
         obj_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(obj->GetTransparency()));
         obj_ddb->SetBlendMode(obj->GetBlendMode());
-        obj_ddb->SetShader(obj->GetShader());
+        obj_ddb->SetShader(obj->GetShaderID());
         gfxDriver->DrawSprite(obj->GetX() + obj_tx.Off.X, obj->GetY() + obj_tx.Off.Y, obj_ddb);
     }
     gfxDriver->EndSpriteBatch();
@@ -2818,7 +2818,7 @@ static void construct_overlays()
         overtx.Ddb->SetRotation(over.rotation);
         overtx.Ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
         overtx.Ddb->SetBlendMode(over.blendMode);
-        overtx.Ddb->SetShader(over.shader_id);
+        overtx.Ddb->SetShader(over.GetShaderID());
         apply_tint_or_light_ddb(overtx, over.tint_light * over.HasLightLevel(), over.tint_level, over.tint_r, over.tint_g, over.tint_b, over.tint_light);
     }
 }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -3046,6 +3046,8 @@ void construct_game_screen_overlay(bool draw_mouse)
         assert(cursor_tx.Ddb); // Test for missing texture, might happen if not marked for update
         if (cursor_tx.Ddb)
         {
+            cursor_tx.Ddb->SetShader(shaderInstances[play.GetCursorShaderID()]);
+
             // Exclusive sub-batch for mouse cursor, to let filter it out (CHECKME later?)
             gfxDriver->BeginSpriteBatch(Rect(), SpriteTransform(), kFlip_None, nullptr, RENDER_BATCH_MOUSE_CURSOR);
             gfxDriver->DrawSprite(mousex - mouse_hotx, mousey - mouse_hoty, cursor_tx.Ddb);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2309,6 +2309,7 @@ void prepare_room_sprites()
                 walkbehinds_generate_sprites();
             }
         }
+        roomBackgroundBmp->SetShader(shaderInstances[croom->GetBgShaderID()]);
         add_thing_to_draw(roomBackgroundBmp, 0, 0);
     }
     current_background_is_dirty = false; // Note this is only place where this flag is checked

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -29,7 +29,12 @@ namespace AGS
     {
         typedef std::shared_ptr<Common::Bitmap> PBitmap;
     }
-    namespace Engine { class IDriverDependantBitmap; }
+    namespace Engine
+    {
+        class IDriverDependantBitmap;
+        class IGraphicShader;
+        class IShaderInstance;
+    }
 }
 using namespace AGS; // FIXME later
 
@@ -104,6 +109,23 @@ void update_shared_texture(uint32_t sprite_id);
 void clear_shared_texture(uint32_t sprite_id);
 // Prepares a texture for the given sprite and stores in the cache
 void texturecache_precache(uint32_t sprite_id);
+
+// Adds a custom shader to the collection at the desired index;
+// if there's any shader on that index then it will get disposed of
+void add_custom_shader(Engine::IGraphicShader *shader, uint32_t at_index);
+// Gets a custom shader by its index
+Engine::IGraphicShader *get_custom_shader(uint32_t sh_index);
+// Deletes a custom shader; this also deletes their instances
+void delete_custom_shader(uint32_t shader_id);
+// Adds a custom shader instance to the collection at the desired index;
+// if there's any shader instance on that index then it will get disposed of
+void add_shader_instance(Engine::IShaderInstance *shader_instance, uint32_t at_index);
+// Gets a shader instance by its index
+Engine::IShaderInstance *get_shader_instance(uint32_t shinst_index);
+// Deletes a custom shader instance
+void delete_shader_instance(uint32_t shader_inst_id);
+// Deletes all custom shaders and their isntances
+void dispose_all_custom_shaders();
 
 // Initializes a loaded sprite for use in the game, adjusts the sprite flags.
 // Returns a resulting bitmap, which may be a new or old bitmap; or null on failure.

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -22,6 +22,7 @@
 #include "ac/dynobj/scriptcontainers.h"
 #include "ac/dynobj/scriptfile.h"
 #include "ac/dynobj/scriptmotionpath.h"
+#include "ac/dynobj/scriptshader.h"
 #include "ac/dynobj/scriptviewport.h"
 #include "ac/game.h"
 #include "ac/gui.h"
@@ -216,6 +217,16 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     {
         ScriptMotionPath *sc_path = new ScriptMotionPath();
         sc_path->Unserialize(index, &mems, data_sz);
+    }
+    else if (strcmp(objectType, "ShaderProgram") == 0)
+    {
+        ScriptShaderProgram *sc_shader = new ScriptShaderProgram();
+        sc_shader->Unserialize(index, &mems, data_sz);
+    }
+    else if (strcmp(objectType, "ShaderInstance") == 0)
+    {
+        ScriptShaderInstance *sc_shinst = new ScriptShaderInstance();
+        sc_shinst->Unserialize(index, &mems, data_sz);
     }
     else
     {

--- a/Engine/ac/dynobj/dynobj_manager.cpp
+++ b/Engine/ac/dynobj/dynobj_manager.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/dynobj/dynobj_manager.h"
+#include "ac/dynobj/scriptshader.h"
 #include <stdlib.h>
 #include <string.h>
 #include "ac/dynobj/managedobjectpool.h"
@@ -57,6 +58,9 @@ int ccUnRegisterManagedObject(void *object) {
 // remove all registered objects
 void ccUnregisterAllObjects() {
     pool.Reset();
+
+    // Some classes need to also reset their static members atm
+    ScriptShaderProgram::ResetFreeIndexes();
 }
 
 // serialize all objects to disk

--- a/Engine/ac/dynobj/dynobj_manager.cpp
+++ b/Engine/ac/dynobj/dynobj_manager.cpp
@@ -144,6 +144,38 @@ int ccReleaseObjectReference(int32_t handle) {
     return pool.SubRefCheckDispose(handle);
 }
 
+int ccAssignObjectHandle(void *address)
+{
+    int handle = ccGetObjectHandleFromAddress(address);
+    if (handle > 0)
+        ccAddObjectReference(handle);
+    return handle;
+}
+
+int ccRemoveObjectHandle(int handle)
+{
+    if (handle > 0)
+        ccReleaseObjectReference(handle);
+    return 0;
+}
+
+int ccReplaceObjectHandle(int32_t old_handle, int32_t new_handle)
+{
+    if (old_handle == new_handle)
+        return new_handle;
+
+    if (old_handle > 0)
+        ccReleaseObjectReference(old_handle);
+    if (new_handle > 0)
+        ccAddObjectReference(new_handle);
+    return new_handle;
+}
+
+int ccReplaceObjectHandle(int32_t old_handle, void *new_address)
+{
+    return ccReplaceObjectHandle(old_handle, ccGetObjectHandleFromAddress(new_address));
+}
+
 void ccTraverseManagedObjects(const String &type, PfnProcessManagedObject callback)
 {
     pool.TraverseManagedObjects(type, callback);

--- a/Engine/ac/dynobj/dynobj_manager.h
+++ b/Engine/ac/dynobj/dynobj_manager.h
@@ -58,6 +58,22 @@ ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&ob
 int ccAddObjectReference(int32_t handle);
 int ccReleaseObjectReference(int32_t handle);
 
+// Helper functions for assigning managed object handles.
+// TODO: implement a RAII kind of a wrapper over managed handle that uses these automatically.
+
+// Retrieves object's handle, adds reference count and returns a handle.
+int ccAssignObjectHandle(void *address);
+// Decrements handle's reference count, returns 0 (easy to use as assigment).
+int ccRemoveObjectHandle(int handle);
+// Replaces one handle with another using same rules as a smart pointer:
+// tests handles for equality, decrements old handle's reference count,
+// increments new handle's reference count. Returns new handle.
+int ccReplaceObjectHandle(int32_t old_handle, int32_t new_handle);
+// Replaces one handle with another (got from real address) using same rules as a smart pointer:
+// tests handles for equality, decrements old handle's reference count,
+// increments new handle's reference count. Returns new handle.
+int ccReplaceObjectHandle(int32_t old_handle, void *new_address);
+
 typedef std::function<void(int handle, IScriptObject *obj)> PfnProcessManagedObject;
 // Iterates all managed objects identified by their Type ID, and runs a callback for each of them
 void ccTraverseManagedObjects(const AGS::Common::String &type, PfnProcessManagedObject proc);

--- a/Engine/ac/dynobj/dynobj_manager.h
+++ b/Engine/ac/dynobj/dynobj_manager.h
@@ -58,7 +58,7 @@ ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&ob
 int ccAddObjectReference(int32_t handle);
 int ccReleaseObjectReference(int32_t handle);
 
-typedef void (*PfnProcessManagedObject)(int handle, IScriptObject *obj);
+typedef std::function<void(int handle, IScriptObject *obj)> PfnProcessManagedObject;
 // Iterates all managed objects identified by their Type ID, and runs a callback for each of them
 void ccTraverseManagedObjects(const AGS::Common::String &type, PfnProcessManagedObject proc);
 

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -112,7 +112,7 @@ public:
     void Reset();
     void PrintStats();
 
-    typedef void (*PfnProcessObject)(int handle, IScriptObject *obj);
+    typedef std::function<void(int handle, IScriptObject *obj)> PfnProcessObject;
     void TraverseManagedObjects(const AGS::Common::String &type, PfnProcessObject proc);
 
     ManagedObjectPool();

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -1,0 +1,34 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "scriptshader.h"
+
+using namespace AGS::Common;
+
+ScriptShaderProgram::ScriptShaderProgram(const String &name, int shader_id)
+    : _name(name)
+    , _shaderID(shader_id)
+{
+}
+
+const char *ScriptShaderProgram::GetType()
+{
+    return "ShaderProgram";
+}
+
+int ScriptShaderProgram::Dispose(void *address, bool force)
+{
+    //gfxDriver->DeleteShader ... ?
+    delete this;
+    return 1;
+}

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -84,14 +84,8 @@ ScriptShaderInstance *ScriptShaderProgram::GetDefaultInstance() const
 
 void ScriptShaderProgram::SetDefaultShaderInstance(ScriptShaderInstance *shader_inst)
 {
-    int new_handle = ccGetObjectHandleFromAddress(shader_inst);
-    // TODO: implement a RAII kind of a wrapper over managed handle that does this automatically
-    if (_defaultInstanceHandle > 0 && _defaultInstanceHandle != new_handle)
-        ccReleaseObjectReference(_defaultInstanceHandle);
     _defaultInstance = shader_inst;
-    _defaultInstanceHandle = new_handle;
-    if (_defaultInstanceHandle > 0)
-        ccAddObjectReference(_defaultInstanceHandle);
+    _defaultInstanceHandle = ccReplaceObjectHandle(_defaultInstanceHandle, ccGetObjectHandleFromAddress(shader_inst));
 }
 
 uint32_t ScriptShaderProgram::GetFreeInstanceIndex()
@@ -213,10 +207,7 @@ ScriptShaderInstance::ScriptShaderInstance(ScriptShaderProgram *sc_shader)
     _id = sc_shader->GetFreeInstanceIndex();
     _name = String::FromFormat("%s.%u", sc_shader->GetName().GetCStr(), _id);
 
-    // TODO: implement a RAII kind of a wrapper over managed handle that does this automatically
-    _shaderHandle = ccGetObjectHandleFromAddress(sc_shader);
-    if (_shaderHandle > 0)
-        ccAddObjectReference(_shaderHandle);
+    _shaderHandle = ccAssignObjectHandle(sc_shader);
 }
 
 ScriptShaderProgram *ScriptShaderInstance::GetScriptShader() const

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -13,7 +13,9 @@
 //=============================================================================
 #include "ac/dynobj/scriptshader.h"
 #include "ac/dynobj/dynobj_manager.h"
+#include "ac/draw.h"
 #include "gfx/graphicsdriver.h"
+#include "util/path.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -22,10 +24,50 @@ using namespace AGS::Engine;
 // consider another way to order shader instance deletion?
 extern IGraphicsDriver *gfxDriver;
 
-ScriptShaderProgram::ScriptShaderProgram(const String &name, uint32_t shader_id)
-    : _name(name)
-    , _shaderID(shader_id)
+uint32_t ScriptShaderProgram::_nextShaderIndex = ScriptShaderProgram::NullShaderID + 1u;
+std::queue<uint32_t> ScriptShaderProgram::_freeShaderIndexes;
+std::unordered_set<String> ScriptShaderProgram::_registeredNames;
+uint32_t ScriptShaderProgram::_nextInstanceIndex = ScriptShaderInstance::NullInstanceID + 1u;
+std::queue<uint32_t> ScriptShaderProgram::_freeInstanceIndexes;
+
+ScriptShaderProgram::ScriptShaderProgram(const String &filename)
+    : _filename(filename)
 {
+    _name = MakeName(filename);
+    _id = GetFreeIndex();
+}
+
+/*static */ uint32_t ScriptShaderProgram::GetFreeIndex()
+{
+    if (_freeShaderIndexes.size() > 0)
+    {
+        uint32_t index = _freeShaderIndexes.front();
+        _freeShaderIndexes.pop();
+        return index;
+    }
+    else
+    {
+        return _nextShaderIndex++;
+    }
+}
+
+/*static*/ String ScriptShaderProgram::MakeName(const String &filepath)
+{
+    String namebase = Path::GetFilenameNoExt(filepath);
+    String usename = namebase;
+    if (_registeredNames.count(namebase) > 0)
+    {
+        for (uint32_t i = 0; i < UINT32_MAX; ++i)
+        {
+            String tryname = String::FromFormat("%s#%u", namebase.GetCStr(), i);
+            if (_registeredNames.count(tryname) == 0)
+            {
+                usename = tryname;
+                break;
+            }
+        }
+    }
+    return usename;
 }
 
 ScriptShaderInstance *ScriptShaderProgram::GetDefaultInstance() const
@@ -47,6 +89,25 @@ void ScriptShaderProgram::SetDefaultShaderInstance(ScriptShaderInstance *shader_
         ccAddObjectReference(_defaultInstanceHandle);
 }
 
+uint32_t ScriptShaderProgram::GetFreeInstanceIndex()
+{
+    if (_freeInstanceIndexes.size() > 0)
+    {
+        uint32_t index = _freeInstanceIndexes.front();
+        _freeInstanceIndexes.pop();
+        return index;
+    }
+    else
+    {
+        return _nextInstanceIndex++;
+    }
+}
+
+void ScriptShaderProgram::ReleaseInstanceIndex(uint32_t shinst_id)
+{
+    _freeInstanceIndexes.push(shinst_id);
+}
+
 const char *ScriptShaderProgram::GetType()
 {
     return "ShaderProgram";
@@ -57,17 +118,20 @@ int ScriptShaderProgram::Dispose(void *address, bool force)
     if (_defaultInstanceHandle > 0)
         ccReleaseObjectReference(_defaultInstanceHandle);
 
-    // NOTE: we probably should not delete shader program in gfx driver here,
+    _freeShaderIndexes.push(_id);
+    _registeredNames.erase(_name);
+    // NOTE: we probably should not delete actual shader program here,
     // as loaded & compiled shaders may be reused later.
     delete this;
     return 1;
 }
 
-ScriptShaderInstance::ScriptShaderInstance(ScriptShaderProgram *sc_shader, const String &name, uint32_t shader_inst_id)
+ScriptShaderInstance::ScriptShaderInstance(ScriptShaderProgram *sc_shader)
     : _scriptShader(sc_shader)
-    , _name(name)
-    , _shaderInstID(shader_inst_id)
 {
+    _id = sc_shader->GetFreeInstanceIndex();
+    _name = String::FromFormat("%s.%u", sc_shader->GetName().GetCStr(), _id);
+
     // TODO: implement a RAII kind of a wrapper over managed handle that does this automatically
     _shaderHandle = ccGetObjectHandleFromAddress(sc_shader);
     if (_shaderHandle > 0)
@@ -88,10 +152,12 @@ const char *ScriptShaderInstance::GetType()
 
 int ScriptShaderInstance::Dispose(void *address, bool force)
 {
+    if (_scriptShader)
+        _scriptShader->ReleaseInstanceIndex(_id);
     if (_shaderHandle > 0)
         ccReleaseObjectReference(_shaderHandle);
 
-    gfxDriver->DeleteShaderInstance(gfxDriver->GetShaderInstance(_shaderInstID));
+    delete_shader_instance(_id);
     delete this;
     return 1;
 }

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -11,15 +11,18 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#include "scriptshader.h"
+#include "ac/dynobj/scriptshader.h"
+#include "ac/dynobj/dynobj_manager.h"
 
 using namespace AGS::Common;
 
-ScriptShaderProgram::ScriptShaderProgram(const String &name, uint32_t shader_id, uint32_t shader_inst_id)
+ScriptShaderProgram::ScriptShaderProgram(const String &name, uint32_t shader_id, int default_inst_ref)
     : _name(name)
     , _shaderID(shader_id)
-    , _shaderInstanceID(shader_inst_id)
+    , _defaultInstanceRef(default_inst_ref)
 {
+    if (_defaultInstanceRef > 0)
+        ccAddObjectReference(_defaultInstanceRef);
 }
 
 const char *ScriptShaderProgram::GetType()
@@ -29,8 +32,30 @@ const char *ScriptShaderProgram::GetType()
 
 int ScriptShaderProgram::Dispose(void *address, bool force)
 {
-    //FIXME: figure out when do we delete actual shaders in gfx driver
+    if (_defaultInstanceRef > 0)
+        ccReleaseObjectReference(_defaultInstanceRef);
+
+    //FIXME: figure out when do we delete actual shaders
     //gfxDriver->DeleteShader ... ?
+    delete this;
+    return 1;
+}
+
+ScriptShaderInstance::ScriptShaderInstance(const String &name, uint32_t shader_inst_id)
+    : _name(name)
+    , _shaderInstID(shader_inst_id)
+{
+}
+
+const char *ScriptShaderInstance::GetType()
+{
+    return "ShaderInstance";
+}
+
+int ScriptShaderInstance::Dispose(void *address, bool force)
+{
+    //FIXME: figure out when do we delete actual shaders
+    //gfxDriver->DeleteShaderInstance ... ?
     delete this;
     return 1;
 }

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -15,9 +15,10 @@
 
 using namespace AGS::Common;
 
-ScriptShaderProgram::ScriptShaderProgram(const String &name, int shader_id)
+ScriptShaderProgram::ScriptShaderProgram(const String &name, uint32_t shader_id, uint32_t shader_inst_id)
     : _name(name)
     , _shaderID(shader_id)
+    , _shaderInstanceID(shader_inst_id)
 {
 }
 

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -28,6 +28,7 @@ const char *ScriptShaderProgram::GetType()
 
 int ScriptShaderProgram::Dispose(void *address, bool force)
 {
+    //FIXME: figure out when do we delete actual shaders in gfx driver
     //gfxDriver->DeleteShader ... ?
     delete this;
     return 1;

--- a/Engine/ac/dynobj/scriptshader.cpp
+++ b/Engine/ac/dynobj/scriptshader.cpp
@@ -108,6 +108,24 @@ void ScriptShaderProgram::ReleaseInstanceIndex(uint32_t shinst_id)
     _freeInstanceIndexes.push(shinst_id);
 }
 
+const String ScriptShaderProgram::GetConstantName(uint32_t index)
+{
+    for (const auto &c : _constantTable)
+        if (c.second == index)
+            return c.first;
+    return {};
+}
+
+uint32_t ScriptShaderProgram::SetConstant(const String &name)
+{
+    auto it_found = _constantTable.find(name);
+    if (it_found != _constantTable.end())
+        return it_found->second;
+
+    _constantTable[name] = _constantTable.size();
+    return _constantTable.size();
+}
+
 const char *ScriptShaderProgram::GetType()
 {
     return "ShaderProgram";
@@ -143,6 +161,26 @@ ScriptShaderProgram *ScriptShaderInstance::GetScriptShader() const
     if (!_scriptShader)
         _scriptShader = static_cast<ScriptShaderProgram*>(ccGetObjectAddressFromHandle(_shaderHandle));
     return _scriptShader;
+}
+
+void ScriptShaderInstance::SetConstantData(const String &name, float value[4], uint32_t size)
+{
+    if (!_scriptShader)
+        return;
+
+    uint32_t index = _scriptShader->SetConstant(name);
+    SetConstantData(index, value, size);
+}
+
+void ScriptShaderInstance::SetConstantData(uint32_t index, float value[4], uint32_t size)
+{
+    if (_constData.size() <= index)
+        _constData.resize(index + 1);
+    _constData[index].Size = size;
+    _constData[index].Val[0] = value[0];
+    _constData[index].Val[1] = value[1];
+    _constData[index].Val[2] = value[2];
+    _constData[index].Val[3] = value[3];
 }
 
 const char *ScriptShaderInstance::GetType()

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -23,13 +23,11 @@ struct ScriptShaderProgram final : CCBasicObject
 public:
     const static uint32_t InvalidShader = -1;
 
-    ScriptShaderProgram(const String &name, uint32_t shader_id, uint32_t shader_inst_id);
+    ScriptShaderProgram(const String &name, uint32_t shader_id, int default_inst_ref);
 
     const String &GetName() const { return _name; }
-    // FIXME make uint32_t, when the script api is fixed to store pointer instead of id
     uint32_t GetShaderID() const { return _shaderID; }
-    // FIXME replace with "default instance"
-    uint32_t GetShaderInstanceID() const { return _shaderInstanceID; }
+    int GetDefaultInstanceRef() const { return _defaultInstanceRef; }
 
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
@@ -37,7 +35,26 @@ public:
 private:
     String _name;
     uint32_t _shaderID = InvalidShader;
-    uint32_t _shaderInstanceID = UINT32_MAX; // FIXME: replace with "default instance"
+    int _defaultInstanceRef = 0;
+};
+
+struct ScriptShaderInstance final : CCBasicObject
+{
+    using String = AGS::Common::String;
+public:
+    const static uint32_t InvalidShader = -1;
+
+    ScriptShaderInstance(const String &name, uint32_t shader_inst_id);
+
+    const String &GetName() const { return _name; }
+    uint32_t GetShaderInstanceID() const { return _shaderInstID; }
+
+    const char *GetType() override;
+    int Dispose(void *address, bool force) override;
+
+private:
+    String _name;
+    uint32_t _shaderInstID = InvalidShader;
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTSHADER_H

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -21,19 +21,23 @@ struct ScriptShaderProgram final : CCBasicObject
 {
     using String = AGS::Common::String;
 public:
-    const static int InvalidShader = -1;
+    const static uint32_t InvalidShader = -1;
 
-    ScriptShaderProgram(const String &name, int shader_id);
+    ScriptShaderProgram(const String &name, uint32_t shader_id, uint32_t shader_inst_id);
 
     const String &GetName() const { return _name; }
-    int GetShaderID() const { return _shaderID; }
+    // FIXME make uint32_t, when the script api is fixed to store pointer instead of id
+    uint32_t GetShaderID() const { return _shaderID; }
+    // FIXME replace with "default instance"
+    uint32_t GetShaderInstanceID() const { return _shaderInstanceID; }
 
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
 
 private:
     String _name;
-    int _shaderID = InvalidShader;
+    uint32_t _shaderID = InvalidShader;
+    uint32_t _shaderInstanceID = UINT32_MAX; // FIXME: replace with "default instance"
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTSHADER_H

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -17,17 +17,21 @@
 #include "ac/dynobj/cc_agsdynamicobject.h"
 #include "util/string.h"
 
-struct ScriptShaderProgram final : CCBasicObject
+class ScriptShaderInstance;
+
+class ScriptShaderProgram final : public CCBasicObject
 {
     using String = AGS::Common::String;
 public:
     const static uint32_t InvalidShader = -1;
 
-    ScriptShaderProgram(const String &name, uint32_t shader_id, int default_inst_ref);
+    ScriptShaderProgram(const String &name, uint32_t shader_id);
+    void SetDefaultShaderInstance(ScriptShaderInstance *shader_inst);
 
     const String &GetName() const { return _name; }
     uint32_t GetShaderID() const { return _shaderID; }
-    int GetDefaultInstanceRef() const { return _defaultInstanceRef; }
+    int GetDefaultInstanceHandle() const { return _defaultInstanceHandle; }
+    ScriptShaderInstance *GetDefaultInstance() const;
 
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
@@ -35,19 +39,21 @@ public:
 private:
     String _name;
     uint32_t _shaderID = InvalidShader;
-    int _defaultInstanceRef = 0;
+    int _defaultInstanceHandle = 0;
+    mutable ScriptShaderInstance *_defaultInstance = nullptr;
 };
 
-struct ScriptShaderInstance final : CCBasicObject
+class ScriptShaderInstance final : public CCBasicObject
 {
     using String = AGS::Common::String;
 public:
     const static uint32_t InvalidShader = -1;
 
-    ScriptShaderInstance(const String &name, uint32_t shader_inst_id);
+    ScriptShaderInstance(ScriptShaderProgram *sc_shader, const String &name, uint32_t shader_inst_id);
 
     const String &GetName() const { return _name; }
     uint32_t GetShaderInstanceID() const { return _shaderInstID; }
+    ScriptShaderProgram *GetScriptShader() const;
 
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
@@ -55,6 +61,8 @@ public:
 private:
     String _name;
     uint32_t _shaderInstID = InvalidShader;
+    int _shaderHandle = 0;
+    mutable ScriptShaderProgram *_scriptShader = nullptr;
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTSHADER_H

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -33,7 +33,7 @@ public:
 
 private:
     String _name;
-    int _shaderID = -1;
+    int _shaderID = InvalidShader;
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTSHADER_H

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -22,11 +22,12 @@
 
 class ScriptShaderInstance;
 
-class ScriptShaderProgram final : public CCBasicObject
+class ScriptShaderProgram final : public AGSCCDynamicObject
 {
     using String = AGS::Common::String;
 public:
     const static uint32_t NullShaderID = 0u;
+    static const char *TypeID;
 
     // Gets next free index for the script shader
     static uint32_t GetFreeIndex();
@@ -56,7 +57,12 @@ public:
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
 
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
 private:
+    size_t CalcSerializeSize(const void *address) override;
+    void   Serialize(const void *address, AGS::Common::Stream *out) override;
+
     String _name;
     String _filename;
     uint32_t _id = NullShaderID;
@@ -82,11 +88,12 @@ private:
     static std::queue<uint32_t> _freeInstanceIndexes;
 };
 
-class ScriptShaderInstance final : public CCBasicObject
+class ScriptShaderInstance final : public AGSCCDynamicObject
 {
     using String = AGS::Common::String;
 public:
     const static uint32_t NullInstanceID = 0u;
+    static const char *TypeID;
 
     ScriptShaderInstance() = default;
     ScriptShaderInstance(ScriptShaderProgram *sc_shader);
@@ -113,7 +120,12 @@ public:
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
 
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
 private:
+    size_t CalcSerializeSize(const void *address) override;
+    void   Serialize(const void *address, AGS::Common::Stream *out) override;
+
     String _name;
     uint32_t _id = NullInstanceID;
     int _shaderHandle = 0; // script shader handle

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -21,6 +21,8 @@ struct ScriptShaderProgram final : CCBasicObject
 {
     using String = AGS::Common::String;
 public:
+    const static int InvalidShader = -1;
+
     ScriptShaderProgram(const String &name, int shader_id);
 
     const String &GetName() const { return _name; }

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_EE_DYNOBJ__SCRIPTSHADER_H
+#define __AGS_EE_DYNOBJ__SCRIPTSHADER_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "util/string.h"
+
+struct ScriptShaderProgram final : CCBasicObject
+{
+    using String = AGS::Common::String;
+public:
+    ScriptShaderProgram(const String &name, int shader_id);
+
+    const String &GetName() const { return _name; }
+    int GetShaderID() const { return _shaderID; }
+
+    const char *GetType() override;
+    int Dispose(void *address, bool force) override;
+
+private:
+    String _name;
+    int _shaderID = -1;
+};
+
+#endif // __AGS_EE_DYNOBJ__SCRIPTSHADER_H

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -34,6 +34,7 @@ public:
     // Generates a shader name from the filepath
     // TODO: move this elsewhere?
     static String MakeName(const String &filepath);
+    static void ResetFreeIndexes();
 
     ScriptShaderProgram() = default;
     ScriptShaderProgram(const String &filename);
@@ -86,6 +87,8 @@ private:
     // NOTE: we are using static (shared) instance indexes to let engine keep all shader indexes in a single list
     static uint32_t _nextInstanceIndex;
     static std::queue<uint32_t> _freeInstanceIndexes;
+
+    friend ScriptShaderInstance; // a dirty solution for resolving free indexes on unserialize
 };
 
 class ScriptShaderInstance final : public AGSCCDynamicObject

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -14,6 +14,8 @@
 #ifndef __AGS_EE_DYNOBJ__SCRIPTSHADER_H
 #define __AGS_EE_DYNOBJ__SCRIPTSHADER_H
 
+#include <queue>
+#include <unordered_set>
 #include "ac/dynobj/cc_agsdynamicobject.h"
 #include "util/string.h"
 
@@ -23,36 +25,60 @@ class ScriptShaderProgram final : public CCBasicObject
 {
     using String = AGS::Common::String;
 public:
-    const static uint32_t InvalidShader = -1;
+    const static uint32_t NullShaderID = 0u;
 
-    ScriptShaderProgram(const String &name, uint32_t shader_id);
-    void SetDefaultShaderInstance(ScriptShaderInstance *shader_inst);
+    // Gets next free index for the script shader
+    static uint32_t GetFreeIndex();
+    // Generates a shader name from the filepath
+    // TODO: move this elsewhere?
+    static String MakeName(const String &filepath);
+
+    ScriptShaderProgram() = default;
+    ScriptShaderProgram(const String &filename);
 
     const String &GetName() const { return _name; }
-    uint32_t GetShaderID() const { return _shaderID; }
+    const String &GetFilename() const { return _filename; }
+    uint32_t GetID() const { return _id; }
     int GetDefaultInstanceHandle() const { return _defaultInstanceHandle; }
     ScriptShaderInstance *GetDefaultInstance() const;
+
+    void SetDefaultShaderInstance(ScriptShaderInstance *shader_inst);
+    uint32_t GetFreeInstanceIndex();
+    void ReleaseInstanceIndex(uint32_t shinst_id);
 
     const char *GetType() override;
     int Dispose(void *address, bool force) override;
 
 private:
     String _name;
-    uint32_t _shaderID = InvalidShader;
+    String _filename;
+    uint32_t _id = NullShaderID;
     int _defaultInstanceHandle = 0;
     mutable ScriptShaderInstance *_defaultInstance = nullptr;
+
+    // The records of logical indexes and names of script shader objects.
+    // TODO: don't use static members, consider put this in a global object like GamePlayState?
+    // This also may be desired if we let create Shader entries in the editor and load them from the game data.
+    // TODO: some helper class over free index counting (see also: overlays and managed pool)
+    static uint32_t _nextShaderIndex;
+    static std::queue<uint32_t> _freeShaderIndexes;
+    static std::unordered_set<String> _registeredNames;
+    // NOTE: we are using static (shared) instance indexes to let engine keep all shader indexes in a single list
+    static uint32_t _nextInstanceIndex;
+    static std::queue<uint32_t> _freeInstanceIndexes;
 };
 
 class ScriptShaderInstance final : public CCBasicObject
 {
     using String = AGS::Common::String;
 public:
-    const static uint32_t InvalidShader = -1;
+    const static uint32_t NullInstanceID = 0u;
 
-    ScriptShaderInstance(ScriptShaderProgram *sc_shader, const String &name, uint32_t shader_inst_id);
+    ScriptShaderInstance() = default;
+    ScriptShaderInstance(ScriptShaderProgram *sc_shader);
 
     const String &GetName() const { return _name; }
-    uint32_t GetShaderInstanceID() const { return _shaderInstID; }
+    uint32_t GetID() const { return _id; }
     ScriptShaderProgram *GetScriptShader() const;
 
     const char *GetType() override;
@@ -60,8 +86,8 @@ public:
 
 private:
     String _name;
-    uint32_t _shaderInstID = InvalidShader;
-    int _shaderHandle = 0;
+    uint32_t _id = NullInstanceID;
+    int _shaderHandle = 0; // script shader handle
     mutable ScriptShaderProgram *_scriptShader = nullptr;
 };
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -537,7 +537,7 @@ void unload_game()
 
     get_overlays().clear();
 
-    resetRoomStatuses();
+    ResetRoomStates();
 
     dispose_room_pathfinder();
 

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -219,8 +219,6 @@ extern int new_room_x, new_room_y, new_room_loop;
 extern bool new_room_placeonwalkable;
 extern int displayed_room;
 extern int frames_per_second; // fixed game fps, set by script
-extern unsigned int loopcounter;
-extern void set_loop_counter(unsigned int new_counter);
 extern int game_paused;
 
 #endif // __AGS_EE_AC__GAME_H

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -282,6 +282,8 @@ void GamePlayState::DeleteRoomViewport(int index)
 {
     if (index < 0 || (size_t)index >= _roomViewports.size())
         return;
+
+    // Invalidate script object
     auto handle = _scViewportHandles[index];
     auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
     if (scobj)
@@ -289,9 +291,15 @@ void GamePlayState::DeleteRoomViewport(int index)
         scobj->Invalidate();
         ccReleaseObjectReference(handle);
     }
+    // Unlink camera
     auto cam = _roomViewports[index]->GetCamera();
     if (cam)
         cam->UnlinkFromViewport(index);
+
+    // Release shader handle (if present)
+    ccRemoveObjectHandle(_roomViewports[index]->GetShaderHandle());
+
+    // Erase viewport object and adjust the cameras lists
     _roomViewports.erase(_roomViewports.begin() + index);
     _scViewportHandles.erase(_scViewportHandles.begin() + index);
     for (size_t i = index; i < _roomViewports.size(); ++i)
@@ -351,6 +359,8 @@ void GamePlayState::DeleteRoomCamera(int index)
 {
     if (index < 0 || (size_t)index >= _roomCameras.size())
         return;
+
+    // Invalidate script object
     auto handle = _scCameraHandles[index];
     auto scobj = (ScriptCamera*)ccGetObjectAddressFromHandle(handle);
     if (scobj)
@@ -358,12 +368,18 @@ void GamePlayState::DeleteRoomCamera(int index)
         scobj->Invalidate();
         ccReleaseObjectReference(handle);
     }
+    // Unlink viewport
     for (auto& viewref : _roomCameras[index]->GetLinkedViewports())
     {
         auto view = viewref.lock();
         if (view)
             view->LinkCamera(nullptr);
     }
+
+    // Release shader handle (if present)
+    ccRemoveObjectHandle(_roomCameras[index]->GetShaderHandle());
+
+    // Erase camera object and adjust the cameras lists
     _roomCameras.erase(_roomCameras.begin() + index);
     _scCameraHandles.erase(_scCameraHandles.begin() + index);
     for (size_t i = index; i < _roomCameras.size(); ++i)

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -395,6 +395,12 @@ ScriptCamera *GamePlayState::GetScriptCamera(int index)
     return (ScriptCamera*)ccGetObjectAddressFromHandle(_scCameraHandles[index]);
 }
 
+void GamePlayState::SetScreenShader(int shader_id, int shader_handle)
+{
+    _screenShaderID = shader_id;
+    _screenShaderHandle = shader_handle;
+}
+
 bool GamePlayState::IsIgnoringInput() const
 {
     return AGS_Clock::now() < _ignoreUserInputUntilTime;
@@ -652,8 +658,17 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
     if (svg_ver >= kGSSvgVersion_400_03)
     {
         face_dir_ratio = in->ReadFloat32();
+        // used since kGSSvgVersion_400_18
+        _screenShaderID = in->ReadInt32();
+        _screenShaderHandle = in->ReadInt32();
         // reserve few more 32-bit values (for a total of 10)
-        in->Seek(sizeof(int32_t) * 9);
+        in->Seek(sizeof(int32_t) * 7);
+    }
+    else
+    {
+        face_dir_ratio = 1.f;
+        _screenShaderID = 0;
+        _screenShaderHandle = 0;
     }
 }
 
@@ -845,11 +860,13 @@ void GamePlayState::WriteForSavegame(Stream *out) const
     out->WriteInt32(dialog_options_gui_y);
     out->WriteInt32(dialog_options_textalign);
     out->WriteInt32(0); // reserve up to 4 ints
-    
+
     // kGSSvgVersion_400_03
     out->WriteFloat32(face_dir_ratio);
+    out->WriteInt32(_screenShaderID); // used since kGSSvgVersion_400_18
+    out->WriteInt32(_screenShaderHandle);
     // reserve few more 32-bit values (for a total of 10)
-    out->WriteByteCount(0, sizeof(int32_t) * 9);
+    out->WriteByteCount(0, sizeof(int32_t) * 7);
 }
 
 void GamePlayState::FreeProperties()

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -401,6 +401,12 @@ void GamePlayState::SetScreenShader(int shader_id, int shader_handle)
     _screenShaderHandle = shader_handle;
 }
 
+void GamePlayState::SetCursorShader(int shader_id, int shader_handle)
+{
+    _cursorShaderID = shader_id;
+    _cursorShaderHandle = shader_handle;
+}
+
 bool GamePlayState::IsIgnoringInput() const
 {
     return AGS_Clock::now() < _ignoreUserInputUntilTime;
@@ -661,14 +667,18 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
         // used since kGSSvgVersion_400_18
         _screenShaderID = in->ReadInt32();
         _screenShaderHandle = in->ReadInt32();
+        _cursorShaderID = in->ReadInt32();
+        _cursorShaderHandle = in->ReadInt32();
         // reserve few more 32-bit values (for a total of 10)
-        in->Seek(sizeof(int32_t) * 7);
+        in->Seek(sizeof(int32_t) * 5);
     }
     else
     {
         face_dir_ratio = 1.f;
         _screenShaderID = 0;
         _screenShaderHandle = 0;
+        _cursorShaderID = 0;
+        _cursorShaderHandle = 0;
     }
 }
 
@@ -865,8 +875,10 @@ void GamePlayState::WriteForSavegame(Stream *out) const
     out->WriteFloat32(face_dir_ratio);
     out->WriteInt32(_screenShaderID); // used since kGSSvgVersion_400_18
     out->WriteInt32(_screenShaderHandle);
+    out->WriteInt32(_cursorShaderID);
+    out->WriteInt32(_cursorShaderHandle);
     // reserve few more 32-bit values (for a total of 10)
-    out->WriteByteCount(0, sizeof(int32_t) * 7);
+    out->WriteByteCount(0, sizeof(int32_t) * 5);
 }
 
 void GamePlayState::FreeProperties()

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -375,6 +375,10 @@ struct GamePlayState
     int GetScreenShaderHandle() const { return _screenShaderHandle; }
     void SetScreenShader(int shader_id, int shader_handle);
 
+    int GetCursorShaderID() const { return _cursorShaderID; }
+    int GetCursorShaderHandle() const { return _cursorShaderHandle; }
+    void SetCursorShader(int shader_id, int shader_handle);
+
     // Tells if engine should apply AA (linear) scaling to the game sprites
     bool ShouldAASprites() const { return enable_antialiasing && (disable_antialiasing == 0); }
 
@@ -447,6 +451,8 @@ private:
     std::vector<int32_t> _scCameraHandles;
     int _screenShaderID = 0;
     int _screenShaderHandle = 0;
+    int _cursorShaderID = 0;
+    int _cursorShaderHandle = 0;
 
     // Tells that the main viewport's position has changed since last game update
     bool  _mainViewportHasChanged = false;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -212,7 +212,7 @@ struct GamePlayState
     bool  raw_modified[MAX_ROOM_BGFRAMES]{}; // tell which current room bgs were modified
     int   room_changes = 0;
     int   mouse_cursor_hidden = 0;
-    unsigned long shakesc_delay = 0;  // unsigned long to match loopcounter
+    uint32_t shakesc_delay = 0; // unsigned to match loopcounter
     int   shakesc_amount = 0;
     int   shakesc_length = 0;
     int   rtint_red = 0;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -49,9 +49,6 @@ struct ScriptCamera;
 struct ScriptOverlay;
 
 // GameState struct's runtime save format
-// This is a length limit for serialized field,
-// not actual api input argument
-#define PLAYMP3FILE_MAX_FILENAME_LEN 50
 enum GameStateSvgVersion
 {
     kGSSvgVersion_Initial   = 0,
@@ -65,6 +62,7 @@ enum GameStateSvgVersion
     kGSSvgVersion_400_08    = 4000008, // palette component range 64->256
     kGSSvgVersion_400_14    = 4000014, // 32-bit ARGB color properties
     kGSSvgVersion_400_17    = 4000017, // compat w kGSSvgVersion_363
+    kGSSvgVersion_400_18    = 4000018, // shaders
 };
 
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -371,6 +371,10 @@ struct GamePlayState
     // because script interpreter does this when acquiring managed pointer.
     ScriptCamera *GetScriptCamera(int index);
 
+    int GetScreenShaderID() const { return _screenShaderID; }
+    int GetScreenShaderHandle() const { return _screenShaderHandle; }
+    void SetScreenShader(int shader_id, int shader_handle);
+
     // Tells if engine should apply AA (linear) scaling to the game sprites
     bool ShouldAASprites() const { return enable_antialiasing && (disable_antialiasing == 0); }
 
@@ -441,6 +445,8 @@ private:
     // could address them and invalidate as the actual object gets destroyed.
     std::vector<int32_t> _scViewportHandles;
     std::vector<int32_t> _scCameraHandles;
+    int _screenShaderID = 0;
+    int _screenShaderHandle = 0;
 
     // Tells that the main viewport's position has changed since last game update
     bool  _mainViewportHasChanged = false;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -449,6 +449,7 @@ private:
     // could address them and invalidate as the actual object gets destroyed.
     std::vector<int32_t> _scViewportHandles;
     std::vector<int32_t> _scCameraHandles;
+    // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _screenShaderID = 0;
     int _screenShaderHandle = 0;
     int _cursorShaderID = 0;

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -111,18 +111,11 @@ void NewRoom(int nrnum) {
 
 void ResetRoom(int nrnum) {
     if (nrnum == displayed_room)
-        quit("!ResetRoom: cannot reset current room");
-    if ((nrnum<0) | (nrnum>=MAX_ROOMS))
-        quit("!ResetRoom: invalid room number");
+        quitprintf("!ResetRoom: cannot reset current room  %d", nrnum);
+    if ((nrnum < 0) || (nrnum >= MAX_ROOMS))
+        quitprintf("!ResetRoom: invalid room number %d", nrnum);
 
-    if (isRoomStatusValid(nrnum))
-    {
-        // FIXME: why not delete RoomStatus object completely?
-        RoomStatus* roomstat = getRoomStatus(nrnum);
-        roomstat->FreeScriptData();
-        roomstat->FreeProperties();
-        roomstat->beenhere = 0;
-    }
+    ResetRoomState(nrnum);
 
     debug_script_log("Room %d reset to original state", nrnum);
 }
@@ -130,10 +123,8 @@ void ResetRoom(int nrnum) {
 int HasPlayerBeenInRoom(int roomnum) {
     if ((roomnum < 0) || (roomnum >= MAX_ROOMS))
         return 0;
-    if (isRoomStatusValid(roomnum))
-        return getRoomStatus(roomnum)->beenhere;
-    else
-        return 0;
+    RoomStatus *roomstat = GetRoomStateIfExists(roomnum);
+    return (roomstat != nullptr) && (roomstat->beenhere != 0);
 }
 
 void CallRoomScript (int value) {
@@ -145,16 +136,6 @@ void CallRoomScript (int value) {
     play.roomscript_finished = 0;
     RuntimeScriptValue params[]{ value , RuntimeScriptValue() };
     get_executingscript()->RunAnother(kScTypeRoom, "on_call", 1, params);
-}
-
-int HasBeenToRoom (int roomnum) {
-    if ((roomnum < 0) || (roomnum >= MAX_ROOMS))
-        quit("!HasBeenToRoom: invalid room number specified");
-
-    if (isRoomStatusValid(roomnum))
-        return getRoomStatus(roomnum)->beenhere;
-    else
-        return 0;
 }
 
 void SetBackgroundFrame(int frnum) {

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -117,6 +117,7 @@ void ResetRoom(int nrnum) {
 
     if (isRoomStatusValid(nrnum))
     {
+        // FIXME: why not delete RoomStatus object completely?
         RoomStatus* roomstat = getRoomStatus(nrnum);
         roomstat->FreeScriptData();
         roomstat->FreeProperties();

--- a/Engine/ac/global_room.h
+++ b/Engine/ac/global_room.h
@@ -24,7 +24,6 @@ void NewRoom(int nrnum);// still widely used
 void ResetRoom(int nrnum);
 int  HasPlayerBeenInRoom(int roomnum);
 void CallRoomScript (int value);
-int  HasBeenToRoom (int roomnum);
 
 void SetBackgroundFrame(int frnum);
 int GetBackgroundFrame() ;

--- a/Engine/ac/global_screen.cpp
+++ b/Engine/ac/global_screen.cpp
@@ -37,7 +37,6 @@ extern RoomStruct thisroom;
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
 extern RGB palette[256];
-extern unsigned int loopcounter;
 
 void FlipScreen(int direction) {
     direction = ValidateFlip("FlipScreen", direction);
@@ -102,14 +101,14 @@ public:
         // TODO: split implementations into two state classes?
         if (gfxDriver->RequiresFullRedrawEachFrame())
         {
-            loopcounter++;
+            increment_loop_counter();
             render_graphics();
             update_polled_stuff();
             WaitForNextFrame();
         }
         else
         {
-            loopcounter++;
+            increment_loop_counter();
             update_shakescreen();
             render_to_screen();
             update_polled_stuff();

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -433,7 +433,7 @@ void GUI_SetShader(ScriptGUI *gui, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(guim.GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    guim.SetShader(shader_inst->GetShaderInstanceID(), new_inst_ref);
+    guim.SetShader(shader_inst->GetID(), new_inst_ref);
 }
 
 float GUI_GetRotation(ScriptGUI *gui) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -423,17 +423,9 @@ ScriptShaderInstance *GUI_GetShader(ScriptGUI *gui)
 
 void GUI_SetShader(ScriptGUI *gui, ScriptShaderInstance *shader_inst)
 {
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
     auto &guim = guis[gui->id];
-    if (guim.GetShaderHandle() == new_inst_ref)
-        return;
-
-    if (guim.GetShaderHandle() > 0)
-        ccReleaseObjectReference(guim.GetShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    guim.SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    guim.SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                   ccReplaceObjectHandle(guim.GetShaderHandle(), shader_inst));
 }
 
 float GUI_GetRotation(ScriptGUI *gui) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -415,6 +415,16 @@ void GUI_SetBlendMode(ScriptGUI *gui, int blend_mode) {
     guis[gui->id].SetBlendMode(ValidateBlendMode("GUI.BlendMode", blend_mode));
 }
 
+int GUI_GetShader(ScriptGUI *gui)
+{
+    return guis[gui->id].GetShader();
+}
+
+void GUI_SetShader(ScriptGUI *gui, int shader_id)
+{
+    guis[gui->id].SetShader(shader_id);
+}
+
 float GUI_GetRotation(ScriptGUI *gui) {
     return guis[gui->id].GetRotation();
 }
@@ -1211,6 +1221,16 @@ RuntimeScriptValue Sc_GUI_SetBlendMode(void *self, const RuntimeScriptValue *par
     API_OBJCALL_VOID_PINT(ScriptGUI, GUI_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_GUI_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetShader);
+}
+
+RuntimeScriptValue Sc_GUI_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptGUI, GUI_SetShader);
+}
+
 RuntimeScriptValue Sc_GUI_GetRotation(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_FLOAT(ScriptGUI, GUI_GetRotation);
@@ -1339,6 +1359,9 @@ void RegisterGUIAPI()
         { "GUI::set_ScaleY",              API_FN_PAIR(GUI_SetScaleY) },
         { "GUI::SetScale",                API_FN_PAIR(GUI_SetScale) },
         { "GUI::SetScale",                API_FN_PAIR(GUI_SetScale) },
+
+        { "GUI::get_Shader",              API_FN_PAIR(GUI_GetShader) },
+        { "GUI::set_Shader",              API_FN_PAIR(GUI_SetShader) },
     };
 
     ccAddExternalFunctions(gui_api);

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -433,7 +433,7 @@ void GUI_SetShader(ScriptGUI *gui, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(guim.GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    guim.SetShader(shader_inst->GetID(), new_inst_ref);
+    guim.SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 float GUI_GetRotation(ScriptGUI *gui) {

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -276,7 +276,7 @@ void GUIControl_SetShader(GUIObject *guio, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(guio->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    guio->SetShader(shader_inst->GetID(), new_inst_ref);
+    guio->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 //=============================================================================

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -276,7 +276,7 @@ void GUIControl_SetShader(GUIObject *guio, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(guio->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    guio->SetShader(shader_inst->GetShaderInstanceID(), new_inst_ref);
+    guio->SetShader(shader_inst->GetID(), new_inst_ref);
 }
 
 //=============================================================================

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -267,16 +267,8 @@ ScriptShaderInstance *GUIControl_GetShader(GUIObject *guio)
 
 void GUIControl_SetShader(GUIObject *guio, ScriptShaderInstance *shader_inst)
 {
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
-    if (guio->GetShaderHandle() == new_inst_ref)
-        return;
-
-    if (guio->GetShaderHandle() > 0)
-        ccReleaseObjectReference(guio->GetShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    guio->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    guio->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                    ccReplaceObjectHandle(guio->GetShaderHandle(), shader_inst));
 }
 
 //=============================================================================

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -258,6 +258,16 @@ bool GUIControl_SetTextProperty(GUIObject *guio, const char *property, const cha
     return set_text_property(play.guicontrolProps[ctrl_type][ctrl_id], property, value);
 }
 
+int GUIControl_GetShader(GUIObject *guio)
+{
+    return guio->GetShader();
+}
+
+void GUIControl_SetShader(GUIObject *guio, int shader_id)
+{
+    guio->SetShader(shader_id);
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -483,6 +493,16 @@ RuntimeScriptValue Sc_GUIControl_SetBlendMode(void *self, const RuntimeScriptVal
     API_OBJCALL_VOID_PINT(GUIObject, GUIControl_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_GUIControl_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIObject, GUIControl_GetShader);
+}
+
+RuntimeScriptValue Sc_GUIControl_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(GUIObject, GUIControl_SetShader);
+}
+
 RuntimeScriptValue Sc_GUIControl_GetProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT_POBJ(GUIObject, GUIControl_GetProperty, const char);
@@ -547,6 +567,9 @@ void RegisterGUIControlAPI()
         { "GUIControl::set_Transparency", API_FN_PAIR(GUIControl_SetTransparency) },
         { "GUIControl::get_BlendMode",    API_FN_PAIR(GUIControl_GetBlendMode) },
         { "GUIControl::set_BlendMode",    API_FN_PAIR(GUIControl_SetBlendMode) },
+
+        { "GUIControl::get_Shader",       API_FN_PAIR(GUIControl_GetShader) },
+        { "GUIControl::set_Shader",       API_FN_PAIR(GUIControl_SetShader) },
     };
 
     ccAddExternalFunctions(guicontrol_api);

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -17,6 +17,8 @@
 #include "ac/draw.h"
 #include "ac/dynobj/scriptmouse.h"
 #include "ac/dynobj/scriptsystem.h"
+#include "ac/dynobj/scriptshader.h"
+#include "ac/dynobj/dynobj_manager.h"
 #include "ac/game.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
@@ -403,6 +405,18 @@ void Mouse_SetAutoLock(bool on)
     }
 }
 
+ScriptShaderInstance *Mouse_GetCursorShader()
+{
+    return static_cast<ScriptShaderInstance *>(ccGetObjectAddressFromHandle(
+        play.GetCursorShaderHandle()));
+}
+
+void Mouse_SetCursorShader(ScriptShaderInstance *shader_inst)
+{
+    play.SetCursorShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                    ccReplaceObjectHandle(play.GetCursorShaderHandle(), shader_inst));
+}
+
 //=============================================================================
 
 void update_script_mouse_coords() {
@@ -656,6 +670,15 @@ RuntimeScriptValue Sc_Mouse_SetAutoLock(const RuntimeScriptValue *params, int32_
     API_SCALL_VOID_PBOOL(Mouse_SetAutoLock);
 }
 
+RuntimeScriptValue Sc_Mouse_GetCursorShader(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptShaderInstance, Mouse_GetCursorShader);
+}
+
+RuntimeScriptValue Sc_Mouse_SetCursorShader(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_POBJ(Mouse_SetCursorShader, ScriptShaderInstance);
+}
 
 RuntimeScriptValue Sc_Mouse_GetSpeed(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -694,6 +717,8 @@ void RegisterMouseAPI()
         { "Mouse::set_AutoLock",              API_FN_PAIR(Mouse_SetAutoLock) },
         { "Mouse::get_ControlEnabled",        Sc_Mouse_GetControlEnabled, Mouse::IsControlEnabled },
         { "Mouse::set_ControlEnabled",        Sc_Mouse_SetControlEnabled, Mouse_EnableControl },
+        { "Mouse::get_CursorShader",          API_FN_PAIR(Mouse_GetCursorShader) },
+        { "Mouse::set_CursorShader",          API_FN_PAIR(Mouse_SetCursorShader) },
         { "Mouse::get_Mode",                  API_FN_PAIR(Mouse_GetCursorMode) },
         { "Mouse::set_Mode",                  API_FN_PAIR(Mouse_SetCursorMode) },
         { "Mouse::get_Speed",                 Sc_Mouse_GetSpeed, Mouse::GetSpeed },

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -874,7 +874,7 @@ void Object_SetShader(ScriptObject *objj, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(obj.shader_handle);
 
     ccAddObjectReference(new_inst_ref);
-    obj.shader_id = shader_inst->GetID();
+    obj.shader_id = shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID;
     obj.shader_handle = new_inst_ref;
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -856,6 +856,16 @@ void Object_SetBlendMode(ScriptObject *objj, int blend_mode) {
     objs[objj->id].blend_mode = ValidateBlendMode("Object.BlendMode", blend_mode);
 }
 
+int Object_GetShader(ScriptObject *objj)
+{
+    return objs[objj->id].shader_id;
+}
+
+void Object_SetShader(ScriptObject *objj, int shader_id)
+{
+    objs[objj->id].shader_id = shader_id;
+}
+
 float Object_GetRotation(ScriptObject *objj) {
     return objs[objj->id].rotation;
 }
@@ -1736,6 +1746,17 @@ RuntimeScriptValue Sc_Object_SetBlendMode(void *self, const RuntimeScriptValue *
     API_OBJCALL_VOID_PINT(ScriptObject, Object_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_Object_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetShader);
+}
+
+// void (ScriptObject *objj, int blendMode)
+RuntimeScriptValue Sc_Object_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptObject, Object_SetShader);
+}
+
 // bool (ScriptObject *objj)
 RuntimeScriptValue Sc_Object_GetUseRegionTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1848,6 +1869,9 @@ void RegisterObjectAPI()
         { "Object::set_UseRegionTint",        API_FN_PAIR(Object_SetUseRegionTint) },
 
         { "Object::get_MotionPath",           API_FN_PAIR(Object_GetMotionPath) },
+
+        { "Object::get_Shader",               API_FN_PAIR(Object_GetShader) },
+        { "Object::set_Shader",               API_FN_PAIR(Object_SetShader) },
     };
 
     ccAddExternalFunctions(object_api);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -874,7 +874,7 @@ void Object_SetShader(ScriptObject *objj, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(obj.shader_handle);
 
     ccAddObjectReference(new_inst_ref);
-    obj.shader_id = shader_inst->GetShaderInstanceID();
+    obj.shader_id = shader_inst->GetID();
     obj.shader_handle = new_inst_ref;
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -864,18 +864,9 @@ ScriptShaderInstance *Object_GetShader(ScriptObject *objj)
 
 void Object_SetShader(ScriptObject *objj, ScriptShaderInstance *shader_inst)
 {
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
     auto &obj = objs[objj->id];
-    if (obj.shader_handle == new_inst_ref)
-        return;
-
-    if (obj.shader_handle > 0)
-        ccReleaseObjectReference(obj.shader_handle);
-
-    ccAddObjectReference(new_inst_ref);
     obj.shader_id = shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID;
-    obj.shader_handle = new_inst_ref;
+    obj.shader_handle = ccReplaceObjectHandle(obj.shader_handle, shader_inst);
 }
 
 float Object_GetRotation(ScriptObject *objj) {

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -499,11 +499,8 @@ static void dispose_overlay(ScreenOverlay &over)
 {
     over.SetImage(nullptr);
     // release shader reference
-    if (over.GetShaderHandle() > 0)
-    {
-        ccReleaseObjectReference(over.GetShaderHandle());
-        over.RemoveShader();
-    }
+    ccRemoveObjectHandle(over.GetShaderHandle());
+    over.RemoveShader();
     // invalidate script object and dispose it if there are no more refs
     if (over.associatedOverlayHandle > 0)
     {

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -328,7 +328,7 @@ void Overlay_SetShader(ScriptOverlay *scover, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(over->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    over->SetShader(shader_inst->GetID(), new_inst_ref);
+    over->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 int Overlay_GetTransparency(ScriptOverlay *scover)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -319,16 +319,8 @@ ScriptShaderInstance *Overlay_GetShader(ScriptOverlay *scover)
 void Overlay_SetShader(ScriptOverlay *scover, ScriptShaderInstance *shader_inst)
 {
     auto *over = GetOverlayValidate("Overlay.Shader", scover);
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
-    if (over->GetShaderHandle() == new_inst_ref)
-        return;
-
-    if (over->GetShaderHandle() > 0)
-        ccReleaseObjectReference(over->GetShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    over->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    over->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                    ccReplaceObjectHandle(over->GetShaderHandle(), shader_inst));
 }
 
 int Overlay_GetTransparency(ScriptOverlay *scover)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -328,7 +328,7 @@ void Overlay_SetShader(ScriptOverlay *scover, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(over->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    over->SetShader(shader_inst->GetShaderInstanceID(), new_inst_ref);
+    over->SetShader(shader_inst->GetID(), new_inst_ref);
 }
 
 int Overlay_GetTransparency(ScriptOverlay *scover)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -309,6 +309,18 @@ void Overlay_SetBlendMode(ScriptOverlay *scover, int blend_mode)
     over->blendMode = ValidateBlendMode("Overlay.BlendMode", blend_mode);
 }
 
+int Overlay_GetShader(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.Shader", scover);
+    return over->shader_id;
+}
+
+void Overlay_SetShader(ScriptOverlay *scover, int shader_id)
+{
+    auto *over = GetOverlayValidate("Overlay.Shader", scover);
+    over->shader_id = shader_id;
+}
+
 int Overlay_GetTransparency(ScriptOverlay *scover)
 {
     auto *over = GetOverlayValidate("Overlay.Transparency", scover);
@@ -847,6 +859,16 @@ RuntimeScriptValue Sc_Overlay_SetBlendMode(void *self, const RuntimeScriptValue 
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetBlendMode);
 }
 
+RuntimeScriptValue Sc_Overlay_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetShader);
+}
+
+RuntimeScriptValue Sc_Overlay_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetShader);
+}
+
 RuntimeScriptValue Sc_Overlay_GetFlip(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetFlip);
@@ -1029,6 +1051,9 @@ void RegisterOverlayAPI()
         { "Overlay::set_Rotation",        API_FN_PAIR(Overlay_SetRotation) },
         { "Overlay::get_Flip",            API_FN_PAIR(Overlay_GetFlip) },
         { "Overlay::set_Flip",            API_FN_PAIR(Overlay_SetFlip) },
+
+        { "Overlay::get_Shader",          API_FN_PAIR(Overlay_GetShader) },
+        { "Overlay::set_Shader",          API_FN_PAIR(Overlay_SetShader) },
     };
 
     ccAddExternalFunctions(overlay_api);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -310,18 +310,15 @@ ScriptPathfinder* Room_GetPathFinder()
 
 //=============================================================================
 
-void save_room_data_segment ()
+void save_room_data_segment()
 {
-    croom->FreeScriptData();
-    
     const auto &globaldata = roomscript->GetGlobalData();
     croom->tsdatasize = globaldata.size();
+    croom->tsdata.resize(globaldata.size());
     if (croom->tsdatasize > 0)
     {
-        croom->tsdata.resize(croom->tsdatasize);
-        memcpy(croom->tsdata.data(),&globaldata[0],croom->tsdatasize);
+        std::copy(globaldata.begin(), globaldata.end(), croom->tsdata.begin());
     }
-
 }
 
 void unload_old_room()
@@ -569,7 +566,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
 
     if ((newnum>=0) & (newnum<MAX_ROOMS))
-        croom = getRoomStatus(newnum);
+        croom = GetRoomState(newnum);
     else
         croom=&troom;
 
@@ -921,15 +918,6 @@ void set_room_placeholder()
 
     reset_temp_room();
     croom = &troom;
-}
-
-int find_highest_room_entered() {
-    int qq,fndas=-1;
-    for (qq=0;qq<MAX_ROOMS;qq++) {
-        if (isRoomStatusValid(qq) && (getRoomStatus(qq)->beenhere != 0))
-            fndas = qq;
-    }
-    return fndas;
 }
 
 void first_room_initialization() {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -11,9 +11,7 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #include <ctype.h> // for toupper
-
 #include "core/platform.h"
 #include "util/string_utils.h" //strlwr()
 #include "ac/common.h"
@@ -44,6 +42,7 @@
 #include "ac/walkablearea.h"
 #include "ac/walkbehind.h"
 #include "ac/dynobj/scriptobjects.h"
+#include "ac/dynobj/scriptshader.h"
 #include "ac/dynobj/scriptuserobject.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "ac/dynobj/all_dynamicclasses.h"
@@ -159,6 +158,18 @@ int Room_GetColorDepth() {
 
 int Room_GetBackgroundCount() {
     return thisroom.BgFrameCount;
+}
+
+ScriptShaderInstance *Room_GetBackgroundShader()
+{
+    return static_cast<ScriptShaderInstance *>(ccGetObjectAddressFromHandle(
+        croom->GetBgShaderHandle()));
+}
+
+void Room_SetBackgroundShader(ScriptShaderInstance *shader_inst)
+{
+    croom->SetBgShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                         ccReplaceObjectHandle(croom->GetBgShaderHandle(), shader_inst));
 }
 
 int Room_GetLeftEdge() {
@@ -1085,6 +1096,16 @@ RuntimeScriptValue Sc_Room_GetBackgroundCount(const RuntimeScriptValue *params, 
     API_SCALL_INT(Room_GetBackgroundCount);
 }
 
+RuntimeScriptValue Sc_Room_GetBackgroundShader(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptShaderInstance, Room_GetBackgroundShader);
+}
+
+RuntimeScriptValue Sc_Room_SetBackgroundShader(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_POBJ(Room_SetBackgroundShader, ScriptShaderInstance);
+}
+
 // int ()
 RuntimeScriptValue Sc_Room_GetLeftEdge(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1193,6 +1214,8 @@ void RegisterRoomAPI()
         { "Room::SetTextProperty^2",                  API_FN_PAIR(Room_SetTextProperty) },
         { "Room::ProcessClick^3",                     API_FN_PAIR(RoomProcessClick) },
         { "Room::get_BackgroundCount",                API_FN_PAIR(Room_GetBackgroundCount) },
+        { "Room::get_BackgroundShader",               API_FN_PAIR(Room_GetBackgroundShader) },
+        { "Room::set_BackgroundShader",               API_FN_PAIR(Room_SetBackgroundShader) },
         { "Room::get_BottomEdge",                     API_FN_PAIR(Room_GetBottomEdge) },
         { "Room::get_ColorDepth",                     API_FN_PAIR(Room_GetColorDepth) },
         { "Room::get_Height",                         API_FN_PAIR(Room_GetHeight) },

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -87,7 +87,6 @@ extern int in_leaves_screen;
 extern CharacterInfo*playerchar;
 extern std::vector<CharacterExtras> charextra;
 extern int starting_room;
-extern unsigned int loopcounter;
 extern IDriverDependantBitmap* roomBackgroundBmp;
 extern IGraphicsDriver *gfxDriver;
 extern RGB palette[256];

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -47,7 +47,6 @@ void  new_room(int newnum,CharacterInfo*forchar);
 // Sets up a placeholder room object; this is used to avoid occasional crashes
 // in case an API function was called that needs to access a room, while no real room is loaded
 void  set_room_placeholder();
-int   find_highest_room_entered();
 void  first_room_initialization();
 void  check_new_room();
 void  compile_room_script();

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -222,7 +222,7 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
     }
     else
     {
-        shader_id = -1;
+        shader_id = 0;
         shader_handle = 0;
     }
 

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -213,6 +213,19 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
         movelist_handle = 0;
     }
 
+    if (cmp_ver >= kRoomStatSvgVersion_40018)
+    {
+        shader_id = in->ReadInt32();
+        shader_handle = in->ReadInt32();
+        in->ReadInt32(); // reserve
+        in->ReadInt32();
+    }
+    else
+    {
+        shader_id = -1;
+        shader_handle = 0;
+    }
+
     spr_width = last_width;
     spr_height = last_height;
     UpdateGraphicSpace();
@@ -270,6 +283,11 @@ void RoomObject::WriteToSavegame(Stream *out) const
     out->WriteInt32(movelist_handle);
     out->WriteInt32(0); // reserve up to 4 ints
     out->WriteInt32(0);
+    out->WriteInt32(0);
+    // kRoomStatSvgVersion_40018
+    out->WriteInt32(shader_id);
+    out->WriteInt32(shader_handle);
+    out->WriteInt32(0); // reserve
     out->WriteInt32(0);
 }
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -60,6 +60,7 @@ struct RoomObject {
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
     Common::String name;
     Common::BlendMode blend_mode;
+    int   shader_id = 0;
     float rotation;
     int   movelist_handle = 0; // handle to the script movelist
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -61,6 +61,7 @@ struct RoomObject {
     Common::String name;
     Common::BlendMode blend_mode;
     int   shader_id = -1;
+    int   shader_handle = 0; // script shader handle
     float rotation;
     int   movelist_handle = 0; // handle to the script movelist
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -60,7 +60,7 @@ struct RoomObject {
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
     Common::String name;
     Common::BlendMode blend_mode;
-    int   shader_id = -1;
+    int   shader_id = 0;
     int   shader_handle = 0; // script shader handle
     float rotation;
     int   movelist_handle = 0; // handle to the script movelist

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -60,7 +60,7 @@ struct RoomObject {
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
     Common::String name;
     Common::BlendMode blend_mode;
-    int   shader_id = 0;
+    int   shader_id = -1;
     float rotation;
     int   movelist_handle = 0; // handle to the script movelist
 

--- a/Engine/ac/roomstatus.cpp
+++ b/Engine/ac/roomstatus.cpp
@@ -99,6 +99,12 @@ void RoomStatus::FreeProperties()
     }
 }
 
+void RoomStatus::SetBgShader(int shader_id, int shader_handle)
+{
+    _bgShaderID = shader_id;
+    _bgShaderHandle = shader_handle;
+}
+
 void RoomStatus::ReadFromSavegame(Stream *in, RoomStatSvgVersion cmp_ver)
 {
     FreeScriptData();
@@ -164,14 +170,21 @@ void RoomStatus::ReadFromSavegame(Stream *in, RoomStatSvgVersion cmp_ver)
         in->ReadInt32();
         in->ReadInt32();
     }
+
     if (cmp_ver >= kRoomStatSvgVersion_40003)
     {
         face_dir_ratio = in->ReadFloat32();
-        // reserve few more 32-bit values (for a total of 4)
-        in->ReadInt32();
-        in->ReadInt32();
-        in->ReadInt32();
+        _bgShaderID = in->ReadInt32(); // used since kRoomStatSvgVersion_40018
+        _bgShaderHandle = in->ReadInt32();
+        in->ReadInt32(); // reserved
     }
+    else
+    {
+        face_dir_ratio = 1.f;
+        _bgShaderID = 0;
+        _bgShaderHandle = 0;
+    }
+
     if (cmp_ver >= kRoomStatSvgVersion_40008)
     {
         for (int i = 0; i < num_regions; ++i)
@@ -234,10 +247,9 @@ void RoomStatus::WriteToSavegame(Stream *out) const
 
     // -- kRoomStatSvgVersion_40003
     out->WriteFloat32(face_dir_ratio);
-    // reserve few more 32-bit values (for a total of 4)
-    out->WriteInt32(0);
-    out->WriteInt32(0);
-    out->WriteInt32(0);
+    out->WriteInt32(_bgShaderID); // used since kRoomStatSvgVersion_40018
+    out->WriteInt32(_bgShaderHandle);
+    out->WriteInt32(0); // reserved
 
     // -- kRoomStatSvgVersion_40008
     for (int i = 0; i < MAX_ROOM_REGIONS; ++i)

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -61,12 +61,14 @@ struct WalkareaState
 };
 
 // RoomStatus contains everything about a room that could change at runtime.
-struct RoomStatus
+class RoomStatus
 {
-    int   beenhere;
-    uint32_t numobj;
+public:
+    // TODO: hide these fields under get/set methods
+    int   beenhere = 0;
+    uint32_t numobj = 0;
     std::vector<RoomObject> obj;
-    uint32_t tsdatasize;
+    uint32_t tsdatasize = 0;
     std::vector<uint8_t> tsdata;
 
     HotspotState hotspot[MAX_ROOM_HOTSPOTS];
@@ -86,7 +88,7 @@ struct RoomStatus
     // We need this for cases when an old format save is restored within an upgraded game
     // (for example, game was upgraded from 3.4.0 to 3.6.0, but player tries loading 3.4.0 save),
     // because room files are only loaded once entered, so we cannot fixup all RoomStatuses at once.
-    RoomStatSvgVersion contentFormat;
+    RoomStatSvgVersion contentFormat = kRoomStatSvgVersion_Current;
 
     RoomStatus();
     ~RoomStatus();
@@ -94,8 +96,17 @@ struct RoomStatus
     void FreeScriptData();
     void FreeProperties();
 
+    int  GetBgShaderID() const { return _bgShaderID; }
+    int  GetBgShaderHandle() const { return _bgShaderHandle; }
+    void SetBgShader(int shader_id, int shader_handle);
+
     void ReadFromSavegame(Common::Stream *in, RoomStatSvgVersion cmp_ver);
     void WriteToSavegame(Common::Stream *out) const;
+
+private:
+    // TODO: a RAII wrapper over managed handle, that auto releases the reference
+    int _bgShaderID = 0;
+    int _bgShaderHandle = 0;
 };
 
 // Replaces all accesses to the roomstats array

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -93,9 +93,6 @@ public:
     RoomStatus();
     ~RoomStatus();
 
-    void FreeScriptData();
-    void FreeProperties();
-
     int  GetBgShaderID() const { return _bgShaderID; }
     int  GetBgShaderHandle() const { return _bgShaderHandle; }
     void SetBgShader(int shader_id, int shader_handle);
@@ -104,18 +101,24 @@ public:
     void WriteToSavegame(Common::Stream *out) const;
 
 private:
+    void FreeScriptData();
+    void FreeProperties();
+
     // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _bgShaderID = 0;
     int _bgShaderHandle = 0;
 };
 
-// Replaces all accesses to the roomstats array
-RoomStatus* getRoomStatus(int room);
-// Used in places where it is only important to know whether the player
-// had previously entered the room. In this case it is not necessary
-// to initialise the status because a player can only have been in
-// a room if the status is already initialised.
-bool isRoomStatusValid(int room);
-void resetRoomStatuses();
+// Retrieves a given room's runtime state. *Allocates* one if it does not exist
+RoomStatus* GetRoomState(int room);
+// Retrieves a existing room's runtime state; returns null if one was not allocated
+RoomStatus *GetRoomStateIfExists(int room);
+// Checks whether the room state exists.
+bool IsRoomStateValid(int room);
+// Deletes particular room's runtime state. This will make the game forget about
+// what happened in that room, and make it start anew whenever player enters it again.
+void ResetRoomState(int room);
+// Deletes all room runtime states.
+void ResetRoomStates();
 
 #endif // __AGS_EE_AC__ROOMSTATUS_H

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -39,6 +39,7 @@ enum RoomStatSvgVersion
     kRoomStatSvgVersion_40003    = 4000003, // room object flags as 32-bit, facedirratio
     kRoomStatSvgVersion_40008    = 4000008, // custom properties for regions and walk-areas
     kRoomStatSvgVersion_40016    = 4000016, // room objects expose script motion path
+    kRoomStatSvgVersion_40018    = 4000018, // shaders
     kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_40016
 };
 

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -835,7 +835,7 @@ void Screen_SetShader(ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(play.GetScreenShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    play.SetScreenShader(shader_inst->GetID(), new_inst_ref);
+    play.SetScreenShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry, bool restrict)

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -828,14 +828,8 @@ ScriptShaderInstance *Screen_GetShader()
 
 void Screen_SetShader(ScriptShaderInstance *shader_inst)
 {
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
-
-    if (play.GetScreenShaderHandle() > 0)
-        ccReleaseObjectReference(play.GetScreenShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    play.SetScreenShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    play.SetScreenShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                         ccReplaceObjectHandle(play.GetScreenShaderHandle(), shader_inst));
 }
 
 ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry, bool restrict)

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -135,7 +135,7 @@ void ScreenOverlay::SetShader(int shader_id, int shader_handle)
 
 void ScreenOverlay::RemoveShader()
 {
-    _shaderID = -1;
+    _shaderID = 0;
     _shaderHandle = 0;
     MarkChanged();
 }

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -126,6 +126,20 @@ void ScreenOverlay::RemoveTint()
     MarkChanged();
 }
 
+void ScreenOverlay::SetShader(int shader_id, int shader_handle)
+{
+    _shaderID = shader_id;
+    _shaderHandle = shader_handle;
+    MarkChanged();
+}
+
+void ScreenOverlay::RemoveShader()
+{
+    _shaderID = -1;
+    _shaderHandle = 0;
+    MarkChanged();
+}
+
 void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_ver)
 {
     ResetImage();

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -213,6 +213,14 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
         in->ReadInt32(); // sprite anchor y
     }
 
+    if (cmp_ver > kOverSvgVersion_40018)
+    {
+        _shaderID = in->ReadInt32();
+        _shaderHandle = in->ReadInt32();
+        in->ReadInt32(); // reserved
+        in->ReadInt32();
+    }
+
     // Convert magic x,y values from the older saves
     if (cmp_ver < kOverSvgVersion_40005)
     {
@@ -265,4 +273,9 @@ void ScreenOverlay::WriteToSavegame(Stream *out) const
     out->WriteInt32(0); // sprite pivot y
     out->WriteInt32(0); // sprite anchor x
     out->WriteInt32(0); // sprite anchor y
+    // kOverSvgVersion_40018
+    out->WriteInt32(_shaderID);
+    out->WriteInt32(_shaderHandle);
+    out->WriteInt32(0); // reserved
+    out->WriteInt32(0);
 }

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -84,7 +84,6 @@ struct ScreenOverlay
     uint8_t tint_r = 0u, tint_g = 0u, tint_b = 0u, tint_level = 0u;
     int tint_light = 0; // -100 to 100 (comply to objects and characters)
     Common::BlendMode blendMode = Common::kBlend_Normal;
-    int shader_id = -1;
     int transparency = 0;
     Common::GraphicSpace _gs;
 
@@ -136,9 +135,17 @@ struct ScreenOverlay
     void SetLightLevel(int light_level);
     // Removes tint and light level
     void RemoveTint();
+    // Gets shader id
+    int  GetShaderID() const { return _shaderID; }
+    // Gets script shader's managed handle
+    int  GetShaderHandle() const { return _shaderHandle; }
+    // Assigns a shader to overlay
+    void SetShader(int shader_id, int shader_handle);
+    // Removes a shader reference
+    void RemoveShader();
     // Tells if Overlay has graphically changed recently
     bool HasChanged() const { return _hasChanged; }
-    // Manually marks GUI as graphically changed
+    // Manually marks overlay as graphically changed
     void MarkChanged() { _hasChanged = true; }
     // Clears changed flag
     void ClearChanged() { _hasChanged = false; }
@@ -155,6 +162,8 @@ private:
     int _flags = 0; // OverlayFlags
     int _sprnum = 0; // sprite id
     Common::SpriteTransformFlags _spritetf = Common::kSprTf_None;
+    int _shaderID = -1;
+    int _shaderHandle = 0;
     bool _hasChanged = false;
 };
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -84,6 +84,7 @@ struct ScreenOverlay
     uint8_t tint_r = 0u, tint_g = 0u, tint_b = 0u, tint_level = 0u;
     int tint_light = 0; // -100 to 100 (comply to objects and characters)
     Common::BlendMode blendMode = Common::kBlend_Normal;
+    int shader_id = 0;
     int transparency = 0;
     Common::GraphicSpace _gs;
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -162,7 +162,7 @@ private:
     int _flags = 0; // OverlayFlags
     int _sprnum = 0; // sprite id
     Common::SpriteTransformFlags _spritetf = Common::kSprTf_None;
-    int _shaderID = -1;
+    int _shaderID = 0;
     int _shaderHandle = 0;
     bool _hasChanged = false;
 };

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -163,6 +163,7 @@ private:
     int _flags = 0; // OverlayFlags
     int _sprnum = 0; // sprite id
     Common::SpriteTransformFlags _spritetf = Common::kSprTf_None;
+    // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _shaderID = 0;
     int _shaderHandle = 0;
     bool _hasChanged = false;

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -84,7 +84,7 @@ struct ScreenOverlay
     uint8_t tint_r = 0u, tint_g = 0u, tint_b = 0u, tint_level = 0u;
     int tint_light = 0; // -100 to 100 (comply to objects and characters)
     Common::BlendMode blendMode = Common::kBlend_Normal;
-    int shader_id = 0;
+    int shader_id = -1;
     int transparency = 0;
     Common::GraphicSpace _gs;
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -61,6 +61,7 @@ enum OverlaySvgVersion
     kOverSvgVersion_36108   = 4, // don't save owned sprites (use dynamic sprites)
     kOverSvgVersion_400     = 4000000, // blend mode, etc
     kOverSvgVersion_40005   = 4000005, // no magic values stored in x,y
+    kOverSvgVersion_40018   = 4000018, // shaders
 };
 
 // TODO: what if we actually register a real dynamic sprite for overlay?

--- a/Engine/ac/shader_script.cpp
+++ b/Engine/ac/shader_script.cpp
@@ -131,6 +131,46 @@ int ShaderProgram_GetShaderID(ScriptShaderProgram *shader_prg)
     return shader_prg->GetShaderID();
 }
 
+void ShaderProgram_SetConstantF(ScriptShaderProgram *shader_prg, const char *name, float value)
+{
+    if (shader_prg->GetShaderID() != ScriptShaderProgram::InvalidShader)
+    {
+        uint32_t const_index = gfxDriver->GetShaderConstant(shader_prg->GetShaderID(), name);
+        if (const_index != UINT32_MAX)
+            gfxDriver->SetShaderConstantF(shader_prg->GetShaderID(), const_index, value);
+    }
+}
+
+void ShaderProgram_SetConstantF2(ScriptShaderProgram *shader_prg, const char *name, float x, float y)
+{
+    if (shader_prg->GetShaderID() != ScriptShaderProgram::InvalidShader)
+    {
+        uint32_t const_index = gfxDriver->GetShaderConstant(shader_prg->GetShaderID(), name);
+        if (const_index != UINT32_MAX)
+            gfxDriver->SetShaderConstantF2(shader_prg->GetShaderID(), const_index, x ,y);
+    }
+}
+
+void ShaderProgram_SetConstantF3(ScriptShaderProgram *shader_prg, const char *name, float x, float y, float z)
+{
+    if (shader_prg->GetShaderID() != ScriptShaderProgram::InvalidShader)
+    {
+        uint32_t const_index = gfxDriver->GetShaderConstant(shader_prg->GetShaderID(), name);
+        if (const_index != UINT32_MAX)
+            gfxDriver->SetShaderConstantF3(shader_prg->GetShaderID(), const_index, x, y, z);
+    }
+}
+
+void ShaderProgram_SetConstantF4(ScriptShaderProgram *shader_prg, const char *name, float x, float y, float z, float w)
+{
+    if (shader_prg->GetShaderID() != ScriptShaderProgram::InvalidShader)
+    {
+        uint32_t const_index = gfxDriver->GetShaderConstant(shader_prg->GetShaderID(), name);
+        if (const_index != UINT32_MAX)
+            gfxDriver->SetShaderConstantF4(shader_prg->GetShaderID(), const_index, x, y, z, w);
+    }
+}
+
 RuntimeScriptValue Sc_ShaderProgram_CreateFromFile(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_POBJ(ScriptShaderProgram, ShaderProgram_CreateFromFile, const char);
@@ -141,11 +181,35 @@ RuntimeScriptValue Sc_ShaderProgram_GetShaderID(void *self, const RuntimeScriptV
     API_OBJCALL_INT(ScriptShaderProgram, ShaderProgram_GetShaderID);
 }
 
+RuntimeScriptValue Sc_ShaderProgram_SetConstantF(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PFLOAT(ScriptShaderProgram, ShaderProgram_SetConstantF, const char);
+}
+
+RuntimeScriptValue Sc_ShaderProgram_SetConstantF2(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PFLOAT2(ScriptShaderProgram, ShaderProgram_SetConstantF2, const char);
+}
+
+RuntimeScriptValue Sc_ShaderProgram_SetConstantF3(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PFLOAT3(ScriptShaderProgram, ShaderProgram_SetConstantF3, const char);
+}
+
+RuntimeScriptValue Sc_ShaderProgram_SetConstantF4(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PFLOAT4(ScriptShaderProgram, ShaderProgram_SetConstantF4, const char);
+}
+
 void RegisterShaderAPI()
 {
     ScFnRegister shader_api[] = {
         { "ShaderProgram::CreateFromFile", API_FN_PAIR(ShaderProgram_CreateFromFile)},
         { "ShaderProgram::get_ShaderID",   API_FN_PAIR(ShaderProgram_GetShaderID)},
+        { "ShaderProgram::SetConstantF",   API_FN_PAIR(ShaderProgram_SetConstantF)},
+        { "ShaderProgram::SetConstantF2",  API_FN_PAIR(ShaderProgram_SetConstantF2)},
+        { "ShaderProgram::SetConstantF3",  API_FN_PAIR(ShaderProgram_SetConstantF3)},
+        { "ShaderProgram::SetConstantF4",  API_FN_PAIR(ShaderProgram_SetConstantF4)},
     };
 
     ccAddExternalFunctions(shader_api);

--- a/Engine/ac/shader_script.cpp
+++ b/Engine/ac/shader_script.cpp
@@ -1,0 +1,73 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Shader script API.
+//
+//=============================================================================
+#include "ac/dynobj/dynobj_manager.h"
+#include "ac/dynobj/scriptshader.h"
+#include "ac/path_helper.h"
+#include "gfx/graphicsdriver.h"
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+
+using namespace AGS::Common;
+using namespace AGS::Engine;
+
+extern IGraphicsDriver *gfxDriver;
+
+ScriptShaderProgram *ShaderProgram_CreateFromFile(const char *filename)
+{
+    uint32_t shader_id = 0;
+    auto stream = ResolveScriptPathAndOpen(filename, kFile_Open, kStream_Read);
+    if (stream)
+    {
+        String shader_src = String::FromStream(stream.get());
+        if (!shader_src.IsEmpty())
+        {
+            shader_id = gfxDriver->CreateShaderProgram(filename, shader_src.GetCStr());
+            if (shader_id == UINT32_MAX)
+                shader_id = 0; // assign an invalid shader
+        }
+    }
+
+    ScriptShaderProgram *shader_prg = new ScriptShaderProgram(filename, shader_id);
+    ccRegisterManagedObject(shader_prg, shader_prg);
+    return shader_prg;
+}
+
+int ShaderProgram_GetShaderID(ScriptShaderProgram *shader_prg)
+{
+    return shader_prg->GetShaderID();
+}
+
+RuntimeScriptValue Sc_ShaderProgram_CreateFromFile(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_POBJ(ScriptShaderProgram, ShaderProgram_CreateFromFile, const char);
+}
+
+RuntimeScriptValue Sc_ShaderProgram_GetShaderID(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptShaderProgram, ShaderProgram_GetShaderID);
+}
+
+void RegisterShaderAPI()
+{
+    ScFnRegister shader_api[] = {
+        { "ShaderProgram::CreateFromFile", API_FN_PAIR(ShaderProgram_CreateFromFile)},
+        { "ShaderProgram::get_ShaderID",   API_FN_PAIR(ShaderProgram_GetShaderID)},
+    };
+
+    ccAddExternalFunctions(shader_api);
+}

--- a/Engine/ac/shader_script.cpp
+++ b/Engine/ac/shader_script.cpp
@@ -87,7 +87,7 @@ ScriptShaderProgram *ShaderProgram_CreateFromFile(const char *filename)
     // Software renderer does not support shaders, so return a dummy shader program
     if (!gfxDriver->HasAcceleratedTransform())
     {
-        ScriptShaderProgram *shader_prg = new ScriptShaderProgram(filename, 0);
+        ScriptShaderProgram *shader_prg = new ScriptShaderProgram(filename, ScriptShaderProgram::InvalidShader, ScriptShaderProgram::InvalidShader);
         ccRegisterManagedObject(shader_prg, shader_prg);
         return shader_prg;
     }
@@ -115,57 +115,66 @@ ScriptShaderProgram *ShaderProgram_CreateFromFile(const char *filename)
             shader = TryCreateShaderFromSource(Path::ReplaceExtension(filename, source_ext), def_filename);
     }
 
-    ScriptShaderProgram *shader_prg = new ScriptShaderProgram(filename, shader->GetID());
+    IShaderInstance *default_inst = gfxDriver->CreateShaderInstance(shader);
+    ScriptShaderProgram *shader_prg = new ScriptShaderProgram(filename, shader->GetID(), default_inst->GetID());
     ccRegisterManagedObject(shader_prg, shader_prg);
     return shader_prg;
 }
 
 int ShaderProgram_GetShaderID(ScriptShaderProgram *shader_prg)
 {
-    return shader_prg->GetShaderID();
+    return shader_prg->GetShaderInstanceID();
 }
 
 void ShaderProgram_SetConstantF(ScriptShaderProgram *shader_prg, const char *name, float value)
 {
-    IGraphicShader *shader = gfxDriver->GetShaderProgram(shader_prg->GetShaderID());
-    if (shader)
+    IShaderInstance *shader_inst = gfxDriver->GetShaderInstance(shader_prg->GetShaderInstanceID());
+    if (shader_inst)
     {
-        uint32_t const_index = shader->GetShaderConstant(name);
+        uint32_t const_index = shader_inst->GetShader()->GetShaderConstant(name);
         if (const_index != UINT32_MAX)
-            shader->SetShaderConstantF(const_index, value);
+        {
+            shader_inst->SetShaderConstantF(const_index, value);
+        }
     }
 }
 
 void ShaderProgram_SetConstantF2(ScriptShaderProgram *shader_prg, const char *name, float x, float y)
 {
-    IGraphicShader *shader = gfxDriver->GetShaderProgram(shader_prg->GetShaderID());
-    if (shader)
+    IShaderInstance *shader_inst = gfxDriver->GetShaderInstance(shader_prg->GetShaderInstanceID());
+    if (shader_inst)
     {
-        uint32_t const_index = shader->GetShaderConstant(name);
+        uint32_t const_index = shader_inst->GetShader()->GetShaderConstant(name);
         if (const_index != UINT32_MAX)
-            shader->SetShaderConstantF2(const_index, x, y);
+        {
+            shader_inst->SetShaderConstantF2(const_index, x, y);
+        }
     }
 }
 
 void ShaderProgram_SetConstantF3(ScriptShaderProgram *shader_prg, const char *name, float x, float y, float z)
 {
-    IGraphicShader *shader = gfxDriver->GetShaderProgram(shader_prg->GetShaderID());
-    if (shader)
+    IShaderInstance *shader_inst = gfxDriver->GetShaderInstance(shader_prg->GetShaderInstanceID());
+    if (shader_inst)
     {
-        uint32_t const_index = shader->GetShaderConstant(name);
+        uint32_t const_index = shader_inst->GetShader()->GetShaderConstant(name);
         if (const_index != UINT32_MAX)
-            shader->SetShaderConstantF3(const_index, x, y, z);
+        {
+            shader_inst->SetShaderConstantF3(const_index, x, y, z);
+        }
     }
 }
 
 void ShaderProgram_SetConstantF4(ScriptShaderProgram *shader_prg, const char *name, float x, float y, float z, float w)
 {
-    IGraphicShader *shader = gfxDriver->GetShaderProgram(shader_prg->GetShaderID());
-    if (shader)
+    IShaderInstance *shader_inst = gfxDriver->GetShaderInstance(shader_prg->GetShaderInstanceID());
+    if (shader_inst)
     {
-        uint32_t const_index = shader->GetShaderConstant(name);
+        uint32_t const_index = shader_inst->GetShader()->GetShaderConstant(name);
         if (const_index != UINT32_MAX)
-            shader->SetShaderConstantF4(const_index, x, y, z, w);
+        {
+            shader_inst->SetShaderConstantF4(const_index, x, y, z, w);
+        }
     }
 }
 

--- a/Engine/ac/shader_script.h
+++ b/Engine/ac/shader_script.h
@@ -22,13 +22,9 @@
 
 // Creates a new shader and registers a ScriptShaderProgram object
 ScriptShaderProgram *CreateScriptShaderProgram(const char *filename);
-// Recreates a shader from existing ScriptShaderProgram object.
-// This is used to reconnect shaders after restoring a save.
-bool RecreateScriptShaderProgram(ScriptShaderProgram *sc_shader);
 // Creates a new shader instance and registers a ScriptShaderInstance object
 ScriptShaderInstance *ShaderProgram_CreateInstance(ScriptShaderProgram *sc_shader);
-// Recreates a shader instance from existing ScriptShaderInstance object.
-// This is used to reconnect shaders after restoring a save.
-bool RecreateShaderInstance(ScriptShaderInstance *sc_shinst);
+// Restore shaders and shader instances after loading a save
+void RestoreShaders();
 
 #endif // __AGS_EE_AC__SHADERSCRIPT_H

--- a/Engine/ac/shader_script.h
+++ b/Engine/ac/shader_script.h
@@ -1,0 +1,34 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Shader script API.
+//
+//=============================================================================
+#ifndef __AGS_EE_AC__SHADERSCRIPT_H
+#define __AGS_EE_AC__SHADERSCRIPT_H
+
+#include "ac/dynobj/scriptshader.h"
+
+// Creates a new shader and registers a ScriptShaderProgram object
+ScriptShaderProgram *CreateScriptShaderProgram(const char *filename);
+// Recreates a shader from existing ScriptShaderProgram object.
+// This is used to reconnect shaders after restoring a save.
+bool RecreateScriptShaderProgram(ScriptShaderProgram *sc_shader);
+// Creates a new shader instance and registers a ScriptShaderInstance object
+ScriptShaderInstance *ShaderProgram_CreateInstance(ScriptShaderProgram *sc_shader);
+// Recreates a shader instance from existing ScriptShaderInstance object.
+// This is used to reconnect shaders after restoring a save.
+bool RecreateShaderInstance(ScriptShaderInstance *sc_shinst);
+
+#endif // __AGS_EE_AC__SHADERSCRIPT_H

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -370,7 +370,7 @@ void Viewport_SetShader(ScriptViewport *scv, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(view->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    view->SetShader(shader_inst->GetShaderInstanceID(), new_inst_ref);
+    view->SetShader(shader_inst->GetID(), new_inst_ref);
 }
 
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -348,6 +348,18 @@ void Viewport_SetZOrder(ScriptViewport *scv, int zorder)
     play.InvalidateViewportZOrder();
 }
 
+int Viewport_GetShader(ScriptViewport *scv)
+{
+    if (scv->GetID() < 0) { debug_script_warn("Viewport.Shader: trying to use deleted viewport"); return 0; }
+    return play.GetRoomViewport(scv->GetID())->GetShaderID();
+}
+
+void Viewport_SetShader(ScriptViewport *scv, int shader_id)
+{
+    if (scv->GetID() < 0) { debug_script_warn("Viewport.Shader: trying to use deleted viewport"); return; }
+    play.GetRoomViewport(scv->GetID())->SetShaderID(shader_id);
+}
+
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 {
     PViewport view = play.GetRoomViewportAt(x, y);
@@ -460,6 +472,16 @@ RuntimeScriptValue Sc_Viewport_SetZOrder(void *self, const RuntimeScriptValue *p
     API_OBJCALL_VOID_PINT(ScriptViewport, Viewport_SetZOrder);
 }
 
+RuntimeScriptValue Sc_Viewport_GetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptViewport, Viewport_GetShader);
+}
+
+RuntimeScriptValue Sc_Viewport_SetShader(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewport, Viewport_SetShader);
+}
+
 RuntimeScriptValue Sc_Viewport_GetAtScreenXY(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_PINT2(ScriptViewport, Viewport_GetAtScreenXY);
@@ -526,6 +548,9 @@ void RegisterViewportAPI()
         { "Viewport::SetPosition",      API_FN_PAIR(Viewport_SetPosition) },
         { "Viewport::ScreenToRoomPoint", API_FN_PAIR(Viewport_ScreenToRoomPoint) },
         { "Viewport::RoomToScreenPoint", API_FN_PAIR(Viewport_RoomToScreenPoint) },
+
+        { "Viewport::get_Shader",       API_FN_PAIR(Viewport_GetShader) },
+        { "Viewport::set_Shader",       API_FN_PAIR(Viewport_SetShader) },
     };
 
     ccAddExternalFunctions(viewport_api);

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -151,17 +151,9 @@ ScriptShaderInstance *Camera_GetShader(ScriptCamera *scam)
 void Camera_SetShader(ScriptCamera *scam, ScriptShaderInstance *shader_inst)
 {
     if (scam->GetID() < 0) { debug_script_warn("Camera.Shader: trying to use deleted camera"); return; }
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
     auto cam = play.GetRoomCamera(scam->GetID());
-    if (cam->GetShaderHandle() == new_inst_ref)
-        return;
-
-    if (cam->GetShaderHandle() > 0)
-        ccReleaseObjectReference(cam->GetShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    cam->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    cam->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                   ccReplaceObjectHandle(cam->GetShaderHandle(), shader_inst));
 }
 
 RuntimeScriptValue Sc_Camera_Create(const RuntimeScriptValue *params, int32_t param_count)
@@ -393,17 +385,9 @@ ScriptShaderInstance *Viewport_GetShader(ScriptViewport *scv)
 void Viewport_SetShader(ScriptViewport *scv, ScriptShaderInstance *shader_inst)
 {
     if (scv->GetID() < 0) { debug_script_warn("Viewport.Shader: trying to use deleted viewport"); return; }
-    // TODO: we need some sort of a RAII wrapper around managed object reference that does all this automatically!
-    const int new_inst_ref = ccGetObjectHandleFromAddress(shader_inst);
     auto view = play.GetRoomViewport(scv->GetID());
-    if (view->GetShaderHandle() == new_inst_ref)
-        return;
-
-    if (view->GetShaderHandle() > 0)
-        ccReleaseObjectReference(view->GetShaderHandle());
-
-    ccAddObjectReference(new_inst_ref);
-    view->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
+    view->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID,
+                    ccReplaceObjectHandle(view->GetShaderHandle(), shader_inst));
 }
 
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -161,7 +161,7 @@ void Camera_SetShader(ScriptCamera *scam, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(cam->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    cam->SetShader(shader_inst->GetID(), new_inst_ref);
+    cam->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 RuntimeScriptValue Sc_Camera_Create(const RuntimeScriptValue *params, int32_t param_count)
@@ -403,7 +403,7 @@ void Viewport_SetShader(ScriptViewport *scv, ScriptShaderInstance *shader_inst)
         ccReleaseObjectReference(view->GetShaderHandle());
 
     ccAddObjectReference(new_inst_ref);
-    view->SetShader(shader_inst->GetID(), new_inst_ref);
+    view->SetShader(shader_inst ? shader_inst->GetID() : ScriptShaderInstance::NullInstanceID, new_inst_ref);
 }
 
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -597,26 +597,6 @@ static HSaveError RestoreAudio(const RestoredData &r_data)
     return HSaveError::None();
 }
 
-// A callback that resolves a ScriptShaderProgram after restoring a save.
-// Used in a call to ccTraverseManagedObjects.
-static void ResolveShader(int handle, IScriptObject *obj)
-{
-    RecreateScriptShaderProgram(static_cast<ScriptShaderProgram *>(obj));
-}
-
-// A callback that resolves a ScriptShaderInstance after restoring a save.
-// Used in a call to ccTraverseManagedObjects.
-static void ResolveShaderInstance(int handle, IScriptObject *obj)
-{
-    RecreateShaderInstance(static_cast<ScriptShaderInstance *>(obj));
-}
-
-static void RestoreShaders()
-{
-    ccTraverseManagedObjects(ScriptShaderProgram::TypeID, ResolveShader);
-    ccTraverseManagedObjects(ScriptShaderInstance::TypeID, ResolveShaderInstance);
-}
-
 static void RestoreViewportsAndCameras(const RestoredData &r_data)
 {
     for (size_t i = 0; i < r_data.Cameras.size(); ++i)

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -489,7 +489,7 @@ void DoBeforeRestore(PreservedParams &pp, SaveCmpSelection select_cmp)
     UnlinkAllScripts();
 
     // reset saved room states
-    resetRoomStatuses();
+    ResetRoomStates();
     // reset temp room state
     troom = RoomStatus();
     // reset (some of the?) GameState data

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -269,9 +269,9 @@ void WriteCameraState(const Camera &cam, Stream *out)
     out->WriteInt32(rc.GetWidth());
     out->WriteInt32(rc.GetHeight());
     // kGSSvgVersion_400_18
-    out->WriteInt32(0); // reserved for camera shader
-    out->WriteInt32(0);
-    out->WriteInt32(0);
+    out->WriteInt32(cam.GetShaderID());
+    out->WriteInt32(cam.GetShaderHandle());
+    out->WriteInt32(0); // reserved
     out->WriteInt32(0);
 }
 
@@ -344,9 +344,9 @@ void ReadCameraState(GameStateSvgVersion svg_ver, RestoredData &r_data, Stream *
     cam.Height = in->ReadInt32();
     if (svg_ver >= kGSSvgVersion_400_18)
     {
-        in->ReadInt32(); // reserved for camera shaders
-        in->ReadInt32();
-        in->ReadInt32();
+        cam.ShaderID = in->ReadInt32();
+        cam.ShaderHandle = in->ReadInt32();
+        in->ReadInt32(); // reserved
         in->ReadInt32();
     }
     r_data.Cameras.push_back(cam);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1449,9 +1449,9 @@ HSaveError WriteRoomStates(Stream *out)
     out->WriteInt32(MAX_ROOMS);
     for (int i = 0; i < MAX_ROOMS; ++i)
     {
-        if (isRoomStatusValid(i))
+        RoomStatus *roomstat = GetRoomStateIfExists(i);
+        if (roomstat)
         {
-            RoomStatus *roomstat = getRoomStatus(i);
             if (roomstat->beenhere)
             {
                 out->WriteInt32(i);
@@ -1460,10 +1460,14 @@ HSaveError WriteRoomStates(Stream *out)
                 WriteFormatTag(out, "RoomState", false);
             }
             else
+            {
                 out->WriteInt32(-1);
+            }
         }
         else
+        {
             out->WriteInt32(-1);
+        }
     }
     return HSaveError::None();
 }
@@ -1482,7 +1486,7 @@ HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Pr
                 return err;
             if (!AssertFormatTagStrict(err, in, "RoomState", true))
                 return err;
-            RoomStatus *roomstat = getRoomStatus(id);
+            RoomStatus *roomstat = GetRoomState(id);
             roomstat->ReadFromSavegame(in, (RoomStatSvgVersion)cmp_ver);
             if (!AssertFormatTagStrict(err, in, "RoomState", false))
                 return err;

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -45,6 +45,7 @@
 #include "gui/guimain.h"
 #include "gui/guislider.h"
 #include "gui/guitextbox.h"
+#include "main/game_run.h"
 #include "media/audio/audio_system.h"
 #include "plugin/plugin_engine.h"
 #include "script/cc_common.h"
@@ -299,7 +300,7 @@ HSaveError WriteGameState(Stream *out)
     play.WriteForSavegame(out);
     // Other dynamic values
     out->WriteInt32(frames_per_second);
-    out->WriteInt32(loopcounter);
+    out->WriteInt32(get_loop_counter());
     out->WriteInt32(ifacepopped);
     out->WriteInt32(game_paused);
     // Mouse cursor

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -215,7 +215,7 @@ struct RestoredData
         int Height = 0;
         int ZOrder = 0;
         int CamID = -1;
-        int ShaderID = -1;
+        int ShaderID = 0;
         int ShaderHandle = 0;
     };
     struct CameraData
@@ -226,6 +226,8 @@ struct RestoredData
         int Top = 0;
         int Width = 0;
         int Height = 0;
+        int ShaderID = 0;
+        int ShaderHandle = 0;
     };
     std::vector<ViewportData> Viewports;
     std::vector<CameraData> Cameras;

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -215,6 +215,8 @@ struct RestoredData
         int Height = 0;
         int ZOrder = 0;
         int CamID = -1;
+        int ShaderID = -1;
+        int ShaderHandle = 0;
     };
     struct CameraData
     {

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -147,7 +147,8 @@ public:
     void SetZOrder(int zorder);
 
     int GetShaderID() const { return _shaderID; }
-    void SetShaderID(int shader_id) { _shaderID = shader_id; }
+    int GetShaderHandle() const { return _shaderHandle; }
+    void SetShader(int shader_id, int shader_handle) { _shaderID = shader_id; _shaderHandle = shader_handle; }
 
     // Calculates room-to-viewport coordinate conversion.
     void AdjustTransformation();
@@ -189,7 +190,8 @@ private:
     glm::mat4 _v2cTransform;
     bool _visible = true;
     int _zorder = 0;
-    int _shaderID = 0;
+    int _shaderID = -1;
+    int _shaderHandle = 0;
     // Flags that tell whether this viewport's position on screen has changed recently
     bool _hasChangedPosition = false;
     bool _hasChangedOffscreen = false;

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -65,6 +65,10 @@ public:
     float GetRotation() const;
     // Sets camera's rotation, in degrees
     void SetRotation(float degrees);
+    int GetShaderID() const { return _shaderID; }
+    int GetShaderHandle() const { return _shaderHandle; }
+    void SetShader(int shader_id, int shader_handle) { _shaderID = shader_id; _shaderHandle = shader_handle; }
+
     // Tells if camera is currently locked at custom position
     bool IsLocked() const;
     // Locks room camera at its current position
@@ -99,6 +103,8 @@ private:
     Rect _position;
     // Rotation in degrees
     float _rotation = 0.0;
+    int _shaderID = 0;
+    int _shaderHandle = 0;
     // Locked or following player automatically
     bool _locked = false;
     // Linked viewport refs, used to notify viewports of camera changes

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -190,7 +190,7 @@ private:
     glm::mat4 _v2cTransform;
     bool _visible = true;
     int _zorder = 0;
-    int _shaderID = -1;
+    int _shaderID = 0;
     int _shaderHandle = 0;
     // Flags that tell whether this viewport's position on screen has changed recently
     bool _hasChangedPosition = false;

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -103,6 +103,7 @@ private:
     Rect _position;
     // Rotation in degrees
     float _rotation = 0.0;
+    // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _shaderID = 0;
     int _shaderHandle = 0;
     // Locked or following player automatically
@@ -196,6 +197,7 @@ private:
     glm::mat4 _v2cTransform;
     bool _visible = true;
     int _zorder = 0;
+    // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _shaderID = 0;
     int _shaderHandle = 0;
     // Flags that tell whether this viewport's position on screen has changed recently

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -146,6 +146,9 @@ public:
     // Sets the viewport's z-order on screen
     void SetZOrder(int zorder);
 
+    int GetShaderID() const { return _shaderID; }
+    void SetShaderID(int shader_id) { _shaderID = shader_id; }
+
     // Calculates room-to-viewport coordinate conversion.
     void AdjustTransformation();
     // Returns linked camera
@@ -186,6 +189,7 @@ private:
     glm::mat4 _v2cTransform;
     bool _visible = true;
     int _zorder = 0;
+    int _shaderID = 0;
     // Flags that tell whether this viewport's position on screen has changed recently
     bool _hasChangedPosition = false;
     bool _hasChangedOffscreen = false;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -725,6 +725,7 @@ bool OGLGraphicsDriver::CreateShaderProgram(ShaderProgram &prg, const String &na
     glDeleteShader(fragment_shader);
 
     prg.Program = program;
+    prg.Name = name;
     Debug::Printf("OpenGL: \"%s\" shader program created successfully", name.GetCStr());
     return true;
 }
@@ -2222,6 +2223,60 @@ void OGLGraphicsDriver::DeleteShaderProgram(const String &name)
     DeleteShaderProgram(_shaders[shader_id]);
     _shaders[shader_id] = {};
     _shaderLookup.erase(name);
+}
+
+uint32_t OGLGraphicsDriver::GetShaderConstant(uint32_t shader_index, const String &const_name)
+{
+    if (shader_index >= _shaders.size())
+        return UINT32_MAX;
+
+    auto &sh = _shaders[shader_index];
+    auto it_found = sh.Constants.find(const_name);
+    if (it_found != sh.Constants.end())
+        return it_found->second;
+
+    GLint index = glGetUniformLocation(sh.Program, const_name.GetCStr());
+    if (index < 0)
+        return UINT32_MAX;
+
+    sh.Constants[const_name] = index;
+    return index;
+}
+
+void OGLGraphicsDriver::SetShaderConstantF(uint32_t shader_index, uint32_t const_index, float value)
+{
+    if (shader_index >= _shaders.size())
+        return;
+
+    glUseProgram(_shaders[shader_index].Program);
+    glUniform1f(const_index, value);
+}
+
+void OGLGraphicsDriver::SetShaderConstantF2(uint32_t shader_index, uint32_t const_index, float x, float y)
+{
+    if (shader_index >= _shaders.size())
+        return;
+
+    glUseProgram(_shaders[shader_index].Program);
+    glUniform2f(const_index, x, y);
+}
+
+void OGLGraphicsDriver::SetShaderConstantF3(uint32_t shader_index, uint32_t const_index, float x, float y, float z)
+{
+    if (shader_index >= _shaders.size())
+        return;
+
+    glUseProgram(_shaders[shader_index].Program);
+    glUniform3f(const_index, x, y, z);
+}
+
+void OGLGraphicsDriver::SetShaderConstantF4(uint32_t shader_index, uint32_t const_index, float x, float y, float z, float w)
+{
+    if (shader_index >= _shaders.size())
+        return;
+
+    glUseProgram(_shaders[shader_index].Program);
+    glUniform4f(const_index, x, y, z, w);
 }
 
 void OGLGraphicsDriver::SetScreenFade(int red, int green, int blue)

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -800,7 +800,7 @@ void OGLGraphicsDriver::OutputShaderLog(GLuint obj_id, const String &shader_name
     }
     else
     {
-        Debug::Printf(mt, "Shader info log was empty.");
+        Debug::Printf(mt, "Shader output log was empty.");
     }
 }
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -2182,7 +2182,7 @@ Texture *OGLGraphicsDriver::CreateTexture(int width, int height, int color_depth
   return txdata;
 }
 
-uint32_t OGLGraphicsDriver::CreateShaderProgram(const String &name, const char *fragment_shader_src)
+uint32_t OGLGraphicsDriver::CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition* /*def*/)
 {
     if (_shaderLookup.find(name) != _shaderLookup.end())
         return UINT32_MAX; // the name is in use
@@ -2198,7 +2198,7 @@ uint32_t OGLGraphicsDriver::CreateShaderProgram(const String &name, const char *
     return shader_id;
 }
 
-uint32_t OGLGraphicsDriver::CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data)
+uint32_t OGLGraphicsDriver::CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition* /*def*/)
 {
     if (_shaderLookup.find(name) != _shaderLookup.end())
         return UINT32_MAX; // the name is in use

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -743,9 +743,10 @@ void OGLGraphicsDriver::AssignBaseShaderArgs(ShaderProgram &prg)
     prg.A_Position = glGetAttribLocation(prg.Program, "a_Position");
     prg.A_TexCoord = glGetAttribLocation(prg.Program, "a_TexCoord");
     prg.MVPMatrix = glGetUniformLocation(prg.Program, "iMVPMatrix");
-    prg.UTime = glGetUniformLocation(prg.Program, "iTime");
-    prg.UFrame = glGetUniformLocation(prg.Program, "iFrame");
-    prg.TextureId = glGetUniformLocation(prg.Program, "iTexture");
+    prg.Time = glGetUniformLocation(prg.Program, "iTime");
+    prg.GameFrame = glGetUniformLocation(prg.Program, "iGameFrame");
+    prg.Texture = glGetUniformLocation(prg.Program, "iTexture");
+    prg.TextureDim = glGetUniformLocation(prg.Program, "iTextureDim");
     prg.Alpha = glGetUniformLocation(prg.Program, "iAlpha");
     glEnableVertexAttribArray(prg.A_Position);
     glEnableVertexAttribArray(prg.A_TexCoord);
@@ -753,20 +754,16 @@ void OGLGraphicsDriver::AssignBaseShaderArgs(ShaderProgram &prg)
 
 void OGLGraphicsDriver::UpdateGlobalShaderArgValues()
 {
-    static int frame = 0; // FIXME: get this game frame index from the engine
     for (auto &sh : _shaders)
     {
         if (sh.Program == 0u)
             continue;
 
-        auto now = AGS_Clock::now();
-        auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
         glUseProgram(sh.Program);
-        glUniform1f(sh.UTime, static_cast<float>(now_ms) / 1000.f);
-        glUniform1i(sh.UFrame, frame);
+        glUniform1f(sh.Time, _globalShaderConst.Time);
+        glUniform1i(sh.GameFrame, _globalShaderConst.GameFrame);
     }
     glUseProgram(0);
-    frame++;
 }
 
 void OGLGraphicsDriver::OutputShaderLog(GLuint obj_id, const String &shader_name, const char *step_name, bool is_shader, bool as_error)
@@ -1204,7 +1201,8 @@ void OGLGraphicsDriver::RenderTexture(OGLBitmap *bmpToDraw, int draw_x, int draw
     glUseProgram(program->Program);
   }
 
-  glUniform1i(program->TextureId, 0);
+  glUniform1i(program->Texture, 0);
+  glUniform2f(program->TextureDim, bmpToDraw->GetWidth(), bmpToDraw->GetHeight());
   glUniform1f(program->Alpha, alpha / 255.0f);
 
   float width = bmpToDraw->GetWidthToRender();

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -2435,6 +2435,13 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
     _spriteList.push_back(OGLDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 
+void OGLGraphicsDriver::SetScreenShader(IShaderInstance *shinst)
+{
+    // TODO: expand this to not depend on whether we use a native-resolution surface or not;
+    // ideally this setup has to be done outside of gfx driver
+    if (_nativeSurface)
+        _nativeSurface->SetShader(shinst);
+}
 
 bool OGLGraphicsDriver::SetVsyncImpl(bool enabled, bool &vsync_res)
 {

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -416,8 +416,6 @@ bool OGLGraphicsDriver::CreateShaders()
     shaders_created &= CreateLightShader(_lightShader, _transparencyShader);
     shaders_created &= CreateDarkenByAlphaShader(_darkenbyAlphaShader, _transparencyShader);
     shaders_created &= CreateLightenByAlphaShader(_lightenByAlphaShader, _transparencyShader);
-    // Reserve custom shader index 0 as "no shader"
-    _shaders.push_back({});
     return shaders_created;
 }
 
@@ -1118,7 +1116,7 @@ void OGLGraphicsDriver::RenderTexture(OGLBitmap *bmpToDraw, int draw_x, int draw
   light_lev = bmpToDraw->GetLightLevel();
   const bool do_tint = tint_sat > 0 && _tintShader.Program > 0;
   const bool do_light = tint_sat == 0 && light_lev > 0 && _lightShader.Program > 0;
-  if (bmpToDraw->GetShader() != 0u && bmpToDraw->GetShader() < _shaders.size())
+  if (bmpToDraw->GetShader() < _shaders.size())
   {
     // Use custom shader
     program = &_shaders[bmpToDraw->GetShader()];

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -376,6 +376,8 @@ private:
         //---------------------------------------
         // Fragment shader:
         // Standard uniforms
+        GLuint UTime = 0;     // real time
+        GLuint UFrame = 0;    // game (?) frame
         GLuint TextureId = 0; // main texture (sprite or render target)
         GLuint Alpha = 0;     // requested global alpha
 
@@ -391,6 +393,7 @@ private:
     // Deletes a shader program
     void DeleteShaderProgram(ShaderProgram &prg);
     void AssignBaseShaderArgs(ShaderProgram &prg);
+    void UpdateGlobalShaderArgValues();
     void OutputShaderError(GLuint obj_id, const String &obj_name, bool is_shader);
 
     //

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -138,9 +138,18 @@ private:
 class OGLShader final : public BaseShader
 {
 public:
+    // Get a number of registered constants
+    uint32_t GetConstantCount() override;
+    // Get a registered constant's name, by its sequential index
+    String GetConstantName(uint32_t iter_index) override;
+    // Get a registered constant's location, by its sequential index;
+    // returns UINT32_MAX if no such constant exists
+    uint32_t GetConstantByIndex(uint32_t iter_index) override;
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
-    uint32_t GetShaderConstant(const String &const_name) override;
+    uint32_t GetConstantByName(const String &const_name) override;
+    // Reset all shader constants to zero
+    void ResetConstants() override;
 
     // A cap of the number of constants that we support (0..N)
     static const uint32_t ConstantCap = 12u;
@@ -175,9 +184,13 @@ public:
         GLuint TintLuminance = 0;
         GLuint LightingAmount = 0;
 
-        // Constants table: maps constant name to the index/register
+        // Constants table: maps constant name to the register
         // in the compiled shader
         std::unordered_map<String, uint32_t> Constants;
+        // Ordered list of constants: lets iterate over them using
+        // a sequential index. Order is by the register (location)
+        // in shader program memory.
+        std::vector<std::pair<uint32_t, String>> ConstantsOrdered;
     };
 
     OGLShader(const String &name);
@@ -207,8 +220,15 @@ public:
     void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override;
     void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override;
 
+    // Gets the allocated size of the constants data
+    size_t GetConstantDataSize() override;
+    // Gets array of constants data, where each constant is represented as 4 floats
+    void GetConstantData(std::vector<float> &data) override;
+
     struct ConstantValue
     {
+        static const uint32_t AllocSize = 4 * sizeof(float);
+
         uint32_t Loc = 0u;  // constant location in program
         uint32_t Size = 0u; // size of the constant, in floats
         float Val[4] = {};

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -414,6 +414,8 @@ public:
     void SetScreenFade(int red, int green, int blue) override;
     // Adds tint overlay fx to the active batch
     void SetScreenTint(int red, int green, int blue) override;
+    // Sets a shader to be applied to the whole screen as a post fx
+    void SetScreenShader(IShaderInstance *shinst) override;
     // Redraw last draw lists, optionally filtering specific batches
     void RedrawLastFrame(uint32_t batch_skip_filter) override;
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -269,6 +269,10 @@ public:
     ///////////////////////////////////////////////////////
     // Shader management
     //
+    // Returns the expected file extension for the precompiled shader
+    const char *GetShaderPrecompiledExtension() override { return ""; }
+    // Returns the expected file extension for the shader source
+    const char *GetShaderSourceExtension() override { return "glsl"; }
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -381,11 +381,11 @@ private:
         //---------------------------------------
         // Fragment shader:
         // Standard uniforms
-        GLuint UTime = 0;     // real time
-        GLuint UFrame = 0;    // game (?) frame
-        GLuint TextureId = 0; // main texture (sprite or render target)
-        //GLuint TextureDim = 0;// main texture dimensions
-        GLuint Alpha = 0;     // requested global alpha
+        GLuint Time = 0;        // real time
+        GLuint GameFrame = 0;   // game (?) frame
+        GLuint Texture = 0;     // texture 0 (sprite or render target)
+        GLuint TextureDim = 0;  // texture 0 dimensions
+        GLuint Alpha = 0;       // requested global alpha
 
         // Specialized uniforms for built-in shaders
         GLuint TintHSV = 0;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -177,6 +177,7 @@ public:
         GLuint Texture = 0;     // texture 0 (sprite or render target)
         GLuint TextureDim = 0;  // texture 0 dimensions
         GLuint Alpha = 0;       // requested global alpha
+        GLuint OutputDim = 0;   // output dimensions
 
         // Specialized uniforms for built-in shaders
         GLuint TintHSV = 0;
@@ -553,6 +554,8 @@ private:
     void SetScissor(const Rect &clip, bool render_on_texture, const Size &surface_size);
     // Configures rendering mode for the render target, depending on its properties
     void SetRenderTarget(const OGLSpriteBatch *batch, Size &surface_sz, Size &rend_sz, glm::mat4 &projection, bool clear);
+    // Assigns shader constants for post fx (rendering final game image)
+    void SetupPostFx(OGLBitmap *surface, const BackbufferState &bufferstate);
     void RenderSpriteBatches();
     size_t RenderSpriteBatch(const OGLSpriteBatch &batch, size_t from, const glm::mat4 &projection,
                              const Size &rend_sz);

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -267,6 +267,18 @@ public:
     std::shared_ptr<Texture> GetTexture(IDriverDependantBitmap *ddb) override;
 
     ///////////////////////////////////////////////////////
+    // Shader management
+    //
+    // Creates shader program from the source code, registers it under given name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;
+    // Looks up for the shader program using a name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    uint32_t FindShaderProgram(const String &name) override;
+    // Deletes particular shader program.
+    void DeleteShaderProgram(const String &name) override;
+
+    ///////////////////////////////////////////////////////
     // Preparing a scene
     //
     // Adds sprite to the active batch, providing it's origin position

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -15,22 +15,18 @@
 // OpenGL graphics factory
 //
 //=============================================================================
-
 #ifndef __AGS_EE_GFX__ALI3DOGL_H
 #define __AGS_EE_GFX__ALI3DOGL_H
 
 #include <memory>
-
 #include "glm/glm.hpp"
-
 #include "gfx/bitmap.h"
 #include "gfx/ddb.h"
 #include "gfx/gfxdriverfactorybase.h"
 #include "gfx/gfxdriverbase.h"
+#include "gfx/ogl_headers.h"
 #include "util/string.h"
 #include "util/version.h"
-
-#include "ogl_headers.h"
 
 namespace AGS
 {
@@ -184,9 +180,9 @@ public:
         std::unordered_map<String, uint32_t> Constants;
     };
 
-    OGLShader(const String &name, uint32_t id);
-    OGLShader(const String &name, uint32_t id, OGLShader::ProgramData &&data);
-    OGLShader(const String &name, uint32_t id, const OGLShader &copy_shader);
+    OGLShader(const String &name);
+    OGLShader(const String &name, OGLShader::ProgramData &&data);
+    OGLShader(const String &name, const OGLShader &copy_shader);
     ~OGLShader();
 
     bool IsValid() const { return _data.Program != 0u; }
@@ -199,7 +195,7 @@ private:
 class OGLShaderInstance final : public BaseShaderInstance
 {
 public:
-    OGLShaderInstance(OGLShader *shader, const String &name, uint32_t id);
+    OGLShaderInstance(OGLShader *shader, const String &name);
     ~OGLShaderInstance() = default;
 
     // Returns a IGraphicShader referenced by this shader instance
@@ -378,20 +374,10 @@ public:
     // Creates shader program from the compiled data, registers it under given name,
     // returns IGraphicShader, or null on failure.
     IGraphicShader *CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override;
-    // Looks up for the shader program using a name,
-    // returns IGraphicShader, or null on failure.
-    IGraphicShader *FindShaderProgram(const String &name) override;
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    IGraphicShader *GetShaderProgram(uint32_t shader_id) override;
     // Deletes particular shader program.
     void DeleteShaderProgram(IGraphicShader *shader) override;
     // Creates shader instance for the given shader.
-    IShaderInstance *CreateShaderInstance(IGraphicShader *shader) override;
-    // Looks up for the shader instance using a name,
-    // returns IShaderInstance, or null on failure.
-    IShaderInstance *FindShaderInstance(const String &name) override;
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    IShaderInstance *GetShaderInstance(uint32_t shader_inst_id) override;
+    IShaderInstance *CreateShaderInstance(IGraphicShader *shader, const String &name) override;
     // Deletes particular shader instance
     void DeleteShaderInstance(IShaderInstance *shader_inst) override;
 
@@ -573,16 +559,13 @@ private:
 
     // Built-in shaders
     // TODO: RAII-wrapper for IGraphicShader / OGLShader pointer
-    OGLShader *_transparencyShader = nullptr;
-    OGLShader *_tintShader = nullptr;
-    OGLShader *_lightShader = nullptr;
-    OGLShader *_darkenbyAlphaShader = nullptr;
-    OGLShader *_lightenByAlphaShader = nullptr;
-    // Custom shaders
-    // TODO: move these and store outside of the gfx driver class, pass interface pointers instead of IDs
-    std::vector<OGLShader*> _shaders;
-    std::unordered_map<String, uint32_t> _shaderLookup;
-    std::vector<OGLShaderInstance*> _shaderInst;
+    std::unique_ptr<OGLShader> _transparencyShader;
+    std::unique_ptr<OGLShader> _tintShader;
+    std::unique_ptr<OGLShader> _lightShader;
+    std::unique_ptr<OGLShader> _darkenbyAlphaShader;
+    std::unique_ptr<OGLShader> _lightenByAlphaShader;
+    // Custom shader references: these are currently required for updating global constants
+    std::vector<OGLShader*> _customShaders;
 
     int device_screen_physical_width;
     int device_screen_physical_height;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -272,6 +272,9 @@ public:
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;
+    // Creates shader program from the compiled data, registers it under given name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) override;
     // Looks up for the shader program using a name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     uint32_t FindShaderProgram(const String &name) override;
@@ -338,16 +341,18 @@ private:
     // Sets up general rendering parameters
     void InitGlParams(const DisplayMode &mode);
     void SetupDefaultVertices();
+    void CreateVirtualScreen();
+    void SetupViewport();
     // Test if rendering to texture is supported
     void TestRenderToTexture();
     // Create shader programs for sprite tinting and changing light level
     bool CreateShaders();
+    // Delete all shader programs
+    void DeleteShaders();
     // Configure native resolution render target, that is used in render-to-texture mode
     void SetupNativeTarget();
     // Unset parameters and release resources related to the display mode
     void ReleaseDisplayMode();
-    void CreateVirtualScreen();
-    void SetupViewport();
 
     ///////////////////////////////////////////////////////
     // Texture management: implementation
@@ -379,6 +384,7 @@ private:
         GLuint UTime = 0;     // real time
         GLuint UFrame = 0;    // game (?) frame
         GLuint TextureId = 0; // main texture (sprite or render target)
+        //GLuint TextureDim = 0;// main texture dimensions
         GLuint Alpha = 0;     // requested global alpha
 
         // Specialized uniforms for built-in shaders

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -394,15 +394,15 @@ private:
     void DeleteShaderProgram(ShaderProgram &prg);
     void AssignBaseShaderArgs(ShaderProgram &prg);
     void UpdateGlobalShaderArgValues();
-    void OutputShaderError(GLuint obj_id, const String &obj_name, bool is_shader);
+    void OutputShaderLog(GLuint obj_id, const String &shader_name, const char *step_name, bool is_shader, bool as_error);
 
     //
     // Specialized shaders
-    bool CreateTransparencyShader(ShaderProgram &prg);
-    bool CreateTintShader(ShaderProgram &prg);
-    bool CreateLightShader(ShaderProgram &prg);
-    bool CreateDarkenByAlphaShader(ShaderProgram &prg);
-    bool CreateLightenByAlphaShader(ShaderProgram &prg);
+    bool CreateTransparencyShader(ShaderProgram &prg, const ShaderProgram &fallback_prg);
+    bool CreateTintShader(ShaderProgram &prg, const ShaderProgram &fallback_prg);
+    bool CreateLightShader(ShaderProgram &prg, const ShaderProgram &fallback_prg);
+    bool CreateDarkenByAlphaShader(ShaderProgram &prg, const ShaderProgram &fallback_prg);
+    bool CreateLightenByAlphaShader(ShaderProgram &prg, const ShaderProgram &fallback_prg);
 
     ///////////////////////////////////////////////////////
     // Preparing a scene: implementation

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -286,6 +286,14 @@ public:
     uint32_t FindShaderProgram(const String &name) override;
     // Deletes particular shader program.
     void DeleteShaderProgram(const String &name) override;
+    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
+    // and constant is present in that shader, or UINT32_MAX on failure.
+    uint32_t GetShaderConstant(uint32_t shader_index, const String &const_name) override;
+    // Sets shader constant, using constant's index (returned by GetShaderConstant)
+    void SetShaderConstantF(uint32_t shader_index, uint32_t const_index, float value) override;
+    void SetShaderConstantF2(uint32_t shader_index, uint32_t const_index, float x, float y) override;
+    void SetShaderConstantF3(uint32_t shader_index, uint32_t const_index, float x, float y, float z) override;
+    void SetShaderConstantF4(uint32_t shader_index, uint32_t const_index, float x, float y, float z, float w) override;
 
     ///////////////////////////////////////////////////////
     // Preparing a scene
@@ -398,6 +406,10 @@ private:
         GLuint TintAmount = 0;
         GLuint TintLuminance = 0;
         GLuint LightingAmount = 0;
+
+        // Constants table: maps constant name to the index/register
+        // in the compiled shader
+        std::unordered_map<String, uint32_t> Constants;
     };
 
     // Compiles and links shader program, using provided vertex and fragment shaders

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -273,12 +273,14 @@ public:
     const char *GetShaderPrecompiledExtension() override { return ""; }
     // Returns the expected file extension for the shader source
     const char *GetShaderSourceExtension() override { return "glsl"; }
+    // Returns the expected file extension for the shader definition file
+    const char *GetShaderDefinitionExtension() override { return ""; }
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def) override;
     // Creates shader program from the compiled data, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) override;
+    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override;
     // Looks up for the shader program using a name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     uint32_t FindShaderProgram(const String &name) override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -294,21 +294,11 @@ public:
     // Creates shader program from the compiled data, registers it under given name;
     // not supported in software driver, always fails.
     IGraphicShader *CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override { return nullptr; }
-    // Looks up for the shader program using a name;
-    // not supported in software driver, always fails.
-    IGraphicShader *FindShaderProgram(const String &name) override { return nullptr; }
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    IGraphicShader *GetShaderProgram(uint32_t shader_id) override { return nullptr; }
     // Deletes particular shader program.
     void DeleteShaderProgram(IGraphicShader *shader) override { /* do nothing */ }
     // Creates shader instance for the given shader;
     // not supported in software driver, always fails.
-    IShaderInstance *CreateShaderInstance(IGraphicShader *shader) override { return nullptr; }
-    // Looks up for the shader instance using a name,
-    // not supported in software driver, always fails.
-    IShaderInstance *FindShaderInstance(const String &name) override { return nullptr; }
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    IShaderInstance *GetShaderInstance(uint32_t shader_inst_id) override { return nullptr; }
+    IShaderInstance *CreateShaderInstance(IGraphicShader *shader, const String &name) override { return nullptr; }
     // Deletes particular shader instance
     void DeleteShaderInstance(IShaderInstance *shader_inst) override { /* do nothing */ }
 

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -105,11 +105,24 @@ public:
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
     uint32_t GetShaderConstant(const String &const_name) override { return UINT32_MAX; }
+};
+
+class SoftwareShaderInstance final : public BaseShaderInstance
+{
+public:
+    virtual IGraphicShader *GetShader() override { return _shader; }
     // Sets shader constant, using constant's index (returned by GetShaderConstant)
-    virtual void SetShaderConstantF(uint32_t const_index, float value) override { /* do nothing */ }
-    virtual void SetShaderConstantF2(uint32_t const_index, float x, float y) override { /* do nothing */ }
-    virtual void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
-    virtual void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
+    void SetShaderConstantF(uint32_t const_index, float value) override { /* do nothing */ }
+    void SetShaderConstantF2(uint32_t const_index, float x, float y) override { /* do nothing */ }
+    void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
+    void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
+
+    SoftwareShaderInstance(SoftwareShaderStub *shader)
+        : _shader(shader)
+    {}
+
+private:
+    SoftwareShaderStub *_shader = nullptr;
 };
 
 
@@ -288,6 +301,16 @@ public:
     IGraphicShader *GetShaderProgram(uint32_t shader_id) override { return nullptr; }
     // Deletes particular shader program.
     void DeleteShaderProgram(IGraphicShader *shader) override { /* do nothing */ }
+    // Creates shader instance for the given shader;
+    // not supported in software driver, always fails.
+    IShaderInstance *CreateShaderInstance(IGraphicShader *shader) override { return nullptr; }
+    // Looks up for the shader instance using a name,
+    // not supported in software driver, always fails.
+    IShaderInstance *FindShaderInstance(const String &name) override { return nullptr; }
+    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
+    IShaderInstance *GetShaderInstance(uint32_t shader_inst_id) override { return nullptr; }
+    // Deletes particular shader instance
+    void DeleteShaderInstance(IShaderInstance *shader_inst) override { /* do nothing */ }
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -102,9 +102,18 @@ class SoftwareShaderStub final : public BaseShader
 public:
     SoftwareShaderStub() = default;
 
+    // Get a number of registered constants
+    uint32_t GetConstantCount() override { return 0u; }
+    // Get a registered constant's name, by its sequential index
+    String GetConstantName(uint32_t iter_index) override { return {}; }
+    // Get a registered constant's location, by its sequential index;
+    // returns UINT32_MAX if no such constant exists
+    uint32_t GetConstantByIndex(uint32_t iter_index) override { return UINT32_MAX; }
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
-    uint32_t GetShaderConstant(const String &const_name) override { return UINT32_MAX; }
+    uint32_t GetConstantByName(const String &const_name) override { return UINT32_MAX; }
+    // Reset all shader constants to zero
+    void ResetConstants() override { /* do nothing */ }
 };
 
 class SoftwareShaderInstance final : public BaseShaderInstance
@@ -116,6 +125,11 @@ public:
     void SetShaderConstantF2(uint32_t const_index, float x, float y) override { /* do nothing */ }
     void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
     void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
+
+    // Gets the allocated size of the constants data
+    size_t GetConstantDataSize() override { return 0u; }
+    // Gets array of constants data, where each constant is represented as 4 floats
+    void GetConstantData(std::vector<float> &data) override { /* do nothing */ }
 
     SoftwareShaderInstance(SoftwareShaderStub *shader)
         : _shader(shader)

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -269,6 +269,14 @@ public:
     uint32_t FindShaderProgram(const String &name) override { return UINT32_MAX; }
     // Deletes particular shader program.
     void DeleteShaderProgram(const String &name) override { /* do nothing */ }
+    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
+    // and constant is present in that shader, or UINT32_MAX on failure.
+    uint32_t GetShaderConstant(uint32_t shader_index, const String &const_name) override { return UINT32_MAX; }
+    // Sets shader constant, using constant's index (returned by GetShaderConstant)
+    void SetShaderConstantF(uint32_t shader_index, uint32_t const_index, float value) override { /* do nothing */ }
+    void SetShaderConstantF2(uint32_t shader_index, uint32_t const_index, float x, float y) override { /* do nothing */ }
+    void SetShaderConstantF3(uint32_t shader_index, uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
+    void SetShaderConstantF4(uint32_t shader_index, uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -249,6 +249,9 @@ public:
     // Creates shader program from the source code, registers it under given name;
     // not supported in software driver, always fails.
     uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override { return UINT32_MAX; }
+    // Creates shader program from the compiled data, registers it under given name;
+    // not supported in software driver, always fails.
+    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) override { return UINT32_MAX; }
     // Looks up for the shader program using a name;
     // not supported in software driver, always fails.
     uint32_t FindShaderProgram(const String &name) override { return UINT32_MAX; }

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -96,6 +96,23 @@ private:
 };
 
 
+// A dummy "shader" class for software renderer, that does nothing
+class SoftwareShaderStub final : public BaseShader
+{
+public:
+    SoftwareShaderStub() = default;
+
+    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
+    // and constant is present in that shader, or UINT32_MAX on failure.
+    uint32_t GetShaderConstant(const String &const_name) override { return UINT32_MAX; }
+    // Sets shader constant, using constant's index (returned by GetShaderConstant)
+    virtual void SetShaderConstantF(uint32_t const_index, float value) override { /* do nothing */ }
+    virtual void SetShaderConstantF2(uint32_t const_index, float x, float y) override { /* do nothing */ }
+    virtual void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
+    virtual void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
+};
+
+
 class SDLRendererGfxModeList : public IGfxModeList
 {
 public:
@@ -260,23 +277,17 @@ public:
     const char *GetShaderDefinitionExtension() override { return ""; }
     // Creates shader program from the source code, registers it under given name;
     // not supported in software driver, always fails.
-    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def) override { return UINT32_MAX; }
+    IGraphicShader *CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def) override { return nullptr; }
     // Creates shader program from the compiled data, registers it under given name;
     // not supported in software driver, always fails.
-    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override { return UINT32_MAX; }
+    IGraphicShader *CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override { return nullptr; }
     // Looks up for the shader program using a name;
     // not supported in software driver, always fails.
-    uint32_t FindShaderProgram(const String &name) override { return UINT32_MAX; }
+    IGraphicShader *FindShaderProgram(const String &name) override { return nullptr; }
+    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
+    IGraphicShader *GetShaderProgram(uint32_t shader_id) override { return nullptr; }
     // Deletes particular shader program.
-    void DeleteShaderProgram(const String &name) override { /* do nothing */ }
-    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
-    // and constant is present in that shader, or UINT32_MAX on failure.
-    uint32_t GetShaderConstant(uint32_t shader_index, const String &const_name) override { return UINT32_MAX; }
-    // Sets shader constant, using constant's index (returned by GetShaderConstant)
-    void SetShaderConstantF(uint32_t shader_index, uint32_t const_index, float value) override { /* do nothing */ }
-    void SetShaderConstantF2(uint32_t shader_index, uint32_t const_index, float x, float y) override { /* do nothing */ }
-    void SetShaderConstantF3(uint32_t shader_index, uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
-    void SetShaderConstantF4(uint32_t shader_index, uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
+    void DeleteShaderProgram(IGraphicShader *shader) override { /* do nothing */ }
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -329,6 +329,8 @@ public:
     void SetScreenFade(int red, int green, int blue) override;
     // Adds tint overlay fx to the active batch
     void SetScreenTint(int red, int green, int blue) override;
+    // Sets a shader to be applied to the whole screen as a post fx
+    void SetScreenShader(IShaderInstance *shinst) override { /*do nothing*/ }
     // Sets stage screen parameters for the current batch.
     void SetStageScreen(const Size &sz, int x = 0, int y = 0) override;
     // Redraw last draw lists, optionally filtering specific batches

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -256,12 +256,14 @@ public:
     const char *GetShaderPrecompiledExtension() override { return ""; }
     // Returns the expected file extension for the shader source
     const char *GetShaderSourceExtension() override { return ""; }
+    // Returns the expected file extension for the shader definition file
+    const char *GetShaderDefinitionExtension() override { return ""; }
     // Creates shader program from the source code, registers it under given name;
     // not supported in software driver, always fails.
-    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override { return UINT32_MAX; }
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def) override { return UINT32_MAX; }
     // Creates shader program from the compiled data, registers it under given name;
     // not supported in software driver, always fails.
-    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) override { return UINT32_MAX; }
+    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override { return UINT32_MAX; }
     // Looks up for the shader program using a name;
     // not supported in software driver, always fails.
     uint32_t FindShaderProgram(const String &name) override { return UINT32_MAX; }

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -242,6 +242,18 @@ public:
     void UpdateTexture(Texture *txdata, const Bitmap*, bool) override { /* not supported */}
     // Retrieve shared texture object from the given DDB
     std::shared_ptr<Texture> GetTexture(IDriverDependantBitmap *ddb) override { return nullptr; /* not supported */ }
+    
+    ///////////////////////////////////////////////////////
+    // Shader management
+    //
+    // Creates shader program from the source code, registers it under given name;
+    // not supported in software driver, always fails.
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override { return UINT32_MAX; }
+    // Looks up for the shader program using a name;
+    // not supported in software driver, always fails.
+    uint32_t FindShaderProgram(const String &name) override { return UINT32_MAX; }
+    // Deletes particular shader program.
+    void DeleteShaderProgram(const String &name) override { /* do nothing */ }
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -96,50 +96,6 @@ private:
 };
 
 
-// A dummy "shader" class for software renderer, that does nothing
-class SoftwareShaderStub final : public BaseShader
-{
-public:
-    SoftwareShaderStub() = default;
-
-    // Get a number of registered constants
-    uint32_t GetConstantCount() override { return 0u; }
-    // Get a registered constant's name, by its sequential index
-    String GetConstantName(uint32_t iter_index) override { return {}; }
-    // Get a registered constant's location, by its sequential index;
-    // returns UINT32_MAX if no such constant exists
-    uint32_t GetConstantByIndex(uint32_t iter_index) override { return UINT32_MAX; }
-    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
-    // and constant is present in that shader, or UINT32_MAX on failure.
-    uint32_t GetConstantByName(const String &const_name) override { return UINT32_MAX; }
-    // Reset all shader constants to zero
-    void ResetConstants() override { /* do nothing */ }
-};
-
-class SoftwareShaderInstance final : public BaseShaderInstance
-{
-public:
-    virtual IGraphicShader *GetShader() override { return _shader; }
-    // Sets shader constant, using constant's index (returned by GetShaderConstant)
-    void SetShaderConstantF(uint32_t const_index, float value) override { /* do nothing */ }
-    void SetShaderConstantF2(uint32_t const_index, float x, float y) override { /* do nothing */ }
-    void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override { /* do nothing */ }
-    void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override { /* do nothing */ }
-
-    // Gets the allocated size of the constants data
-    size_t GetConstantDataSize() override { return 0u; }
-    // Gets array of constants data, where each constant is represented as 4 floats
-    void GetConstantData(std::vector<float> &data) override { /* do nothing */ }
-
-    SoftwareShaderInstance(SoftwareShaderStub *shader)
-        : _shader(shader)
-    {}
-
-private:
-    SoftwareShaderStub *_shader = nullptr;
-};
-
-
 class SDLRendererGfxModeList : public IGfxModeList
 {
 public:

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -252,6 +252,10 @@ public:
     ///////////////////////////////////////////////////////
     // Shader management
     //
+    // Returns the expected file extension for the precompiled shader
+    const char *GetShaderPrecompiledExtension() override { return ""; }
+    // Returns the expected file extension for the shader source
+    const char *GetShaderSourceExtension() override { return ""; }
     // Creates shader program from the source code, registers it under given name;
     // not supported in software driver, always fails.
     uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override { return UINT32_MAX; }

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -174,6 +174,12 @@ public:
     bool ShouldReleaseRenderTargets() override { return false; }
 
     ///////////////////////////////////////////////////////
+    // Miscelaneous setup
+    //
+    // Sets values for global shader constants
+    void SetGlobalShaderConstants(const GlobalShaderConstants &constants) override { /* not supported */ }
+
+    ///////////////////////////////////////////////////////
     // Mode initialization
     //
     // Initialize given display mode

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -70,6 +70,8 @@ enum TextureFlags
     kTxFlags_Opaque = 0x0002,
 };
 
+class IShaderInstance;
+
 // The "texture sprite" object, contains Texture object ref,
 // which may be either shared or exclusive to this sprite.
 // Lets assign various effects and transformations which will be
@@ -106,8 +108,8 @@ public:
     virtual void SetTint(int red, int green, int blue, int tintSaturation) = 0; // 0-255
     virtual Common::BlendMode GetBlendMode() const = 0;
     virtual void SetBlendMode(Common::BlendMode blendMode) = 0;
-    virtual uint32_t GetShader() const = 0;
-    virtual void SetShader(uint32_t shader_id) = 0;
+    virtual IShaderInstance *GetShader() const = 0;
+    virtual void SetShader(IShaderInstance *shader_inst) = 0;
 
     // Tells if this DDB has an actual render data assigned to it.
     virtual bool IsValid() const = 0;

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -106,6 +106,8 @@ public:
     virtual void SetTint(int red, int green, int blue, int tintSaturation) = 0; // 0-255
     virtual Common::BlendMode GetBlendMode() const = 0;
     virtual void SetBlendMode(Common::BlendMode blendMode) = 0;
+    virtual uint32_t GetShader() const = 0;
+    virtual void SetShader(uint32_t shader_id) = 0;
 
     // Tells if this DDB has an actual render data assigned to it.
     virtual bool IsValid() const = 0;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -225,6 +225,11 @@ bool VideoMemoryGraphicsDriver::GetStageMatrixes(RenderMatrixes &rm)
     return true;
 }
 
+void VideoMemoryGraphicsDriver::SetGlobalShaderConstants(const GlobalShaderConstants &constants)
+{
+    _globalShaderConst = constants;
+}
+
 IDriverDependantBitmap *VideoMemoryGraphicsDriver::CreateDDBFromBitmap(const Bitmap *bitmap, int txflags)
 {
     IDriverDependantBitmap *ddb = CreateDDB(bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth(), txflags);

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -319,6 +319,23 @@ protected:
 };
 
 
+class BaseShaderInstance : public IShaderInstance
+{
+public:
+    // Gets this shader's name, which uniquely identifies this shader
+    const String &GetName() const override { return _name; }
+    uint32_t GetID() const override { return _id; }
+
+protected:
+    BaseShaderInstance() = default;
+    BaseShaderInstance(const String &name, uint32_t id)
+        : _name(name), _id(id) {}
+
+    String _name;
+    uint32_t _id = UINT32_MAX;
+};
+
+
 // Generic TextureTile base
 struct TextureTile
 {

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -374,6 +374,12 @@ public:
     bool UsesMemoryBackBuffer() override { return false; }
 
     ///////////////////////////////////////////////////////
+    // Miscelaneous setup
+    //
+    // Sets values for global shader constants
+    void SetGlobalShaderConstants(const GlobalShaderConstants &constants) override;
+
+    ///////////////////////////////////////////////////////
     // Texture management
     // 
     // Creates new DDB and copy bitmap contents over
@@ -435,6 +441,9 @@ protected:
     // Stage matrixes are used to let plugins with hardware acceleration know model matrix;
     // these matrixes are filled compatible with each given renderer
     RenderMatrixes _stageMatrixes;
+
+    // Global shader constants; these are applied to all shaders before each render pass.
+    GlobalShaderConstants _globalShaderConst;
 
     // Color component shifts in video bitmap format (set by implementations)
     int _vmem_a_shift_32;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -273,8 +273,8 @@ public:
     }
     Common::BlendMode GetBlendMode() const { return _blendMode; }
     void SetBlendMode(Common::BlendMode blendMode) override { _blendMode = blendMode; }
-    uint32_t GetShader() const override { return _shader; }
-    void SetShader(uint32_t shader_id) override { _shader = shader_id; }
+    IShaderInstance *GetShader() const override { return _shader; }
+    void SetShader(IShaderInstance *shader_inst) override { _shader = shader_inst; }
 
     int  GetTextureFlags() const { return _txFlags; }
     const Size &GetSize() const { return _size; }
@@ -295,7 +295,7 @@ protected:
     float _rotation = 0.f; // either in degrees or radians, depending on impl
     int _alpha = 255;
     Common::BlendMode _blendMode = Common::kBlend_Normal;
-    uint32_t _shader = UINT32_MAX;
+    IShaderInstance *_shader = nullptr;
     int _red = 0, _green = 0, _blue = 0;
     int _tintSaturation = 0;
     int _lightLevel = 0;
@@ -305,34 +305,31 @@ protected:
 class BaseShader : public IGraphicShader
 {
 public:
-    // Gets this shader's name, which uniquely identifies this shader
+    // Gets this shader's name, this is not a unique identification,
+    // but rather a tag meant for debugging purposes.
     const String &GetName() const override { return _name; }
-    uint32_t GetID() const override { return _id; }
 
 protected:
     BaseShader() = default;
-    BaseShader(const String &name, uint32_t id)
-        : _name(name), _id(id) {}
+    BaseShader(const String &name) : _name(name) {}
 
+private:
     String _name;
-    uint32_t _id = UINT32_MAX;
 };
 
 
 class BaseShaderInstance : public IShaderInstance
 {
 public:
-    // Gets this shader's name, which uniquely identifies this shader
+    // Gets this shader's name, this is not a unique identification,
+    // but rather a tag meant for debugging purposes.
     const String &GetName() const override { return _name; }
-    uint32_t GetID() const override { return _id; }
 
 protected:
     BaseShaderInstance() = default;
-    BaseShaderInstance(const String &name, uint32_t id)
-        : _name(name), _id(id) {}
+    BaseShaderInstance(const String &name) : _name(name) {}
 
     String _name;
-    uint32_t _id = UINT32_MAX;
 };
 
 
@@ -411,6 +408,8 @@ public:
     // Miscelaneous setup
     //
     // Sets values for global shader constants
+    // TODO: think how this could be moved to IGraphicShader;
+    // had to leave this in gfx driver class right now, because it's more convenient to apply constants...
     void SetGlobalShaderConstants(const GlobalShaderConstants &constants) override;
 
     ///////////////////////////////////////////////////////

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -273,6 +273,8 @@ public:
     }
     Common::BlendMode GetBlendMode() const { return _blendMode; }
     void SetBlendMode(Common::BlendMode blendMode) override { _blendMode = blendMode; }
+    uint32_t GetShader() const override { return _shader; }
+    void SetShader(uint32_t shader_id) override { _shader = shader_id; }
 
     int  GetTextureFlags() const { return _txFlags; }
     const Size &GetSize() const { return _size; }
@@ -293,6 +295,7 @@ protected:
     float _rotation = 0.f; // either in degrees or radians, depending on impl
     int _alpha = 255;
     Common::BlendMode _blendMode = Common::kBlend_Normal;
+    uint32_t _shader = 0u;
     int _red = 0, _green = 0, _blue = 0;
     int _tintSaturation = 0;
     int _lightLevel = 0;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -295,7 +295,7 @@ protected:
     float _rotation = 0.f; // either in degrees or radians, depending on impl
     int _alpha = 255;
     Common::BlendMode _blendMode = Common::kBlend_Normal;
-    uint32_t _shader = 0u;
+    uint32_t _shader = UINT32_MAX;
     int _red = 0, _green = 0, _blue = 0;
     int _tintSaturation = 0;
     int _lightLevel = 0;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -302,6 +302,23 @@ protected:
 };
 
 
+class BaseShader : public IGraphicShader
+{
+public:
+    // Gets this shader's name, which uniquely identifies this shader
+    const String &GetName() const override { return _name; }
+    uint32_t GetID() const override { return _id; }
+
+protected:
+    BaseShader() = default;
+    BaseShader(const String &name, uint32_t id)
+        : _name(name), _id(id) {}
+
+    String _name;
+    uint32_t _id = UINT32_MAX;
+};
+
+
 // Generic TextureTile base
 struct TextureTile
 {

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -87,6 +87,8 @@ typedef void (*GFXDRV_CLIENTCALLBACKINITGFX)(void *data);
 class IGraphicsDriver
 {
 public:
+    using String = AGS::Common::String;
+public:
     virtual ~IGraphicsDriver() = default;
 
     ///////////////////////////////////////////////////////
@@ -204,6 +206,18 @@ public:
     virtual void UpdateTexture(Texture *txdata, const Bitmap *bmp, bool opaque = false) = 0;
     // Retrieve shared texture object from the given DDB
     virtual std::shared_ptr<Texture> GetTexture(IDriverDependantBitmap *ddb) = 0;
+
+    ///////////////////////////////////////////////////////
+    // Shader management
+    //
+    // Creates shader program from the source code, registers it under given name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    virtual uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) = 0;
+    // Looks up for the shader program using a name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    virtual uint32_t FindShaderProgram(const String &name) = 0;
+    // Deletes particular shader program.
+    virtual void DeleteShaderProgram(const String &name) = 0;
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -253,6 +253,17 @@ public:
     virtual uint32_t FindShaderProgram(const String &name) = 0;
     // Deletes particular shader program.
     virtual void DeleteShaderProgram(const String &name) = 0;
+    //
+    // TODO: create a separate Shader interface for handling following per-shader operations.
+    // 
+    // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
+    // and constant is present in that shader, or UINT32_MAX on failure.
+    virtual uint32_t GetShaderConstant(uint32_t shader_index, const String &const_name) = 0;
+    // Sets shader constant, using constant's index (returned by GetShaderConstant)
+    virtual void SetShaderConstantF(uint32_t shader_index, uint32_t const_index, float value) = 0;
+    virtual void SetShaderConstantF2(uint32_t shader_index, uint32_t const_index, float x, float y) = 0;
+    virtual void SetShaderConstantF3(uint32_t shader_index, uint32_t const_index, float x, float y, float z) = 0;
+    virtual void SetShaderConstantF4(uint32_t shader_index, uint32_t const_index, float x, float y, float z, float w) = 0;
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -80,6 +80,13 @@ struct RenderMatrixes
     glm::mat4 Projection;
 };
 
+// Provides a way to set global shader constant values in gfx driver
+struct GlobalShaderConstants
+{
+    float Time = 0.f;
+    int GameFrame = 0;
+};
+
 typedef void (*GFXDRV_CLIENTCALLBACK)();
 typedef bool (*GFXDRV_CLIENTCALLBACKEVT)(int evt, intptr_t data);
 typedef void (*GFXDRV_CLIENTCALLBACKINITGFX)(void *data);
@@ -175,6 +182,9 @@ public:
     virtual bool SupportsGammaControl() = 0;
     // Sets gamma level
     virtual void SetGamma(int newGamma) = 0;
+    // Sets values for global shader constants;
+    // these will be applied to all shaders at the next render pass.
+    virtual void SetGlobalShaderConstants(const GlobalShaderConstants &constants) = 0;
 
     ///////////////////////////////////////////////////////
     // Texture management

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -112,11 +112,9 @@ public:
 public:
     virtual ~IGraphicShader() = default;
 
-    // Gets this shader's name, which uniquely identifies this shader
+    // Gets this shader's name, this is not a unique identification,
+    // but rather a tag meant for debugging purposes.
     virtual const String &GetName() const = 0;
-    // Gets this shader's numberic ID, which may be used to reference it in gfx driver
-    // TODO: remove numeric id when we store shaders outside of the gfx driver class
-    virtual uint32_t GetID() const = 0;
 
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
@@ -134,11 +132,9 @@ public:
 public:
     virtual ~IShaderInstance() = default;
 
-    // Gets this shader instance's name, which uniquely identifies it
+    // Gets this shader's name, this is not a unique identification,
+    // but rather a tag meant for debugging purposes.
     virtual const String &GetName() const = 0;
-    // Gets this shader instance's numberic ID, which may be used to reference it in gfx driver
-    // TODO: remove numeric id when we store shaders outside of the gfx driver class
-    virtual uint32_t GetID() const = 0;
     // Returns a IGraphicShader referenced by this shader instance
     virtual IGraphicShader *GetShader() = 0;
 
@@ -295,21 +291,11 @@ public:
     // Creates shader program from the compiled data, registers it under given name,
     // returns IGraphicShader, or null on failure.
     virtual IGraphicShader *CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def = nullptr) = 0;
-    // Looks up for the shader program using a name,
-    // returns IGraphicShader, or null on failure.
-    virtual IGraphicShader *FindShaderProgram(const String &name) = 0;
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    virtual IGraphicShader *GetShaderProgram(uint32_t shader_id) = 0;
     // Deletes particular shader program.
     virtual void DeleteShaderProgram(IGraphicShader *shader) = 0;
     // Creates shader instance for the given shader.
-    // TODO: move this to IGraphicShader interface, when custom shaders are stored outside of gfx driver.
-    virtual IShaderInstance *CreateShaderInstance(IGraphicShader *shader) = 0;
-    // Looks up for the shader instance using a name,
-    // returns IShaderInstance, or null on failure.
-    virtual IShaderInstance *FindShaderInstance(const String &name) = 0;
-    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
-    virtual IShaderInstance *GetShaderInstance(uint32_t shader_inst_id) = 0;
+    // TODO: consider moving this to IGraphicShader interface? along with DeleteShaderInstance
+    virtual IShaderInstance *CreateShaderInstance(IGraphicShader *shader, const String &name) = 0;
     // Deletes particular shader instance
     virtual void DeleteShaderInstance(IShaderInstance *shader_inst) = 0;
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -213,6 +213,9 @@ public:
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     virtual uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) = 0;
+    // Creates shader program from the compiled data, registers it under given name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    virtual uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) = 0;
     // Looks up for the shader program using a name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     virtual uint32_t FindShaderProgram(const String &name) = 0;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -116,9 +116,18 @@ public:
     // but rather a tag meant for debugging purposes.
     virtual const String &GetName() const = 0;
 
+    // Get a number of registered constants
+    virtual uint32_t GetConstantCount() = 0;
+    // Get a registered constant's name, by its sequential index
+    virtual String GetConstantName(uint32_t iter_index) = 0;
+    // Get a registered constant's location, by its sequential index;
+    // returns UINT32_MAX if no such constant exists
+    virtual uint32_t GetConstantByIndex(uint32_t iter_index) = 0;
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
-    virtual uint32_t GetShaderConstant(const String &const_name) = 0;
+    virtual uint32_t GetConstantByName(const String &const_name) = 0;
+    // Reset all shader constants to zero
+    virtual void ResetConstants() = 0;
 };
 
 // IShaderInstance is a interface of a single shader configuration,
@@ -143,6 +152,11 @@ public:
     virtual void SetShaderConstantF2(uint32_t const_index, float x, float y) = 0;
     virtual void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) = 0;
     virtual void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) = 0;
+
+    // Gets the allocated size of the constants data
+    virtual size_t GetConstantDataSize() = 0;
+    // Gets array of allocated constants data, where each constant is represented as 4 floats
+    virtual void GetConstantData(std::vector<float> &data) = 0;
 };
 
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -348,6 +348,8 @@ public:
     // Adds tint overlay fx to the active batch
     // TODO: redesign this to allow various post-fx per sprite batch?
     virtual void SetScreenTint(int red, int green, int blue) = 0;
+    // Sets a shader to be applied to the whole screen as a post fx
+    virtual void SetScreenShader(IShaderInstance *shinst) = 0;
     // Sets stage screen parameters for the current batch.
     // Currently includes size and optional position offset;
     // the position is relative, as stage screens are using sprite batch transforms.

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -220,6 +220,10 @@ public:
     ///////////////////////////////////////////////////////
     // Shader management
     //
+    // Returns the expected file extension for the precompiled shader
+    virtual const char *GetShaderPrecompiledExtension() = 0;
+    // Returns the expected file extension for the shader source
+    virtual const char *GetShaderSourceExtension() = 0;
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     virtual uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) = 0;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -25,6 +25,7 @@
 #include "gfx/gfxdefines.h"
 #include "gfx/gfxmodelist.h"
 #include "util/geometry.h"
+#include "util/string_types.h"
 
 namespace AGS
 {
@@ -85,6 +86,21 @@ struct GlobalShaderConstants
 {
     float Time = 0.f;
     int GameFrame = 0;
+};
+
+// Describes a shader layout for the graphics driver.
+// Used when a driver class does not support a reflection on a compiled shader.
+struct ShaderDefinition
+{
+    // Compilation target (if applicable)
+    AGS::Common::String CompileTarget;
+    // Entry point function's name
+    AGS::Common::String EntryPoint;
+
+    // Constants table: maps constant name to the index/register
+    // in the compiled shader
+    std::unordered_map<AGS::Common::String, uint32_t>
+                        Constants;
 };
 
 typedef void (*GFXDRV_CLIENTCALLBACK)();
@@ -224,12 +240,14 @@ public:
     virtual const char *GetShaderPrecompiledExtension() = 0;
     // Returns the expected file extension for the shader source
     virtual const char *GetShaderSourceExtension() = 0;
+    // Returns the expected file extension for the shader definition file
+    virtual const char *GetShaderDefinitionExtension() = 0;
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    virtual uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) = 0;
+    virtual uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def = nullptr) = 0;
     // Creates shader program from the compiled data, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    virtual uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) = 0;
+    virtual uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def = nullptr) = 0;
     // Looks up for the shader program using a name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     virtual uint32_t FindShaderProgram(const String &name) = 0;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -121,7 +121,28 @@ public:
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
     virtual uint32_t GetShaderConstant(const String &const_name) = 0;
-    // Sets shader constant, using constant's index (returned by GetShaderConstant)
+};
+
+// IShaderInstance is a interface of a single shader configuration,
+// which has exclusive set of constant values.
+// NOTE: if we support Materials at some point, then a material interface
+// would likely supercede IShaderInstance.
+class IShaderInstance
+{
+public:
+    using String = AGS::Common::String;
+public:
+    virtual ~IShaderInstance() = default;
+
+    // Gets this shader instance's name, which uniquely identifies it
+    virtual const String &GetName() const = 0;
+    // Gets this shader instance's numberic ID, which may be used to reference it in gfx driver
+    // TODO: remove numeric id when we store shaders outside of the gfx driver class
+    virtual uint32_t GetID() const = 0;
+    // Returns a IGraphicShader referenced by this shader instance
+    virtual IGraphicShader *GetShader() = 0;
+
+    // Sets shader constant, using constant's index (returned by IGraphicShader::GetShaderConstant)
     virtual void SetShaderConstantF(uint32_t const_index, float value) = 0;
     virtual void SetShaderConstantF2(uint32_t const_index, float x, float y) = 0;
     virtual void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) = 0;
@@ -281,6 +302,16 @@ public:
     virtual IGraphicShader *GetShaderProgram(uint32_t shader_id) = 0;
     // Deletes particular shader program.
     virtual void DeleteShaderProgram(IGraphicShader *shader) = 0;
+    // Creates shader instance for the given shader.
+    // TODO: move this to IGraphicShader interface, when custom shaders are stored outside of gfx driver.
+    virtual IShaderInstance *CreateShaderInstance(IGraphicShader *shader) = 0;
+    // Looks up for the shader instance using a name,
+    // returns IShaderInstance, or null on failure.
+    virtual IShaderInstance *FindShaderInstance(const String &name) = 0;
+    // Gets the shader program using its internal numeric ID; returns null if no such shader ID exists.
+    virtual IShaderInstance *GetShaderInstance(uint32_t shader_inst_id) = 0;
+    // Deletes particular shader instance
+    virtual void DeleteShaderInstance(IShaderInstance *shader_inst) = 0;
 
     ///////////////////////////////////////////////////////
     // Preparing a scene

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -98,8 +98,8 @@ static bool ShouldStayInWaitMode();
 
 float fps = std::numeric_limits<float>::quiet_NaN();
 static auto t1 = AGS_Clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
-unsigned int loopcounter=0;
-static unsigned int lastcounter=0;
+uint32_t loopcounter=0;
+static unsigned int lastcounter=0; // CHECME: not sure if needed, review its use
 static size_t numEventsAtStartOfFunction; // CHECKME: research and document this
 
 // Kinds of conditions used when "waiting" for something
@@ -1154,11 +1154,20 @@ float get_real_fps() {
     return fps;
 }
 
-void set_loop_counter(unsigned int new_counter) {
+void set_loop_counter(uint32_t new_counter) {
     loopcounter = new_counter;
-    t1 = AGS_Clock::now();
     lastcounter = loopcounter;
+    t1 = AGS_Clock::now();
     fps = std::numeric_limits<float>::quiet_NaN();
+}
+
+void increment_loop_counter() {
+    loopcounter++;
+    lastcounter = loopcounter;
+}
+
+uint32_t get_loop_counter() {
+    return loopcounter;
 }
 
 void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int extraX, int extraY) {
@@ -1467,6 +1476,11 @@ void SyncDrawablesState()
 void ShutGameWaitState()
 {
     restrict_until = {};
+}
+
+unsigned GetGameFrameIndex()
+{
+    return loopcounter;
 }
 
 void update_polled_stuff()

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -50,11 +50,19 @@ void SyncDrawablesState();
 bool IsInWaitMode();
 // Shuts down game's waiting state, if one is running right now.
 void ShutGameWaitState();
+
 // Gets current logical game FPS, this is normally a fixed number set in script;
 // in case of "maxed fps" mode this function returns real measured FPS.
 float get_game_fps();
 // Gets real fps, calculated based on the game performance.
 float get_real_fps();
+// Sets game frame index
+void set_loop_counter(uint32_t new_counter);
+// Increments game frame index once
+void increment_loop_counter();
+// Gets game frame index, counted since the game started
+uint32_t get_loop_counter();
+
 // Runs service key controls, returns false if no key was pressed or key input was claimed by the engine,
 // otherwise returns true and provides a keycode.
 bool run_service_key_controls(KeyInput &kgn);

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -674,7 +674,7 @@ void update_audio_system_on_game_loop ()
 
     audio_update_polled_stuff();
 
-    if (loopcounter % 5 == 0) // TODO: investigate why we do this each 5 frames?
+    if (get_loop_counter() % 5 == 0) // TODO: investigate why we do this each 5 frames?
     {
         update_directional_sound_vol();
     }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -2366,6 +2366,9 @@ IGraphicShader *D3DGraphicsDriver::GetShaderProgram(uint32_t shader_id)
 
 void D3DGraphicsDriver::DeleteShaderProgram(IGraphicShader *shader)
 {
+    assert(shader);
+    if (!shader)
+        return;
     assert(shader->GetID() < _shaders.size());
     if (shader->GetID() < _shaders.size())
     {
@@ -2407,6 +2410,9 @@ IShaderInstance *D3DGraphicsDriver::GetShaderInstance(uint32_t shader_inst_id)
 
 void D3DGraphicsDriver::DeleteShaderInstance(IShaderInstance *shader_inst)
 {
+    assert(shader_inst);
+    if (!shader_inst)
+        return;
     assert(shader_inst->GetID() < _shaderInst.size());
     if (shader_inst->GetID() < _shaderInst.size())
     {

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -2417,6 +2417,14 @@ void D3DGraphicsDriver::SetScreenTint(int red, int green, int blue)
     _spriteList.push_back(D3DDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 
+void D3DGraphicsDriver::SetScreenShader(IShaderInstance *shinst)
+{
+    // TODO: expand this to not depend on whether we use a native-resolution surface or not;
+    // ideally this setup has to be done outside of gfx driver
+    if (_nativeSurface)
+        _nativeSurface->SetShader(shinst);
+}
+
 bool D3DGraphicsDriver::SetVsyncImpl(bool enabled, bool &vsync_res) 
 {
     d3dpp.PresentationInterval = enabled ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -2083,6 +2083,21 @@ Texture *D3DGraphicsDriver::CreateTexture(int width, int height, int color_depth
   return txdata;
 }
 
+uint32_t D3DGraphicsDriver::CreateShaderProgram(const String &name, const char *fragment_shader_src)
+{
+    return UINT32_MAX; // TODO
+}
+
+uint32_t D3DGraphicsDriver::FindShaderProgram(const String &name)
+{
+    return UINT32_MAX; // TODO
+}
+
+void D3DGraphicsDriver::DeleteShaderProgram(const String &name)
+{
+    // TODO
+}
+
 void D3DGraphicsDriver::SetScreenFade(int red, int green, int blue)
 {
     assert(_actSpriteBatch != UINT32_MAX);

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -830,8 +830,6 @@ bool D3DGraphicsDriver::CreateShaders()
 
     bool shaders_created = true;
     shaders_created &= CreateTintShader(_tintShader, _dummyShader);
-    // Reserve custom shader index 0 as "no shader"
-    _shaders.push_back({});
     return shaders_created;
 }
 
@@ -1234,7 +1232,7 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
   light_lev = bmpToDraw->GetLightLevel();
   const bool do_tint = tint_sat > 0 && _tintShader.ShaderPtr;
 
-  if (bmpToDraw->GetShader() != 0u && bmpToDraw->GetShader() < _shaders.size())
+  if (bmpToDraw->GetShader() < _shaders.size())
   {
     // Use custom shader
     const ShaderProgram *program = program = &_shaders[bmpToDraw->GetShader()];

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -427,6 +427,8 @@ public:
     // Adds tint overlay fx to the active batch
     // TODO: redesign this to allow various post-fx per sprite batch?
     void SetScreenTint(int red, int green, int blue) override;
+    // Sets a shader to be applied to the whole screen as a post fx
+    void SetScreenShader(IShaderInstance *shinst) override;
     // Redraw saved draw lists, optionally filtering specific batches
     void RedrawLastFrame(uint32_t batch_skip_filter) override;
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -507,8 +507,8 @@ private:
     //
 #if (DIRECT3D_USE_D3DCOMPILER)
     // TODO: should we let configure syntax level and optimization level, entrypoint name?
-    // FIXME: move to the most modern compile target supported by Direct3D.
-    const char *DefaultShaderCompileTarget = "ps_2_0"; // "ps_4_0_level_9_3"
+    // TODO: move to the most modern compile target supported by Direct3D? ("ps_4_0_level_9_3")
+    const char *DefaultShaderCompileTarget = "ps_2_b"; // same as "ps_2_0", but higher capabilities
     const UINT  DefaultShaderCompileFlags  = D3DCOMPILE_OPTIMIZATION_LEVEL3;
     const char *DefaultShaderEntryPoint    = "main";
 #endif

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -273,6 +273,18 @@ public:
     std::shared_ptr<Texture> GetTexture(IDriverDependantBitmap *ddb) override;
 
     ///////////////////////////////////////////////////////
+    // Shader management
+    //
+    // Creates shader program from the source code, registers it under given name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;
+    // Looks up for the shader program using a name,
+    // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
+    uint32_t FindShaderProgram(const String &name) override;
+    // Deletes particular shader program.
+    void DeleteShaderProgram(const String &name) override;
+
+    ///////////////////////////////////////////////////////
     // Preparing a scene
     // 
     // Adds sprite to the active batch, providing it's origin position

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -209,6 +209,7 @@ public:
         Register GameFrame;    // game frame
         Register TextureDim;   // texture 0 dimensions
         Register Alpha;        // requested global alpha
+        Register OutputDim;    // output dimensions
 
         // Specialized constants for built-in shaders
         Register TintHSV;      // float4
@@ -585,6 +586,8 @@ private:
     // Configures rendering mode for the render target, depending on its properties
     // TODO: find a good way to merge with SetRenderTarget
     void SetRenderTarget(const D3DSpriteBatch *batch, Size &surface_sz, bool clear);
+    // Assigns shader constants for post fx (rendering final game image)
+    void SetupPostFx(D3DBitmap *surface, const BackbufferState &bufferstate);
     void RenderSpriteBatches();
     size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from, const Size &rend_sz);
     void RenderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal,

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -289,12 +289,14 @@ public:
     const char *GetShaderPrecompiledExtension() override { return "fxo"; }
     // Returns the expected file extension for the shader source
     const char *GetShaderSourceExtension() override { return "hlsl"; }
+    // Returns the expected file extension for the shader definition file
+    const char *GetShaderDefinitionExtension() override { return "d3ddef"; }
     // Creates shader program from the source code, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src) override;
+    uint32_t CreateShaderProgram(const String &name, const char *fragment_shader_src, const ShaderDefinition *def) override;
     // Creates shader program from the compiled data, registers it under given name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
-    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data) override;
+    uint32_t CreateShaderProgram(const String &name, const std::vector<uint8_t> &compiled_data, const ShaderDefinition *def) override;
     // Looks up for the shader program using a name,
     // returns internal shader index which may be used as a reference, or UINT32_MAX on failure.
     uint32_t FindShaderProgram(const String &name) override;
@@ -395,6 +397,7 @@ private:
     // FIXME: move to the most modern compile target supported by Direct3D.
     const char *DefaultShaderCompileTarget = "ps_2_0"; // "ps_4_0_level_9_3"
     const UINT  DefaultShaderCompileFlags  = D3DCOMPILE_OPTIMIZATION_LEVEL3;
+    const char *DefaultShaderEntryPoint    = "main";
 #endif
     // Shader program and its variable references;
     // the variables are rather specific for AGS use (sprite tinting).
@@ -422,12 +425,12 @@ private:
     bool CreateShaderProgramFromResource(ShaderProgram &prg, const String &name, const char *resource_name);
     // Deletes a shader program
     void DeleteShaderProgram(ShaderProgram &prg);
-    void AssignBaseShaderArgs(ShaderProgram &prg);
+    void AssignBaseShaderArgs(ShaderProgram &prg, const ShaderDefinition *def);
     void UpdateGlobalShaderArgValues();
 #if (DIRECT3D_USE_D3DCOMPILER)
     void OutputShaderLog(ComPtr<ID3DBlob> &out_errors, const String &shader_name, bool as_error);
 #endif
-    uint32_t AddShaderToCollection(ShaderProgram &prg, const String &name);
+    uint32_t AddShaderToCollection(ShaderProgram &prg, const String &name, const ShaderDefinition *def);
 
     //
     // Specialized shaders

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -386,9 +386,10 @@ private:
         //---------------------------------------
         // Fragment shader:
         // Standard uniforms
-        UINT UTime = 0u;     // real time
-        UINT UFrame = 0u;    // game (?) frame
-        UINT Alpha = 0u;     // requested global alpha
+        UINT Time = 0u;         // real time
+        UINT GameFrame = 0u;    // game frame
+        UINT TextureDim = 0u;   // texture 0 dimensions
+        UINT Alpha = 0u;        // requested global alpha
 
         // Specialized uniforms for built-in shaders
         UINT TintHSV = 0u; // float4

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -162,9 +162,18 @@ public:
     D3DShader(const String &name, const D3DShader &copy_shader);
     ~D3DShader() = default;
 
+    // Get a number of registered constants
+    uint32_t GetConstantCount() override;
+    // Get a registered constant's name, by its sequential index
+    String GetConstantName(uint32_t iter_index) override;
+    // Get a registered constant's location, by its sequential index;
+    // returns UINT32_MAX if no such constant exists
+    uint32_t GetConstantByIndex(uint32_t iter_index) override;
     // Looks up for the constant in a shader. Returns a valid index if such shader is registered,
     // and constant is present in that shader, or UINT32_MAX on failure.
-    uint32_t GetShaderConstant(const String &const_name) override;
+    uint32_t GetConstantByName(const String &const_name) override;
+    // Reset all shader constants to zero
+    void ResetConstants() override;
 
     // A single constant register size *in floats*
     static const uint32_t ConstantSize = 4u;
@@ -208,6 +217,10 @@ public:
         // Constants table: maps constant name to the index/register
         // in the compiled shader
         std::unordered_map<String, uint32_t> Constants;
+        // Ordered list of constants: lets iterate over them using
+        // a sequential index. Order is by the register (location)
+        // in shader program memory.
+        std::vector<std::pair<uint32_t, String>> ConstantsOrdered;
     };
 
     bool IsValid() const { return _data.ShaderPtr != nullptr; }
@@ -231,6 +244,11 @@ public:
     void SetShaderConstantF2(uint32_t const_index, float x, float y) override;
     void SetShaderConstantF3(uint32_t const_index, float x, float y, float z) override;
     void SetShaderConstantF4(uint32_t const_index, float x, float y, float z, float w) override;
+
+    // Gets the allocated size of the constants data
+    size_t GetConstantDataSize() override;
+    // Gets array of constants data, where each constant is represented as 4 floats
+    void GetConstantData(std::vector<float> &data) override;
 
     const D3DShader::ProgramData &GetShaderData() const { return _shader->GetData(); }
     float *GetConstantData() { return _constantData.data(); }

--- a/Engine/resource/version.rc
+++ b/Engine/resource/version.rc
@@ -26,7 +26,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 // DATA
 //
 
-PIXEL_SHADER            DATA                    "tintshader.fxo"
+TINT_PIXEL_SHADER    DATA    "tintshader.fxo"
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -62,6 +62,8 @@ extern void RegisterVideoAPI();
 extern void RegisterWalkareaAPI();
 extern void RegisterWalkbehindAPI();
 
+extern void RegisterShaderAPI();
+
 extern void RegisterStaticObjects();
 
 void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
@@ -109,6 +111,8 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterVideoAPI();
     RegisterWalkareaAPI();
     RegisterWalkbehindAPI();
+
+    RegisterShaderAPI();
 
     RegisterStaticObjects();
 }

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -588,6 +588,26 @@ inline const char *ScriptVSprintf(std::vector<char> &buf, const char *format, va
     METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue); \
     return RuntimeScriptValue((int32_t)0)
 
+#define API_OBJCALL_VOID_POBJ_PFLOAT(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
+    METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].FValue); \
+    return RuntimeScriptValue((int32_t)0)
+
+#define API_OBJCALL_VOID_POBJ_PFLOAT2(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 3); \
+    METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].FValue, params[2].FValue); \
+    return RuntimeScriptValue((int32_t)0)
+
+#define API_OBJCALL_VOID_POBJ_PFLOAT3(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 4); \
+    METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].FValue, params[2].FValue, params[3].FValue); \
+    return RuntimeScriptValue((int32_t)0)
+
+#define API_OBJCALL_VOID_POBJ_PFLOAT4(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 3); \
+    METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, params[1].FValue, params[2].FValue, params[3].FValue, params[4].FValue); \
+    return RuntimeScriptValue((int32_t)0)
+
 #define API_OBJCALL_VOID_POBJ2(CLASS, METHOD, P1CLASS, P2CLASS) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
     METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr, (P2CLASS*)params[1].Ptr); \

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -775,6 +775,7 @@
     <ClInclude Include="..\..\Common\util\scaling.h" />
     <ClInclude Include="..\..\Common\util\smart_ptr.h" />
     <ClInclude Include="..\..\Common\util\stdio_compat.h" />
+    <ClInclude Include="..\..\Common\util\stl_utils.h" />
     <ClInclude Include="..\..\Common\util\stream.h" />
     <ClInclude Include="..\..\Common\util\string.h" />
     <ClInclude Include="..\..\Common\util\string_compat.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -850,5 +850,8 @@
     <ClInclude Include="..\..\Common\util\transformstream.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\stl_utils.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -789,6 +789,7 @@
     <ClInclude Include="..\..\Engine\ac\overlay.h" />
     <ClInclude Include="..\..\Engine\ac\parser.h" />
     <ClInclude Include="..\..\Engine\ac\path_helper.h" />
+    <ClInclude Include="..\..\Engine\ac\shader_script.h" />
     <ClInclude Include="..\..\Engine\ac\touch.h" />
     <ClInclude Include="..\..\Engine\ac\properties.h" />
     <ClInclude Include="..\..\Engine\ac\route_finder_impl.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -214,7 +214,7 @@
       <TreatSpecificWarningsAsErrors>4013; 4133; 4311; 4150; 4477; 4715</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Common_d.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Common_d.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;D3DCompiler.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -243,7 +243,7 @@
       <TreatSpecificWarningsAsErrors>4013; 4133; 4311; 4150; 4477; 4715</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Common_d.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Common_d.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;D3DCompiler.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -258,7 +258,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Engine;..\..\Engine\libsrc\apeg-1.2.1;..\..\Engine\libsrc\glad\include;..\..\libsrc\glm;..\..\Plugins;..\..\libsrc\allegro\include;..\..\libsrc\mojoAL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;WIN_XP_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -288,7 +288,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Engine;..\..\Engine\libsrc\apeg-1.2.1;..\..\Engine\libsrc\glad\include;..\..\libsrc\glm;..\..\Plugins;..\..\libsrc\allegro\include;..\..\libsrc\mojoAL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;WIN_XP_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -327,7 +327,7 @@
       <TreatSpecificWarningsAsErrors>4013; 4133; 4311; 4150; 4477; 4715</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Common.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Common.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;D3DCompiler.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -362,7 +362,7 @@
       <TreatSpecificWarningsAsErrors>4013; 4133; 4311; 4150; 4477; 4715</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Common.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Common.lib;SDL2.lib;SDL2main.lib;SDL2_sound-static.lib;d3d9.lib;D3DCompiler.lib;shlwapi.lib;winmm.lib;opengl32.lib;libogg_static.lib;libvorbis_static.lib;libtheora_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -385,7 +385,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Engine;..\..\Engine\libsrc\apeg-1.2.1;..\..\Engine\libsrc\glad\include;..\..\libsrc\glm;..\..\Plugins;..\..\libsrc\allegro\include;..\..\libsrc\mojoAL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;WIN_XP_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -422,7 +422,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Engine;..\..\Engine\libsrc\apeg-1.2.1;..\..\Engine\libsrc\glad\include;..\..\libsrc\glm;..\..\Plugins;..\..\libsrc\allegro\include;..\..\libsrc\mojoAL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;AL_LIBTYPE_STATIC;ALLEGRO_STATICLINK;DISABLE_MPEG_AUDIO;AGS_HAS_CD_AUDIO;WIN_XP_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -498,6 +498,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptjoystick.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptoverlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptpathfinder.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptshader.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptstring.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptsystem.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scripttouchpointer.cpp" />
@@ -543,6 +544,7 @@
     <ClCompile Include="..\..\Engine\ac\properties.cpp" />
     <ClCompile Include="..\..\Engine\ac\route_finder_impl.cpp" />
     <ClCompile Include="..\..\Engine\ac\scriptcontainers.cpp" />
+    <ClCompile Include="..\..\Engine\ac\shader_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\sys_events.cpp" />
     <ClCompile Include="..\..\Engine\ac\region.cpp" />
     <ClCompile Include="..\..\Engine\ac\room.cpp" />
@@ -744,6 +746,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptpathfinder.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptrestoredsaveinfo.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptshader.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptstring.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptsystem.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scripttouchpointer.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1562,6 +1562,9 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptshader.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\shader_script.h">
+      <Filter>Header Files\ac</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\Engine\resource\game-1.ico">

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -774,6 +774,12 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scripttouchpointer.cpp">
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\shader_script.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptshader.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1551,6 +1557,9 @@
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scripttouchpointer.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptshader.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Addresses #2705

### Changes to graphic drivers:

1. Direct3D and OpenGL graphic drivers support creating and registering custom pixel shaders. Currently OpenGL supports creating shaders from GLSL source by compiling them, and Direct3D supports only loading precompiled shader objects created by Microsoft's fxc utility.
2. Shaders are identified by both string name and uint, string is used as a lookup and may be useful for serialization. A uint id is used for a quick reference when rendering.
3. DDB objects in the engine let assign a custom shader id to them.

### Changes to Script API:

Added `ShaderProgram` and `ShaderInstance` structs:
```
builtin managed struct ShaderProgram {
  /// Creates a new ShaderProgram by either loading a precompiled shader, or reading source code and compiling one.
  import static ShaderProgram* CreateFromFile(const string filename); // $AUTOCOMPLETESTATICONLY$
  /// Creates a new shader instance of this shader program.
  import ShaderInstance* CreateInstance();
  /// Gets the default shader instance of this shader program.
  import readonly attribute ShaderInstance* Default;
};

builtin managed struct ShaderInstance {
  /// Sets a shader's constant value as 1 float
  import void SetConstantF(const string name, float value);
  /// Sets a shader's constant value as 2 floats
  import void SetConstantF2(const string name, float x, float y);
  /// Sets a shader's constant value as 3 floats
  import void SetConstantF3(const string name, float x, float y, float z);
  /// Sets a shader's constant value as 4 floats
  import void SetConstantF4(const string name, float x, float y, float z, float w);
  /// Gets this instance's parent Shader
  import readonly attribute ShaderProgram* Shader;
};
```

Here `ShaderProgram` represents a compiled shader itself, and `ShaderInstance` is shader's setup with certain constant values. You may think of ShaderInstance as a kind of a limited "material" type.

Added `ShaderInstance* Shader` attribute to all drawable game objects, Camera, Viewport and Screen (static property).

Basic idea is that you create a ShaderProgram using `CreateFromFile` static method, and then either assign ShaderProgram.Default to objects, or create new ShaderInstances and assign them to objects.
ShaderInstance may be assigned to multiple objects, in which case they all will share same shader setup.

Because not every graphics driver supports shaders, and for general convenience, CreateFromFile always returns a valid ShaderProgram object, but if there was error creating one, then using this "shader" will make renderer fallback to default shader (or no shader in case of software renderer).

ShaderProgram.CreateFromFile supports all locations that File.Open supports (including files packaged into game pak).

ShaderProgram.CreateFromFile accepts following file extensions:
* "glsl" - for OpenGL shader sources
* "hlsl" - for D3D9 shader sources
* "fxo" - for D3D9 compiled shaders

To make things more convenient, user does not have to make a switch in the code: engine does it for them. If you pass "myshader.glsl", and engine is running a Direct3D driver, then it will look for "myshader.fxo" and "myshader.hlsl" instead. You may even skip extension completely.

### Shader def files for Direct3D

Although engine can now compile Direct3D shaders from source code, using D3D_compile library (standard part of DirectX since Windows 7), it cannot know its constants, because Direct3D9 interface lacks the necessary abilities (we'd have to link a deprecated utility library for that, and I doubt that's a good idea).
For that reason, I decided to introduce a separate helper file that may optionally accompany shader file (whether precompiled or source code). The file should be called `"<shadername>.d3ddef"` (extension means "d3d shader definition"). This file is simply an ini format (because we already use ini format for several things), which contains a number of optional entries:

```
[compiler]
target = compilation target ("ps_2_0", and so on)
entry = entry function name (e.g. "main")

[constants]
<constant_name> = register index (a number >= 0)
```

About compiler targets:
https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/specifying-compiler-targets#direct3d-91-92-and-93-feature-levels

If "compiler" options are not present, Direct3D will use defaults.
If "constants" are not present, Direct3D will use default hardcoded register values.

### Built-in shader constants

When writing shaders you are allowed to use a number of constants (or uniforms in GLSL) provided by the engine.
In GLSL these must match the name and type, but their order is not important (they may be not present if not used too).
In HLSL, because engine currently only uses precompiled shaders, and is missing a utility library to get shader info, these constants must match the type and the *register* (but name may be any). This may change in future updates of this draft.

Here's a list of constants:
* float iTime - current time in seconds;
* int iGameFrame - current game frame index (NOTE: must be float in HLSL, because apparently it D3D9-compatible mode does not support integer constants? at least that's what I read somewhere);
* sampler2D iTexture - sprite's texture reference;
* vec2 iTextureDim - texture's dimensions in pixels (type `float2` in HLSL);
* float iAlpha - sprite's general alpha (object's transparency);

Other predefined input parameters:
* vec2 vTexCoord - is predefined for GLSL only, gets current texture coordinate for the pixel. HLSL should use TEXCOORD0 input parameter (see shader examples below).

Example of declaring parameters in GLSL:
```
uniform float iTime;
uniform int iGameFrame;
uniform sampler2D iTexture;
uniform vec2 iTextureDim;
uniform float iAlpha;

varying vec2 vTexCoord;
```

Example of declaring parameters in HLSL (names do not have to match if you precompile, but notice the order of registers!):
```
// Pixel shader input structure
struct PS_INPUT
{
    float2 Texture    : TEXCOORD0;
};

// Pixel shader output structure
struct PS_OUTPUT
{
    float4 Color   : COLOR0;
};

sampler2D iTexture; // is in sampler register 0

const float  iTime:         register( c0 );
const float  iGameFrame:    register( c1 );
const float2 iTextureDim:   register( c2 );
const float  iAlpha:        register( c3 );
```

FXC utility:
https://github.com/user-attachments/files/19633366/fxc.zip
(courtesy of @AlanDrake )

Simple demo project:
https://www.dropbox.com/scl/fi/ifgmbhnmevzlv0jw0z1f6/ags4-shadertest.zip?rlkey=yxvrbna340ftyzzeuef7n787m&st=447hyl5j&dl=0
Example shaders:
[colorwave_shader.zip](https://github.com/user-attachments/files/19714581/colorwave_shader.zip)

It took me some time to learn how to convert GLSL to HLSL, some things are trivial, others require to read through docs and online discussions... Still, there are some mistakes, where HLSL and GLSL variants seem to have an opposite Y offset in  calculations. I was not able to understand where the mistake is yet.

### PLANNED TODO

1. **[DONE]** Support compiling HLSL shaders from source.

For that we'd need to link to `d3dcompiler.lib` and `d3dcompiler_47.dll`.
Related documentation: https://learn.microsoft.com/en-us/windows/win32/api/d3dcompiler/nf-d3dcompiler-d3dcompile

2. **[DONE]** Support custom shader parameters.

This problem is split between script API and passing parameters along with the DDBs into graphic driver.
In #2705 it was suggested that shaders should have a number of predefined user parameters. This may be the easiest way to go if we only support precompiled shaders for Direct3D. If we solve p1 and compile shaders at runtime, then this is still a option to consider.

In regards to the script API, I've been thinking about introducing a separate struct, working title is `ShaderInstance` (may be a subject for change). Such struct would hold a reference to `ShaderProgram` and user parameter values, as well as functions for setting them. And then it will be `ShaderInstance` that is assigned to game objects.

3. **[DONE]** Make a good rule for switching between shader assets. E.g. CreateFromFile may require to pass only filename without extension, and engine would add extension depending on the active gfx driver, and look for that file.

4. Add shaders right in the Editor. Make a "Shaders" node in the project tree, where user may add shader items. Editor will generate ShaderProgram variables in script for these, and these will be initialized automatically on game launch.

5. As you may notice, I added Shader attribute to Viewport struct, so you can have a full-room shader. There's a related issue with this: having a shader applied to room viewport requires viewport or camera to be a texture. Currently this breaks "Render sprites at screen resolution" setting. I believe that it's possible to fix this, but would require certain rewrite in gfx drivers code.

6. **[DONE]** Similarly, we could add "fullscreen" shader. And then it will also require that aforementioned rewrite in order to keep "Render sprites at screen resolution" option working.

7. Optionally, we could support shaders with additional textures attached to them. For example a shader that blends certain preset sprite to a game object. I think that may be possible if `ShaderInstance` would let assign sprite numbers as "texture reference" parameters, and these sprites are converted to textures and used within gfx drivers when such shader is run. That's just a vague idea for now.

8. Switch to using a modern GLSL syntax with explicit input and output parameters in the "main" function.

9. **[DONE]** Serialize shader references in game saves.