### PR TITLE
AGS 4 Editor: Cleanup delegate calls and declarations

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -356,7 +356,7 @@ namespace AGS.Editor
 
             _game = new Game();
             _debugger = new DebugController(_engineComms);
-            _debugger.BreakAtLocation += new DebugController.BreakAtLocationHandler(_debugger_BreakAtLocation);
+            _debugger.BreakAtLocation += _debugger_BreakAtLocation;
 
             _builtInScriptHeader = new Script(BUILT_IN_HEADER_FILE_NAME, Resources.ResourceManager.GetResourceAsString("agsdefns.sh"), true);
             AutoComplete.ConstructCache(_builtInScriptHeader, null);

--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -28,17 +28,17 @@ namespace AGS.Editor
             _nativeProxy = Factory.NativeProxy;
             _pluginEditorController = new AGSEditorController(_componentController, _agsEditor, _guiController);
 
-            _events.GameLoad += new EditorEvents.GameLoadHandler(_events_GameLoad);
-            _events.GamePostLoad += new EditorEvents.GamePostLoadHandler(_events_GamePostLoad);
-            _events.GameSettingsChanged += new EditorEvents.ParameterlessDelegate(_events_GameSettingsChanged);
-            _events.ImportedOldGame += new EditorEvents.ParameterlessDelegate(_events_ImportedOldGame);
-            _events.RefreshAllComponentsFromGame += new EditorEvents.ParameterlessDelegate(_events_RefreshAllComponentsFromGame);
-            _events.SavingGame += new EditorEvents.SavingGameHandler(_events_SavingGame);
-            _events.SavingUserData += new EditorEvents.SavingUserDataHandler(_events_SavingUserData);
-            _events.LoadedUserData += new EditorEvents.LoadedUserDataHandler(_events_LoadedUserData);
-            _agsEditor.PreSaveGame += new AGSEditor.PreSaveGameHandler(_agsEditor_PreSaveGame);
+            _events.GameLoad += _events_GameLoad;
+            _events.GamePostLoad += _events_GamePostLoad;
+            _events.GameSettingsChanged += _events_GameSettingsChanged;
+            _events.ImportedOldGame += _events_ImportedOldGame;
+            _events.RefreshAllComponentsFromGame += _events_RefreshAllComponentsFromGame;
+            _events.SavingGame += _events_SavingGame;
+            _events.SavingUserData += _events_SavingUserData;
+            _events.LoadedUserData += _events_LoadedUserData;
+            _agsEditor.PreSaveGame += _agsEditor_PreSaveGame;
 
-            _guiController.OnEditorShutdown += new GUIController.EditorShutdownHandler(GUIController_OnEditorShutdown);
+            _guiController.OnEditorShutdown += GUIController_OnEditorShutdown;
             _guiController.Initialize(_agsEditor);
             _agsEditor.DoEditorInitialization();
             CreateComponents();

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -62,7 +62,7 @@ namespace AGS.Editor.Components
             _iconMappings.Add(AudioClipFileType.MIDI, "AGSAudioClipIconMidi");
             _iconMappings.Add(AudioClipFileType.MOD, "AGSAudioClipIconMod");
 
-            _agsEditor.PreCompileGame += new AGSEditor.PreCompileGameHandler(_agsEditor_PreCompileGame);
+            _agsEditor.PreCompileGame += _agsEditor_PreCompileGame;
 
             RecreateDocument();
             _guiController.RegisterIcon("AGSAudioClipsIcon", Resources.ResourceManager.GetIcon("audio.ico"));
@@ -76,7 +76,7 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon("AGSAudioSpeechIcon", Resources.ResourceManager.GetIcon("audio_speech.ico"));
             _guiController.RegisterIcon(AUDIO_CLIP_TYPE_ICON, Resources.ResourceManager.GetIcon("tree_audio_generic.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Audio", "AGSAudioClipsIcon");
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
             RePopulateTreeView();
         }
 

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -31,10 +31,10 @@ namespace AGS.Editor.Components
         public BuildCommandsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            ScriptEditor.AttemptToEditScript += new ScriptEditor.AttemptToEditScriptHandler(ScriptEditor_AttemptToEditScript);
-            _guiController.QueryEditorShutdown += new GUIController.QueryEditorShutdownHandler(guiController_QueryEditorShutdown);
-            _guiController.InteractiveTasks.TestGameStarting += new InteractiveTasks.TestGameStartingHandler(AGSEditor_TestGameStarting);
-            _guiController.InteractiveTasks.TestGameFinished += new InteractiveTasks.TestGameFinishedHandler(AGSEditor_TestGameFinished);
+            ScriptEditor.AttemptToEditScript += ScriptEditor_AttemptToEditScript;
+            _guiController.QueryEditorShutdown += guiController_QueryEditorShutdown;
+            _guiController.InteractiveTasks.TestGameStarting += AGSEditor_TestGameStarting;
+            _guiController.InteractiveTasks.TestGameFinished += AGSEditor_TestGameFinished;
             _guiController.RegisterIcon("BuildIcon", Resources.ResourceManager.GetIcon("build.ico"));
             _guiController.RegisterIcon("RunIcon", Resources.ResourceManager.GetIcon("run.ico"));
             _guiController.RegisterIcon("StepIcon", Resources.ResourceManager.GetIcon("step.ico"));
@@ -86,8 +86,8 @@ namespace AGS.Editor.Components
             Factory.ToolBarManager.AddGlobalItems(this, _debugToolbarCommands);
             Factory.ToolBarManager.UpdateItemEnabledStates(_debugToolbarCommands);
 
-            _agsEditor.Debugger.DebugStateChanged += new DebugController.DebugStateChangedHandler(Debugger_DebugStateChanged);
-            _agsEditor.AttemptToSaveGame += new AGSEditor.AttemptToSaveGameHandler(_agsEditor_AttemptToSaveGame);
+            _agsEditor.Debugger.DebugStateChanged += Debugger_DebugStateChanged;
+            _agsEditor.AttemptToSaveGame += _agsEditor_AttemptToSaveGame;
         }
 
         private void ScriptEditor_AttemptToEditScript(ref bool allowEdit)

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -28,8 +28,8 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("dialog.ico"));
             _guiController.RegisterIcon("DialogIcon", Resources.ResourceManager.GetIcon("dialog-item.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Dialogs", ICON_KEY);
-			_guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
+			_guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
 			RePopulateTreeView();
         }
 

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -30,8 +30,8 @@ namespace AGS.Editor.Components
         public FileCommandsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _guiController.InteractiveTasks.TestGameStarting += new InteractiveTasks.TestGameStartingHandler(AGSEditor_TestGameStarting);
-            _guiController.InteractiveTasks.TestGameFinished += new InteractiveTasks.TestGameFinishedHandler(AGSEditor_TestGameFinished);
+            _guiController.InteractiveTasks.TestGameStarting += AGSEditor_TestGameStarting;
+            _guiController.InteractiveTasks.TestGameFinished += AGSEditor_TestGameFinished;
 
             _guiController.RegisterIcon("OpenIcon", Resources.ResourceManager.GetIcon("open.ico"));
             _guiController.RegisterIcon("SaveIcon", Resources.ResourceManager.GetIcon("save.ico"));

--- a/Editor/AGS.Editor/Components/GlobalVariablesComponent.cs
+++ b/Editor/AGS.Editor/Components/GlobalVariablesComponent.cs
@@ -28,9 +28,9 @@ namespace AGS.Editor.Components
             _scriptModule = new Script(GLOBAL_VARS_SCRIPT_FILE_NAME, string.Empty, false);
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("globalvars.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Global variables", ICON_KEY);
-            _editor.GlobalVariableChanged += new GlobalVariablesEditor.GlobalVariableChangedHandler(_editor_GlobalVariableChanged);
-            _agsEditor.GetScriptHeaderList += new GetScriptHeaderListHandler(_agsEditor_GetScriptHeaderList);
-            _agsEditor.GetScriptModuleList += new GetScriptModuleListHandler(_agsEditor_GetScriptModuleList);
+            _editor.GlobalVariableChanged += _editor_GlobalVariableChanged;
+            _agsEditor.GetScriptHeaderList += _agsEditor_GetScriptHeaderList;
+            _agsEditor.GetScriptModuleList += _agsEditor_GetScriptModuleList;
         }
 
         public void SelectGlobalVariable(string variableName)

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -193,8 +193,8 @@ namespace AGS.Editor.Components
 			{
 				List<MenuCommand> toolbarIcons = CreateToolbarIcons();
 				GUIEditor editor = new GUIEditor(chosenGui, toolbarIcons);
-				editor.OnControlsChanged += new GUIEditor.ControlsChanged(_guiEditor_OnControlsChanged);
-				editor.OnGuiNameChanged += new GUIEditor.GuiNameChanged(_guiEditor_OnGuiNameChanged);
+				editor.OnControlsChanged += _guiEditor_OnControlsChanged;
+				editor.OnGuiNameChanged += _guiEditor_OnGuiNameChanged;
                 document = new ContentDocument(editor, chosenGui.WindowTitle,
                     this, ICON_KEY, GUIEditor.ConstructPropertyObjectList(chosenGui));
                 _documents[chosenGui] = document;

--- a/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
@@ -67,7 +67,7 @@ namespace AGS.Editor.Components
 
             _guiController.AddMenu(this, GUIController.HELP_MENU_ID, "&Help");
 
-            _guiController.OnLaunchHelp += new GUIController.LaunchHelpHandler(_guiController_OnLaunchHelp);
+            _guiController.OnLaunchHelp += _guiController_OnLaunchHelp;
 
             MenuCommands commands = new MenuCommands(GUIController.HELP_MENU_ID, null);
             commands.Commands.Add(new MenuCommand(LAUNCH_HELP_COMMAND, "&Dynamic Help", Keys.F1, "MenuIconDynamicHelp"));

--- a/Editor/AGS.Editor/Components/PluginsComponent.cs
+++ b/Editor/AGS.Editor/Components/PluginsComponent.cs
@@ -45,10 +45,10 @@ namespace AGS.Editor.Components
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Plugins", "PluginIcon");
             RepopulateTreeView();
 
-            _agsEditor.GetScriptHeaderList += new GetScriptHeaderListHandler(AGSEditor_GetScriptHeaderList);
-            _agsEditor.Tasks.GetFilesForInclusionInTemplate += new Tasks.GetFilesForInclusionInTemplateHandler(AGSEditor_GetFilesForInclusionInTemplate);
-            _agsEditor.Tasks.NewGameFilesExtracted += new Tasks.NewGameFilesExtractedHandler(AGSEditor_NewGameFilesExtracted);
-			Factory.Events.GetAboutDialogText += new EditorEvents.GetAboutDialogTextHandler(Events_GetAboutDialogText);
+            _agsEditor.GetScriptHeaderList += AGSEditor_GetScriptHeaderList;
+            _agsEditor.Tasks.GetFilesForInclusionInTemplate += AGSEditor_GetFilesForInclusionInTemplate;
+            _agsEditor.Tasks.NewGameFilesExtracted += AGSEditor_NewGameFilesExtracted;
+			Factory.Events.GetAboutDialogText += Events_GetAboutDialogText;
         }
 
 		private void Events_GetAboutDialogText(GetAboutDialogTextEventArgs evArgs)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -94,16 +94,16 @@ namespace AGS.Editor.Components
 
 			_nativeProxy = Factory.NativeProxy;
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Rooms", "RoomsIcon");
-            _guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScript += new GUIController.GetScriptHandler(GUIController_OnGetScript);
-            _guiController.OnScriptChanged += new GUIController.ScriptChangedHandler(GUIController_OnScriptChanged);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
-            _agsEditor.PreCompileGame += new AGSEditor.PreCompileGameHandler(AGSEditor_PreCompileGame);
-            _agsEditor.PreSaveGame += new AGSEditor.PreSaveGameHandler(AGSEditor_PreSaveGame);
-            _agsEditor.ProcessAllGameTexts += new AGSEditor.ProcessAllGameTextsHandler(AGSEditor_ProcessAllGameTexts);
-			_agsEditor.PreDeleteSprite += new AGSEditor.PreDeleteSpriteHandler(AGSEditor_PreDeleteSprite);
+            _guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScript += GUIController_OnGetScript;
+            _guiController.OnScriptChanged += GUIController_OnScriptChanged;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
+            _agsEditor.PreCompileGame += AGSEditor_PreCompileGame;
+            _agsEditor.PreSaveGame += AGSEditor_PreSaveGame;
+            _agsEditor.ProcessAllGameTexts += AGSEditor_ProcessAllGameTexts;
+			_agsEditor.PreDeleteSprite += AGSEditor_PreDeleteSprite;
             Factory.Events.GamePostLoad += ConvertAllRoomsFromCrmToOpenFormat;
-            _modifiedChangedHandler = new Room.RoomModifiedChangedHandler(_loadedRoom_RoomModifiedChanged);
+            _modifiedChangedHandler = _loadedRoom_RoomModifiedChanged;
             RePopulateTreeView();
         }
 
@@ -886,7 +886,7 @@ namespace AGS.Editor.Components
         {
             ScriptEditor scriptEditor = new ScriptEditor(selectedRoom.Script, _agsEditor, null);
             scriptEditor.RoomNumber = selectedRoom.Number;
-            scriptEditor.IsModifiedChanged += new EventHandler(ScriptEditor_IsModifiedChanged);
+            scriptEditor.IsModifiedChanged += ScriptEditor_IsModifiedChanged;
             if (scriptEditor.DockingContainer == null)
             {
                 scriptEditor.DockingContainer = new DockingContainer(scriptEditor);
@@ -1157,8 +1157,8 @@ namespace AGS.Editor.Components
                 _roomSettings.PreferredDockData = previousDockData;
             }
             _roomSettings.SelectedPropertyGridObject = _loadedRoom;
-            editor.SaveRoom += new RoomSettingsEditor.SaveRoomHandler(RoomEditor_SaveRoom);
-            editor.AbandonChanges += new RoomSettingsEditor.AbandonChangesHandler(RoomsComponent_AbandonChanges);
+            editor.SaveRoom += RoomEditor_SaveRoom;
+            editor.AbandonChanges += RoomsComponent_AbandonChanges;
             RoomDesignData.LoadFromUserFile(_loadedRoom, editor);
             editor.RefreshLayersTree();
             // Reset the Modified flag in case initialization triggered some events

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -69,11 +69,11 @@ namespace AGS.Editor.Components
 
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Scripts", "ScriptsIcon");
             RePopulateTreeView(null);
-            _guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScript += new GUIController.GetScriptHandler(GUIController_OnGetScript);
-            _guiController.OnScriptChanged += new GUIController.ScriptChangedHandler(GUIController_OnScriptChanged);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+            _guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScript += GUIController_OnGetScript;
+            _guiController.OnScriptChanged += GUIController_OnScriptChanged;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
 
             Factory.Events.GamePostLoad += Events_GamePostLoad;
         }
@@ -562,7 +562,7 @@ namespace AGS.Editor.Components
             chosenItem.LoadFromDisk();
             ScriptEditor newEditor = new ScriptEditor(chosenItem, _agsEditor, ShowMatchingScriptOrHeader);
             newEditor.DockingContainer = new DockingContainer(newEditor);
-            newEditor.IsModifiedChanged += new EventHandler(ScriptEditor_IsModifiedChanged);
+            newEditor.IsModifiedChanged += ScriptEditor_IsModifiedChanged;
             _editors[chosenItem] = new ContentDocument(newEditor, chosenItem.FileName, this, ICON_KEY, null);
             _editors[chosenItem].PanelClosed += _panelClosedHandler;
             _editors[chosenItem].ToolbarCommands = newEditor.ToolbarIcons;

--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -35,8 +35,8 @@ namespace AGS.Editor.Components
         public SpeechComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _agsEditor.ExtraCompilationStep += new AGSEditor.ExtraCompilationStepHandler(_agsEditor_ExtraCompilationStep);
-            _agsEditor.ExtraOutputCreationStep += new AGSEditor.ExtraOutputCreationStepHandler(_agsEditor_ExtraOutputCreationStep);
+            _agsEditor.ExtraCompilationStep += _agsEditor_ExtraCompilationStep;
+            _agsEditor.ExtraOutputCreationStep += _agsEditor_ExtraOutputCreationStep;
         }
 
         private void _agsEditor_ExtraCompilationStep(CompilationStepArgs args)

--- a/Editor/AGS.Editor/Components/SpriteManagerComponent.cs
+++ b/Editor/AGS.Editor/Components/SpriteManagerComponent.cs
@@ -22,8 +22,8 @@ namespace AGS.Editor.Components
             Init();
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("iconspr.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Sprites", ICON_KEY);
-            Factory.Events.ShowSpriteManager += new EditorEvents.ShowSpriteManagerHandler(Events_ShowSpriteManager);
-            Factory.Events.SpritesImported += new EditorEvents.SpriteImportHandler(Events_OnSpritesImported);
+            Factory.Events.ShowSpriteManager += Events_ShowSpriteManager;
+            Factory.Events.SpritesImported += Events_OnSpritesImported;
             RefreshDataFromGame();
         }
 

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -41,10 +41,10 @@ namespace AGS.Editor.Components
         public TranslationsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
-            _agsEditor.PreCompileGame += new AGSEditor.PreCompileGameHandler(AGSEditor_PreCompileGame);
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
+            _agsEditor.PreCompileGame += AGSEditor_PreCompileGame;
             _timer.Interval = 20;
-            _timer.Tick += new EventHandler(_timer_Tick);
+            _timer.Tick += _timer_Tick;
 
             //_documents = new Dictionary<AGS.Types.Font, ContentDocument>();
             _guiController.RegisterIcon("TranslationsIcon", Resources.ResourceManager.GetIcon("translations.ico"));

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -20,18 +20,16 @@ namespace AGS.Editor.Components
         private const string ICON_KEY = "ViewsIcon";
         
         private Dictionary<View, ContentDocument> _documents;
-        private Game.ViewListUpdatedHandler _viewsUpdatedHandler;
         private Game _eventHookedToGame = null;
 
         public ViewsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor, "ViewEditor")
         {
             _documents = new Dictionary<View, ContentDocument>();
-            _viewsUpdatedHandler = new Game.ViewListUpdatedHandler(CurrentGame_ViewListUpdated);
             _guiController.RegisterIcon(ICON_KEY, ResourceManager.GetIcon("view.ico"));
             _guiController.RegisterIcon("ViewIcon", ResourceManager.GetIcon("view-item.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Views", ICON_KEY);
-			_guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+			_guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
 			RefreshDataFromGame();
         }
 
@@ -234,7 +232,7 @@ namespace AGS.Editor.Components
         {
             if (_eventHookedToGame != null)
             {
-                _eventHookedToGame.ViewListUpdated -= _viewsUpdatedHandler;
+                _eventHookedToGame.ViewListUpdated -= CurrentGame_ViewListUpdated;
             }
 
             foreach (ContentDocument doc in _documents.Values)
@@ -247,7 +245,7 @@ namespace AGS.Editor.Components
             RePopulateTreeView();
 
             _eventHookedToGame = _agsEditor.CurrentGame;
-            _eventHookedToGame.ViewListUpdated += _viewsUpdatedHandler;
+            _eventHookedToGame.ViewListUpdated += CurrentGame_ViewListUpdated;
         }
 
         private void CurrentGame_ViewListUpdated()

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -839,7 +839,7 @@ namespace AGS.Editor
 
             public void PopulateViews(IViewFolder folder, Game game)
             {
-                FolderHelper.ForEachViewFolder(folder, game, new FolderHelper.ViewFolderProcessing(PopulateViews));
+                FolderHelper.ForEachViewFolder(folder, game, PopulateViews);
                 foreach (View view in folder.Views)
                 {
                     views[view.ID - 1] = view;

--- a/Editor/AGS.Editor/Debugger/DebugController.cs
+++ b/Editor/AGS.Editor/Debugger/DebugController.cs
@@ -46,7 +46,7 @@ namespace AGS.Editor
         public DebugController(IEngineCommunication communicator)
         {
             _communicator = communicator;
-            _communicator.MessageReceived += new MessageReceivedHandler(_communicator_MessageReceived);
+            _communicator.MessageReceived += _communicator_MessageReceived;
         }
 
 		public bool CanUseDebugger

--- a/Editor/AGS.Editor/Debugger/FileBasedEngineCommunication.cs
+++ b/Editor/AGS.Editor/Debugger/FileBasedEngineCommunication.cs
@@ -51,7 +51,7 @@ namespace AGS.Editor
 
             string path = Path.Combine(Directory.GetCurrentDirectory(), DIRECTORY_FOR_FILES);
             _watcher = new FileSystemWatcher(path, RECIEVE_MESSAGE_FILE);
-            _watcher.Changed += new FileSystemEventHandler(_watcher_Changed);
+            _watcher.Changed += _watcher_Changed;
             _watcher.NotifyFilter = NotifyFilters.LastWrite;
             _watcher.EnableRaisingEvents = true;
         }

--- a/Editor/AGS.Editor/Debugger/NamedPipesEngineCommunication.cs
+++ b/Editor/AGS.Editor/Debugger/NamedPipesEngineCommunication.cs
@@ -26,7 +26,7 @@ namespace AGS.Editor
             _instanceIdentifier = System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
             _readServer = new NamedPipesServer(@"\\.\pipe\AGSEditorDebuggerGameToEd" + _instanceIdentifier.ToString(), NamedPipeType.Read);
             _writeServer = new NamedPipesServer(@"\\.\pipe\AGSEditorDebuggerEdToGame" + _instanceIdentifier.ToString(), NamedPipeType.Write);
-            _readServer.MessageReceived += new NamedPipesServer.MessageReceivedHandler(_server_MessageReceived);
+            _readServer.MessageReceived += _server_MessageReceived;
             _readServer.Start();
             _writeServer.Start();
 

--- a/Editor/AGS.Editor/Entities/LogBuffer.cs
+++ b/Editor/AGS.Editor/Entities/LogBuffer.cs
@@ -185,7 +185,7 @@ namespace AGS.Editor
                 _debounceTimer = null;
             }
             _debounceTimer = new System.Timers.Timer(10);
-            _debounceTimer.Elapsed += new System.Timers.ElapsedEventHandler(elapse); // subscribing to the elapse event
+            _debounceTimer.Elapsed += elapse; // subscribing to the elapse event
             _debounceTimer.Start();
         }
 

--- a/Editor/AGS.Editor/GUI/BusyDialog.cs
+++ b/Editor/AGS.Editor/GUI/BusyDialog.cs
@@ -163,7 +163,7 @@ namespace AGS.Editor
         {
             _timer = new System.Windows.Forms.Timer();
             _timer.Interval = TIMER_INTERVAL_MS;
-            _timer.Tick += new EventHandler(_timer_Tick);
+            _timer.Tick += _timer_Tick;
             _timer.Start();
             _threadFinished = false;
             _exceptionThrownOnThread = null;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -979,19 +979,19 @@ namespace AGS.Editor
                 _mainForm = new frmMain();
                 SetEditorWindowSize();
                 _treeManager = new ProjectTree(_mainForm.projectPanel.projectTree);
-                _treeManager.OnContextMenuClick += new ProjectTree.MenuClickHandler(_mainForm_OnMenuClick);
+                _treeManager.OnContextMenuClick += _mainForm_OnMenuClick;
                 _toolBarManager = new ToolBarManager(_mainForm.toolStrip);
                 _windowsMenuManager = new WindowsMenuManager(_mainForm.windowsToolStripMenuItem, 
                     _mainForm.DockPanes, _mainForm.mainContainer, _mainForm.GetLayoutManager());
                 _menuManager = new MainMenuManager(_mainForm.mainMenu, _windowsMenuManager);
-                _mainForm.OnEditorShutdown += new frmMain.EditorShutdownHandler(_mainForm_OnEditorShutdown);
-                _mainForm.OnPropertyChanged += new frmMain.PropertyChangedHandler(_mainForm_OnPropertyChanged);
-                _mainForm.OnPropertyObjectChanged += new frmMain.PropertyObjectChangedHandler(_mainForm_OnPropertyObjectChanged);
-                _mainForm.OnActiveDocumentChanged += new frmMain.ActiveDocumentChangedHandler(_mainForm_OnActiveDocumentChanged);
-                _mainForm.OnMainWindowActivated += new EventHandler(_mainForm_OnMainWindowActivated);
-                _menuManager.OnMenuClick += new MainMenuManager.MenuClickHandler(_mainForm_OnMenuClick);
-                AutoComplete.BackgroundCacheUpdateStatusChanged += new AutoComplete.BackgroundCacheUpdateStatusChangedHandler(AutoComplete_BackgroundCacheUpdateStatusChanged);
-				SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanging);
+                _mainForm.OnEditorShutdown += _mainForm_OnEditorShutdown;
+                _mainForm.OnPropertyChanged += _mainForm_OnPropertyChanged;
+                _mainForm.OnPropertyObjectChanged += _mainForm_OnPropertyObjectChanged;
+                _mainForm.OnActiveDocumentChanged += _mainForm_OnActiveDocumentChanged;
+                _mainForm.OnMainWindowActivated += _mainForm_OnMainWindowActivated;
+                _menuManager.OnMenuClick += _mainForm_OnMenuClick;
+                AutoComplete.BackgroundCacheUpdateStatusChanged += AutoComplete_BackgroundCacheUpdateStatusChanged;
+				SystemEvents.DisplaySettingsChanged += SystemEvents_DisplaySettingsChanging;
 
                 RegisterIcon("SpriteIcon", Resources.ResourceManager.GetIcon("iconspr.ico"));
                 RegisterIcon("BuildIcon", Resources.ResourceManager.GetIcon("menu_build_rebuild-files.ico"));
@@ -1003,16 +1003,16 @@ namespace AGS.Editor
                 _mainForm.mainMenu.ImageList = _imageList;
 				_mainForm.pnlOutput.SetImageList(_imageList);
 
-                ViewUIEditor.ViewSelectionGUI = new ViewUIEditor.ViewSelectionGUIType(ShowViewChooserFromPropertyGrid);
-                SpriteSelectUIEditor.SpriteSelectionGUI = new SpriteSelectUIEditor.SpriteSelectionGUIType(ShowSpriteChooserFromPropertyGrid);
-                CustomPropertiesUIEditor.CustomPropertiesGUI = new CustomPropertiesUIEditor.CustomPropertiesGUIType(ShowPropertiesEditorFromPropertyGrid);
-                PropertyTabInteractions.UpdateEventName = new PropertyTabInteractions.UpdateEventNameHandler(PropertyTabInteractions_UpdateEventName);
-                ScriptFunctionUIEditor.OpenScriptFunction = new ScriptFunctionUIEditor.OpenScriptFunctionHandler(ScriptFunctionUIEditor_OpenScriptFunction);
-                ScriptFunctionUIEditor.CreateScriptFunction = new ScriptFunctionUIEditor.CreateScriptFunctionHandler(ScriptFunctionUIEditor_CreateScriptFunction);
-                CustomResolutionUIEditor.CustomResolutionSetGUI = new CustomResolutionUIEditor.CustomResolutionGUIType(ShowCustomResolutionChooserFromPropertyGrid);
-                ColorUIEditor.ColorGUI = new ColorUIEditor.ColorGUIType(ShowColorDialog);
-                MultiLineStringUIEditor.MultilineStringGUI = new MultiLineStringUIEditor.MultilineStringGUIType(ShowMultilineStringDialog);
-                AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = new AudioClipSourceFileUIEditor.AudioClipSourceFileGUIType(ShowAudioClipSourceFileChooserFromPropertyGrid);
+                ViewUIEditor.ViewSelectionGUI = ShowViewChooserFromPropertyGrid;
+                SpriteSelectUIEditor.SpriteSelectionGUI = ShowSpriteChooserFromPropertyGrid;
+                CustomPropertiesUIEditor.CustomPropertiesGUI = ShowPropertiesEditorFromPropertyGrid;
+                PropertyTabInteractions.UpdateEventName = PropertyTabInteractions_UpdateEventName;
+                ScriptFunctionUIEditor.OpenScriptFunction = ScriptFunctionUIEditor_OpenScriptFunction;
+                ScriptFunctionUIEditor.CreateScriptFunction = ScriptFunctionUIEditor_CreateScriptFunction;
+                CustomResolutionUIEditor.CustomResolutionSetGUI = ShowCustomResolutionChooserFromPropertyGrid;
+                ColorUIEditor.ColorGUI = ShowColorDialog;
+                MultiLineStringUIEditor.MultilineStringGUI = ShowMultilineStringDialog;
+                AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = ShowAudioClipSourceFileChooserFromPropertyGrid;
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GotoLineDialog.cs
+++ b/Editor/AGS.Editor/GUI/GotoLineDialog.cs
@@ -16,11 +16,9 @@ namespace AGS.Editor
             (this.upDownLineNumber.Controls[1] as TextBox).Enter += upDownLineNumber_Controls1_Enter;
         }
 
-        private delegate void Action();
-
         private void upDownLineNumber_Controls1_Enter(object sender, EventArgs e)
         {
-            BeginInvoke((Action)(() =>
+            BeginInvoke(new Action(() =>
             {
                 (this.upDownLineNumber.Controls[1] as TextBox).SelectAll();
             }));

--- a/Editor/AGS.Editor/GUI/ProjectTree.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTree.cs
@@ -33,16 +33,16 @@ namespace AGS.Editor
             _projectTree = projectTree;
             _treeNodes = new Dictionary<string, IEditorComponent>();
 
-            _projectTree.MouseClick += new System.Windows.Forms.MouseEventHandler(this.projectTree_MouseClick);
-            _projectTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.projectTree_NodeMouseDoubleClick);
-            _projectTree.DoubleClick += new System.EventHandler(this.projectTree_DoubleClick);
-            _projectTree.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.projectTree_AfterLabelEdit);
-            _projectTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.projectTree_AfterSelect);
-            _projectTree.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.projectTree_KeyPress);
-            _projectTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.projectTree_KeyDown);
-            _projectTree.BeforeLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.projectTree_BeforeLabelEdit);
-			_projectTree.BeforeExpand += new TreeViewCancelEventHandler(_projectTree_BeforeExpand);
-			_projectTree.BeforeCollapse += new TreeViewCancelEventHandler(_projectTree_BeforeCollapse);
+            _projectTree.MouseClick += projectTree_MouseClick;
+            _projectTree.NodeMouseDoubleClick += projectTree_NodeMouseDoubleClick;
+            _projectTree.DoubleClick += projectTree_DoubleClick;
+            _projectTree.AfterLabelEdit += projectTree_AfterLabelEdit;
+            _projectTree.AfterSelect += projectTree_AfterSelect;
+            _projectTree.KeyPress += projectTree_KeyPress;
+            _projectTree.KeyDown += projectTree_KeyDown;
+            _projectTree.BeforeLabelEdit += projectTree_BeforeLabelEdit;
+			_projectTree.BeforeExpand += _projectTree_BeforeExpand;
+			_projectTree.BeforeCollapse += _projectTree_BeforeCollapse;
 			_projectTree.ItemTryDrag += projectTree_ItemTryDrag;
             _projectTree.ItemDragOver += _projectTree_ItemDragOver;
             _projectTree.ItemDragDrop += _projectTree_ItemDragDrop;

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -45,9 +45,9 @@ namespace AGS.Editor
             _activeDocumentChanging = new TabbedDocumentManager.ActiveDocumentChangeHandler(tabbedDocumentContainer1_ActiveDocumentChanging);
             tabbedDocumentContainer1.ActiveDocumentChanged += _activeDocumentChanged;
             tabbedDocumentContainer1.ActiveDocumentChanging += _activeDocumentChanging;
-			this.Load += new EventHandler(frmMain_Load);
-            this.Activated += new EventHandler(frmMain_Activated);
-            this.Deactivate += new EventHandler(frmMain_Deactivated);
+			this.Load += frmMain_Load;
+            this.Activated += frmMain_Activated;
+            this.Deactivate += frmMain_Deactivated;
         }
 
         private List<DockContent> GetStartupPanes()

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -12,10 +12,8 @@ namespace AGS.Editor
         private const int ENGINE_EXIT_CODE_ERROR  = 93;
 
         private delegate void TestGameFinishedDelegate(int exitCode);
-        public delegate void TestGameFinishedHandler();
-        public event TestGameFinishedHandler TestGameFinished;
-        public delegate void TestGameStartingHandler();
-        public event TestGameStartingHandler TestGameStarting;
+        public event Action TestGameFinished;
+        public event Action TestGameStarting;
 
         private Control _mainGUIThread;
         private bool _currentlyTesting = false;
@@ -24,7 +22,7 @@ namespace AGS.Editor
         public InteractiveTasks(Tasks tasks)
         {
             _tasks = tasks;
-            _tasks.TestGameFinished += new Tasks.TestGameFinishedHandler(Tasks_TestGameFinished);
+            _tasks.TestGameFinished += Tasks_TestGameFinished;
         }
 
         public static void ReportTaskException(string errorMsg, Exception ex)

--- a/Editor/AGS.Editor/Panes/AudioEditor.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.cs
@@ -12,8 +12,6 @@ namespace AGS.Editor
 {
     public partial class AudioEditor : EditorContentPanel
     {
-        private delegate void NoParametersDelegate();
-
         private object _selectedItem = null;
         private IAudioPreviewer _previewer = null;
         private bool _paused = false;
@@ -98,7 +96,7 @@ namespace AGS.Editor
 
                 if (_previewer != null)
                 {
-                    _previewer.PlayFinished += new PlayFinishedHandler(_previewer_PlayFinished);
+                    _previewer.PlayFinished += _previewer_PlayFinished;
                     btnPlay.Enabled = true;
                     grpAudioClip.Visible = true;
 
@@ -126,7 +124,7 @@ namespace AGS.Editor
                 _paused = false;
                 _timer = new Timer();
                 _timer.Interval = 900;
-                _timer.Tick += new EventHandler(_timer_Tick);
+                _timer.Tick += _timer_Tick;
                 _timer.Start();
                 _previewer.Play();
                 btnPlay.Enabled = false;
@@ -157,7 +155,7 @@ namespace AGS.Editor
 
         private void _timer_Tick(object sender, EventArgs e)
         {
-            this.Invoke(new NoParametersDelegate(PollPreviewer));
+            this.Invoke(new Action(PollPreviewer));
         }
 
         protected override void OnPanelClosing(bool canCancel, ref bool cancelClose)
@@ -189,7 +187,7 @@ namespace AGS.Editor
 
         private void _previewer_PlayFinished(AudioClip clip)
         {
-            btnPlay.Invoke(new NoParametersDelegate(ResetControlsForSoundFinished));
+            btnPlay.Invoke(new Action(ResetControlsForSoundFinished));
         }
 
         private void btnPause_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/DefaultSetupPane.cs
+++ b/Editor/AGS.Editor/Panes/DefaultSetupPane.cs
@@ -32,7 +32,7 @@ namespace AGS.Editor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
             this.Name = "DefaultRuntimeSetupPane";
-            this.Load += new System.EventHandler(this.DefaultRuntimeSetupPane_Load);
+            this.Load += DefaultRuntimeSetupPane_Load;
             this.ResumeLayout(false);
         }
 

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -19,7 +19,7 @@ namespace AGS.Editor
         {
             InitializeComponent();
             Init(dialogToEdit);
-            this.Load += new EventHandler(DialogEditor_Load);
+            this.Load += DialogEditor_Load;
         }
 
         private void Init(Dialog dialog)

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -54,10 +54,10 @@ namespace AGS.Editor
             sldZoomLevel.Maximum = ZOOM_MAX_VALUE / ZOOM_STEP_VALUE;
             sldZoomLevel.Value = 100 / ZOOM_STEP_VALUE;
             
-            PreviewKeyDown += new PreviewKeyDownEventHandler(GUIEditor_PreviewKeyDown);
-            MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
-            bgPanel.MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
-            sldZoomLevel.MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
+            PreviewKeyDown += GUIEditor_PreviewKeyDown;
+            MouseWheel += GUIEditor_MouseWheel;
+            bgPanel.MouseWheel += GUIEditor_MouseWheel;
+            sldZoomLevel.MouseWheel += GUIEditor_MouseWheel;
             
             _drawSnapPen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
 
@@ -107,7 +107,7 @@ namespace AGS.Editor
         public GUIEditor()
         {
             InitializeComponent();
-            Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
         }
 
 
@@ -1224,7 +1224,7 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
         private bool DoesThisPanelHaveFocus()

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -138,7 +138,7 @@ namespace AGS.Editor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
             this.Name = "GeneralSettingsPane";
-            this.Load += new System.EventHandler(this.GeneralSettingsPane_Load);
+            this.Load += GeneralSettingsPane_Load;
             this.ResumeLayout(false);
         }
 

--- a/Editor/AGS.Editor/Panes/LipSyncEditor.cs
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.cs
@@ -56,7 +56,7 @@ namespace AGS.Editor
                 textBox.Size = new Size(textBoxWidth, rowHeight);
                 textBox.Tag = i;
                 textBox.Text = _lipSync.CharactersPerFrame[i];
-                textBox.TextChanged += new EventHandler(textBox_TextChanged);
+                textBox.TextChanged += textBox_TextChanged;
 
                 int row = i;
                 int column = 0;

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -26,7 +26,7 @@ namespace AGS.Editor
         {
             InitializeComponent();
             _colourFinder = tabControl.TabPages[1];
-            Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _selectedIndexes.Add(0);
             GameChanged();
         }
@@ -358,7 +358,7 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
 		private void btnColorDialog_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -36,7 +36,6 @@ namespace AGS.Editor
 			Pens.LightGreen, Pens.Cyan, Pens.Red, Pens.Pink,
 			Pens.Yellow, Pens.White};
 
-        private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         protected readonly Room _room;
         protected Panel _panel;
         RoomSettingsEditor _editor;
@@ -96,7 +95,6 @@ namespace AGS.Editor
             _roomController = roomController;
             _panel = displayPanel;
             _editor = editor;
-            _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
             UpdateUndoButtonEnabledState();
             RoomItemRefs = new SortedDictionary<string, int>();
             DesignItems = new SortedDictionary<string, DesignTimeProperties>();
@@ -607,7 +605,7 @@ namespace AGS.Editor
                 DeselectArea();
             }
             SelectedAreaChanged(_selectedArea);
-            Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
 
             FilterActivated();
             _isOn = true;
@@ -622,7 +620,7 @@ namespace AGS.Editor
 
             _drawMode = _baseDrawMode;
             _mouseDown = false;
-            Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
             _editor.ContentDocument.ToolbarCommands = null;
             Factory.ToolBarManager.RefreshCurrentPane();
             _isOn = false;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
@@ -19,7 +19,6 @@ namespace AGS.Editor
         protected Room _room;
         protected Panel _panel;
         protected RoomSettingsEditor _editor;
-        private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         protected TThing _selectedObject = null;
         protected TThing _lastSelectedObject = null;
         // Object moving handling
@@ -37,7 +36,6 @@ namespace AGS.Editor
             _room = room;
             _panel = displayPanel;
             _editor = editor;
-            _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
 
             RoomItemRefs = new SortedDictionary<string, TThing>();
             DesignItems = new SortedDictionary<string, DesignTimeProperties>();
@@ -121,7 +119,7 @@ namespace AGS.Editor
         public void FilterOn()
         {
             SetPropertyGridList();
-            Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _isOn = true;
             ClearMovingState();
             FilterActivated();
@@ -129,7 +127,7 @@ namespace AGS.Editor
 
         public void FilterOff()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
             _isOn = false;
             ClearMovingState();
             FilterDeactivated();

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -132,10 +132,10 @@ namespace AGS.Editor
             // TODO: choose default zoom based on the room size vs window size?
             SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
 
-            MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
-            bufferedPanel1.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
-            sldZoomLevel.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
-            cmbBackgrounds.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            MouseWheel += RoomSettingsEditor_MouseWheel;
+            bufferedPanel1.MouseWheel += RoomSettingsEditor_MouseWheel;
+            sldZoomLevel.MouseWheel += RoomSettingsEditor_MouseWheel;
+            cmbBackgrounds.MouseWheel += RoomSettingsEditor_MouseWheel;
             bufferedPanel1.PanButtons = MouseButtons.Middle;
 
             _editorConstructed = true;

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -17,7 +17,7 @@ namespace AGS.Editor
         public delegate void AttemptToEditScriptHandler(ref bool allowEdit);
         public static event AttemptToEditScriptHandler AttemptToEditScript;
 
-        private delegate void AnonymousDelegate();
+        private Action _anonymousDelegate;
 
         // Custom Edit menu commands
         private const string TOGGLE_BREAKPOINT_COMMAND = "ToggleBreakpoint";
@@ -57,8 +57,8 @@ namespace AGS.Editor
             _roomNumber = -1;
             Init(scriptToEdit);
 
-            this.Load += new EventHandler(ScriptEditor_Load);
-            this.Resize += new EventHandler(ScriptEditor_Resize);
+            this.Load += ScriptEditor_Load;
+            this.Resize += ScriptEditor_Resize;
         }
 
         public string GetScriptTabName()
@@ -344,7 +344,7 @@ namespace AGS.Editor
             {
                 if (this.IsHandleCreated)
                 {
-                    this.Invoke(new AnonymousDelegate(UpdateFunctionList));
+                    this.Invoke(new Action(_anonymousDelegate));
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -509,7 +509,7 @@ namespace AGS.Editor
         {
             FindReplace findReplace = new FindReplace(_iScript, _agsEditor,
                 _lastSearchText, _lastCaseSensitive);
-            findReplace.LastSearchTextChanged += new FindReplace.LastSearchTextChangedHandler(findReplace_LastSearchTextChanged);
+            findReplace.LastSearchTextChanged += findReplace_LastSearchTextChanged;
             findReplace.ShowFindReplaceDialog(showReplace, showAll);
         }
 

--- a/Editor/AGS.Editor/Panes/SpriteManager.cs
+++ b/Editor/AGS.Editor/Panes/SpriteManager.cs
@@ -12,18 +12,16 @@ namespace AGS.Editor
     public partial class SpriteManager : EditorContentPanel
     {
         private Sprite[] _selectedSprites = null;
-        private SpriteFolder.SpritesUpdatedHandler _spriteUpdateHandler;
         private SpriteFolder _attachedToFolder = null;
 		private bool _pendingRefreshes = false;
 
         public SpriteManager()
         {
-            _spriteUpdateHandler = new SpriteFolder.SpritesUpdatedHandler(RootSpriteFolder_SpritesUpdated);
             InitializeComponent();
-            spriteSelector.OnSelectionChanged += new SpriteSelector.SelectionChangedHandler(spriteSelector_OnSelectionChanged);
+            spriteSelector.OnSelectionChanged += spriteSelector_OnSelectionChanged;
 
             _attachedToFolder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
-            _attachedToFolder.SpritesUpdated += _spriteUpdateHandler;
+            _attachedToFolder.SpritesUpdated += RootSpriteFolder_SpritesUpdated;
         }
 
         protected override string OnGetHelpKeyword()
@@ -129,10 +127,10 @@ namespace AGS.Editor
         {
             if (_attachedToFolder != null) 
             {
-                _attachedToFolder.SpritesUpdated -= _spriteUpdateHandler;
+                _attachedToFolder.SpritesUpdated -= RootSpriteFolder_SpritesUpdated;
             }
             _attachedToFolder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
-            _attachedToFolder.SpritesUpdated += _spriteUpdateHandler;
+            _attachedToFolder.SpritesUpdated += RootSpriteFolder_SpritesUpdated;
 
             spriteSelector.SetDataSource(_attachedToFolder);
         }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -100,7 +100,7 @@ namespace AGS.Editor
                 _spManagerIcons.Images.Add("OpenFolder", Resources.ResourceManager.GetIcon("openfldr.ico"));
             }
             folderList.ImageList = _spManagerIcons;
-            folderList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.folderList_KeyDown);
+            folderList.KeyDown += folderList_KeyDown;
             folderList.ItemTryDrag += FolderList_ItemTryDrag;
             folderList.ItemDragOver += FolderList_ItemDragOver;
             folderList.ItemDragDrop += FolderList_ItemDragDrop;
@@ -366,7 +366,7 @@ namespace AGS.Editor
                         {
                             _timer = new Timer();
                             _timer.Interval = 50;
-                            _timer.Tick += new EventHandler(_timer_Tick);
+                            _timer.Tick += _timer_Tick;
                             _timer.Tag = spriteNumber;
                             _timer.Start();
                         }

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -14,7 +14,6 @@ namespace AGS.Editor
 
         private AGS.Types.View _editingView;
         private List<ViewLoopEditor> _loopPanes = new List<ViewLoopEditor>();
-        private AGS.Types.View.ViewUpdatedHandler _viewUpdateHandler;
 		private delegate void CorrectAutoScrollDelegate(Point p);
         private GUIController _guiController;
         private bool _processingSelection = false;
@@ -26,9 +25,8 @@ namespace AGS.Editor
         public ViewEditor(AGS.Types.View viewToEdit)
         {
             _guiController = Factory.GUIController;
-            _guiController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
-            _viewUpdateHandler = new AGS.Types.View.ViewUpdatedHandler(View_ViewUpdated);
-            viewToEdit.ViewUpdated += _viewUpdateHandler;
+            _guiController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
+            viewToEdit.ViewUpdated += View_ViewUpdated;
 
             InitializeComponent();
 
@@ -111,16 +109,16 @@ namespace AGS.Editor
             loopPane.ZoomLevel = sldZoomLevel.ZoomScale;
             loopPane.Top = 10 + _loopPanes.Count * loopPane.Height + editorPanel.AutoScrollPosition.Y;
             loopPane.HandleRangeSelection = false; // we will handle multi-loop selection ourselves
-            loopPane.SelectedFrameChanged += new ViewLoopEditor.SelectedFrameChangedHandler(loopPane_SelectedFrameChanged);
-			loopPane.NewFrameAdded += new ViewLoopEditor.NewFrameAddedHandler(loopPane_NewFrameAdded);
+            loopPane.SelectedFrameChanged += loopPane_SelectedFrameChanged;
+			loopPane.NewFrameAdded += loopPane_NewFrameAdded;
             loopPane.OnContextMenu += loopPane_OnContextMenu;
             if (loop.ID == _editingView.Loops.Count - 1)
             {
                 loopPane.IsLastLoop = true;
             }
-			loopPane.Enter += new EventHandler(loopPane_GotFocus);
-			//loopPane.GotFocus += new EventHandler(loopPane_GotFocus);
-			//loopPane.Leave += new EventHandler(loopPane_GotFocus);
+			loopPane.Enter += loopPane_GotFocus;
+			//loopPane.GotFocus += loopPane_GotFocus;
+			//loopPane.Leave += loopPane_GotFocus;
             editorPanel.Controls.Add(loopPane);
             editorPanel.AutoScrollPosition = new Point(0, editorPanel.VerticalScroll.Maximum);
             _loopPanes.Add(loopPane);
@@ -388,8 +386,8 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            _editingView.ViewUpdated -= _viewUpdateHandler;
-            _guiController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            _editingView.ViewUpdated -= View_ViewUpdated;
+            _guiController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
         private void btnNewLoop_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -340,7 +340,7 @@ namespace AGS.Editor
                 if (_animationTimer == null)
                 {
                     _animationTimer = new Timer();
-                    _animationTimer.Tick += new EventHandler(_animationTimer_Tick);
+                    _animationTimer.Tick += _animationTimer_Tick;
 		            _animationTimer.Interval = MILLISECONDS_IN_SECOND / DEFUALT_FRAME_RATE;
                 }
 				UpdateDelayForThisFrame();

--- a/Editor/AGS.Editor/Program.cs
+++ b/Editor/AGS.Editor/Program.cs
@@ -39,9 +39,9 @@ namespace AGS.Editor
             {
 #endif
                 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
-                Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);
-                AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
-                AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+                Application.ThreadException += Application_ThreadException;
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+                AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
 				string filePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
 				Directory.SetCurrentDirectory(Path.GetDirectoryName(filePath));
@@ -49,17 +49,17 @@ namespace AGS.Editor
 #if BIBLE_EDITION
                 Application.Run(new SelectReligion());
                 // Need to re-add these because the end of Application.Run removes them
-                Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);
-                AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
+                Application.ThreadException += Application_ThreadException;
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 #endif
 
                 SplashScreen splash = new SplashScreen();
-                splash.Load += new EventHandler(splash_Load);
+                splash.Load += splash_Load;
                 Application.Run(splash);
 
                 // Need to re-add these because the end of Application.Run removes them
-                Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);
-                AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
+                Application.ThreadException += Application_ThreadException;
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 
                 _application.StartGUI(args);
 #if !DEBUG
@@ -78,7 +78,7 @@ namespace AGS.Editor
             // it has done so.
             Timer timer = new Timer();
             timer.Interval = 40;
-            timer.Tick += new EventHandler(startupTimer_Tick);
+            timer.Tick += startupTimer_Tick;
             timer.Start();
         }
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -853,7 +853,7 @@ namespace AGS.Editor
                 if (raiseEventOnExit)
                 {
                     _testGameProcess.EnableRaisingEvents = true;
-                    _testGameProcess.Exited += new EventHandler(_testGameProcess_Exited);
+                    _testGameProcess.Exited += _testGameProcess_Exited;
                 }
                 _testGameProcess.Start();
             }

--- a/Editor/AGS.Types/PropertyGridExtras/BuildTargetUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/BuildTargetUIEditor.cs
@@ -11,7 +11,7 @@ namespace AGS.Types
         public BuildTargetUIEditor()
             : base()
         {
-            editor.ItemCheck += new ItemCheckEventHandler(editor_ItemCheck);
+            editor.ItemCheck += editor_ItemCheck;
         }
 
         void editor_ItemCheck(object sender, ItemCheckEventArgs e)


### PR DESCRIPTION
This change cleans up the event handlers using a simplified syntax and replaces delegates without arguments with [System.Action](https://learn.microsoft.com/en-us/dotnet/api/system.action-1?view=netframework-4.6) to simplify the syntax.