### PR TITLE
DRAFT AGS 4 Editor: Add double-buffer support for TreeView

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -480,6 +480,7 @@
     <Compile Include="Utils\ArgumentBuilder.cs" />
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
+    <Compile Include="Utils\ControlExtensions.cs" />
     <Compile Include="Utils\Debounce.cs" />
     <Compile Include="Utils\DirectoryInfoExtensions.cs" />
     <Compile Include="Utils\FileWatcher.cs" />

--- a/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewWithDragDrop.cs
@@ -1,5 +1,4 @@
-﻿using AGS.Types;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -45,6 +44,12 @@ namespace AGS.Editor
             Controls.Add(_lineInBetween);
             _lineInBetween.BringToFront();
             _lineInBetween.Hide();
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            this.EnableDoubleBuffering();
+            base.OnHandleCreated(e);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/GUI/ViewChooser.cs
+++ b/Editor/AGS.Editor/GUI/ViewChooser.cs
@@ -1,10 +1,5 @@
 using AGS.Types;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 
 namespace AGS.Editor
@@ -17,6 +12,7 @@ namespace AGS.Editor
         public ViewChooser(int currentView)
         {
             InitializeComponent();
+            this.viewTree.EnableDoubleBuffering();
             _startingView = currentView;
         }
 

--- a/Editor/AGS.Editor/Utils/ControlExtensions.cs
+++ b/Editor/AGS.Editor/Utils/ControlExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public static class ControlExtensions
+    {
+        // Pinvoke:
+        private const int TVM_SETEXTENDEDSTYLE = 0x1100 + 44;
+        private const int TVM_GETEXTENDEDSTYLE = 0x1100 + 45;
+        private const int TVS_EX_DOUBLEBUFFER = 0x0004;
+
+        /// <summary>
+        /// Enables double buffering so that the control does not flicker.
+        /// 
+        /// See <see href="https://stackoverflow.com/a/10364283/20494">this StackOverflow answer</see> for more details.
+        /// </summary>
+        /// <param name="control"></param>
+        public static void EnableDoubleBuffering(this Control control)
+        {
+            SendMessage(control.Handle, TVM_SETEXTENDEDSTYLE, (IntPtr)TVS_EX_DOUBLEBUFFER, (IntPtr)TVS_EX_DOUBLEBUFFER);
+        }
+        
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+    }
+}


### PR DESCRIPTION
(Will update the description once I get feedback/create a PR ready for review)

## Changes

This fixes something that has bothered me for the longest time. When clicking/hovering over the tree views, they flicker. This is due to how they are set up by default to accommodate Windows XP limitations, which the editor no longer supports. See this article for details: https://stackoverflow.com/a/10364283/20494


## Preview

TODO

Before:

After: