### PR TITLE
Engine: consistent translation: only translate a text when displaying

### DIFF
--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -103,8 +103,6 @@ void Button_GetText(GUIButton *butt, char *buffer) {
 }
 
 void Button_SetText(GUIButton *butt, const char *newtx) {
-    newtx = get_translation(newtx);
-
     if (butt->GetText() != newtx) {
         butt->SetText(newtx);
     }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2720,8 +2720,6 @@ void display_speech(const char *texx, int aschar, int xx, int yy, int widd, bool
     }
     said_text = 1;
 
-    // the strings are pre-translated
-    //texx = get_translation(texx);
     set_our_eip(150);
 
     int isPause = 1;

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -372,7 +372,7 @@ const char* Dialog_GetOptionText(ScriptDialog *sd, int option)
 
   option--; // option id is 1-based in script, and 0 is entry point
 
-  return CreateNewScriptString(get_translation(dialog[sd->id].optionnames[option]));
+  return CreateNewScriptString(dialog[sd->id].optionnames[option]);
 }
 
 int Dialog_GetID(ScriptDialog *sd) {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -565,7 +565,7 @@ const char *GetLocationName(int x, int y)
             if (play.get_loc_name_last_time != 1000 + mover)
                 GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
             play.get_loc_name_last_time = 1000 + mover;
-            out_name = get_translation(game.invinfo[mover].name.GetCStr());
+            out_name = game.invinfo[mover].name.GetCStr();
         }
         else if ((play.get_loc_name_last_time > 1000) && (play.get_loc_name_last_time < 1000 + MAX_INV)) {
             // no longer selecting an item
@@ -599,7 +599,7 @@ const char *GetLocationName(int x, int y)
     if (loctype == LOCTYPE_CHAR)
     {
         onhs = getloctype_index;
-        out_name = get_translation(game.chars[onhs].name.GetCStr());
+        out_name = game.chars[onhs].name.GetCStr();
         if (play.get_loc_name_last_time != 2000+onhs)
             GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
         play.get_loc_name_last_time = 2000+onhs;
@@ -609,7 +609,7 @@ const char *GetLocationName(int x, int y)
     if (loctype == LOCTYPE_OBJ)
     {
         aa = getloctype_index;
-        out_name = get_translation(croom->obj[aa].name.GetCStr());
+        out_name = croom->obj[aa].name.GetCStr();
         if (play.get_loc_name_last_time != 3000+aa)
             GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
         play.get_loc_name_last_time = 3000+aa;
@@ -617,7 +617,7 @@ const char *GetLocationName(int x, int y)
     }
     onhs = getloctype_index;
     if (onhs>0)
-        out_name = get_translation(croom->hotspot[onhs].Name.GetCStr());
+        out_name = croom->hotspot[onhs].Name.GetCStr();
     if (play.get_loc_name_last_time != onhs)
         GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
     play.get_loc_name_last_time = onhs;

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -125,7 +125,7 @@ ScriptHotspot *Hotspot_GetAtScreenXY(int x, int y)
 const char* Hotspot_GetName_New(ScriptHotspot *hss) {
     if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
         quit("!Hotspot.Name: invalid hotspot number");
-    return CreateNewScriptString(get_translation(croom->hotspot[hss->id].Name.GetCStr()));
+    return CreateNewScriptString(croom->hotspot[hss->id].Name);
 }
 
 void Hotspot_SetName(ScriptHotspot *hss, const char *newName) {

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -127,7 +127,7 @@ ScriptInvItem *InventoryItem_GetAtScreenXY(int xx, int yy) {
 }
 
 const char* InventoryItem_GetName_New(ScriptInvItem *invitem) {
-  return CreateNewScriptString(get_translation(game.invinfo[invitem->id].name.GetCStr()));
+  return CreateNewScriptString(game.invinfo[invitem->id].name);
 }
 
 int InventoryItem_GetGraphic(ScriptInvItem *iitem) {

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -34,8 +34,6 @@ void Label_GetText(GUILabel *labl, char *buffer) {
 }
 
 void Label_SetText(GUILabel *labl, const char *newtx) {
-    newtx = get_translation(newtx);
-
     if (labl->GetText() != newtx) {
         labl->SetText(newtx);
     }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -641,7 +641,7 @@ const char* Object_GetName_New(ScriptObject *objj) {
     if (!is_valid_object(objj->id))
         quit("!Object.Name: invalid object number");
 
-    return CreateNewScriptString(get_translation(croom->obj[objj->id].name.GetCStr()));
+    return CreateNewScriptString(croom->obj[objj->id].name);
 }
 
 void Object_SetName(ScriptObject *objj, const char *newName) {


### PR DESCRIPTION
Resolves #1940

This removes inconsistent translation of game texts when they are either assigned to object properties or retrieved from ones. The principle to follow is this: properties set and get untranslated strings, the text is only automatically translated when displayed or drawn somewhere. Note: user still has an option to explicitly translate anything using GetTranslation function.