### PR TITLE
AGS 4 Editor: Clean up event handlers

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -38,7 +38,7 @@ namespace AGS.Editor
             _events.LoadedUserData += new EditorEvents.LoadedUserDataHandler(_events_LoadedUserData);
             _agsEditor.PreSaveGame += new AGSEditor.PreSaveGameHandler(_agsEditor_PreSaveGame);
 
-            _guiController.OnEditorShutdown += new GUIController.EditorShutdownHandler(GUIController_OnEditorShutdown);
+            _guiController.OnEditorShutdown += GUIController_OnEditorShutdown;
             _guiController.Initialize(_agsEditor);
             _agsEditor.DoEditorInitialization();
             CreateComponents();

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -76,7 +76,7 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon("AGSAudioSpeechIcon", Resources.ResourceManager.GetIcon("audio_speech.ico"));
             _guiController.RegisterIcon(AUDIO_CLIP_TYPE_ICON, Resources.ResourceManager.GetIcon("tree_audio_generic.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Audio", "AGSAudioClipsIcon");
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
             RePopulateTreeView();
         }
 

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -32,9 +32,9 @@ namespace AGS.Editor.Components
             : base(guiController, agsEditor)
         {
             ScriptEditor.AttemptToEditScript += new ScriptEditor.AttemptToEditScriptHandler(ScriptEditor_AttemptToEditScript);
-            _guiController.QueryEditorShutdown += new GUIController.QueryEditorShutdownHandler(guiController_QueryEditorShutdown);
-            _guiController.InteractiveTasks.TestGameStarting += new InteractiveTasks.TestGameStartingHandler(AGSEditor_TestGameStarting);
-            _guiController.InteractiveTasks.TestGameFinished += new InteractiveTasks.TestGameFinishedHandler(AGSEditor_TestGameFinished);
+            _guiController.QueryEditorShutdown += guiController_QueryEditorShutdown;
+            _guiController.InteractiveTasks.TestGameStarting += AGSEditor_TestGameStarting;
+            _guiController.InteractiveTasks.TestGameFinished += AGSEditor_TestGameFinished;
             _guiController.RegisterIcon("BuildIcon", Resources.ResourceManager.GetIcon("build.ico"));
             _guiController.RegisterIcon("RunIcon", Resources.ResourceManager.GetIcon("run.ico"));
             _guiController.RegisterIcon("StepIcon", Resources.ResourceManager.GetIcon("step.ico"));

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -28,8 +28,8 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("dialog.ico"));
             _guiController.RegisterIcon("DialogIcon", Resources.ResourceManager.GetIcon("dialog-item.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Dialogs", ICON_KEY);
-			_guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
+			_guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
 			RePopulateTreeView();
         }
 

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -30,8 +30,8 @@ namespace AGS.Editor.Components
         public FileCommandsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _guiController.InteractiveTasks.TestGameStarting += new InteractiveTasks.TestGameStartingHandler(AGSEditor_TestGameStarting);
-            _guiController.InteractiveTasks.TestGameFinished += new InteractiveTasks.TestGameFinishedHandler(AGSEditor_TestGameFinished);
+            _guiController.InteractiveTasks.TestGameStarting += AGSEditor_TestGameStarting;
+            _guiController.InteractiveTasks.TestGameFinished += AGSEditor_TestGameFinished;
 
             _guiController.RegisterIcon("OpenIcon", Resources.ResourceManager.GetIcon("open.ico"));
             _guiController.RegisterIcon("SaveIcon", Resources.ResourceManager.GetIcon("save.ico"));

--- a/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
@@ -66,7 +66,7 @@ namespace AGS.Editor.Components
 
             _guiController.AddMenu(this, GUIController.HELP_MENU_ID, "&Help");
 
-            _guiController.OnLaunchHelp += new GUIController.LaunchHelpHandler(_guiController_OnLaunchHelp);
+            _guiController.OnLaunchHelp += _guiController_OnLaunchHelp;
 
             MenuCommands commands = new MenuCommands(GUIController.HELP_MENU_ID, null);
             commands.Commands.Add(new MenuCommand(LAUNCH_HELP_COMMAND, "&Dynamic Help", Keys.F1, "MenuIconDynamicHelp"));

--- a/Editor/AGS.Editor/Components/PluginsComponent.cs
+++ b/Editor/AGS.Editor/Components/PluginsComponent.cs
@@ -46,8 +46,8 @@ namespace AGS.Editor.Components
             RepopulateTreeView();
 
             _agsEditor.GetScriptHeaderList += new GetScriptHeaderListHandler(AGSEditor_GetScriptHeaderList);
-            _agsEditor.Tasks.GetFilesForInclusionInTemplate += new Tasks.GetFilesForInclusionInTemplateHandler(AGSEditor_GetFilesForInclusionInTemplate);
-            _agsEditor.Tasks.NewGameFilesExtracted += new Tasks.NewGameFilesExtractedHandler(AGSEditor_NewGameFilesExtracted);
+            _agsEditor.Tasks.GetFilesForInclusionInTemplate += AGSEditor_GetFilesForInclusionInTemplate;
+            _agsEditor.Tasks.NewGameFilesExtracted += AGSEditor_NewGameFilesExtracted;
 			Factory.Events.GetAboutDialogText += new EditorEvents.GetAboutDialogTextHandler(Events_GetAboutDialogText);
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -94,10 +94,10 @@ namespace AGS.Editor.Components
 
 			_nativeProxy = Factory.NativeProxy;
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Rooms", "RoomsIcon");
-            _guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScript += new GUIController.GetScriptHandler(GUIController_OnGetScript);
-            _guiController.OnScriptChanged += new GUIController.ScriptChangedHandler(GUIController_OnScriptChanged);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
+            _guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScript += GUIController_OnGetScript;
+            _guiController.OnScriptChanged += GUIController_OnScriptChanged;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
             _agsEditor.PreCompileGame += new AGSEditor.PreCompileGameHandler(AGSEditor_PreCompileGame);
             _agsEditor.PreSaveGame += new AGSEditor.PreSaveGameHandler(AGSEditor_PreSaveGame);
             _agsEditor.ProcessAllGameTexts += new AGSEditor.ProcessAllGameTextsHandler(AGSEditor_ProcessAllGameTexts);

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -69,11 +69,11 @@ namespace AGS.Editor.Components
 
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Scripts", "ScriptsIcon");
             RePopulateTreeView(null);
-            _guiController.OnZoomToFile += new GUIController.ZoomToFileHandler(GUIController_OnZoomToFile);
-            _guiController.OnGetScript += new GUIController.GetScriptHandler(GUIController_OnGetScript);
-            _guiController.OnScriptChanged += new GUIController.ScriptChangedHandler(GUIController_OnScriptChanged);
-            _guiController.OnGetScriptEditorControl += new GUIController.GetScriptEditorControlHandler(_guiController_OnGetScriptEditorControl);
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+            _guiController.OnZoomToFile += GUIController_OnZoomToFile;
+            _guiController.OnGetScript += GUIController_OnGetScript;
+            _guiController.OnScriptChanged += GUIController_OnScriptChanged;
+            _guiController.OnGetScriptEditorControl += _guiController_OnGetScriptEditorControl;
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
 
             Factory.Events.GamePostLoad += Events_GamePostLoad;
         }

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -41,7 +41,7 @@ namespace AGS.Editor.Components
         public TranslationsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+            _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
             _agsEditor.PreCompileGame += new AGSEditor.PreCompileGameHandler(AGSEditor_PreCompileGame);
             _timer.Interval = 20;
             _timer.Tick += new EventHandler(_timer_Tick);

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -20,18 +20,16 @@ namespace AGS.Editor.Components
         private const string ICON_KEY = "ViewsIcon";
         
         private Dictionary<View, ContentDocument> _documents;
-        private Game.ViewListUpdatedHandler _viewsUpdatedHandler;
         private Game _eventHookedToGame = null;
 
         public ViewsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor, "ViewEditor")
         {
             _documents = new Dictionary<View, ContentDocument>();
-            _viewsUpdatedHandler = new Game.ViewListUpdatedHandler(CurrentGame_ViewListUpdated);
             _guiController.RegisterIcon(ICON_KEY, ResourceManager.GetIcon("view.ico"));
             _guiController.RegisterIcon("ViewIcon", ResourceManager.GetIcon("view-item.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Views", ICON_KEY);
-			_guiController.ProjectTree.OnAfterLabelEdit += new ProjectTree.AfterLabelEditHandler(ProjectTree_OnAfterLabelEdit);
+			_guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
 			RefreshDataFromGame();
         }
 
@@ -234,7 +232,7 @@ namespace AGS.Editor.Components
         {
             if (_eventHookedToGame != null)
             {
-                _eventHookedToGame.ViewListUpdated -= _viewsUpdatedHandler;
+                _eventHookedToGame.ViewListUpdated -= CurrentGame_ViewListUpdated;
             }
 
             foreach (ContentDocument doc in _documents.Values)
@@ -247,7 +245,7 @@ namespace AGS.Editor.Components
             RePopulateTreeView();
 
             _eventHookedToGame = _agsEditor.CurrentGame;
-            _eventHookedToGame.ViewListUpdated += _viewsUpdatedHandler;
+            _eventHookedToGame.ViewListUpdated += CurrentGame_ViewListUpdated;
         }
 
         private void CurrentGame_ViewListUpdated()

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -839,7 +839,7 @@ namespace AGS.Editor
 
             public void PopulateViews(IViewFolder folder, Game game)
             {
-                FolderHelper.ForEachViewFolder(folder, game, new FolderHelper.ViewFolderProcessing(PopulateViews));
+                FolderHelper.ForEachViewFolder(folder, game, PopulateViews);
                 foreach (View view in folder.Views)
                 {
                     views[view.ID - 1] = view;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -979,19 +979,19 @@ namespace AGS.Editor
                 _mainForm = new frmMain();
                 SetEditorWindowSize();
                 _treeManager = new ProjectTree(_mainForm.projectPanel.projectTree);
-                _treeManager.OnContextMenuClick += new ProjectTree.MenuClickHandler(_mainForm_OnMenuClick);
+                _treeManager.OnContextMenuClick += _mainForm_OnMenuClick;
                 _toolBarManager = new ToolBarManager(_mainForm.toolStrip);
                 _windowsMenuManager = new WindowsMenuManager(_mainForm.windowsToolStripMenuItem, 
                     _mainForm.DockPanes, _mainForm.mainContainer, _mainForm.GetLayoutManager());
                 _menuManager = new MainMenuManager(_mainForm.mainMenu, _windowsMenuManager);
-                _mainForm.OnEditorShutdown += new frmMain.EditorShutdownHandler(_mainForm_OnEditorShutdown);
-                _mainForm.OnPropertyChanged += new frmMain.PropertyChangedHandler(_mainForm_OnPropertyChanged);
-                _mainForm.OnPropertyObjectChanged += new frmMain.PropertyObjectChangedHandler(_mainForm_OnPropertyObjectChanged);
-                _mainForm.OnActiveDocumentChanged += new frmMain.ActiveDocumentChangedHandler(_mainForm_OnActiveDocumentChanged);
-                _mainForm.OnMainWindowActivated += new EventHandler(_mainForm_OnMainWindowActivated);
-                _menuManager.OnMenuClick += new MainMenuManager.MenuClickHandler(_mainForm_OnMenuClick);
-                AutoComplete.BackgroundCacheUpdateStatusChanged += new AutoComplete.BackgroundCacheUpdateStatusChangedHandler(AutoComplete_BackgroundCacheUpdateStatusChanged);
-				SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanging);
+                _mainForm.OnEditorShutdown += _mainForm_OnEditorShutdown;
+                _mainForm.OnPropertyChanged += _mainForm_OnPropertyChanged;
+                _mainForm.OnPropertyObjectChanged += _mainForm_OnPropertyObjectChanged;
+                _mainForm.OnActiveDocumentChanged += _mainForm_OnActiveDocumentChanged;
+                _mainForm.OnMainWindowActivated += _mainForm_OnMainWindowActivated;
+                _menuManager.OnMenuClick += _mainForm_OnMenuClick;
+                AutoComplete.BackgroundCacheUpdateStatusChanged += AutoComplete_BackgroundCacheUpdateStatusChanged;
+				SystemEvents.DisplaySettingsChanged += SystemEvents_DisplaySettingsChanging;
 
                 RegisterIcon("SpriteIcon", Resources.ResourceManager.GetIcon("iconspr.ico"));
                 RegisterIcon("BuildIcon", Resources.ResourceManager.GetIcon("menu_build_rebuild-files.ico"));
@@ -1003,16 +1003,16 @@ namespace AGS.Editor
                 _mainForm.mainMenu.ImageList = _imageList;
 				_mainForm.pnlOutput.SetImageList(_imageList);
 
-                ViewUIEditor.ViewSelectionGUI = new ViewUIEditor.ViewSelectionGUIType(ShowViewChooserFromPropertyGrid);
-                SpriteSelectUIEditor.SpriteSelectionGUI = new SpriteSelectUIEditor.SpriteSelectionGUIType(ShowSpriteChooserFromPropertyGrid);
-                CustomPropertiesUIEditor.CustomPropertiesGUI = new CustomPropertiesUIEditor.CustomPropertiesGUIType(ShowPropertiesEditorFromPropertyGrid);
-                PropertyTabInteractions.UpdateEventName = new PropertyTabInteractions.UpdateEventNameHandler(PropertyTabInteractions_UpdateEventName);
-                ScriptFunctionUIEditor.OpenScriptFunction = new ScriptFunctionUIEditor.OpenScriptFunctionHandler(ScriptFunctionUIEditor_OpenScriptFunction);
-                ScriptFunctionUIEditor.CreateScriptFunction = new ScriptFunctionUIEditor.CreateScriptFunctionHandler(ScriptFunctionUIEditor_CreateScriptFunction);
-                CustomResolutionUIEditor.CustomResolutionSetGUI = new CustomResolutionUIEditor.CustomResolutionGUIType(ShowCustomResolutionChooserFromPropertyGrid);
-                ColorUIEditor.ColorGUI = new ColorUIEditor.ColorGUIType(ShowColorDialog);
-                MultiLineStringUIEditor.MultilineStringGUI = new MultiLineStringUIEditor.MultilineStringGUIType(ShowMultilineStringDialog);
-                AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = new AudioClipSourceFileUIEditor.AudioClipSourceFileGUIType(ShowAudioClipSourceFileChooserFromPropertyGrid);
+                ViewUIEditor.ViewSelectionGUI = ShowViewChooserFromPropertyGrid;
+                SpriteSelectUIEditor.SpriteSelectionGUI = ShowSpriteChooserFromPropertyGrid;
+                CustomPropertiesUIEditor.CustomPropertiesGUI = ShowPropertiesEditorFromPropertyGrid;
+                PropertyTabInteractions.UpdateEventName = PropertyTabInteractions_UpdateEventName;
+                ScriptFunctionUIEditor.OpenScriptFunction = ScriptFunctionUIEditor_OpenScriptFunction;
+                ScriptFunctionUIEditor.CreateScriptFunction = ScriptFunctionUIEditor_CreateScriptFunction;
+                CustomResolutionUIEditor.CustomResolutionSetGUI = ShowCustomResolutionChooserFromPropertyGrid;
+                ColorUIEditor.ColorGUI = ShowColorDialog;
+                MultiLineStringUIEditor.MultilineStringGUI = ShowMultilineStringDialog;
+                AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = ShowAudioClipSourceFileChooserFromPropertyGrid;
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GotoLineDialog.cs
+++ b/Editor/AGS.Editor/GUI/GotoLineDialog.cs
@@ -16,11 +16,9 @@ namespace AGS.Editor
             (this.upDownLineNumber.Controls[1] as TextBox).Enter += upDownLineNumber_Controls1_Enter;
         }
 
-        private delegate void Action();
-
         private void upDownLineNumber_Controls1_Enter(object sender, EventArgs e)
         {
-            BeginInvoke((Action)(() =>
+            BeginInvoke(new Action(() =>
             {
                 (this.upDownLineNumber.Controls[1] as TextBox).SelectAll();
             }));

--- a/Editor/AGS.Editor/GUI/SpriteChooser.Designer.cs
+++ b/Editor/AGS.Editor/GUI/SpriteChooser.Designer.cs
@@ -43,8 +43,8 @@ namespace AGS.Editor
 			this.spriteSelector1.ShowUseThisSpriteOption = false;
 			this.spriteSelector1.Size = new System.Drawing.Size(629, 386);
 			this.spriteSelector1.TabIndex = 0;
-			this.spriteSelector1.OnSelectionChanged += new AGS.Editor.SpriteSelector.SelectionChangedHandler(this.spriteSelector1_OnSelectionChanged);
-			this.spriteSelector1.OnSpriteActivated += new AGS.Editor.SpriteSelector.SpriteActivatedHandler(this.spriteSelector1_OnSpriteActivated);
+			this.spriteSelector1.OnSelectionChanged += spriteSelector1_OnSelectionChanged;
+			this.spriteSelector1.OnSpriteActivated += spriteSelector1_OnSpriteActivated;
 			// 
 			// btnOK
 			// 

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -12,10 +12,8 @@ namespace AGS.Editor
         private const int ENGINE_EXIT_CODE_ERROR  = 93;
 
         private delegate void TestGameFinishedDelegate(int exitCode);
-        public delegate void TestGameFinishedHandler();
-        public event TestGameFinishedHandler TestGameFinished;
-        public delegate void TestGameStartingHandler();
-        public event TestGameStartingHandler TestGameStarting;
+        public event Action TestGameFinished;
+        public event Action TestGameStarting;
 
         private Control _mainGUIThread;
         private bool _currentlyTesting = false;
@@ -24,7 +22,7 @@ namespace AGS.Editor
         public InteractiveTasks(Tasks tasks)
         {
             _tasks = tasks;
-            _tasks.TestGameFinished += new Tasks.TestGameFinishedHandler(Tasks_TestGameFinished);
+            _tasks.TestGameFinished += Tasks_TestGameFinished;
         }
 
         public static void ReportTaskException(string errorMsg, Exception ex)

--- a/Editor/AGS.Editor/Panes/AudioEditor.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.cs
@@ -12,8 +12,6 @@ namespace AGS.Editor
 {
     public partial class AudioEditor : EditorContentPanel
     {
-        private delegate void NoParametersDelegate();
-
         private object _selectedItem = null;
         private IAudioPreviewer _previewer = null;
         private bool _paused = false;
@@ -157,7 +155,7 @@ namespace AGS.Editor
 
         private void _timer_Tick(object sender, EventArgs e)
         {
-            this.Invoke(new NoParametersDelegate(PollPreviewer));
+            this.Invoke(new Action(PollPreviewer));
         }
 
         protected override void OnPanelClosing(bool canCancel, ref bool cancelClose)
@@ -189,7 +187,7 @@ namespace AGS.Editor
 
         private void _previewer_PlayFinished(AudioClip clip)
         {
-            btnPlay.Invoke(new NoParametersDelegate(ResetControlsForSoundFinished));
+            btnPlay.Invoke(new Action(ResetControlsForSoundFinished));
         }
 
         private void btnPause_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -107,7 +107,7 @@ namespace AGS.Editor
         public GUIEditor()
         {
             InitializeComponent();
-            Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
         }
 
 
@@ -1224,7 +1224,7 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
         private bool DoesThisPanelHaveFocus()

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -26,7 +26,7 @@ namespace AGS.Editor
         {
             InitializeComponent();
             _colourFinder = tabControl.TabPages[1];
-            Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _selectedIndexes.Add(0);
             GameChanged();
         }
@@ -358,7 +358,7 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
 		private void btnColorDialog_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -36,7 +36,6 @@ namespace AGS.Editor
 			Pens.LightGreen, Pens.Cyan, Pens.Red, Pens.Pink,
 			Pens.Yellow, Pens.White};
 
-        private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         protected readonly Room _room;
         protected Panel _panel;
         RoomSettingsEditor _editor;
@@ -96,7 +95,6 @@ namespace AGS.Editor
             _roomController = roomController;
             _panel = displayPanel;
             _editor = editor;
-            _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
             UpdateUndoButtonEnabledState();
             RoomItemRefs = new SortedDictionary<string, int>();
             DesignItems = new SortedDictionary<string, DesignTimeProperties>();
@@ -607,7 +605,7 @@ namespace AGS.Editor
                 DeselectArea();
             }
             SelectedAreaChanged(_selectedArea);
-            Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
 
             FilterActivated();
             _isOn = true;
@@ -622,7 +620,7 @@ namespace AGS.Editor
 
             _drawMode = _baseDrawMode;
             _mouseDown = false;
-            Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
             _editor.ContentDocument.ToolbarCommands = null;
             Factory.ToolBarManager.RefreshCurrentPane();
             _isOn = false;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseThingEditorFilter.cs
@@ -19,7 +19,6 @@ namespace AGS.Editor
         protected Room _room;
         protected Panel _panel;
         protected RoomSettingsEditor _editor;
-        private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         protected TThing _selectedObject = null;
         protected TThing _lastSelectedObject = null;
         // Object moving handling
@@ -37,7 +36,6 @@ namespace AGS.Editor
             _room = room;
             _panel = displayPanel;
             _editor = editor;
-            _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
 
             RoomItemRefs = new SortedDictionary<string, TThing>();
             DesignItems = new SortedDictionary<string, DesignTimeProperties>();
@@ -121,7 +119,7 @@ namespace AGS.Editor
         public void FilterOn()
         {
             SetPropertyGridList();
-            Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _isOn = true;
             ClearMovingState();
             FilterActivated();
@@ -129,7 +127,7 @@ namespace AGS.Editor
 
         public void FilterOff()
         {
-            Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
             _isOn = false;
             ClearMovingState();
             FilterDeactivated();

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -17,7 +17,7 @@ namespace AGS.Editor
         public delegate void AttemptToEditScriptHandler(ref bool allowEdit);
         public static event AttemptToEditScriptHandler AttemptToEditScript;
 
-        private delegate void AnonymousDelegate();
+        private Action _anonymousDelegate;
 
         // Custom Edit menu commands
         private const string TOGGLE_BREAKPOINT_COMMAND = "ToggleBreakpoint";
@@ -344,7 +344,7 @@ namespace AGS.Editor
             {
                 if (this.IsHandleCreated)
                 {
-                    this.Invoke(new AnonymousDelegate(UpdateFunctionList));
+                    this.Invoke(new Action(_anonymousDelegate));
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -509,7 +509,7 @@ namespace AGS.Editor
         {
             FindReplace findReplace = new FindReplace(_iScript, _agsEditor,
                 _lastSearchText, _lastCaseSensitive);
-            findReplace.LastSearchTextChanged += new FindReplace.LastSearchTextChangedHandler(findReplace_LastSearchTextChanged);
+            findReplace.LastSearchTextChanged += findReplace_LastSearchTextChanged;
             findReplace.ShowFindReplaceDialog(showReplace, showAll);
         }
 

--- a/Editor/AGS.Editor/Panes/SpriteManager.cs
+++ b/Editor/AGS.Editor/Panes/SpriteManager.cs
@@ -12,18 +12,16 @@ namespace AGS.Editor
     public partial class SpriteManager : EditorContentPanel
     {
         private Sprite[] _selectedSprites = null;
-        private SpriteFolder.SpritesUpdatedHandler _spriteUpdateHandler;
         private SpriteFolder _attachedToFolder = null;
 		private bool _pendingRefreshes = false;
 
         public SpriteManager()
         {
-            _spriteUpdateHandler = new SpriteFolder.SpritesUpdatedHandler(RootSpriteFolder_SpritesUpdated);
             InitializeComponent();
-            spriteSelector.OnSelectionChanged += new SpriteSelector.SelectionChangedHandler(spriteSelector_OnSelectionChanged);
+            spriteSelector.OnSelectionChanged += spriteSelector_OnSelectionChanged;
 
             _attachedToFolder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
-            _attachedToFolder.SpritesUpdated += _spriteUpdateHandler;
+            _attachedToFolder.SpritesUpdated += RootSpriteFolder_SpritesUpdated;
         }
 
         protected override string OnGetHelpKeyword()
@@ -129,10 +127,10 @@ namespace AGS.Editor
         {
             if (_attachedToFolder != null) 
             {
-                _attachedToFolder.SpritesUpdated -= _spriteUpdateHandler;
+                _attachedToFolder.SpritesUpdated -= RootSpriteFolder_SpritesUpdated;
             }
             _attachedToFolder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
-            _attachedToFolder.SpritesUpdated += _spriteUpdateHandler;
+            _attachedToFolder.SpritesUpdated += RootSpriteFolder_SpritesUpdated;
 
             spriteSelector.SetDataSource(_attachedToFolder);
         }

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -14,7 +14,6 @@ namespace AGS.Editor
 
         private AGS.Types.View _editingView;
         private List<ViewLoopEditor> _loopPanes = new List<ViewLoopEditor>();
-        private AGS.Types.View.ViewUpdatedHandler _viewUpdateHandler;
 		private delegate void CorrectAutoScrollDelegate(Point p);
         private GUIController _guiController;
         private bool _processingSelection = false;
@@ -26,9 +25,8 @@ namespace AGS.Editor
         public ViewEditor(AGS.Types.View viewToEdit)
         {
             _guiController = Factory.GUIController;
-            _guiController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
-            _viewUpdateHandler = new AGS.Types.View.ViewUpdatedHandler(View_ViewUpdated);
-            viewToEdit.ViewUpdated += _viewUpdateHandler;
+            _guiController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
+            viewToEdit.ViewUpdated += View_ViewUpdated;
 
             InitializeComponent();
 
@@ -388,8 +386,8 @@ namespace AGS.Editor
 
         protected override void OnDispose()
         {
-            _editingView.ViewUpdated -= _viewUpdateHandler;
-            _guiController.OnPropertyObjectChanged -= new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
+            _editingView.ViewUpdated -= View_ViewUpdated;
+            _guiController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
         private void btnNewLoop_Click(object sender, EventArgs e)

--- a/Editor/AGS.Types/SpriteFolder.cs
+++ b/Editor/AGS.Types/SpriteFolder.cs
@@ -11,12 +11,11 @@ namespace AGS.Types
         private IList<Sprite> _sprites;
         private List<ISpriteFolder> _subFolders;
 
-        public delegate void SpritesUpdatedHandler();
         /// <summary>
         /// Fired when an external client makes changes to the sprites
         /// (root sprite folder only)
         /// </summary>
-        public event SpritesUpdatedHandler SpritesUpdated;
+        public event Action SpritesUpdated;
 
         public SpriteFolder(string name)
         {

--- a/Editor/AGS.Types/View.cs
+++ b/Editor/AGS.Types/View.cs
@@ -9,8 +9,7 @@ namespace AGS.Types
     [DefaultProperty("Name")]
     public class View : IToXml, IComparable<View>
     {
-        public delegate void ViewUpdatedHandler(View view);
-        public event ViewUpdatedHandler ViewUpdated;
+        public event Action<View> ViewUpdated;
 
         private string _name;
         private int _id;


### PR DESCRIPTION
This change cleans up the event handlers using a simplified syntax and replaces delegates without arguments with [System.Action](https://learn.microsoft.com/en-us/dotnet/api/system.action-1?view=netframework-4.6) to simplify the syntax.

