### PR TITLE
AGS 4 Editor: Update .NET framework from 4.6 to 4.7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -315,7 +315,7 @@ build_editor_task:
     set "UseEnv=true" &&
     copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
-    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
+    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.7\Lib\um\x86;!LIB!" &&
     msbuild AGS.Editor.Full.sln /p:PlatformToolset=v142 /p:VCToolsVersion=14.29.30133 /p:Configuration=Debug /p:Platform="Win32" /maxcpucount /nologo"
   test_debug_script: |
     curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
@@ -328,7 +328,7 @@ build_editor_task:
     set "UseEnv=true" &&
     copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
-    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
+    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.7\Lib\um\x86;!LIB!" &&
     msbuild AGS.Editor.Full.sln /p:PlatformToolset=v142 /p:VCToolsVersion=14.29.30133 /p:Configuration=Release /p:Platform="Win32" /maxcpucount /nologo"
   test_release_script: |
     curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt

--- a/Changes.txt
+++ b/Changes.txt
@@ -20,6 +20,7 @@ Common:
  - Removed support for '[' as a linebreak character in text.
 
 Editor:
+ - Editor requires .NET Framework 4.7 to run.
  - Open room project format: rooms are now saved as subfolders in "Rooms" folder, where each
    component has its own separate file (room data, backgrounds, masks and scripts).
  - "Fonts" node in the Project Explorer now contains separate "Font Files" and "Fonts" sublists.

--- a/Editor/AGS.CScript.Compiler/AGS.CScript.Compiler.csproj
+++ b/Editor/AGS.CScript.Compiler/AGS.CScript.Compiler.csproj
@@ -23,7 +23,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Editor/AGS.Controls/AGS.Controls.csproj
+++ b/Editor/AGS.Controls/AGS.Controls.csproj
@@ -35,7 +35,7 @@
     <SccProvider>
     </SccProvider>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AGS</RootNamespace>
     <AssemblyName>AGS.Editor.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -23,6 +23,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -25,7 +25,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Editor/AGS.Editor/app.config
+++ b/Editor/AGS.Editor/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Editor/AGS.Editor/app.config
+++ b/Editor/AGS.Editor/app.config
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup useLegacyV2RuntimeActivationPolicy="true">
-  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+  </startup>
   <System.Windows.Forms.ApplicationConfigurationSection>
     <!-- Enables High DPI support. DO NOT COMMIT UNCOMMENTED until the AGS Editor fully supports it.
     <add key="DpiAwareness" value="PerMonitorV2" />

--- a/Editor/AGS.Editor/app.config
+++ b/Editor/AGS.Editor/app.config
@@ -1,3 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup useLegacyV2RuntimeActivationPolicy="true">
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup>
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <!-- Enables High DPI support. DO NOT COMMIT UNCOMMENTED until the AGS Editor fully supports it.
+    <add key="DpiAwareness" value="PerMonitorV2" />
+    -->
+  </System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>

--- a/Editor/AGS.Editor/app.manifest
+++ b/Editor/AGS.Editor/app.manifest
@@ -27,9 +27,6 @@
            is designed to work with. Uncomment the appropriate elements and Windows will 
            automatically selected the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/Editor/AGS.Editor/app.manifest
+++ b/Editor/AGS.Editor/app.manifest
@@ -45,18 +45,6 @@
     </application>
   </compatibility>
 
-  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
-       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-    </windowsSettings>
-  </application>
-  -->
-
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--
   <dependency>

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{65A387AF-C78C-492B-AB93-E13C6090355D}</ProjectGuid>
     <RootNamespace>AGS.Native</RootNamespace>
     <Keyword>AtlProj</Keyword>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -24,7 +24,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -208,12 +208,12 @@ const
   VCPP_REDIST_MAJOR_VERSION = 14.42;
   VCPP_REDIST_BUILD_VERSION = 34433;
 
-  // .NET Framework 4.6 or newer
+  // .NET Framework 4.7 or newer
   // in theory this is only needed for OS versions older than Windows 10
   // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#minimum-version
-  DOT_NET_46_RELEASE_VERSION = 393295;
-  NEED_DOT_NET_ERROR_MESSAGE = 'AGS needs the Microsoft .NET Framework 4.6 or later to be installed on this computer. Press OK to visit the Microsoft website and download this, then run Setup again.';
-  DOT_NET_INSTALL_URL = 'https://dotnet.microsoft.com/download/dotnet-framework';
+  DOTNET_FRAMEWORK_RELEASE_VERSION = 460798;
+  NEED_DOTNET_ERROR_MESSAGE = 'The AGS Editor requires the .NET Framework 4.7 (or later) Runtime to be installed. Press OK to visit the .NET website and download it, then re-run this setup after installing it.';
+  DOTNET_INSTALL_URL = 'https://dotnet.microsoft.com/en-us/download/dotnet-framework/net47';
 
 function VCRedistInstalled: Boolean;
 var
@@ -234,7 +234,7 @@ begin
     HKLM,
     'Software\Microsoft\NET Framework Setup\NDP\v4\Full',
     'Release',
-    version)) AND (version >= DOT_NET_46_RELEASE_VERSION);
+    version)) AND (version >= DOTNET_FRAMEWORK_RELEASE_VERSION);
 end;
 
 function IsWindowsVersionOrNewer(Major, Minor: Integer): Boolean;
@@ -264,8 +264,8 @@ begin
   begin
     if NOT WizardSilent then
     begin
-      MsgBox(NEED_DOT_NET_ERROR_MESSAGE, mbInformation, MB_OK);
-      ShellExecAsOriginalUser('', DOT_NET_INSTALL_URL, '', '', SW_SHOW, ewNoWait, ErrorCode);
+      MsgBox(NEED_DOTNET_ERROR_MESSAGE, mbInformation, MB_OK);
+      ShellExecAsOriginalUser('', DOTNET_INSTALL_URL, '', '', SW_SHOW, ewNoWait, ErrorCode);
     end;
     Result := False;
   end

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -16,7 +16,7 @@ The following are instructions on how to build the Engine and Editor from the so
   - libtheora-1.0 or higher ([Download](https://www.xiph.org/downloads/))
   - libvorbis-1.2.0 or higher ([Download](https://www.xiph.org/downloads/))
 - Specifically for the Editor:
-  - irrKlang 1.6 (32-bit) assembly pack for .NET 4.6 ([Download](https://www.ambiera.com/irrklang/downloads.html)).
+  - irrKlang 1.6 (32-bit) assembly pack for .NET 4.7 ([Download](https://www.ambiera.com/irrklang/downloads.html)).
 - To build Windows installer:
   - Inno Setup 6.2.2 or higher ([Download](http://www.jrsoftware.org/isdl.php))
   - (optional) PowerShell ([Download](https://aka.ms/powershell-release?tag=stable))

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -6,8 +6,8 @@ RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
 
 # .NET Framework 4.7 Developer Pack
 RUN pushd %TEMP% && \
-  curl -fLO https://download.microsoft.com/download/3/5/1/351f9afb-0505-47dc-a42e-34935707f300/NDP47-DevPack-KB3186612-ENU.exe && \
-  start /install /quiet /norestart && \
+  curl -fL https://download.microsoft.com/download/3/5/1/351f9afb-0505-47dc-a42e-34935707f300/NDP47-DevPack-KB3186612-ENU.exe -o dotnetsetup.exe && \
+  start /wait dotnetsetup.exe /install /quiet /norestart && \
   popd && \
   mkdir empty && \
   robocopy empty %TEMP% /MIR > nul & \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -4,10 +4,10 @@ FROM ghcr.io/ericoporto/min-ags-dev-env:2.0.16
 # if no temp folder exists by default, create it
 RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
 
-# Windows 10.0.10240 SDK (but only install the .NET 4.6 SDK)
+# .NET Framework 4.7 Developer Pack
 RUN pushd %TEMP% && \
-  curl -fLO https://download.microsoft.com/download/E/1/F/E1F1E61E-F3C6-4420-A916-FB7C47FBC89E/standalonesdk/sdksetup.exe && \
-  start /wait sdksetup /ceip off /features OptionID.NetFxSoftwareDevelopmentKit /quiet /norestart && \
+  curl -fLO https://download.microsoft.com/download/3/5/1/351f9afb-0505-47dc-a42e-34935707f300/NDP47-DevPack-KB3186612-ENU.exe && \
+  start /install /quiet /norestart && \
   popd && \
   mkdir empty && \
   robocopy empty %TEMP% /MIR > nul & \


### PR DESCRIPTION
This updates the .NET framework used for the AGS Editor from 4.6 to [4.7](https://devblogs.microsoft.com/dotnet/announcing-the-net-framework-4-7) for a couple of good reasons:

1. Enable improved support for high DPI scaling. This has been attempted before and had to be rolled back (See #2087), but I'd like to take advantage of the [improved support](https://devblogs.microsoft.com/dotnet/announcing-the-net-framework-4-7/?WT.mc_id=dotnet-35129-website#take-advantage-of-high-dpi) and [new API introduced in 4.7](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.logicaltodeviceunits?view=netframework-4.7) onward to make changes to the controls to support it.
2. It's still compatible with Win 7 SP1: https://learn.microsoft.com/en-us/dotnet/framework/get-started/system-requirements#installation-requirements
3. Editor seems to run with no issues with this updated framework

## TODOs

- [x] Update builds to use an updated framework
- [x] Update Editor installer to use new framework (if needed
- [x] Update dev environment READMEs
