### PR TITLE
AGS4 Engine: fixing movement issues

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2469,7 +2469,7 @@ builtin managed struct Object {
   /// Gets/sets whether the object will be drawn and updated during the game update.
   import attribute bool Enabled;
   /// Gets this object's current MotionPath, or null if it's not moving.
-  import attribute MotionPath* MotionPath;
+  import readonly attribute MotionPath* MotionPath;
 #endif // SCRIPT_API_v400
 #ifdef SCRIPT_API_v400_18
   /// Gets/sets the shader of this object.
@@ -2740,7 +2740,7 @@ builtin managed struct Character {
   /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection while Character moves and turns.
   import attribute float FaceDirectionRatio;
   /// Gets this character's current MotionPath, or null if it's not moving.
-  import attribute MotionPath* MotionPath;
+  import readonly attribute MotionPath* MotionPath;
 #endif // SCRIPT_API_v400
 #ifdef SCRIPT_API_v400_18
   /// Gets/sets the shader of this character.

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -84,6 +84,14 @@ void MoveList::SetStageProgress(float progress)
     curpos = CalcCurrentPos();
 }
 
+// for do_movelist_move, that needs to elbaorate the current step before moving to the next
+bool MoveList::GetAndForward()
+{
+    bool progressChanged = OnProgressChanged();
+    onpart += 1.f;
+    return progressChanged;
+}
+
 bool MoveList::Forward()
 {
     onpart += 1.f;

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -107,6 +107,8 @@ public:
     void SetStageDoneSteps(float parts);
     // Set MoveList's progress within the current stage [0.0; 1.0)
     void SetStageProgress(float progress);
+    // Elaborates current step before incrementing stage progress, for do_movelist_move()
+    bool GetAndForward();
     // Increment current stage's progress, update object position;
     // if the stage is complete, then progress to the next stage;
     // returns if there's a new stage available

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -74,7 +74,7 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     // TODO: find out what this value means and refactor
     int need_to_fix_sprite = 0;
     const int old_stage = cmls.GetStage();
-    if (cmls.Forward())
+    if (cmls.GetAndForward())
     {
         pos_x = cmls.GetCurrentPos().X;
         pos_y = cmls.GetCurrentPos().Y;


### PR DESCRIPTION
This hotfix should resolve the change in behavior after the last refactor that was causing movement skips, because `do_movelist_move()` needs to process the current stage before increasing onpart (as per original behavior).

So I added a new method to avoid interfering with the MotionPath script API.

There were (and still are) some mismatches in the reported MotionPath coordinates when comparing from script the X/Y of player vs motionpath, apparently related to walkable area zoom.
I suspect it's an issue with the old hacks to slow down movement at smaller scalings. If that's the case, the proper fix could be using float coordinates internally, but that's another matter.