### PR TITLE
AGS 4.0: Support ViewFrame offsets, make most properties settable in script

### DIFF
--- a/Common/ac/view.h
+++ b/Common/ac/view.h
@@ -20,10 +20,12 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-struct ViewFrame {
+struct ViewFrame
+{
     int   pic = 0;
-    short xoffs = 0, yoffs = 0;
-    short speed = 0;
+    int16_t xoffs = 0;
+    int16_t yoffs = 0;
+    int16_t speed = 0;
     Common::SpriteTransformFlags flags = Common::kSprTf_None;
     int   sound = -1;  // play sound when this frame comes round
     int   reserved_for_future[2] = { 0 }; // kept only for plugin api // CLNUP: may remove in ags4?

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -267,12 +267,15 @@ void GUIButton::SetPushedImage(int image)
     UpdateCurrentImage();
 }
 
-void GUIButton::SetImages(int normal, int over, int pushed, SpriteTransformFlags flags)
+void GUIButton::SetImages(int normal, int over, int pushed,
+                          SpriteTransformFlags flags, int xoff, int yoff)
 {
     _image = normal;
     _mouseOverImage = over;
     _pushedImage = pushed;
     _imageFlags = flags;
+    _imageXOff = xoff;
+    _imageYOff = yoff;
     UpdateCurrentImage();
 }
 
@@ -281,12 +284,15 @@ int32_t GUIButton::CurrentImage() const
     return _currentImage;
 }
 
-void GUIButton::SetCurrentImage(int32_t new_image, SpriteTransformFlags flags)
+void GUIButton::SetCurrentImage(int32_t new_image, SpriteTransformFlags flags, int xoff, int yoff)
 {
     if (_currentImage == new_image && _curImageFlags == flags)
         return;
+
     _currentImage = new_image;
     _curImageFlags = flags;
+    _curImageXOff = xoff;
+    _curImageYOff = yoff;
     MarkChanged();
 }
 
@@ -365,6 +371,7 @@ void GUIButton::UpdateCurrentImage()
 {
     int new_image = _currentImage;
     SpriteTransformFlags new_flags = kSprTf_None;
+    int new_xoff = 0, new_yoff = 0;
 
     if (_isPushed && (_pushedImage > 0))
     {
@@ -378,9 +385,11 @@ void GUIButton::UpdateCurrentImage()
     {
         new_image = _image;
         new_flags = _imageFlags;
+        new_xoff = _imageXOff;
+        new_yoff = _imageYOff;
     }
 
-    SetCurrentImage(new_image, new_flags);
+    SetCurrentImage(new_image, new_flags, new_xoff, new_yoff);
 }
 
 void GUIButton::WriteToFile(Stream *out) const
@@ -498,7 +507,10 @@ void GUIButton::DrawImageButton(Bitmap *ds, int x, int y, bool draw_disabled)
         ds->SetClip(RectWH(x, y, _width, _height));
 
     if (spriteset.DoesSpriteExist(_currentImage))
-        draw_gui_sprite_flipped(ds, _currentImage, x, y, kBlend_Normal, GfxDef::GetFlipFromFlags(_curImageFlags));
+    {
+        draw_gui_sprite_flipped(ds, _currentImage, x + _curImageXOff, y + _curImageYOff,
+                                kBlend_Normal, GfxDef::GetFlipFromFlags(_curImageFlags));
+    }
 
     // Draw active inventory item
     const int gui_inv_pic = GUI::Context.InventoryPic;

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -87,11 +87,11 @@ public:
     Rect CalcGraphicRect(bool clipped) override;
     void Draw(Bitmap *ds, int x = 0, int y = 0) override;
     void SetClipImage(bool on);
-    void SetCurrentImage(int image, SpriteTransformFlags flags = kSprTf_None);
+    void SetCurrentImage(int image, SpriteTransformFlags flags = kSprTf_None, int xoff = 0, int yoff = 0);
     void SetMouseOverImage(int image);
     void SetNormalImage(int image);
     void SetPushedImage(int image);
-    void SetImages(int normal, int over, int pushed, SpriteTransformFlags flags = kSprTf_None);
+    void SetImages(int normal, int over, int pushed, SpriteTransformFlags flags = kSprTf_None, int xoff = 0, int yoff = 0);
     void SetText(const String &text);
     void SetWrapText(bool on);
 
@@ -120,6 +120,8 @@ private:
     FrameAlignment _textAlignment = kAlignTopCenter;
     // TODO: flags for each kind of image?
     SpriteTransformFlags _imageFlags = kSprTf_None;
+    int     _imageXOff = 0;
+    int     _imageYOff = 0;
     int     _textPaddingHor = DefaultHorPadding;
     int     _textPaddingVer = DefaultVerPadding;
     // Click actions for left and right mouse buttons
@@ -136,6 +138,8 @@ private:
     // Active displayed image
     int     _currentImage = -1;
     SpriteTransformFlags _curImageFlags = kSprTf_None;
+    int     _curImageXOff = 0;
+    int     _curImageYOff = 0;
     // Text property set by user
     String  _text;
     // type of content placeholder, if any

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -133,9 +133,10 @@ namespace AGS.Editor
          * 4.00.00.12     - ViewFrame.Flip has full flip selection.
          * 4.00.00.14     - Obligatory alpha component in 32-bit color.
          * 4.00.00.16     - GUIControl.BlendMode and Transparency.
+         * 4.00.00.18     - ViewFrame offsets.
          *
         */
-        public const int    LATEST_XML_VERSION_INDEX = 4000016;
+        public const int    LATEST_XML_VERSION_INDEX = 4000018;
         /// <summary>
         /// XML version index on the release of AGS 4.0.0, this constant be used to determine
         /// if upgrade of Rooms/Sprites/etc. to new format have been performed.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -869,8 +869,8 @@ namespace AGS.Editor
                         {
                             ViewFrame frame = view.Loops[i].Frames[j];
                             writer.Write(frame.Image);
-                            writer.Write((short)0); // unused x-offset
-                            writer.Write((short)0); // unused y-offset
+                            writer.Write((short)frame.XOffset);
+                            writer.Write((short)frame.YOffset);
                             writer.Write((short)frame.Delay);
                             writer.Write((short)0); // struct alignment padding
                             writer.Write((int)frame.Flip);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -755,8 +755,8 @@ builtin managed struct Set
 builtin managed struct AudioClip;
 
 builtin managed struct ViewFrame {
-  /// Gets whether this frame is flipped.
-  readonly import attribute eFlipDirection Flipped;
+  /// Gets/sets whether this frame is flipped.
+  import attribute eFlipDirection Flipped;
   /// Gets the frame number of this frame.
   readonly import attribute int Frame;
   /// Gets/sets the sprite that is displayed by this frame.
@@ -765,10 +765,14 @@ builtin managed struct ViewFrame {
   import attribute AudioClip* LinkedAudio;
   /// Gets the loop number of this frame.
   readonly import attribute int Loop;
-  /// Gets the delay of this frame.
-  readonly import attribute int Speed;
+  /// Gets/sets the delay of this frame.
+  import attribute int Speed;
   /// Gets the view number that this frame is part of.
   readonly import attribute int View;
+  /// Gets/sets the relative x offset applied to this frame.
+  import attribute int XOffset;
+  /// Gets/sets the relative y offset applied to this frame.
+  import attribute int YOffset;
 };
 
 builtin managed struct DrawingSurface {

--- a/Editor/AGS.Types/ViewFrame.cs
+++ b/Editor/AGS.Types/ViewFrame.cs
@@ -14,6 +14,8 @@ namespace AGS.Types
         private SpriteFlipStyle _flip = SpriteFlipStyle.None;
         private int _sound = AudioClip.FixedIndexNoValue;
         private int _speed = 0;
+        private int _xoff = 0;
+        private int _yoff = 0;
 
         public ViewFrame()
         {
@@ -48,6 +50,22 @@ namespace AGS.Types
         {
             get { return _flip; }
             set { _flip = value; }
+        }
+
+        [Description("This sprite's X offset relative to the object's position")]
+        [Category("Appearance")]
+        public int XOffset
+        {
+            get { return _xoff; }
+            set { _xoff = value; }
+        }
+
+        [Description("This sprite's Y offset relative to the object's position")]
+        [Category("Appearance")]
+        public int YOffset
+        {
+            get { return _yoff; }
+            set { _yoff = value; }
         }
 
         [Obsolete]

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -40,10 +40,9 @@ std::vector<AnimatingGUIButton> animbuts;
 void UpdateButtonState(const AnimatingGUIButton &abtn)
 {
     // Assign view frame as normal image and reset all the rest
-    int image = views[abtn.view].loops[abtn.loop].frames[abtn.frame].pic;
-    SpriteTransformFlags flags = views[abtn.view].loops[abtn.loop].frames[abtn.frame].flags;
+    const auto &vf = views[abtn.view].loops[abtn.loop].frames[abtn.frame];
     guibuts[abtn.buttonid].SetImages(
-        views[abtn.view].loops[abtn.loop].frames[abtn.frame].pic, 0, 0, flags);
+        vf.pic, 0, 0, vf.flags, vf.xoffs, vf.yoffs);
 }
 
 void Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat,

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2543,7 +2543,8 @@ void update_character_scale(int charid)
         chin.frame = 0;
     }
 
-    const int pic = views[chin.view].loops[chin.loop].frames[chin.frame].pic;
+    const ViewFrame &vf = views[chin.view].loops[chin.loop].frames[chin.frame];
+    const int pic = vf.pic;
     int zoom, zoom_offs, scale_width, scale_height;
     update_object_scale(zoom, scale_width, scale_height,
         chin.x, chin.y, pic,
@@ -2554,6 +2555,8 @@ void update_character_scale(int charid)
     chex.zoom = zoom;
     chex.spr_width = game.SpriteInfos[pic].Width;
     chex.spr_height = game.SpriteInfos[pic].Height;
+    chex.spr_xoff = vf.xoffs;
+    chex.spr_yoff = vf.yoffs;
     chex.width = scale_width;
     chex.height = scale_height;
     chex.zoom_offs = zoom_offs;

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -22,8 +22,8 @@ using namespace AGS::Common;
 void CharacterExtras::UpdateGraphicSpace(const CharacterInfo *chin)
 {
     _gs = GraphicSpace(
-        chin->x - width / 2 + chin->pic_xoffs * zoom_offs / 100,
-        chin->y - height    - (chin->z + chin->pic_yoffs) * zoom_offs / 100,
+        chin->x - width / 2 + (chin->pic_xoffs + spr_xoff) * zoom_offs / 100,
+        chin->y - height    + (-chin->z + chin->pic_yoffs + spr_yoff) * zoom_offs / 100,
         spr_width, spr_height, width, height, rotation);
 }
 

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -54,9 +54,11 @@ class CharacterExtras
 public:
     short invorder[MAX_INVORDER]{};
     short invorder_count = 0;
-    int spr_width = 0; // last used sprite's size
-    int spr_height = 0;
-    short width = 0; // width/height last time drawn (includes scaling)
+    int   spr_width = 0; // current sprite size
+    int   spr_height = 0;
+    int   spr_xoff = 0; // current sprite (frame) offset
+    int   spr_yoff = 0;
+    short width = 0; // width/height (includes character scaling!)
     short height = 0;
     short zoom = 100;
     short xwas = 0; // TODO: figure out how these xwas,ywas are being used and comment them

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2098,7 +2098,7 @@ bool construct_object_gfx(int objid, bool force_software)
     return construct_object_gfx(
         (obj.view != UINT16_MAX) ? &views[obj.view].loops[obj.loop].frames[obj.frame] : nullptr,
         sprite_id,
-        Size(obj.last_width, obj.last_height),
+        Size(obj.width, obj.height),
         obj.flags & OBJF_TINTLIGHTMASK,
         objsrc,
         objcache[objid],
@@ -2134,11 +2134,14 @@ void prepare_objects_for_drawing()
         const bool actsp_modified = !construct_object_gfx(objid, false);
         // Prepare the object texture
         prepare_and_add_object_gfx(objsav, actsp, actsp_modified,
-            Size(obj.last_width, obj.last_height), imgx, imgy, usebasel,
+            Size(obj.width, obj.height), imgx, imgy, usebasel,
             (obj.flags & OBJF_NOWALKBEHINDS) == 0,
             obj.GetOrigin(), obj.transparent, obj.blend_mode, obj.shader_id, hw_accel);
         // Finally, add the texture to the draw list
-        add_to_sprite_list(actsp.Ddb, obj.x, obj.y, aabb, usebasel, actsp.DrawIndex);
+        // CHECKME: remind why do we have to recalculate charx/y instead of using GS?
+        const int objx = obj.x + (obj.spr_xoff) * obj.zoom / 100;
+        const int objy = obj.y + (obj.spr_yoff) * obj.zoom / 100;
+        add_to_sprite_list(actsp.Ddb, objx, objy, aabb, usebasel, actsp.DrawIndex);
     }
 }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2249,8 +2249,8 @@ void prepare_characters_for_drawing()
             chex.GetOrigin(), chin.transparency, chex.blend_mode, chex.shader_id, hw_accel);
         // Finally, add the texture to the draw list
         // CHECKME: remind why do we have to recalculate charx/y instead of using GS?
-        const int charx = chin.x + chin.pic_xoffs * chex.zoom_offs / 100;
-        const int chary = chin.y - chin.z + chin.pic_yoffs * chex.zoom_offs / 100;
+        const int charx = chin.x + (chin.pic_xoffs + chex.spr_xoff) * chex.zoom_offs / 100;
+        const int chary = chin.y + (-chin.z + chin.pic_yoffs + chex.spr_yoff) * chex.zoom_offs / 100;
         add_to_sprite_list(actsp.Ddb, charx, chary, aabb, usebasel, actsp.DrawIndex);
     }
 }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -1059,8 +1059,13 @@ void update_object_scale(int objid)
     obj.zoom = zoom;
     obj.spr_width = game.SpriteInfos[obj.num].Width;
     obj.spr_height = game.SpriteInfos[obj.num].Height;
-    obj.last_width = scale_width;
-    obj.last_height = scale_height;
+    if (obj.cycling != 0)
+    {
+        obj.spr_xoff = views[obj.view].loops[obj.loop].frames[obj.frame].xoffs;
+        obj.spr_yoff = views[obj.view].loops[obj.loop].frames[obj.frame].yoffs;
+    }
+    obj.width = scale_width;
+    obj.height = scale_height;
     obj.UpdateGraphicSpace();
 }
 
@@ -1069,11 +1074,11 @@ void get_object_blocking_rect(int objid, int *x1, int *y1, int *width, int *y2) 
     int cwidth, fromx;
 
     if (tehobj->blocking_width < 1)
-        cwidth = tehobj->last_width - 4;
+        cwidth = tehobj->width - 4;
     else
         cwidth = tehobj->blocking_width;
 
-    fromx = tehobj->x + (tehobj->last_width / 2) - cwidth / 2;
+    fromx = tehobj->x + (tehobj->width / 2) - cwidth / 2;
     if (fromx < 0) {
         cwidth += fromx;
         fromx = 0;

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -40,7 +40,8 @@ RoomObject::RoomObject()
     tint_light = 0;
     zoom = 100;
     spr_width = spr_height = 0;
-    last_width = last_height = 0;
+    spr_xoff = spr_yoff = 0;
+    width = height = 0;
     num = 0;
     baseline = -1;
     view = NoView;
@@ -59,16 +60,16 @@ RoomObject::RoomObject()
 
 int RoomObject::get_width() const {
     // FIXME: don't use global game object here, instead make sure last_width is always valid
-    if (last_width == 0)
+    if (width == 0)
         return game.SpriteInfos[num].Width;
-    return last_width;
+    return width;
 }
 
 int RoomObject::get_height() const {
     // FIXME: don't use global game object here, instead make sure last_height is always valid
-    if (last_height == 0)
+    if (height == 0)
         return game.SpriteInfos[num].Height;
-    return last_height;
+    return height;
 }
 
 int RoomObject::get_baseline() const {
@@ -144,8 +145,8 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
     tint_level = in->ReadInt16();
     tint_light = in->ReadInt16();
     zoom = in->ReadInt16();
-    last_width = in->ReadInt16();
-    last_height = in->ReadInt16();
+    width = in->ReadInt16();
+    height = in->ReadInt16();
     num = in->ReadInt16();
     baseline = in->ReadInt16();
     view = in->ReadInt16();
@@ -228,8 +229,8 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
         shader_handle = 0;
     }
 
-    spr_width = last_width;
-    spr_height = last_height;
+    spr_width = width;
+    spr_height = height;
     UpdateGraphicSpace();
 }
 
@@ -244,8 +245,8 @@ void RoomObject::WriteToSavegame(Stream *out) const
     out->WriteInt16(tint_level);
     out->WriteInt16(tint_light);
     out->WriteInt16(zoom);
-    out->WriteInt16(last_width);
-    out->WriteInt16(last_height);
+    out->WriteInt16(width);
+    out->WriteInt16(height);
     out->WriteInt16(num);
     out->WriteInt16(baseline);
     out->WriteInt16(view);
@@ -295,5 +296,7 @@ void RoomObject::WriteToSavegame(Stream *out) const
 
 void RoomObject::UpdateGraphicSpace()
 {
-    _gs = GraphicSpace(x, y - last_height, spr_width, spr_height, last_width, last_height, rotation);
+    _gs = GraphicSpace(x          + (spr_xoff) * zoom / 100,
+                       y - height + (spr_xoff) * zoom / 100,
+                       spr_width, spr_height, width, height, rotation);
 }

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -48,7 +48,8 @@ public:
     short tint_light;
     short zoom;           // zoom level, either manual or from the current area
     int   spr_width, spr_height; // last used sprite's size
-    short last_width, last_height;  // width/height based on a scaled sprite
+    int   spr_xoff, spr_yoff; // sprite offsets (when using a view)
+    short width, height;  // width/height based on a scaled sprite
     uint16_t num;            // sprite slot number
     short baseline;       // <=0 to use Y co-ordinate; >0 for specific baseline
     uint16_t view,loop,frame; // only used to track animation - 'num' holds the current sprite

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -31,51 +31,88 @@ extern std::vector<ViewStruct> views;
 extern CCAudioClip ccDynamicAudioClip;
 
 
-int ViewFrame_GetFlipped(ScriptViewFrame *svf) {
-  // We can return GraphicFlip here, because old boolean value matches horizontal flip
-  return GfxDef::GetFlipFromFlags(views[svf->view].loops[svf->loop].frames[svf->frame].flags);
+int ViewFrame_GetFlipped(ScriptViewFrame *svf)
+{
+    // We can return GraphicFlip here, because old boolean value matches horizontal flip
+    return GfxDef::GetFlipFromFlags(views[svf->view].loops[svf->loop].frames[svf->frame].flags);
 }
 
-int ViewFrame_GetGraphic(ScriptViewFrame *svf) {
-  return views[svf->view].loops[svf->loop].frames[svf->frame].pic;
+void ViewFrame_SetFlipped(ScriptViewFrame *svf, int flip)
+{
+    views[svf->view].loops[svf->loop].frames[svf->frame].flags = GfxDef::GetFlagsFromFlip((GraphicFlip)flip);
 }
 
-void ViewFrame_SetGraphic(ScriptViewFrame *svf, int newPic) {
-  views[svf->view].loops[svf->loop].frames[svf->frame].pic = newPic;
+int ViewFrame_GetGraphic(ScriptViewFrame *svf)
+{
+    return views[svf->view].loops[svf->loop].frames[svf->frame].pic;
+}
+
+void ViewFrame_SetGraphic(ScriptViewFrame *svf, int newPic)
+{
+    views[svf->view].loops[svf->loop].frames[svf->frame].pic = newPic;
 }
 
 ScriptAudioClip* ViewFrame_GetLinkedAudio(ScriptViewFrame *svf) 
 {
-  int soundIndex = views[svf->view].loops[svf->loop].frames[svf->frame].sound;
-  if (soundIndex < 0)
-    return nullptr;
+    int soundIndex = views[svf->view].loops[svf->loop].frames[svf->frame].sound;
+    if (soundIndex < 0)
+        return nullptr;
 
-  return &game.audioClips[soundIndex];
+    return &game.audioClips[soundIndex];
 }
 
 void ViewFrame_SetLinkedAudio(ScriptViewFrame *svf, ScriptAudioClip* clip) 
 {
-  int newSoundIndex = -1;
-  if (clip != nullptr)
-    newSoundIndex = clip->id;
-
-  views[svf->view].loops[svf->loop].frames[svf->frame].sound = newSoundIndex;
+    int newSoundIndex = -1;
+    if (clip != nullptr)
+        newSoundIndex = clip->id;
+    
+    views[svf->view].loops[svf->loop].frames[svf->frame].sound = newSoundIndex;
 }
 
-int ViewFrame_GetSpeed(ScriptViewFrame *svf) {
-  return views[svf->view].loops[svf->loop].frames[svf->frame].speed;
+int ViewFrame_GetSpeed(ScriptViewFrame *svf)
+{
+    return views[svf->view].loops[svf->loop].frames[svf->frame].speed;
 }
 
-int ViewFrame_GetView(ScriptViewFrame *svf) {
-  return svf->view + 1;
+void ViewFrame_SetSpeed(ScriptViewFrame *svf, int speed)
+{
+    views[svf->view].loops[svf->loop].frames[svf->frame].speed = speed;
 }
 
-int ViewFrame_GetLoop(ScriptViewFrame *svf) {
-  return svf->loop;
+int ViewFrame_GetXOffset(ScriptViewFrame *svf)
+{
+    return views[svf->view].loops[svf->loop].frames[svf->frame].xoffs;
 }
 
-int ViewFrame_GetFrame(ScriptViewFrame *svf) {
-  return svf->frame;
+void ViewFrame_SetXOffset(ScriptViewFrame *svf, int xoff)
+{
+    views[svf->view].loops[svf->loop].frames[svf->frame].xoffs = xoff;
+}
+
+int ViewFrame_GetYOffset(ScriptViewFrame *svf)
+{
+    return views[svf->view].loops[svf->loop].frames[svf->frame].xoffs;
+}
+
+void ViewFrame_SetYOffset(ScriptViewFrame *svf, int yoff)
+{
+    views[svf->view].loops[svf->loop].frames[svf->frame].yoffs = yoff;
+}
+
+int ViewFrame_GetView(ScriptViewFrame *svf)
+{
+    return svf->view + 1;
+}
+
+int ViewFrame_GetLoop(ScriptViewFrame *svf)
+{
+    return svf->loop;
+}
+
+int ViewFrame_GetFrame(ScriptViewFrame *svf)
+{
+    return svf->frame;
 }
 
 //=============================================================================
@@ -159,6 +196,11 @@ RuntimeScriptValue Sc_ViewFrame_GetFlipped(void *self, const RuntimeScriptValue 
     API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetFlipped);
 }
 
+RuntimeScriptValue Sc_ViewFrame_SetFlipped(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewFrame, ViewFrame_SetFlipped);
+}
+
 // int (ScriptViewFrame *svf)
 RuntimeScriptValue Sc_ViewFrame_GetFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -189,15 +231,20 @@ RuntimeScriptValue Sc_ViewFrame_SetLinkedAudio(void *self, const RuntimeScriptVa
 }
 
 // int (ScriptViewFrame *svf)
-RuntimeScriptValue Sc_ViewFrame_GetLoop(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetLoop);
-}
-
-// int (ScriptViewFrame *svf)
 RuntimeScriptValue Sc_ViewFrame_GetSpeed(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetSpeed);
+}
+
+RuntimeScriptValue Sc_ViewFrame_SetSpeed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewFrame, ViewFrame_SetSpeed);
+}
+
+// int (ScriptViewFrame *svf)
+RuntimeScriptValue Sc_ViewFrame_GetLoop(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetLoop);
 }
 
 // int (ScriptViewFrame *svf)
@@ -206,11 +253,32 @@ RuntimeScriptValue Sc_ViewFrame_GetView(void *self, const RuntimeScriptValue *pa
     API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetView);
 }
 
+RuntimeScriptValue Sc_ViewFrame_GetXOffset(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetXOffset);
+}
+
+RuntimeScriptValue Sc_ViewFrame_SetXOffset(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewFrame, ViewFrame_SetXOffset);
+}
+
+RuntimeScriptValue Sc_ViewFrame_GetYOffset(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptViewFrame, ViewFrame_GetYOffset);
+}
+
+RuntimeScriptValue Sc_ViewFrame_SetYOffset(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewFrame, ViewFrame_SetYOffset);
+}
+
 
 void RegisterViewFrameAPI()
 {
     ScFnRegister viewframe_api[] = {
         { "ViewFrame::get_Flipped",       API_FN_PAIR(ViewFrame_GetFlipped) },
+        { "ViewFrame::set_Flipped",       API_FN_PAIR(ViewFrame_SetFlipped) },
         { "ViewFrame::get_Frame",         API_FN_PAIR(ViewFrame_GetFrame) },
         { "ViewFrame::get_Graphic",       API_FN_PAIR(ViewFrame_GetGraphic) },
         { "ViewFrame::set_Graphic",       API_FN_PAIR(ViewFrame_SetGraphic) },
@@ -218,7 +286,12 @@ void RegisterViewFrameAPI()
         { "ViewFrame::set_LinkedAudio",   API_FN_PAIR(ViewFrame_SetLinkedAudio) },
         { "ViewFrame::get_Loop",          API_FN_PAIR(ViewFrame_GetLoop) },
         { "ViewFrame::get_Speed",         API_FN_PAIR(ViewFrame_GetSpeed) },
+        { "ViewFrame::set_Speed",         API_FN_PAIR(ViewFrame_SetSpeed) },
         { "ViewFrame::get_View",          API_FN_PAIR(ViewFrame_GetView) },
+        { "ViewFrame::get_XOffset",       API_FN_PAIR(ViewFrame_GetXOffset) },
+        { "ViewFrame::set_XOffset",       API_FN_PAIR(ViewFrame_SetXOffset) },
+        { "ViewFrame::get_YOffset",       API_FN_PAIR(ViewFrame_GetYOffset) },
+        { "ViewFrame::set_YOffset",       API_FN_PAIR(ViewFrame_SetYOffset) },
     };
 
     ccAddExternalFunctions(viewframe_api);


### PR DESCRIPTION
This adds ViewFrame.XOffset and YOffset properties in the Editor.
Curiously, ViewFrame always had "xoff/yoff" fields serialized in game data, but they were never used. I do not know the history behind these, maybe they were planned at some point but never implemented.

Support these offsets when the frames with these are applied to Character, Object, and Button animations. Character and Objects apply these offsets scaled along with the object scaling. Button offsets only the image displayed within the button control's rect, but *not* the control's position itself.

In script API added setters to previously existing properties: ViewFrame.Flipped and ViewFrame.Speed.
Added new properties ViewFrame.XOffset and YOffset.