### PR TITLE
Script API: implement Button.GraphicFlip

### DIFF
--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -102,6 +102,26 @@ int GUIButton::GetPushedImage() const
     return _pushedImage;
 }
 
+SpriteTransformFlags GUIButton::GetImageFlags() const
+{
+    return _imageFlags;
+}
+
+GraphicFlip GUIButton::GetImageFlip() const
+{
+    return GfxDef::GetFlipFromFlags(_imageFlags);
+}
+
+SpriteTransformFlags GUIButton::GetCurrentImageFlags() const
+{
+    return _curImageFlags;
+}
+
+GraphicFlip GUIButton::GetCurrentImageFlip() const
+{
+    return GfxDef::GetFlipFromFlags(_curImageFlags);
+}
+
 GUIButtonPlaceholder GUIButton::GetPlaceholder() const
 {
     return _placeholder;
@@ -279,6 +299,17 @@ void GUIButton::SetImages(int normal, int over, int pushed,
     UpdateCurrentImage();
 }
 
+void GUIButton::SetImageFlags(SpriteTransformFlags flags)
+{
+    _imageFlags = flags;
+    UpdateCurrentImage();
+}
+
+void GUIButton::SetImageFlip(GraphicFlip flip)
+{
+    SetImageFlags((SpriteTransformFlags)((_imageFlags & ~kSprTf_FlipXY) | GfxDef::GetFlagsFromFlip(flip)));
+}
+
 void GUIButton::SetCurrentImage(int32_t new_image, SpriteTransformFlags flags, int xoff, int yoff)
 {
     if (_currentImage == new_image && _curImageFlags == flags)
@@ -365,7 +396,7 @@ void GUIButton::OnMouseUp()
 void GUIButton::UpdateCurrentImage()
 {
     int new_image = _currentImage;
-    SpriteTransformFlags new_flags = kSprTf_None;
+    SpriteTransformFlags new_flags = _imageFlags;
     int new_xoff = 0, new_yoff = 0;
 
     if (_isPushed && (_pushedImage > 0))
@@ -379,7 +410,6 @@ void GUIButton::UpdateCurrentImage()
     else
     {
         new_image = _image;
-        new_flags = _imageFlags;
         new_xoff = _imageXOff;
         new_yoff = _imageYOff;
     }

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -73,6 +73,10 @@ public:
     int  GetNormalImage() const;
     int  GetMouseOverImage() const;
     int  GetPushedImage() const;
+    SpriteTransformFlags GetImageFlags() const;
+    GraphicFlip GetImageFlip() const;
+    SpriteTransformFlags GetCurrentImageFlags() const;
+    GraphicFlip GetCurrentImageFlip() const;
     GUIButtonPlaceholder GetPlaceholder() const;
     const String &GetText() const;
     bool IsImageButton() const;
@@ -91,6 +95,8 @@ public:
     void SetNormalImage(int image);
     void SetPushedImage(int image);
     void SetImages(int normal, int over, int pushed, SpriteTransformFlags flags = kSprTf_None, int xoff = 0, int yoff = 0);
+    void SetImageFlags(SpriteTransformFlags flags);
+    void SetImageFlip(GraphicFlip flip);
     void SetText(const String &text);
     void SetWrapText(bool on);
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1655,6 +1655,10 @@ builtin managed struct Button extends GUIControl {
   /// Gets/sets amount of padding, restricting the text from top and bottom
   import attribute int TextPaddingVertical;
 #endif // SCRIPT_API_v362
+#ifdef SCRIPT_API_v400
+  /// Gets/sets the flip direction of the button's graphic
+  import attribute eFlipDirection GraphicFlip;
+#endif // SCRIPT_API_v400
 };
 
 builtin managed struct Slider extends GUIControl {

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -134,6 +134,16 @@ int Button_GetGraphic(GUIButton *butt) {
     return butt->GetCurrentImage();
 }
 
+int Button_GetGraphicFlip(GUIButton *butt)
+{
+    return butt->GetImageFlip();
+}
+
+void Button_SetGraphicFlip(GUIButton *butt, int flip)
+{
+    butt->SetImageFlip((GraphicFlip)flip);
+}
+
 int Button_GetMouseOverGraphic(GUIButton *butt) {
     return butt->GetMouseOverImage();
 }
@@ -402,6 +412,16 @@ RuntimeScriptValue Sc_Button_GetGraphic(void *self, const RuntimeScriptValue *pa
     API_OBJCALL_INT(GUIButton, Button_GetGraphic);
 }
 
+RuntimeScriptValue Sc_Button_GetGraphicFlip(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetGraphicFlip);
+}
+
+RuntimeScriptValue Sc_Button_SetGraphicFlip(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(GUIButton, Button_SetGraphicFlip);
+}
+
 // int | GUIButton *butt
 RuntimeScriptValue Sc_Button_GetMouseOverGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -539,6 +559,8 @@ void RegisterButtonAPI()
         { "Button::set_Font",             API_FN_PAIR(Button_SetFont) },
         { "Button::get_Frame",            API_FN_PAIR(Button_GetAnimFrame) },
         { "Button::get_Graphic",          API_FN_PAIR(Button_GetGraphic) },
+        { "Button::get_GraphicFlip",      API_FN_PAIR(Button_GetGraphicFlip) },
+        { "Button::set_GraphicFlip",      API_FN_PAIR(Button_SetGraphicFlip) },
         { "Button::get_Loop",             API_FN_PAIR(Button_GetAnimLoop) },
         { "Button::get_MouseOverGraphic", API_FN_PAIR(Button_GetMouseOverGraphic) },
         { "Button::set_MouseOverGraphic", API_FN_PAIR(Button_SetMouseOverGraphic) },


### PR DESCRIPTION
Based on a feature in a "Draconian" engine version, this adds a Button.GraphicFlip property that flips a button image (in all 3 states - normal, over and pressed).
This does not affect animated buttons, as they receive the flip option from the view frames. In fact, Animate() will reset the GraphicFlip property as it resets NormalGraphic.

The property name is "GraphicFlip", and not e.g. "Flip", because this flips only the assigned graphic, not whole control.