### PR TITLE
4.0: Color finder displays color number as hex

### DIFF
--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -21,6 +21,7 @@ namespace AGS.Editor
         private bool _noUpdates = false;
         private List<int> _selectedIndexes = new List<int>();
         private TabPage _colourFinder;
+        private Color _currentColor = Color.Black;
 
         public PaletteEditor()
         {
@@ -29,6 +30,7 @@ namespace AGS.Editor
             Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _selectedIndexes.Add(0);
             GameChanged();
+            UpdateNumberFromScrollBars();
         }
 
         protected override void OnPropertyChanged(string propertyName, object oldValue)
@@ -93,8 +95,11 @@ namespace AGS.Editor
             if (!_noUpdates)
             {
                 int newVal = 0;
-                Int32.TryParse(txtColourNumber.Text, out newVal);
-                if ((newVal < 0) || (newVal > int.MaxValue))
+                try
+                {
+                    newVal = Convert.ToInt32(txtColourNumber.Text, 16);
+                }
+                catch (Exception)
                 {
                     newVal = 0;
                 }
@@ -103,7 +108,8 @@ namespace AGS.Editor
                 trackBarRed.Value = newColor.R;
                 trackBarGreen.Value = newColor.G;
                 trackBarBlue.Value = newColor.B;
-				ColourSlidersUpdated();
+                _currentColor = newColor;
+                ColourSlidersUpdated();
             }
         }
 
@@ -120,18 +126,15 @@ namespace AGS.Editor
             _noUpdates = true;
             var newColor = Color.FromArgb(trackBarRed.Value, trackBarGreen.Value, trackBarBlue.Value);
             int newValue = ColorMapper.ColorToAgsColourNumberDirect(newColor);
-            txtColourNumber.Text = newValue.ToString();
+            txtColourNumber.Text = newValue.ToString("X8");
+            _currentColor = newColor;
             _noUpdates = false;
             blockOfColour.Invalidate();
         }
 
         private void blockOfColour_Paint(object sender, PaintEventArgs e)
         {
-            int colourVal = 0;
-            Int32.TryParse(txtColourNumber.Text, out colourVal);
-
-            Color color = Factory.AGSEditor.ColorMapper.MapAgsColourNumberToRgbColor(colourVal);
-            using (Brush brush = new SolidBrush(color))
+            using (Brush brush = new SolidBrush(_currentColor))
             {
                 e.Graphics.FillRectangle(brush, 0, 0, blockOfColour.Width, blockOfColour.Height);
             }

--- a/Editor/AGS.Types/PropertyGridExtras/CustomColorConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/CustomColorConverter.cs
@@ -69,6 +69,17 @@ namespace AGS.Types
 
         private Color ColorFromString(string value)
         {
+            // First try reading a hexadecimal number
+            try
+            {
+                int argb = Convert.ToInt32(value, 16);
+                return Color.FromArgb(argb);
+            }
+            catch (Exception)
+            {
+            }
+
+            // If failed, then try to parse as color components
             var rgb = value.Split(';');
             switch (rgb.Length)
             {


### PR DESCRIPTION
Fix #2743

Color Finder displays color numbers as a hexadecimal number, because it's inconvenient and confusing when the number is a negative integer.

Color properties allow to paste or type a hexadecimal number too now, along with the previously supported 3,4 - component string.

The only caveat here is that when pasting in script you must type "0x" part by hand. I am in doubts whether Color Finder has to print the number with "0x" or not. But technically there's no problem in doing that (then properties grid will have to account for possible "0x" prefix as well).