### PR TITLE
4.0: redesign Color Finder, parse colors in various notations

### DIFF
--- a/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
@@ -28,6 +28,7 @@ namespace AGS.Editor
         /// </summary>
         private void InitializeComponent()
         {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PaletteEditor));
             this.tabControl = new System.Windows.Forms.TabControl();
             this.palettePage = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -36,17 +37,13 @@ namespace AGS.Editor
             this.lblPaletteIntro = new System.Windows.Forms.Label();
             this.colourFinderPage = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.txtCommaSeparated = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.txtWebColor = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
             this.btnColorDialog = new System.Windows.Forms.Button();
             this.blockOfColour = new AGS.Editor.BufferedPanel();
-            this.lblBlueVal = new System.Windows.Forms.Label();
-            this.lblGreenVal = new System.Windows.Forms.Label();
-            this.lblRedVal = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.trackBarBlue = new System.Windows.Forms.TrackBar();
-            this.label4 = new System.Windows.Forms.Label();
-            this.trackBarGreen = new System.Windows.Forms.TrackBar();
-            this.label3 = new System.Windows.Forms.Label();
-            this.trackBarRed = new System.Windows.Forms.TrackBar();
             this.txtColourNumber = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
@@ -55,9 +52,6 @@ namespace AGS.Editor
             this.groupBox2.SuspendLayout();
             this.colourFinderPage.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).BeginInit();
             this.SuspendLayout();
             // 
             // tabControl
@@ -110,8 +104,8 @@ namespace AGS.Editor
             this.palettePanel.Name = "palettePanel";
             this.palettePanel.Size = new System.Drawing.Size(364, 320);
             this.palettePanel.TabIndex = 1;
-			this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
             this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
+            this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
             // 
             // lblPaletteIntro
             // 
@@ -119,7 +113,7 @@ namespace AGS.Editor
             this.lblPaletteIntro.Location = new System.Drawing.Point(16, 17);
             this.lblPaletteIntro.MaximumSize = new System.Drawing.Size(400, 0);
             this.lblPaletteIntro.Name = "lblPaletteIntro";
-			this.lblPaletteIntro.Size = new System.Drawing.Size(394, 26);
+            this.lblPaletteIntro.Size = new System.Drawing.Size(395, 26);
             this.lblPaletteIntro.TabIndex = 0;
             this.lblPaletteIntro.Text = "This palette information will only be used for drawing any 8-bit graphics that yo" +
     "u may have imported.";
@@ -137,30 +131,73 @@ namespace AGS.Editor
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.label5);
+            this.groupBox1.Controls.Add(this.txtCommaSeparated);
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.txtWebColor);
+            this.groupBox1.Controls.Add(this.label3);
             this.groupBox1.Controls.Add(this.btnColorDialog);
             this.groupBox1.Controls.Add(this.blockOfColour);
-            this.groupBox1.Controls.Add(this.lblBlueVal);
-            this.groupBox1.Controls.Add(this.lblGreenVal);
-            this.groupBox1.Controls.Add(this.lblRedVal);
-            this.groupBox1.Controls.Add(this.label5);
-            this.groupBox1.Controls.Add(this.trackBarBlue);
-            this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.trackBarGreen);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.trackBarRed);
             this.groupBox1.Controls.Add(this.txtColourNumber);
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Location = new System.Drawing.Point(6, 6);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(395, 337);
+            this.groupBox1.Size = new System.Drawing.Size(435, 337);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Colour Finder";
             // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(194, 172);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(15, 13);
+            this.label5.TabIndex = 19;
+            this.label5.Text = "#";
+            // 
+            // txtCommaSeparated
+            // 
+            this.txtCommaSeparated.Location = new System.Drawing.Point(213, 195);
+            this.txtCommaSeparated.MaxLength = 0;
+            this.txtCommaSeparated.Name = "txtCommaSeparated";
+            this.txtCommaSeparated.Size = new System.Drawing.Size(99, 21);
+            this.txtCommaSeparated.TabIndex = 18;
+            this.txtCommaSeparated.Text = "0";
+            this.txtCommaSeparated.TextChanged += new System.EventHandler(this.txtCommaSeparated_TextChanged);
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(16, 199);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(157, 13);
+            this.label4.TabIndex = 17;
+            this.label4.Text = "Comma separated (R, G, B, A):";
+            // 
+            // txtWebColor
+            // 
+            this.txtWebColor.Location = new System.Drawing.Point(213, 168);
+            this.txtWebColor.MaxLength = 8;
+            this.txtWebColor.Name = "txtWebColor";
+            this.txtWebColor.Size = new System.Drawing.Size(99, 21);
+            this.txtWebColor.TabIndex = 16;
+            this.txtWebColor.Text = "0";
+            this.txtWebColor.TextChanged += new System.EventHandler(this.txtWebColor_TextChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(16, 172);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(124, 13);
+            this.label3.TabIndex = 15;
+            this.label3.Text = "Web color (RRGGBBAA):";
+            // 
             // btnColorDialog
             // 
-            this.btnColorDialog.Location = new System.Drawing.Point(201, 74);
+            this.btnColorDialog.Location = new System.Drawing.Point(318, 142);
             this.btnColorDialog.Name = "btnColorDialog";
             this.btnColorDialog.Size = new System.Drawing.Size(96, 21);
             this.btnColorDialog.TabIndex = 14;
@@ -170,108 +207,18 @@ namespace AGS.Editor
             // 
             // blockOfColour
             // 
-            this.blockOfColour.Location = new System.Drawing.Point(23, 242);
+            this.blockOfColour.Location = new System.Drawing.Point(19, 229);
             this.blockOfColour.Name = "blockOfColour";
-            this.blockOfColour.Size = new System.Drawing.Size(245, 47);
+            this.blockOfColour.Size = new System.Drawing.Size(395, 47);
             this.blockOfColour.TabIndex = 12;
             this.blockOfColour.Paint += new System.Windows.Forms.PaintEventHandler(this.blockOfColour_Paint);
             // 
-            // lblBlueVal
-            // 
-            this.lblBlueVal.AutoSize = true;
-            this.lblBlueVal.Location = new System.Drawing.Point(278, 192);
-            this.lblBlueVal.Name = "lblBlueVal";
-            this.lblBlueVal.Size = new System.Drawing.Size(13, 13);
-            this.lblBlueVal.TabIndex = 11;
-            this.lblBlueVal.Text = "0";
-            // 
-            // lblGreenVal
-            // 
-            this.lblGreenVal.AutoSize = true;
-            this.lblGreenVal.Location = new System.Drawing.Point(278, 153);
-            this.lblGreenVal.Name = "lblGreenVal";
-            this.lblGreenVal.Size = new System.Drawing.Size(13, 13);
-            this.lblGreenVal.TabIndex = 10;
-            this.lblGreenVal.Text = "0";
-            // 
-            // lblRedVal
-            // 
-            this.lblRedVal.AutoSize = true;
-            this.lblRedVal.Location = new System.Drawing.Point(278, 115);
-            this.lblRedVal.Name = "lblRedVal";
-            this.lblRedVal.Size = new System.Drawing.Size(13, 13);
-            this.lblRedVal.TabIndex = 9;
-            this.lblRedVal.Text = "0";
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(18, 192);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(31, 13);
-            this.label5.TabIndex = 8;
-            this.label5.Text = "Blue:";
-            // 
-            // trackBarBlue
-            // 
-            this.trackBarBlue.LargeChange = 40;
-            this.trackBarBlue.Location = new System.Drawing.Point(61, 188);
-            this.trackBarBlue.Maximum = 255;
-            this.trackBarBlue.Name = "trackBarBlue";
-            this.trackBarBlue.Size = new System.Drawing.Size(208, 42);
-            this.trackBarBlue.SmallChange = 8;
-            this.trackBarBlue.TabIndex = 7;
-            this.trackBarBlue.TickFrequency = 16;
-            this.trackBarBlue.Scroll += new System.EventHandler(this.trackBarBlue_Scroll);
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(18, 153);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(40, 13);
-            this.label4.TabIndex = 6;
-            this.label4.Text = "Green:";
-            // 
-            // trackBarGreen
-            // 
-            this.trackBarGreen.LargeChange = 40;
-            this.trackBarGreen.Location = new System.Drawing.Point(61, 149);
-            this.trackBarGreen.Maximum = 255;
-            this.trackBarGreen.Name = "trackBarGreen";
-            this.trackBarGreen.Size = new System.Drawing.Size(208, 42);
-            this.trackBarGreen.SmallChange = 8;
-            this.trackBarGreen.TabIndex = 5;
-            this.trackBarGreen.TickFrequency = 16;
-            this.trackBarGreen.Scroll += new System.EventHandler(this.trackBarGreen_Scroll);
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(18, 115);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(30, 13);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Red:";
-            // 
-            // trackBarRed
-            // 
-            this.trackBarRed.LargeChange = 40;
-            this.trackBarRed.Location = new System.Drawing.Point(61, 111);
-            this.trackBarRed.Maximum = 255;
-            this.trackBarRed.Name = "trackBarRed";
-            this.trackBarRed.Size = new System.Drawing.Size(208, 42);
-            this.trackBarRed.SmallChange = 8;
-            this.trackBarRed.TabIndex = 3;
-            this.trackBarRed.TickFrequency = 16;
-            this.trackBarRed.Scroll += new System.EventHandler(this.trackBarRed_Scroll);
-            // 
             // txtColourNumber
             // 
-            this.txtColourNumber.Location = new System.Drawing.Point(110, 74);
+            this.txtColourNumber.Location = new System.Drawing.Point(213, 142);
             this.txtColourNumber.MaxLength = 10;
             this.txtColourNumber.Name = "txtColourNumber";
-            this.txtColourNumber.Size = new System.Drawing.Size(85, 21);
+            this.txtColourNumber.Size = new System.Drawing.Size(99, 21);
             this.txtColourNumber.TabIndex = 2;
             this.txtColourNumber.Text = "0";
             this.txtColourNumber.TextChanged += new System.EventHandler(this.txtColourNumber_TextChanged);
@@ -279,22 +226,21 @@ namespace AGS.Editor
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(16, 77);
+            this.label2.Location = new System.Drawing.Point(16, 146);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(81, 13);
+            this.label2.Size = new System.Drawing.Size(158, 13);
             this.label2.TabIndex = 1;
-            this.label2.Text = "Colour number:";
+            this.label2.Text = "Colour number (0xAARRGGBB):";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(16, 26);
-            this.label1.MaximumSize = new System.Drawing.Size(350, 0);
+            this.label1.MaximumSize = new System.Drawing.Size(400, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(335, 26);
+            this.label1.Size = new System.Drawing.Size(400, 104);
             this.label1.TabIndex = 0;
-            this.label1.Text = "You can use the controls below to find the AGS Colour Number for a particular col" +
-    "our.";
+            this.label1.Text = resources.GetString("label1.Text");
             // 
             // PaletteEditor
             // 
@@ -312,9 +258,6 @@ namespace AGS.Editor
             this.colourFinderPage.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -328,20 +271,16 @@ namespace AGS.Editor
         private System.Windows.Forms.TabPage colourFinderPage;
         private System.Windows.Forms.GroupBox groupBox1;
         private BufferedPanel blockOfColour;
-        private System.Windows.Forms.Label lblBlueVal;
-        private System.Windows.Forms.Label lblGreenVal;
-        private System.Windows.Forms.Label lblRedVal;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.TrackBar trackBarBlue;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.TrackBar trackBarGreen;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.TrackBar trackBarRed;
         private System.Windows.Forms.TextBox txtColourNumber;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private BufferedPanel palettePanel;
         private System.Windows.Forms.Label label6;
 		private System.Windows.Forms.Button btnColorDialog;
+        private System.Windows.Forms.TextBox txtWebColor;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.TextBox txtCommaSeparated;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label5;
     }
 }

--- a/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
@@ -33,25 +33,31 @@ namespace AGS.Editor
             this.palettePage = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.label6 = new System.Windows.Forms.Label();
-            this.palettePanel = new AGS.Editor.BufferedPanel();
             this.lblPaletteIntro = new System.Windows.Forms.Label();
             this.colourFinderPage = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.txtLegacyColourNumber = new System.Windows.Forms.TextBox();
+            this.label7 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.txtCommaSeparated = new System.Windows.Forms.TextBox();
             this.label4 = new System.Windows.Forms.Label();
             this.txtWebColor = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.btnColorDialog = new System.Windows.Forms.Button();
-            this.blockOfColour = new AGS.Editor.BufferedPanel();
             this.txtColourNumber = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
+            this.palettePanel = new AGS.Editor.BufferedPanel();
+            this.blockOfColour = new AGS.Editor.BufferedPanel();
             this.tabControl.SuspendLayout();
             this.palettePage.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.colourFinderPage.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.panel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl
@@ -98,15 +104,6 @@ namespace AGS.Editor
             this.label6.Text = "Click in the grid below to select a colour. Control-click to select additional co" +
     "lours; Shift-click to select a range.  Right click to import/export.";
             // 
-            // palettePanel
-            // 
-            this.palettePanel.Location = new System.Drawing.Point(19, 85);
-            this.palettePanel.Name = "palettePanel";
-            this.palettePanel.Size = new System.Drawing.Size(364, 320);
-            this.palettePanel.TabIndex = 1;
-            this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
-            this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
-            // 
             // lblPaletteIntro
             // 
             this.lblPaletteIntro.AutoSize = true;
@@ -131,116 +128,161 @@ namespace AGS.Editor
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.label5);
-            this.groupBox1.Controls.Add(this.txtCommaSeparated);
-            this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.txtWebColor);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.btnColorDialog);
-            this.groupBox1.Controls.Add(this.blockOfColour);
-            this.groupBox1.Controls.Add(this.txtColourNumber);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Controls.Add(this.panel2);
+            this.groupBox1.Controls.Add(this.panel1);
             this.groupBox1.Location = new System.Drawing.Point(6, 6);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(435, 337);
+            this.groupBox1.Size = new System.Drawing.Size(435, 411);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Colour Finder";
             // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Location = new System.Drawing.Point(6, 20);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(420, 145);
+            this.panel1.TabIndex = 22;
+            // 
+            // label1
+            // 
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(420, 145);
+            this.label1.TabIndex = 1;
+            this.label1.Text = resources.GetString("label1.Text");
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.txtLegacyColourNumber);
+            this.panel2.Controls.Add(this.label7);
+            this.panel2.Controls.Add(this.label5);
+            this.panel2.Controls.Add(this.txtCommaSeparated);
+            this.panel2.Controls.Add(this.label4);
+            this.panel2.Controls.Add(this.txtWebColor);
+            this.panel2.Controls.Add(this.label3);
+            this.panel2.Controls.Add(this.btnColorDialog);
+            this.panel2.Controls.Add(this.blockOfColour);
+            this.panel2.Controls.Add(this.txtColourNumber);
+            this.panel2.Controls.Add(this.label2);
+            this.panel2.Location = new System.Drawing.Point(6, 168);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(420, 237);
+            this.panel2.TabIndex = 23;
+            // 
+            // txtLegacyColourNumber
+            // 
+            this.txtLegacyColourNumber.Location = new System.Drawing.Point(207, 90);
+            this.txtLegacyColourNumber.MaxLength = 0;
+            this.txtLegacyColourNumber.Name = "txtLegacyColourNumber";
+            this.txtLegacyColourNumber.Size = new System.Drawing.Size(99, 21);
+            this.txtLegacyColourNumber.TabIndex = 32;
+            this.txtLegacyColourNumber.Text = "0";
+            this.txtLegacyColourNumber.TextChanged += new System.EventHandler(this.txtLegacyColourNumber_TextChanged);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(10, 94);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(168, 13);
+            this.label7.TabIndex = 31;
+            this.label7.Text = "Legacy (AGS 3.*) Colour number:\r\n";
+            // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(194, 172);
+            this.label5.Location = new System.Drawing.Point(188, 40);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(15, 13);
-            this.label5.TabIndex = 19;
+            this.label5.TabIndex = 30;
             this.label5.Text = "#";
             // 
             // txtCommaSeparated
             // 
-            this.txtCommaSeparated.Location = new System.Drawing.Point(213, 195);
+            this.txtCommaSeparated.Location = new System.Drawing.Point(207, 63);
             this.txtCommaSeparated.MaxLength = 0;
             this.txtCommaSeparated.Name = "txtCommaSeparated";
             this.txtCommaSeparated.Size = new System.Drawing.Size(99, 21);
-            this.txtCommaSeparated.TabIndex = 18;
+            this.txtCommaSeparated.TabIndex = 29;
             this.txtCommaSeparated.Text = "0";
             this.txtCommaSeparated.TextChanged += new System.EventHandler(this.txtCommaSeparated_TextChanged);
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(16, 199);
+            this.label4.Location = new System.Drawing.Point(10, 67);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(157, 13);
-            this.label4.TabIndex = 17;
+            this.label4.TabIndex = 28;
             this.label4.Text = "Comma separated (R, G, B, A):";
             // 
             // txtWebColor
             // 
-            this.txtWebColor.Location = new System.Drawing.Point(213, 168);
+            this.txtWebColor.Location = new System.Drawing.Point(207, 36);
             this.txtWebColor.MaxLength = 8;
             this.txtWebColor.Name = "txtWebColor";
             this.txtWebColor.Size = new System.Drawing.Size(99, 21);
-            this.txtWebColor.TabIndex = 16;
+            this.txtWebColor.TabIndex = 27;
             this.txtWebColor.Text = "0";
             this.txtWebColor.TextChanged += new System.EventHandler(this.txtWebColor_TextChanged);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(16, 172);
+            this.label3.Location = new System.Drawing.Point(10, 40);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(124, 13);
-            this.label3.TabIndex = 15;
+            this.label3.TabIndex = 26;
             this.label3.Text = "Web color (RRGGBBAA):";
             // 
             // btnColorDialog
             // 
-            this.btnColorDialog.Location = new System.Drawing.Point(318, 142);
+            this.btnColorDialog.Location = new System.Drawing.Point(312, 10);
             this.btnColorDialog.Name = "btnColorDialog";
             this.btnColorDialog.Size = new System.Drawing.Size(96, 21);
-            this.btnColorDialog.TabIndex = 14;
+            this.btnColorDialog.TabIndex = 25;
             this.btnColorDialog.Text = "Find Colour...";
             this.btnColorDialog.UseVisualStyleBackColor = true;
             this.btnColorDialog.Click += new System.EventHandler(this.btnColorDialog_Click);
             // 
-            // blockOfColour
-            // 
-            this.blockOfColour.Location = new System.Drawing.Point(19, 229);
-            this.blockOfColour.Name = "blockOfColour";
-            this.blockOfColour.Size = new System.Drawing.Size(395, 47);
-            this.blockOfColour.TabIndex = 12;
-            this.blockOfColour.Paint += new System.Windows.Forms.PaintEventHandler(this.blockOfColour_Paint);
-            // 
             // txtColourNumber
             // 
-            this.txtColourNumber.Location = new System.Drawing.Point(213, 142);
+            this.txtColourNumber.Location = new System.Drawing.Point(207, 10);
             this.txtColourNumber.MaxLength = 10;
             this.txtColourNumber.Name = "txtColourNumber";
             this.txtColourNumber.Size = new System.Drawing.Size(99, 21);
-            this.txtColourNumber.TabIndex = 2;
+            this.txtColourNumber.TabIndex = 23;
             this.txtColourNumber.Text = "0";
             this.txtColourNumber.TextChanged += new System.EventHandler(this.txtColourNumber_TextChanged);
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(16, 146);
+            this.label2.Location = new System.Drawing.Point(10, 14);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(158, 13);
-            this.label2.TabIndex = 1;
+            this.label2.TabIndex = 22;
             this.label2.Text = "Colour number (0xAARRGGBB):";
             // 
-            // label1
+            // palettePanel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(16, 26);
-            this.label1.MaximumSize = new System.Drawing.Size(400, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(400, 104);
-            this.label1.TabIndex = 0;
-            this.label1.Text = resources.GetString("label1.Text");
+            this.palettePanel.Location = new System.Drawing.Point(19, 85);
+            this.palettePanel.Name = "palettePanel";
+            this.palettePanel.Size = new System.Drawing.Size(364, 320);
+            this.palettePanel.TabIndex = 1;
+            this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
+            this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
+            // 
+            // blockOfColour
+            // 
+            this.blockOfColour.Location = new System.Drawing.Point(13, 131);
+            this.blockOfColour.Name = "blockOfColour";
+            this.blockOfColour.Size = new System.Drawing.Size(395, 47);
+            this.blockOfColour.TabIndex = 24;
+            this.blockOfColour.Paint += new System.Windows.Forms.PaintEventHandler(this.blockOfColour_Paint);
             // 
             // PaletteEditor
             // 
@@ -257,7 +299,9 @@ namespace AGS.Editor
             this.groupBox2.PerformLayout();
             this.colourFinderPage.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -270,17 +314,21 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblPaletteIntro;
         private System.Windows.Forms.TabPage colourFinderPage;
         private System.Windows.Forms.GroupBox groupBox1;
+        private BufferedPanel palettePanel;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.TextBox txtLegacyColourNumber;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox txtCommaSeparated;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox txtWebColor;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Button btnColorDialog;
         private BufferedPanel blockOfColour;
         private System.Windows.Forms.TextBox txtColourNumber;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label label1;
-        private BufferedPanel palettePanel;
-        private System.Windows.Forms.Label label6;
-		private System.Windows.Forms.Button btnColorDialog;
-        private System.Windows.Forms.TextBox txtWebColor;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.TextBox txtCommaSeparated;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label5;
     }
 }

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -158,10 +158,7 @@ namespace AGS.Editor
 
         private void blockOfColour_Paint(object sender, PaintEventArgs e)
         {
-            using (Brush brush = new SolidBrush(_currentColor))
-            {
-                e.Graphics.FillRectangle(brush, 0, 0, blockOfColour.Width, blockOfColour.Height);
-            }
+            AGS.Types.Utilities.PaintColorBlock(_currentColor, e.Graphics, e.ClipRectangle);
         }
 
         private void palettePanel_Paint(object sender, PaintEventArgs e)

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -21,6 +21,7 @@ namespace AGS.Editor
         private bool _noUpdates = false;
         private List<int> _selectedIndexes = new List<int>();
         private TabPage _colourFinder;
+        private Color _currentColor = Color.Black;
 
         public PaletteEditor()
         {
@@ -29,6 +30,7 @@ namespace AGS.Editor
             Factory.GUIController.OnPropertyObjectChanged += GUIController_OnPropertyObjectChanged;
             _selectedIndexes.Add(0);
             GameChanged();
+            UpdateColor();
         }
 
         protected override void OnPropertyChanged(string propertyName, object oldValue)
@@ -70,68 +72,72 @@ namespace AGS.Editor
             UpdatePropertyGrid();
         }
 
-        private void trackBarRed_Scroll(object sender, EventArgs e)
-        {
-            ColourSlidersUpdated();
-            UpdateNumberFromScrollBars();
-        }
-
-        private void trackBarGreen_Scroll(object sender, EventArgs e)
-        {
-            ColourSlidersUpdated();
-            UpdateNumberFromScrollBars();
-        }
-
-        private void trackBarBlue_Scroll(object sender, EventArgs e)
-        {
-            ColourSlidersUpdated();
-            UpdateNumberFromScrollBars();
-        }
-
         private void txtColourNumber_TextChanged(object sender, EventArgs e)
         {
             if (!_noUpdates)
             {
-                int newVal = 0;
-                Int32.TryParse(txtColourNumber.Text, out newVal);
-                if ((newVal < 0) || (newVal > int.MaxValue))
-                {
-                    newVal = 0;
-                }
-
-                Color newColor = ColorMapper.AgsColourNumberToColorDirect(newVal);
-                trackBarRed.Value = newColor.R;
-                trackBarGreen.Value = newColor.G;
-                trackBarBlue.Value = newColor.B;
-				ColourSlidersUpdated();
+                _currentColor = AGS.Types.Utilities.ColorFromARGBHex(txtColourNumber.Text);
+                UpdateColor(txtColourNumber);
             }
         }
 
-        private void ColourSlidersUpdated()
+        private void txtWebColor_TextChanged(object sender, EventArgs e)
         {
-            lblRedVal.Text = trackBarRed.Value.ToString();
-            lblGreenVal.Text = trackBarGreen.Value.ToString();
-            lblBlueVal.Text = trackBarBlue.Value.ToString();
-            blockOfColour.Invalidate();
+            if (!_noUpdates)
+            {
+                _currentColor = AGS.Types.Utilities.ColorFromHTMLHex(txtWebColor.Text);
+                UpdateColor(txtWebColor);
+            }
         }
 
-        private void UpdateNumberFromScrollBars()
+        private void txtCommaSeparated_TextChanged(object sender, EventArgs e)
+        {
+            if (!_noUpdates)
+            {
+                _currentColor = AGS.Types.Utilities.ColorFromSeparatedRGBA(txtCommaSeparated.Text, ',');
+                if (_currentColor.IsEmpty)
+                    _currentColor = AGS.Types.Utilities.ColorFromSeparatedRGBA(txtCommaSeparated.Text, ';');
+                UpdateColor(txtCommaSeparated);
+            }
+        }
+
+        private void UpdateColor(TextBox ignoreText = null)
         {
             _noUpdates = true;
-            var newColor = Color.FromArgb(trackBarRed.Value, trackBarGreen.Value, trackBarBlue.Value);
-            int newValue = ColorMapper.ColorToAgsColourNumberDirect(newColor);
-            txtColourNumber.Text = newValue.ToString();
-            _noUpdates = false;
+            if (ignoreText != txtColourNumber)
+            {
+                txtColourNumber.Text = $"0x{AGS.Types.Utilities.ColorToARGBInt32(_currentColor).ToString("X8")}";
+            }
+            if (ignoreText != txtWebColor)
+            {
+                if (_currentColor.A == 255)
+                {
+                    txtWebColor.Text = AGS.Types.Utilities.ColorToRGBInt32(_currentColor).ToString("X6");
+                }
+                else
+                {
+                    txtWebColor.Text = AGS.Types.Utilities.ColorToRGBAInt32(_currentColor).ToString("X8");
+                }
+            }
+            if (ignoreText != txtCommaSeparated)
+            {
+                if (_currentColor.A == 255)
+                {
+                    txtCommaSeparated.Text = $"{_currentColor.R}, {_currentColor.G}, {_currentColor.B}";
+                }
+                else
+                {
+                    txtCommaSeparated.Text = $"{_currentColor.R}, {_currentColor.G}, {_currentColor.B}, {_currentColor.A}";
+                }
+            }
+
             blockOfColour.Invalidate();
+            _noUpdates = false;
         }
 
         private void blockOfColour_Paint(object sender, PaintEventArgs e)
         {
-            int colourVal = 0;
-            Int32.TryParse(txtColourNumber.Text, out colourVal);
-
-            Color color = Factory.AGSEditor.ColorMapper.MapAgsColourNumberToRgbColor(colourVal);
-            using (Brush brush = new SolidBrush(color))
+            using (Brush brush = new SolidBrush(_currentColor))
             {
                 e.Graphics.FillRectangle(brush, 0, 0, blockOfColour.Width, blockOfColour.Height);
             }
@@ -361,22 +367,19 @@ namespace AGS.Editor
             Factory.GUIController.OnPropertyObjectChanged -= GUIController_OnPropertyObjectChanged;
         }
 
-		private void btnColorDialog_Click(object sender, EventArgs e)
-		{
-			ColorDialog dialog = new ColorDialog();
-			dialog.Color = Color.FromArgb(trackBarRed.Value, trackBarGreen.Value, trackBarBlue.Value);
-			dialog.AnyColor = true;
-			dialog.FullOpen = true;
-			if (dialog.ShowDialog() == DialogResult.OK)
-			{
-				trackBarRed.Value = dialog.Color.R;
-				trackBarGreen.Value = dialog.Color.G;
-				trackBarBlue.Value = dialog.Color.B;
-				ColourSlidersUpdated();
-				UpdateNumberFromScrollBars();
-			}
-			dialog.Dispose();
-		}
+        private void btnColorDialog_Click(object sender, EventArgs e)
+        {
+            ColorDialog dialog = new ColorDialog();
+            dialog.Color = _currentColor;
+            dialog.AnyColor = true;
+            dialog.FullOpen = true;
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                _currentColor = dialog.Color;
+                UpdateColor();
+            }
+            dialog.Dispose();
+        }
 
         private void LoadColorTheme(ColorTheme t)
         {

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -101,6 +101,20 @@ namespace AGS.Editor
             }
         }
 
+        private void txtLegacyColourNumber_TextChanged(object sender, EventArgs e)
+        {
+            if (!_noUpdates)
+            {
+                int oldValue = 0;
+                int.TryParse(txtLegacyColourNumber.Text, out oldValue);
+                int newValue = ColorMapper.RemapFromLegacyColourNumber(oldValue,
+                    Factory.AGSEditor.CurrentGame.Palette,
+                    Factory.AGSEditor.CurrentGame.Settings.ColorDepth, false);
+                _currentColor = Color.FromArgb(newValue);
+                UpdateColor(txtLegacyColourNumber);
+            }
+        }
+
         private void UpdateColor(TextBox ignoreText = null)
         {
             _noUpdates = true;
@@ -129,6 +143,13 @@ namespace AGS.Editor
                 {
                     txtCommaSeparated.Text = $"{_currentColor.R}, {_currentColor.G}, {_currentColor.B}, {_currentColor.A}";
                 }
+            }
+            if (ignoreText != txtLegacyColourNumber)
+            {
+                txtLegacyColourNumber.Text =
+                    ColorMapper.MapRgbColorToLegacyColourNumber(_currentColor,
+                    Factory.AGSEditor.CurrentGame.Palette,
+                    Factory.AGSEditor.CurrentGame.Settings.ColorDepth).ToString();
             }
 
             blockOfColour.Invalidate();
@@ -410,7 +431,6 @@ namespace AGS.Editor
                     a.Graphics.DrawString(tab.Text, tab.Font, new SolidBrush(t.GetColor("palette/draw-item/foreground")), a.Bounds.X, a.Bounds.Y + 5);
                 };
             }
-
         }
 
         private void PaletteEditor_Load(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/PaletteEditor.resx
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.resx
@@ -117,4 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="label1.Text" xml:space="preserve">
+    <value>You can use the controls below to find the AGS Colour Number for a particular colour. AGS Colour is displayed as a hexadecimal number and may be used to assign color value directly in script.
+Web color input field may be used to paste a color in HTML format which presents colors using #RRGGBBAA notation.
+Comma separated representation suits inserting arguments into the Game.GetColorFromRGB function.
+
+</value>
+  </data>
 </root>

--- a/Editor/AGS.Editor/Panes/PaletteEditor.resx
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.resx
@@ -121,6 +121,7 @@
     <value>You can use the controls below to find the AGS Colour Number for a particular colour. AGS Colour is displayed as a hexadecimal number and may be used to assign color value directly in script.
 Web color input field may be used to paste a color in HTML format which presents colors using #RRGGBBAA notation.
 Comma separated representation suits inserting arguments into the Game.GetColorFromRGB function.
+Legacy (AGS 3.*) Colour Number may be used to paste colors from old scripts when porting games to AGS 4.
 
 </value>
   </data>

--- a/Editor/AGS.Editor/Utils/ColorMapper.cs
+++ b/Editor/AGS.Editor/Utils/ColorMapper.cs
@@ -192,6 +192,27 @@ namespace AGS.Editor
         }
 
         /// <summary>
+        /// Generates a legacy (AGS 3.*) color number from a Color.
+        /// </summary>
+        public static int MapRgbColorToLegacyColourNumber(Color rgbColor, PaletteEntry[] palette, GameColorDepth gameColorDepth)
+        {
+            int green = rgbColor.G;
+
+            if (rgbColor.R == 0 && rgbColor.G == 0 && rgbColor.B > 0)
+            {
+                // make sure the colour number doesn't end up being a special EGA colour
+                green = 4;
+            }
+            else if (gameColorDepth == GameColorDepth.Palette)
+            {
+                return FindNearestColourInGamePalette(rgbColor, palette);
+            }
+
+            // Generate a 16-bit R5G6R5 color number
+            return (rgbColor.B >> 3) + ((rgbColor.G >> 2) << 5) + ((rgbColor.R >> 3) << 11);
+        }
+
+        /// <summary>
         /// Makes a opaque colour number value from a number which presumably may not have an alpha component.
         /// </summary>
         public static int MakeOpaque(int colorNumber, GameColorDepth gameColorDepth)

--- a/Editor/AGS.Types/PaletteEntry.cs
+++ b/Editor/AGS.Types/PaletteEntry.cs
@@ -27,6 +27,7 @@ namespace AGS.Types
         [Category("Appearance")]
         [DisplayName(PROPERTY_COLOR_RGB)]
         [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        [TypeConverter(typeof(CustomColorConverter))]
         public Color Colour
         {
             get { return _color; }

--- a/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
@@ -59,27 +59,7 @@ namespace AGS.Types
         public override void PaintValue(PaintValueEventArgs e)
         {
             Color color = ColorFromPropertyValue(e.Context, e.Value);
-            if (color.A > 0)
-            {
-                // Fixup alpha value for display
-                // TODO: possibly paint using alpha component when we actually support it here
-                color = Color.FromArgb(0xFF, color.R, color.G, color.B);
-                using (SolidBrush brush = new SolidBrush(color))
-                {
-                    e.Graphics.FillRectangle(brush, e.Bounds);
-                }
-            }
-            else
-            {
-                using (SolidBrush brush1 = new SolidBrush(Color.White))
-                using (SolidBrush brush2 = new SolidBrush(Color.DarkGray))
-                {
-                    e.Graphics.FillRectangle(brush1, e.Bounds.Left, e.Bounds.Top, e.Bounds.Width / 2, e.Bounds.Height / 2);
-                    e.Graphics.FillRectangle(brush1, e.Bounds.Left + e.Bounds.Width / 2, e.Bounds.Top + e.Bounds.Height / 2, e.Bounds.Width / 2, e.Bounds.Height / 2);
-                    e.Graphics.FillRectangle(brush2, e.Bounds.Left + e.Bounds.Width / 2, e.Bounds.Top, e.Bounds.Width / 2, e.Bounds.Height / 2);
-                    e.Graphics.FillRectangle(brush2, e.Bounds.Left, e.Bounds.Top + e.Bounds.Height / 2, e.Bounds.Width / 2, e.Bounds.Height / 2);
-                }
-            }
+            Utilities.PaintColorBlock(color, e.Graphics, e.Bounds);
         }
     }
 }

--- a/Editor/AGS.Types/PropertyGridExtras/CustomColorConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/CustomColorConverter.cs
@@ -69,13 +69,32 @@ namespace AGS.Types
 
         private Color ColorFromString(string value)
         {
-            var rgb = value.Split(';');
-            switch (rgb.Length)
+            if (string.IsNullOrEmpty(value))
+                return Color.FromArgb(0); // return transparent color on failure
+
+            // First check explicit notations
+            if (value.StartsWith("#"))
             {
-                case 3: return Color.FromArgb(int.Parse(rgb[0]), int.Parse(rgb[1]), int.Parse(rgb[2]));
-                case 4: return Color.FromArgb(int.Parse(rgb[3]), int.Parse(rgb[0]), int.Parse(rgb[1]), int.Parse(rgb[2]));
-                default: return Color.FromArgb(0); // return transparent color on failure
+                return Utilities.ColorFromHTMLHex(value);
             }
+            else if (value.StartsWith("0x"))
+            {
+                return Utilities.ColorFromARGBHex(value);
+            }
+
+            // If there's no explicit notation prefix, then try to parse as a HTML hex (expect failure!)
+            Color color = Utilities.ColorFromHTMLHex(value);
+            if (!color.IsEmpty)
+                return color;
+
+            // If it's not hex of any kind, then try to parse as color components
+            // separated either by comma or semicolon
+            color = AGS.Types.Utilities.ColorFromSeparatedRGBA(value, ',');
+            if (color.IsEmpty)
+                color = AGS.Types.Utilities.ColorFromSeparatedRGBA(value, ';');
+            if (!color.IsEmpty)
+                return color;
+            return Color.FromArgb(0); // return transparent color on failure
         }
 
         private string ColorToString(Color color)

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -274,5 +274,102 @@ namespace AGS.Types
             input.Close();
             return true;
         }
+
+        /// <summary>
+        /// Converts a string in 0xAARRGGBB notation into a Color.
+        /// Returns Color.Empty on any exception.
+        /// </summary>
+        public static Color ColorFromARGBHex(string hexString)
+        {
+            try
+            {
+                if (hexString.StartsWith("0x") || hexString.StartsWith("0X"))
+                    hexString = hexString.Substring(2);
+
+                return Color.FromArgb(Convert.ToInt32(hexString, 16));
+            }
+            catch
+            {
+                return Color.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Converts a string in HTML #RRGGBBAA notation into a Color.
+        /// NOTE: this method is required because converting using standard .NET
+        /// utilities treat higher byte as a alpha instead.
+        /// Returns Color.Empty on any exception.
+        /// </summary>
+        public static Color ColorFromHTMLHex(string hexString)
+        {
+            try
+            {
+                if (hexString.StartsWith("#"))
+                    hexString = hexString.Substring(1);
+
+                int value = Convert.ToInt32(hexString, 16);
+                if (hexString.Length == 8)
+                {
+                    return Color.FromArgb(value & 0xFF, (value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF);
+                }
+                else
+                {
+                    return Color.FromArgb(value);
+                }
+            }
+            catch
+            {
+                return Color.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Parses the input string as a separated RGBA values.
+        /// Returns resulting Color, or Color.Empty on failure.
+        /// </summary>
+        public static Color ColorFromSeparatedRGBA(string text, char separator)
+        {
+            try
+            {
+                if (text.IndexOf(separator) >= 0)
+                {
+                    var rgba = text.Split(separator);
+                    switch (rgba.Length)
+                    {
+                        case 3: return Color.FromArgb(int.Parse(rgba[0]), int.Parse(rgba[1]), int.Parse(rgba[2]));
+                        case 4: return Color.FromArgb(int.Parse(rgba[3]), int.Parse(rgba[0]), int.Parse(rgba[1]), int.Parse(rgba[2]));
+                        default: return Color.Empty;
+                    }
+                }
+            }
+            catch
+            {
+            }
+            return Color.Empty;
+        }
+
+        /// <summary>
+        /// Converts a Color into a 32-bit integer value representing color in RGB format.
+        /// </summary>
+        public static int ColorToRGBInt32(Color color)
+        {
+            return (color.B) | (color.G << 8) | (color.R << 16);
+        }
+
+        /// <summary>
+        /// Converts a Color into a 32-bit integer value representing color in ARGB format.
+        /// </summary>
+        public static int ColorToARGBInt32(Color color)
+        {
+            return (color.B) | (color.G << 8) | (color.R << 16) | (color.A << 24);
+        }
+
+        /// <summary>
+        /// Converts a Color into a 32-bit integer value representing color in RGBA format.
+        /// </summary>
+        public static int ColorToRGBAInt32(Color color)
+        {
+            return (color.B << 8) | (color.G << 16) | (color.R << 24) | (color.A);
+        }
     }
 }

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -314,7 +314,7 @@ namespace AGS.Types
                 }
                 else
                 {
-                    return Color.FromArgb(value);
+                    return Color.FromArgb((value >> 16) & 0xFF, (value >> 8) & 0xFF, (value) & 0xFF);
                 }
             }
             catch

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -371,5 +371,42 @@ namespace AGS.Types
         {
             return (color.B << 8) | (color.G << 16) | (color.R << 24) | (color.A);
         }
+
+        /// <summary>
+        /// Paints a block of color (rectangular shape) over a checkered background (meant for demonstrating alpha value).
+        /// </summary>
+        public static void PaintColorBlock(Color color, Graphics g, Rectangle rect)
+        {
+            if (color.A == 255)
+            {
+                // If alpha is max, then simply paint an opaque block of color
+                using (SolidBrush brush = new SolidBrush(color))
+                {
+                    g.FillRectangle(brush, rect);
+                }
+            }
+            else
+            {
+                // Paint the checkered background
+                using (SolidBrush brush1 = new SolidBrush(Color.White))
+                using (SolidBrush brush2 = new SolidBrush(Color.DarkGray))
+                {
+                    g.FillRectangle(brush1, rect.Left, rect.Top, rect.Width / 2, rect.Height / 2);
+                    g.FillRectangle(brush1, rect.Left + rect.Width / 2, rect.Top + rect.Height / 2, rect.Width / 2, rect.Height / 2);
+                    g.FillRectangle(brush2, rect.Left + rect.Width / 2, rect.Top, rect.Width / 2, rect.Height / 2);
+                    g.FillRectangle(brush2, rect.Left, rect.Top + rect.Height / 2, rect.Width / 2, rect.Height / 2);
+                }
+
+                // Make half translucent, half opaque color block
+                using (SolidBrush brush = new SolidBrush(color))
+                {
+                    g.FillRectangle(brush, new Rectangle(rect.X, rect.Y, rect.Width / 2, rect.Height));
+                }
+                using (SolidBrush brush = new SolidBrush(Color.FromArgb(255, color.R, color.G, color.B)))
+                {
+                    g.FillRectangle(brush, new Rectangle(rect.X + rect.Width / 2, rect.Y, rect.Width / 2, rect.Height));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #2743

Redesigns Color Finder:
* Removed RGB sliders, as mostly useless;
* Display 3 text boxes:
  * Color in programmer's hex notation `0xAARRGGBB`, useful to copy and insert into the script where you assign this value directly to a color variable;
  * Color in HTML notation `#RRGGBBAA` (where AA may be omited), useful to paste from the paint software;
  * Color in a comma-separated decimal notation `R, G, B, A` (where AA may be omited), useful to copy into the script where you have a `Game.GetColorFromRGB/A` function call.

![colorfinder-ex](https://github.com/user-attachments/assets/ddd475dd-85ce-4182-a33c-002ed78f9a93)




Adjust Color properties in Property Grid, allow them accept *any* of the above notation, in addition to the current semicolon-separated notation. This lets copy & paste these values back and forth between Color Finder and properties.