### PR TITLE
Add statistics gathering and simple video-audio synchronization in VideoPlayer

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2340,22 +2340,30 @@ void draw_fps(const Rect &viewport)
     fpsDisplay->ClearTransparent();
     const color_t text_color = fpsDisplay->GetCompatibleColor(14);
     char base_buffer[20];
-    if (!isTimerFpsMaxed()) {
+    if (!isTimerFpsMaxed())
+    {
         snprintf(base_buffer, sizeof(base_buffer), "%d", frames_per_second);
-    } else {
+    }
+    else
+    {
         snprintf(base_buffer, sizeof(base_buffer), "unlimited");
     }
 
     char fps_buffer[60];
     // Don't display fps if we don't have enough information (because loop count was just reset)
     float fps = get_real_fps();
-    if (!std::isnan(fps)) {
+    float time = 0.f;
+    if (!std::isnan(fps))
+    {
         snprintf(fps_buffer, sizeof(fps_buffer), "FPS: %2.1f / %s", fps, base_buffer);
-    } else {
+        time = loopcounter / fps;
+    }
+    else
+    {
         snprintf(fps_buffer, sizeof(fps_buffer), "FPS: --.- / %s", base_buffer);
     }
-    char loop_buffer[60];
-    snprintf(loop_buffer, sizeof(loop_buffer), "Loop %u", loopcounter);
+    char loop_buffer[128];
+    snprintf(loop_buffer, sizeof(loop_buffer), "Loop %u Time %.2f", loopcounter, time);
 
     int text_off = get_font_surface_extent(font).first; // TODO: a generic function that accounts for this?
     wouttext_outline(fpsDisplay.get(), 1, 1 - text_off, font, text_color, fps_buffer);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -928,11 +928,11 @@ int Game_InBlockingWait()
 
 void Game_PrecacheSprite(int sprnum)
 {
-    const auto tp_start = AGS_FastClock::now();
+    const auto tp_start = FastClock::now();
     spriteset.PrecacheSprite(sprnum);
-    const auto tp_filedone = AGS_FastClock::now();
+    const auto tp_filedone = FastClock::now();
     texturecache_precache(sprnum);
-    const auto tp_texturedone = AGS_FastClock::now();
+    const auto tp_texturedone = FastClock::now();
 
     const auto dur1 = ToMilliseconds(tp_filedone - tp_start);
     const auto dur2 = ToMilliseconds(tp_texturedone - tp_filedone);
@@ -1641,18 +1641,18 @@ void precache_view(int view, int first_loop, int last_loop, bool with_sounds)
         for (int j = 0; j < views[view].loops[i].numFrames; ++j, ++total_frames)
         {
             const auto &frame = views[view].loops[i].frames[j];
-            const auto tp_detail1 = AGS_FastClock::now();
+            const auto tp_detail1 = FastClock::now();
             spriteset.PrecacheSprite(frame.pic);
-            const auto tp_detail2 = AGS_FastClock::now();
+            const auto tp_detail2 = FastClock::now();
             texturecache_precache(frame.pic);
-            const auto tp_detail3 = AGS_FastClock::now();
+            const auto tp_detail3 = FastClock::now();
 
             if (with_sounds && frame.audioclip >= 0)
             {
                 ScriptAudioClip *clip = &game.audioClips[frame.audioclip];
                 auto assetpath = get_audio_clip_assetpath(clip->bundlingType, clip->fileName);
                 soundcache_precache(assetpath);
-                dur_sound_load += ToMilliseconds(AGS_FastClock::now() - tp_detail3);
+                dur_sound_load += ToMilliseconds(FastClock::now() - tp_detail3);
                 total_sounds++;
             }
             dur_sp_load += ToMilliseconds(tp_detail2 - tp_detail1);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -406,18 +406,18 @@ ScriptCamera *GamePlayState::GetScriptCamera(int index)
 
 bool GamePlayState::IsIgnoringInput() const
 {
-    return AGS_Clock::now() < _ignoreUserInputUntilTime;
+    return Clock::now() < _ignoreUserInputUntilTime;
 }
 
 void GamePlayState::SetIgnoreInput(int timeout_ms)
 {
-    if (AGS_Clock::now() + std::chrono::milliseconds(timeout_ms) > _ignoreUserInputUntilTime)
-        _ignoreUserInputUntilTime = AGS_Clock::now() + std::chrono::milliseconds(timeout_ms);
+    if (Clock::now() + std::chrono::milliseconds(timeout_ms) > _ignoreUserInputUntilTime)
+        _ignoreUserInputUntilTime = Clock::now() + std::chrono::milliseconds(timeout_ms);
 }
 
 void GamePlayState::ClearIgnoreInput()
 {
-    _ignoreUserInputUntilTime = AGS_Clock::now();
+    _ignoreUserInputUntilTime = Clock::now();
 }
 
 void GamePlayState::SetWaitSkipResult(int how, int data)

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -481,7 +481,7 @@ private:
     // Tells that room viewports need z-order resort
     bool  _roomViewportZOrderChanged = false;
 
-    AGS_Clock::time_point _ignoreUserInputUntilTime{};
+    AGS::Engine::Clock::time_point _ignoreUserInputUntilTime{};
 };
 
 // Converts legacy alignment type used in script API

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -11,7 +11,6 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-
 #include <stdio.h>
 #include "ac/common.h"
 #include "ac/game.h"
@@ -27,10 +26,11 @@
 #include "main/engine.h"
 #include "media/audio/audio_core.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 #include "util/string_compat.h"
+#include "util/time_util.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern RoomStruct thisroom;
@@ -548,7 +548,7 @@ static void stop_voice_clip_impl()
     play.music_master_volume = play.music_vol_was;
     // update the music in a bit (fixes two speeches follow each other
     // and music going up-then-down)
-    schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
+    schedule_music_update_at(Clock::now() + std::chrono::milliseconds(500));
     stop_and_destroy_channel(SCHAN_SPEECH);
 }
 

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -94,7 +94,7 @@ void PlayVideo(const char* name, int skip, int scr_flags)
     -- since 3.6.0:
     20: play both game audio and video's own audio
     */
-    int video_flags = kVideo_EnableVideo | kVideo_DropFrames;
+    int video_flags = kVideo_EnableVideo | kVideo_DropFrames | kVideo_SyncAudioVideo;
     int state_flags = 0;
     // video size
     switch (scr_flags % 10)

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -635,7 +635,7 @@ struct TouchState
     // Max delay between finger actions which will still count as double tap
     const std::chrono::milliseconds quick_tap_delay = std::chrono::milliseconds(300);
     // The last tapping action timestamp
-    AGS_Clock::time_point last_tap_ts = AGS_Clock::now();
+    Clock::time_point last_tap_ts = Clock::now();
     // The last tap's finger index
     int last_tap_finger = 0;
     // Same finger consecutive taps counter
@@ -725,7 +725,7 @@ static void send_mouse_motion_event(int x, int y, int xrel, int yrel)
 // Handles double tap detection (multiple touch downs and ups)
 static void detect_double_tap(const SDL_TouchFingerEvent &event, bool down)
 {
-    auto tap_ts = AGS_Clock::now();
+    auto tap_ts = Clock::now();
     if ((touch.last_tap_finger == event.fingerId) &&
         (tap_ts < (touch.last_tap_ts + touch.quick_tap_delay)))
     {

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -23,6 +23,8 @@
 #include "SDL.h"
 #endif
 
+using namespace AGS::Engine;
+
 extern volatile bool game_update_suspend;
 extern volatile bool want_exit, abort_engine;
 
@@ -34,8 +36,8 @@ auto tick_duration = std::chrono::microseconds(1000000LL/40);
 auto framerate = 0;
 auto framerate_maxed = false;
 
-auto last_tick_time = AGS_Clock::now();
-auto next_frame_timestamp = AGS_Clock::now();
+auto last_tick_time = Clock::now();
+auto next_frame_timestamp = Clock::now();
 
 }
 
@@ -73,7 +75,7 @@ void WaitForNextFrame()
     audio_core_entry_poll();
 #endif
 
-    const auto now = AGS_Clock::now();
+    const auto now = Clock::now();
     const auto frameDuration = GetFrameDuration();
 
     // early exit if we're trying to maximise framerate
@@ -98,7 +100,7 @@ void WaitForNextFrame()
     if (frame_time_remaining > std::chrono::milliseconds::zero()) {
 #if AGS_PLATFORM_OS_EMSCRIPTEN
         // pass the time as negative in Emscripten Platform Driver
-        platform->Delay(-std::chrono::duration_cast<std::chrono::milliseconds>(frame_time_remaining).count());
+        platform->Delay(-ToMilliseconds(frame_time_remaining));
 #else
         std::this_thread::sleep_for(frame_time_remaining);
 #endif
@@ -116,6 +118,6 @@ void WaitForNextFrame()
 
 void skipMissedTicks()
 {
-    last_tick_time = AGS_Clock::now();
-    next_frame_timestamp = AGS_Clock::now();
+    last_tick_time = Clock::now();
+    next_frame_timestamp = Clock::now();
 }

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -12,28 +12,13 @@
 //
 //=============================================================================
 //
-//
+// Game update timer control.
 //
 //=============================================================================
 #ifndef __AGS_EE_AC__TIMER_H
 #define __AGS_EE_AC__TIMER_H
 
-#include <type_traits>
-#include <chrono>
-
-// use high resolution clock only if we know it is monotonic/steady.
-// refer to https://stackoverflow.com/a/38253266/84262
-using AGS_Clock = std::conditional<
-        std::chrono::high_resolution_clock::is_steady,
-        std::chrono::high_resolution_clock, std::chrono::steady_clock
-      >::type;
-using AGS_FastClock = std::chrono::system_clock;
-
-template <typename TDur>
-inline int64_t ToMilliseconds(TDur dur)
-{
-    return std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-}
+#include "util/time_util.h"
 
 // Sleeps for time remaining until the next game frame, updates next frame timestamp
 extern void WaitForNextFrame();

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1166,8 +1166,8 @@ void engine_init_editor_debugging(const ConfigTree &cfg)
     if (!init_editor_debugging(cfg))
         return;
 
-    auto waitUntil = AGS_Clock::now() + std::chrono::milliseconds(500);
-    while (waitUntil > AGS_Clock::now())
+    auto waitUntil = Clock::now() + std::chrono::milliseconds(500);
+    while (waitUntil > Clock::now())
     {
         // pick up any breakpoints in game_start
         check_for_messages_from_debugger();

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -95,7 +95,7 @@ extern char check_dynamic_sprites_at_exit;
 static bool ShouldStayInWaitMode();
 
 float fps = std::numeric_limits<float>::quiet_NaN();
-static auto t1 = AGS_Clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
+static auto t1 = Clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
 unsigned int loopcounter=0;
 static unsigned int lastcounter=0;
 static size_t numEventsAtStartOfFunction; // CHECKME: research and document this
@@ -958,7 +958,7 @@ static void game_loop_update_loop_counter()
 
 static void game_loop_update_fps()
 {
-    auto t2 = AGS_Clock::now();
+    auto t2 = Clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
     auto frames = loopcounter - lastcounter;
 
@@ -984,7 +984,7 @@ float get_real_fps() {
 
 void set_loop_counter(unsigned int new_counter) {
     loopcounter = new_counter;
-    t1 = AGS_Clock::now();
+    t1 = Clock::now();
     lastcounter = loopcounter;
     fps = std::numeric_limits<float>::quiet_NaN();
 }

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -761,13 +761,13 @@ std::unique_ptr<SoundClip> cachedQueuedMusic;
 // Music update is scheduled when the voice speech stops;
 // we do a small delay before reverting any volume adjustments
 static bool music_update_scheduled = false;
-static auto music_update_at = AGS_Clock::now();
+static auto music_update_at = Clock::now();
 
 void cancel_scheduled_music_update() {
     music_update_scheduled = false;
 }
 
-void schedule_music_update_at(AGS_Clock::time_point at) {
+void schedule_music_update_at(Clock::time_point at) {
     music_update_scheduled = true;
     music_update_at = at;
 }
@@ -779,7 +779,7 @@ void postpone_scheduled_music_update_by(std::chrono::milliseconds duration) {
 
 void process_scheduled_music_update() {
     if (!music_update_scheduled) { return; }
-    if (music_update_at > AGS_Clock::now()) { return; }
+    if (music_update_at > Clock::now()) { return; }
     cancel_scheduled_music_update();
     update_music_volume();
     apply_volume_drop_modifier(false);

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -21,7 +21,7 @@
 #include "ac/dynobj/scriptaudiochannel.h"
 #include "media/audio/ambientsound.h"
 #include "media/audio/soundclip.h"
-#include "ac/timer.h"
+#include "util/time_util.h"
 
 class AudioChans
 {
@@ -113,7 +113,7 @@ std::unique_ptr<SoundClip> load_music_from_disk(int mnum, bool doRepeat);
 void        newmusic(int mnum);
 
 extern void cancel_scheduled_music_update();
-extern void schedule_music_update_at(AGS_Clock::time_point);
+extern void schedule_music_update_at(AGS::Engine::Clock::time_point);
 extern void postpone_scheduled_music_update_by(std::chrono::milliseconds);
 
 // crossFading is >0 (channel number of new track), or -1 (old

--- a/Engine/media/audio/audioplayer.cpp
+++ b/Engine/media/audio/audioplayer.cpp
@@ -47,15 +47,15 @@ void AudioPlayer::Poll()
         return;
 
     // Read data from Decoder and pass into the Al Source
-    if (!_bufferPending.Data && !_decoder->EOS())
+    if (!_bufferPending.Data() && !_decoder->EOS())
     { // if no buffer saved, and still something to decode, then read a buffer
         _bufferPending = _decoder->GetData();
-        assert(_bufferPending.Data || (_bufferPending.Size == 0));
+        assert(_bufferPending.Data() || (_bufferPending.Size() == 0));
     }
-    if (_bufferPending.Data && (_bufferPending.Size > 0))
+    if (_bufferPending.Data() && (_bufferPending.Size() > 0))
     { // if having a buffer already, then try to put into source
         if (_source->PutData(_bufferPending) > 0)
-            _bufferPending = SoundBuffer(); // clear buffer on success
+            _bufferPending = SoundBufferPtr(); // clear buffer on success
     }
     _source->Poll();
     // If both finished decoding and playing, we done here.
@@ -111,7 +111,7 @@ void AudioPlayer::Stop()
     case PlayStatePaused:
         _playState = PlayStateStopped;
         _source->Stop();
-        _bufferPending = SoundBuffer(); // clear
+        _bufferPending = SoundBufferPtr(); // clear
         break;
     default:
         break;
@@ -131,7 +131,7 @@ void AudioPlayer::Seek(float pos_ms)
     case PlayStateStopped:
         {
             _source->Stop();
-            _bufferPending = SoundBuffer(); // clear
+            _bufferPending = SoundBufferPtr(); // clear
             float new_pos = _decoder->Seek(pos_ms);
             _source->SetPlaybackPosMs(new_pos);
         }

--- a/Engine/media/audio/audioplayer.h
+++ b/Engine/media/audio/audioplayer.h
@@ -44,7 +44,7 @@ public:
     // FIXME: rework this! -- a quick hack to let external user know the future player state on init stage
     PlaybackState GetPlayStateNormal() const { return _playState == PlayStateInitial ? _onLoadPlayState : _playState; }
     // Gets frequency (sample rate)
-    float GetFrequency() const { return _decoder->GetFreq(); }
+    float GetFrequency() const { return static_cast<float>(_decoder->GetFreq()); }
     // Gets duration, in ms
     float GetDurationMs() const { return _decoder->GetDurationMs(); }
     // Gets playback position, in ms
@@ -79,7 +79,7 @@ private:
     PlaybackState _playState = PlayStateInitial;
     PlaybackState _onLoadPlayState = PlayStatePaused;
     float _onLoadPositionMs = 0.0f;
-    SoundBuffer _bufferPending{};
+    SoundBufferPtr _bufferPending{};
 };
 
 } // namespace Engine

--- a/Engine/media/audio/openalsource.h
+++ b/Engine/media/audio/openalsource.h
@@ -53,7 +53,7 @@ public:
 
     // Try putting data into the queue; returns amount of data copied,
     // or 0 if data cannot be accepted at the moment.
-    size_t PutData(const SoundBuffer &data);
+    size_t PutData(const SoundBufferPtr &data);
     // Updates the state, processes the sound queue
     ALuint Poll();
 

--- a/Engine/media/audio/sdldecoder.cpp
+++ b/Engine/media/audio/sdldecoder.cpp
@@ -140,10 +140,10 @@ float SDLDecoder::Seek(float pos_ms)
     return pos_ms; // new pos on success
 }
 
-SoundBuffer SDLDecoder::GetData()
+SoundBufferPtr SDLDecoder::GetData()
 {
     if (!_sample || _EOS)
-        return SoundBuffer();
+        return SoundBufferPtr();
     float old_pos = _posMs;
     size_t sz = 0;
     do
@@ -158,7 +158,7 @@ SoundBuffer SDLDecoder::GetData()
         {
             _EOS = true;
             if ((_sample->flags & SOUND_SAMPLEFLAG_ERROR) != 0)
-                return SoundBuffer();
+                return SoundBufferPtr();
             // if repeat, then seek to start.
             else if (_repeat) {
                 _EOS = Sound_Rewind(_sample.get()) == 0;
@@ -167,7 +167,7 @@ SoundBuffer SDLDecoder::GetData()
             }
         }
     } while (!_EOS && (sz == 0));
-    return SoundBuffer(_sample->buffer, sz, old_pos,
+    return SoundBufferPtr(_sample->buffer, sz, old_pos,
         SoundHelper::MillisecondsFromBytes(sz, _sample->desired.format, _sample->desired.channels, _sample->desired.rate));
 }
 

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -48,23 +48,94 @@ struct SoundSampleDeleterFunctor
 
 using SoundSampleUniquePtr = std::unique_ptr<Sound_Sample, SoundSampleDeleterFunctor>;
 
-// A thin *non-owning* wrapper over a array containing constant sound data;
-// meant mostly to group and pass the buffer and associated parameters.
-struct SoundBuffer
+// AudioFrameRecord describes parameters of a single audio chunk
+struct AudioFrameRecord
 {
-    const void *Data = nullptr;
     size_t Size = 0u;
-    float Ts = -1.f; // timestamp; negative means undefined
-    float DurMs = 0.f; // buffer duration, in ms
+    float Timestamp = -1.f; // negative means undefined
+    float DurationMs = 0.f;
 
+    AudioFrameRecord() = default;
+    AudioFrameRecord(size_t sz, float ts, float dur_ms)
+        : Size(sz), Timestamp(ts), DurationMs(dur_ms) {}
+};
+
+// A thin *non-owning* wrapper over a array containing constant sound data;
+// meant to group and pass the buffer pointer and associated parameters.
+// TODO: add full audio format
+struct SoundBufferPtr
+{
+public:
+    SoundBufferPtr() = default;
+    SoundBufferPtr(const void *data, size_t sz, float ts = -1.f, float dur_ms = 0.f)
+        : _data(data), _rec(sz, ts, dur_ms) {}
+    SoundBufferPtr(const SoundBufferPtr &buf) = default;
+    SoundBufferPtr(SoundBufferPtr &&buf)
+        : _data(buf._data), _rec(buf._rec) { buf = SoundBufferPtr(); }
+    SoundBufferPtr &operator=(const SoundBufferPtr &buf) = default;
+    operator bool() const { return _data && Size() > 0; }
+
+    const void *Data() const { return _data; }
+    const AudioFrameRecord &GetFrameRecord() const { return _rec; }
+    size_t  Size() const { return _rec.Size; }
+    float   Timestamp() const { return _rec.Timestamp; }
+    float   DurationMs() const { return _rec.DurationMs; }
+
+protected:
+    const void *_data = nullptr;
+    AudioFrameRecord _rec;
+};
+
+// A sound buffer, holding audio data and associated parameters
+struct SoundBuffer final : SoundBufferPtr
+{
     SoundBuffer() = default;
+    SoundBuffer(size_t sz, float ts = -1.f, float dur_ms = 0.f)
+    {
+        _buf.resize(sz);
+        _data = _buf.data();
+        _rec = AudioFrameRecord(sz, ts, dur_ms);
+    }
     SoundBuffer(const void *data, size_t sz, float ts = -1.f, float dur_ms = 0.f)
-        : Data(data), Size(sz), Ts(ts), DurMs(dur_ms) {}
-    SoundBuffer(const SoundBuffer &buf) = default;
+    {
+        _buf.resize(sz);
+        _data = _buf.data();
+        memcpy(_buf.data(), data, sz);
+        _rec = AudioFrameRecord(sz, ts, dur_ms);
+    }
+    SoundBuffer(const SoundBuffer &buf)
+    {
+        *this = buf;
+    }
     SoundBuffer(SoundBuffer &&buf)
-        : Data(buf.Data), Size(buf.Size), Ts(buf.Ts), DurMs(buf.DurMs) { buf = SoundBuffer(); }
-    SoundBuffer &operator=(const SoundBuffer &buf) = default;
-    operator bool() const { return Data && Size > 0; }
+    {
+        _buf = std::move(buf._buf);
+        _data = _buf.data();
+        _rec = std::move(buf._rec);
+        buf = SoundBuffer();
+    }
+
+    SoundBuffer &operator=(const SoundBuffer &buf)
+    {
+        _buf = buf._buf;
+        _data = _buf.data();
+        _rec = buf._rec;
+        return *this;
+    }
+
+    void AssignData(const void *data, size_t sz, float ts = -1.f, float dur_ms = 0.f)
+    {
+        if (_buf.size() != sz)
+        {
+            _buf.resize(sz);
+            _data = _buf.data();
+        }
+        memcpy(_buf.data(), data, sz);
+        _rec = AudioFrameRecord(sz, ts, dur_ms);
+    }
+
+private:
+    std::vector<uint8_t> _buf;
 };
 
 // RAII wrapper over SDL resampling filter;
@@ -132,7 +203,7 @@ public:
     // Seeks to the given read position; returns the new position
     float Seek(float pos_ms);
     // Returns the next chunk of data; may return empty buffer in EOS or error
-    SoundBuffer GetData();
+    SoundBufferPtr GetData();
 
 private:
     SDL_RWops *_rwops = nullptr;

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -70,7 +70,7 @@ public:
     SoundBufferPtr(const void *data, size_t sz, float ts = -1.f, float dur_ms = 0.f)
         : _data(data), _rec(sz, ts, dur_ms) {}
     SoundBufferPtr(const SoundBufferPtr &buf) = default;
-    SoundBufferPtr(SoundBufferPtr &&buf)
+    SoundBufferPtr(SoundBufferPtr &&buf) noexcept
         : _data(buf._data), _rec(buf._rec) { buf = SoundBufferPtr(); }
     SoundBufferPtr &operator=(const SoundBufferPtr &buf) = default;
     operator bool() const { return _data && Size() > 0; }
@@ -104,10 +104,11 @@ struct SoundBuffer final : SoundBufferPtr
         _rec = AudioFrameRecord(sz, ts, dur_ms);
     }
     SoundBuffer(const SoundBuffer &buf)
+        : SoundBufferPtr()
     {
         *this = buf;
     }
-    SoundBuffer(SoundBuffer &&buf)
+    SoundBuffer(SoundBuffer &&buf) noexcept
     {
         _buf = std::move(buf._buf);
         _data = _buf.data();

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -134,6 +134,11 @@ struct SoundBuffer final : SoundBufferPtr
         _rec = AudioFrameRecord(sz, ts, dur_ms);
     }
 
+    void SetTimestamp(float ts)
+    {
+        _rec.Timestamp = ts;
+    }
+
 private:
     std::vector<uint8_t> _buf;
 };

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -40,7 +40,7 @@ SoundClip::SoundClip(int slot, int snd_type, bool loop)
 
     const auto player = audio_core_get_player(slot);
     lengthMs = (int)std::round(player->GetDurationMs());
-    freq = player->GetFrequency();
+    freq = static_cast<int>(player->GetFrequency());
 }
 
 SoundClip::~SoundClip()

--- a/Engine/media/video/flic_player.cpp
+++ b/Engine/media/video/flic_player.cpp
@@ -79,8 +79,10 @@ void FlicPlayer::CloseImpl()
     set_palette_range(_oldpal, 0, 255, 0);
 }
 
-bool FlicPlayer::NextVideoFrame(Bitmap *dst)
+bool FlicPlayer::NextVideoFrame(Bitmap *dst, float &ts)
 {
+    ts = -1.f; // reset in case of error
+
     // actual FLI playback state, base on original Allegro 4's do_play_fli
 
     /* get next frame */
@@ -97,6 +99,7 @@ bool FlicPlayer::NextVideoFrame(Bitmap *dst)
             fli_bitmap->w, 1 + fli_bmp_dirty_to - fli_bmp_dirty_from);
     }
 
+    ts = _videoFramesDecoded * _frameTime;
     _videoFramesDecoded++;
     reset_fli_variables();
     return true;

--- a/Engine/media/video/flic_player.h
+++ b/Engine/media/video/flic_player.h
@@ -38,7 +38,7 @@ private:
         const String &name, int &flags, int target_depth) override;
     void CloseImpl() override;
     // Retrieves next video frame, implementation-specific
-    bool NextVideoFrame(Common::Bitmap *dst) override;
+    bool NextVideoFrame(Common::Bitmap *dst, float &ts) override;
 
     PACKFILE *_pf = nullptr;
     RGB _oldpal[256]{};

--- a/Engine/media/video/theora_player.cpp
+++ b/Engine/media/video/theora_player.cpp
@@ -185,12 +185,12 @@ bool TheoraPlayer::NextVideoFrame(Bitmap *dst)
     return true;
 }
 
-SoundBuffer TheoraPlayer::NextAudioFrame()
+bool TheoraPlayer::NextAudioFrame(SoundBuffer &abuf)
 {
     assert(_apegStream);
     assert((_apegStream->flags & APEG_HAS_AUDIO) != 0);
     if ((_apegStream->flags & APEG_HAS_AUDIO) == 0)
-        return SoundBuffer();
+        return SoundBufferPtr();
 
     // reset some data
     _apegStream->audio.flushed = FALSE;
@@ -199,8 +199,10 @@ SoundBuffer TheoraPlayer::NextAudioFrame()
     int count = 0;
     int ret = apeg_get_audio_frame(_apegStream, &buf, &count);
     if (ret == APEG_ERROR || ret == APEG_EOF)
-        return SoundBuffer();
-    return SoundBuffer(buf, count, -1.f, SoundHelper::MillisecondsFromBytes(count, _audioFormat, _audioChannels, _audioFreq));
+        return false;
+
+    abuf.AssignData(buf, count, -1.f, SoundHelper::MillisecondsFromBytes(count, _audioFormat, _audioChannels, _audioFreq));
+    return true;
 }
 
 } // namespace Engine

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -42,7 +42,7 @@ private:
     // Retrieves next video frame, implementation-specific
     bool NextVideoFrame(Common::Bitmap *dst) override;
     // Retrieves next audio frame, implementation-specific
-    SoundBuffer NextAudioFrame() override;
+    bool NextAudioFrame(SoundBuffer &abuf) override;
 
     Common::HError OpenAPEGStream(Stream *data_stream, const String &name, int flags, int target_depth);
 

--- a/Engine/media/video/theora_player.h
+++ b/Engine/media/video/theora_player.h
@@ -40,7 +40,7 @@ private:
     void CloseImpl() override;
     bool RewindImpl() override;
     // Retrieves next video frame, implementation-specific
-    bool NextVideoFrame(Common::Bitmap *dst) override;
+    bool NextVideoFrame(Common::Bitmap *dst, float &ts) override;
     // Retrieves next audio frame, implementation-specific
     bool NextAudioFrame(SoundBuffer &abuf) override;
 
@@ -54,7 +54,10 @@ private:
     std::unique_ptr<Common::Bitmap> _theoraFullFrame;
     // Wrapper over portion of theora frame which we want to use
     std::unique_ptr<Common::Bitmap> _theoraSrcFrame;
-    uint64_t _videoFramesDecoded = 0u; // how many frames loaded and decoded
+    uint64_t _videoFramesDecodedTotal = 0u; // how many frames loaded and decoded total (includes rewinds!)
+    uint64_t _videoFramesDecoded = 0u; // sequential count of video frames since the video beginning
+    float _nextFrameTs = 0.f; // next frame presentation time
+                              // this is based on previous frame's end pos granule in Ogg stream
 };
 
 } // namespace Engine

--- a/Engine/media/video/videoplayer.cpp
+++ b/Engine/media/video/videoplayer.cpp
@@ -448,7 +448,7 @@ void VideoPlayer::BufferVideo()
     _stats.VideoIn.RawDecodedConvDataSz = target_frame->GetDataSize();
     _stats.VideoIn.AvgTimePerFrame = _stats.VideoIn.TotalTime / _stats.VideoIn.Frames;
     _stats.VideoIn.MaxTimePerFrame = std::max(_stats.VideoIn.MaxTimePerFrame, static_cast<uint32_t>(input_dur_ms));
-    _stats.MaxBufferedVideo = std::max(_stats.MaxBufferedVideo, _videoFrameQueue.size());
+    _stats.MaxBufferedVideo = std::max<uint32_t>(_stats.MaxBufferedVideo, _videoFrameQueue.size());
     // TODO: maybe record this every 10 - 100 frames?
     _stats.BufferedVideoAccum += _videoFrameQueue.size();
 

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -40,6 +40,7 @@
 #include "media/audio/openalsource.h"
 #include "util/error.h"
 #include "util/stream.h"
+#include "util/time_util.h"
 
 namespace AGS
 {
@@ -194,10 +195,10 @@ private:
     // note that these are "virtual time", and are adjusted whenever playback
     // is paused and resumed, or playback speed changes.
     bool _resetStartTime = false;
-    AGS_Clock::time_point _startTs; // time when the data was first prepared for the output
-    AGS_Clock::time_point _pollTs; // timestamp of the last Poll in autoplay mode
-    AGS_Clock::duration _playbackDuration; // full playback time
-    AGS_Clock::time_point _pauseTs; // time when the playback was paused
+    Clock::time_point _startTs; // time when the data was first prepared for the output
+    Clock::time_point _pollTs; // timestamp of the last Poll in autoplay mode
+    Clock::duration _playbackDuration; // full playback time
+    Clock::time_point _pauseTs; // time when the playback was paused
     uint32_t _wantFrameIndex = 0u; // expected video frame at this time
     // Audio
     // Audio queue (single frame for now, because output buffers too)

--- a/Engine/media/video/videoplayer.h
+++ b/Engine/media/video/videoplayer.h
@@ -140,7 +140,7 @@ protected:
     // Rewind to the start
     virtual bool RewindImpl() { return false; }
     // Retrieves next video frame, implementation-specific
-    virtual bool NextVideoFrame(Common::Bitmap *dst) { return false; };
+    virtual bool NextVideoFrame(Common::Bitmap *dst, float &ts) { return false; };
     // Retrieves next audio frame, implementation-specific
     // TODO: change return type to a proper allocated buffer
     // when we support a proper audio queue here.

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -261,7 +261,7 @@ int cd_player_control(int cmdd, int datt) {
 #endif // AGS_HAS_CD_AUDIO
 
 void AGSPlatformDriver::Delay(int millis) {
-  auto now = AGS_Clock::now();
+  auto now = Clock::now();
   auto delayUntil = now + std::chrono::milliseconds(millis);
 
   for (;;) {
@@ -269,12 +269,12 @@ void AGSPlatformDriver::Delay(int millis) {
 
     auto duration = std::min<std::chrono::nanoseconds>(delayUntil - now, MaximumDelayBetweenPolling);
     std::this_thread::sleep_for(duration);
-    now = AGS_Clock::now(); // update now
+    now = Clock::now(); // update now
 
     if (now >= delayUntil) { break; }
 
     // don't allow it to check for debug messages, since this Delay()
     // call might be from within a debugger polling loop
-    now = AGS_Clock::now(); // update now
+    now = Clock::now(); // update now
   }
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -35,9 +35,11 @@
 #include "util/file.h"
 #include "util/memory.h"
 #include "util/string_utils.h" // linux strnicmp definition
+#include "util/time_util.h"
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
+using namespace AGS::Engine;
 
 
 enum ScriptOpArgIsReg
@@ -589,7 +591,7 @@ ccInstError ccInstance::Run(int32_t curpc)
     unsigned loopCheckIterations = 0u; // loop iterations accumulated only if check is enabled
 
     const auto timeout = std::chrono::milliseconds(_timeoutCheckMs);
-    _lastAliveTs = AGS_FastClock::now();
+    _lastAliveTs = FastClock::now();
 
     /* Main bytecode execution loop */
     //=====================================================================
@@ -1040,12 +1042,12 @@ ccInstError ccInstance::Run(int32_t curpc)
                 }
                 else if ((loopIterations & 0x3FF) == 0 && // test each 1024 loops (arbitrary)
                     (std::chrono::duration_cast<std::chrono::milliseconds>(
-                        AGS_FastClock::now() - _lastAliveTs) > timeout))
+                        FastClock::now() - _lastAliveTs) > timeout))
                 { // minimal timeout occured
                     // NOTE: removed timeout_abort check for now: was working *logically* wrong;
                     // at least let user to manipulate the game window
                     sys_evt_process_pending();
-                    _lastAliveTs = AGS_FastClock::now();
+                    _lastAliveTs = FastClock::now();
                 }
             }
             break;
@@ -1731,7 +1733,7 @@ bool ccInstance::IsBeingRun() const
 void ccInstance::NotifyAlive()
 {
     _flags |= INSTF_RUNNING;
-    _lastAliveTs = AGS_FastClock::now();
+    _lastAliveTs = FastClock::now();
 }
 
 bool ccInstance::_Create(PScript scri, const ccInstance *joined)

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -22,12 +22,12 @@
 #include <memory>
 #include <unordered_map>
 
-#include "ac/timer.h"
 #include "script/cc_script.h"  // ccScript
 #include "script/cc_internal.h"  // bytecode constants
 #include "script/runtimescriptvalue.h"
 #include "script/systemimports.h"
 #include "util/string.h"
+#include "util/time_util.h"
 
 using namespace AGS;
 
@@ -300,7 +300,7 @@ private:
     // after which the interpreter will abort
     static unsigned _maxWhileLoops;
     // Last time the script was noted of being "alive"
-    AGS_FastClock::time_point _lastAliveTs;
+    AGS::Engine::FastClock::time_point _lastAliveTs;
 };
 
 #endif // __CC_INSTANCE_H

--- a/Engine/util/time_util.h
+++ b/Engine/util/time_util.h
@@ -1,0 +1,78 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2025 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+//
+// Various time-related utilities
+//
+//=============================================================================
+#ifndef __AGS_EE_UTIL_TIMEUTIL_H
+#define __AGS_EE_UTIL_TIMEUTIL_H
+
+#include <type_traits>
+#include <chrono>
+
+namespace AGS
+{
+namespace Engine
+{
+
+// Clock is a high-resolution clock, used when we need max precision.
+// Use high resolution clock only if we know it is monotonic/steady.
+// refer to https://stackoverflow.com/a/38253266/84262
+using Clock = std::conditional<
+    std::chrono::high_resolution_clock::is_steady,
+    std::chrono::high_resolution_clock, std::chrono::steady_clock
+>::type;
+// FastClock is a higher performance clock, used when the speed is a priority,
+// but precision may be sacrificed.
+using FastClock = std::chrono::system_clock;
+
+template <typename TDur>
+inline int64_t ToMilliseconds(TDur dur)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+}
+
+template <typename TClock>
+class TStopwatch final
+{
+public:
+    using Duration = typename TClock::duration;
+    using TimePoint = typename TClock::time_point;
+
+    TStopwatch()
+    {
+        _start = TClock::now();
+    }
+
+    void Start()
+    {
+        _start = TClock::now();
+    }
+
+    Duration Check() const
+    {
+        return TClock::now() - _start;
+    }
+
+private:
+    TimePoint _start;
+};
+
+typedef TStopwatch<Clock> Stopwatch;
+typedef TStopwatch<FastClock> FastStopwatch;
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_UTIL_TIMEUTIL_H

--- a/Engine/util/time_util.h
+++ b/Engine/util/time_util.h
@@ -43,6 +43,12 @@ inline int64_t ToMilliseconds(TDur dur)
     return std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
 }
 
+template <typename TDur>
+inline float ToMillisecondsF(TDur dur)
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(dur).count() * 0.001;
+}
+
 template <typename TClock>
 class TStopwatch final
 {

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -949,6 +949,7 @@
     <ClInclude Include="..\..\Engine\util\library.h" />
     <ClInclude Include="..\..\Engine\util\library_windows.h" />
     <ClInclude Include="..\..\Engine\util\sdl2_util.h" />
+    <ClInclude Include="..\..\Engine\util\time_util.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\al.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\alc.h" />
   </ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1649,6 +1649,9 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptrestoredsaveinfo.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\util\time_util.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\Engine\resource\game-1.ico">


### PR DESCRIPTION
VideoPlayer gathers statistics about amounts of input & output data, time differences, etc, and posts this into the log after stopping.

Introduced a simple synchronization mechanism that forces video to sync with audio if their timing is too far apart. Audio is chosen as a leader here, because audio is more sensible for human perception:
* if video is late, then the new frames will be dropped (not rendered) until it reaches audio timing.
* if audio is late, then the current video frame will be held, until audio reaches video timing.