### PR TITLE
New compiler: Check arguments of format functions (`String.Format()` …)  at compile time

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -11,9 +11,8 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <algorithm>
+#include <string>
 
 #include "cc_symboltable.h"
 #include "script/cc_internal.h"
@@ -335,6 +334,7 @@ AGS::SymbolTable::SymbolTable()
     AddKeyword(kKW_Extends, "extends");
     AddKeyword(kKW_FallThrough, "fallthrough");
     AddKeyword(kKW_For, "for");
+    AddKeyword(kKW_Format, "__format");
     AddKeyword(kKW_If, "if");
     AddKeyword(kKW_ImportStd, "import");
     AddKeyword(kKW_ImportTry, "_tryimport");
@@ -383,7 +383,16 @@ AGS::SymbolTable::SymbolTable()
         entries[float_zero_sym].LiteralD->Value = 0;
         entries[float_zero_sym].LiteralD->Vartype = kKW_Float;
     }
-    _lastAllocated = VartypeWithConst(kKW_String);
+    VartypeWithConst(kKW_String);
+
+    // Wbenever the size of 'entries' is extended in this
+    // function (e.g., in order to accomodate for another
+    // keyword), this affects about two dozen googletests
+    // that need to be updated and re-checked. To mitigate
+    // this, extend 'entries' in blocks of ten.
+    size_t const blocksize = 10u;
+    entries.resize(((entries.size() + blocksize - 1u) / blocksize) * blocksize);
+    _lastAllocated = entries.size() - 1u;
 }
 
 bool AGS::SymbolTable::IsVTT(Symbol s, VartypeType vtt) const

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -199,6 +199,7 @@ enum Predefined : Symbol
     kKW_Extends,        // "extends"
     kKW_FallThrough,    // "fallthrough"
     kKW_For,            // "for"
+    kKW_Format,         // "__format
     kKW_If,             // "if"
     kKW_ImportStd,      // "import"
     kKW_ImportTry,      // "_tryimport"
@@ -228,6 +229,7 @@ struct FuncParameterDesc
     AGS::Vartype Vartype = kKW_NoSymbol;
     Symbol Name = kKW_NoSymbol;
     Symbol Default = kKW_NoSymbol;
+    bool IsFormatParam = false;
     size_t Declared = SIZE_MAX;
 };
 
@@ -305,6 +307,7 @@ struct SymbolTableEntry : public SymbolTableConstant
         CodeLoc Offset = 0;
         bool IsConstructor = false;
         bool IsVariadic = false;
+        bool IsFormat = false;
         bool NoLoopCheck = false;
     } *FunctionD = nullptr;
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1046,9 +1046,29 @@ void AGS::Parser::ParseVarname0(bool const accept_member_access, Symbol &structn
 
 void AGS::Parser::ParseFuncdecl_Parameters_Param(Symbol const name_of_func, bool const body_follows, bool const read_only, size_t const param_idx)
 {
+    auto &parameters = _sym[name_of_func].FunctionD->Parameters;
+    size_t const declared = _src.GetCursor();
+
+    bool const is_format_param = (kKW_Format == _src.PeekNext());
+    if (is_format_param)
+    {
+        SkipNextSymbol(_src, kKW_Format);
+        if (_sym[name_of_func].FunctionD->IsFormat)
+            UserError(
+                "Parameter #%u: Can only declare at most one parameter per function as '%s'",
+                param_idx,
+                _sym.GetName(kKW_Format).c_str());
+        _sym[name_of_func].FunctionD->IsFormat = true;
+    }
+
     Vartype param_vartype = ParseVartype(_src);
 
-    size_t const declared = _src.GetCursor();
+    if (is_format_param && !_sym.IsAnyStringVartype(param_vartype))
+        UserError(
+            "Expected a string type for the '%s' parameter #%u, found '%s' instead",
+            _sym.GetName(kKW_Format).c_str(),
+            param_idx,
+            _sym.GetName(param_vartype).c_str());
 
     if (kKW_Void == param_vartype)
         UserError("Parameter #%u: Cannot use the type 'void' in a parameter list", param_idx);
@@ -1081,8 +1101,6 @@ void AGS::Parser::ParseFuncdecl_Parameters_Param(Symbol const name_of_func, bool
     Symbol const param_default =
         ParseFuncdecl_Parameters_ParamDefaultValue(param_vartype, param_idx);
 
-    auto &parameters = _sym[name_of_func].FunctionD->Parameters;
-
     if (!body_follows &&
         kKW_NoSymbol == param_default &&
         !parameters.empty() &&
@@ -1096,6 +1114,7 @@ void AGS::Parser::ParseFuncdecl_Parameters_Param(Symbol const name_of_func, bool
     fpd.Name = param_name;
     fpd.Default = param_default;
     fpd.Declared = declared;
+    fpd.IsFormatParam = is_format_param;
     parameters.push_back(fpd);
 
     if (PP::kMain != _pp || !body_follows)
@@ -1153,7 +1172,14 @@ void AGS::Parser::ParseFuncdecl_Parameters(Symbol name_of_func, bool body_follow
         Symbol const punctuation = _src.GetNext();
         Expect(SymbolList{ kKW_Comma, kKW_CloseParenthesis }, punctuation);
         if (kKW_CloseParenthesis == punctuation)
+        {
+            if (_sym[name_of_func].FunctionD->IsFormat)
+                UserError(
+                    "Function '%s' has a '%s' parameter and thus must be variadic",
+                    _sym.GetName(name_of_func).c_str(),
+                    _sym.GetName(kKW_Format).c_str());
             return;
+        }
         continue;
     } // while
 
@@ -2876,7 +2902,7 @@ void AGS::Parser::AccessData_GenerateDynarrayLengthAttrib(EvaluationResult &eres
 }
 
                                                         
-void AGS::Parser::AccessData_FunctionCall_Arguments_Named(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool const is_variadic, SrcList &arg_srcs, std::vector<SrcList> &arg_exprs)
+void AGS::Parser::AccessData_FunctionCall_Arguments_Named(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, SrcList &arg_srcs, std::vector<SrcList> &arg_exprs)
 {
     if (_sym[name_of_func].FunctionD->ParamNamingInconsistency.Exists)
     {
@@ -2954,7 +2980,7 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Named(Symbol const name_of_f
     }
 }
 
-void AGS::Parser::AccessData_FunctionCall_Arguments_Sequence(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool const is_variadic, SrcList &arg_list, std::vector<SrcList> &arg_exprs)
+void AGS::Parser::AccessData_FunctionCall_Arguments_Sequence(Symbol const name_of_func, std::vector<FuncParameterDesc> const &param_desc, SrcList &arg_list, std::vector<SrcList> &arg_exprs)
 {
     // [0u] is unused (reserved for the return value)
     arg_exprs.push_back(SrcList{ arg_list, 0u, 0u });
@@ -2994,38 +3020,124 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Sequence(Symbol const name_o
     }
 }
 
-void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bool const func_is_import, size_t args_count, std::vector<SrcList> arg_exprs, bool use_named_args, std::vector<AGS::FuncParameterDesc> const &param_descs)
+void AGS::Parser::AccessData_FunctionCall_AnalyseFormatString(std::vector<FuncParameterDesc> const &param_descs, std::vector<SrcList> &arg_exprs, bool &check_vartypes_by_format, std::vector<std::string> &format_strings)
+{
+    check_vartypes_by_format = false;
+
+    // Find the index of the format parameter
+    auto it = std::find_if(
+        param_descs.begin(), param_descs.end(),
+        [](FuncParameterDesc const &fpd) -> bool { return fpd.IsFormatParam; });
+    if (it == param_descs.end())
+        InternalError("Cannot find the format string");
+    size_t param_idx = it - param_descs.begin();
+
+    // Find the corresponding argument and make sure that it's a string literal
+    auto &arg_expr = arg_exprs[param_idx];
+    if (arg_expr.Length() != 1)
+        return;
+    Symbol format_sym = arg_expr[0u];
+    if (!_sym.IsLiteral(format_sym) ||
+        !_sym.IsAnyStringVartype(_sym[format_sym].LiteralD->Vartype))
+        return; // Can only check literals
+
+    check_vartypes_by_format = true;
+
+    // Get the actual characters of the format string
+    auto format_cstr = &(_scrip.strings[_sym[format_sym].LiteralD->Value]);
+    std::string format{ format_cstr };
+
+    // Extract the specifiers
+    static std::string const format_letters = "cdfs";
+    for (size_t format_idx1 = 0; format_idx1 < format.length(); format_idx1++)
+    {
+        if (format[format_idx1] != '%')
+            continue;
+
+        if (format_idx1 + 1u < format.length() && format[format_idx1 + 1u] == '%')
+        {   
+            format_idx1++; // Skip "%%"
+            continue;
+        }
+
+        // Find the index of the format letter that is eventually following the '%'
+        for (size_t format_idx2 = format_idx1 + 1u; format_idx2 < format.length(); format_idx2++)
+        {
+            char const ch = format[format_idx2];
+            if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z'))
+            {
+                auto const spec = format.substr(format_idx1, format_idx2 - format_idx1 + 1u);
+                if (std::string::npos == format_letters.find(ch))
+                    UserError(
+                        "Argument #%u: Cannot process '%s' in the format string literal",
+                        param_idx,
+                        spec.c_str());
+                format_strings.push_back(spec);
+                format_idx1 = format_idx2;
+                break;
+            }
+        }
+    }
+}
+
+// Note, we _must_ pass 'args_size' to this function, we can't deduce that from 'arg_exprs',
+// or else things will get awry when the last parameter has a default and an argument is not supplied for it.
+void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bool func_is_import, size_t args_size,
+    std::vector<SrcList> arg_exprs, bool use_named_args, std::vector<AGS::FuncParameterDesc> const &param_descs,
+    bool check_format, std::vector<std::string> const formats)
 {
     auto const no_desc = FuncParameterDesc{};
+    size_t const first_variadic_idx = param_descs.size();
+    size_t const variadic_args_count = args_size - param_descs.size();
+
+    // Check the type specification of the format if applicable
+    if (check_format && (formats.size() > args_size - first_variadic_idx))
+        UserError(
+            "Call to function '%s': "
+            "The format string provides specifications for %u variadic argument(s) "
+            " but only %u variadic argument(s) are passed",
+            _sym.GetName(name_of_func).c_str(),
+            formats.size(),
+            variadic_args_count);
+    if (check_format && (formats.size() < args_size - first_variadic_idx))
+        UserError(
+            "Call to function '%s': "
+            "%u variadic argument(s) are passed, but "
+            " the format string provides specifications for only %u variadic argument(s)",
+            _sym.GetName(name_of_func).c_str(),
+            variadic_args_count,
+            formats.size());
 
     // Push the arguments
     // In reverse order because the engine expects them this way
-    for (size_t idx = args_count; idx >= 1u; --idx)
+    for (size_t idx = args_size - 1u; idx >= 1u; --idx)
     {
         // For error messages
         std::string ctfp = "Call to function '<func>', <name>: ";
         string_replace(ctfp, "<func>", _sym.GetName(name_of_func));
-        std::string name = "";
+        std::string argument_name = "";
         if (use_named_args &&
             idx < param_descs.size() &&
             !_sym[name_of_func].FunctionD->ParamNamingInconsistency.Exists)
         {
-            name = "parameter '<param>'";
-            string_replace(name, "<param>", _sym.GetName(param_descs[idx].Name));
-            if (name == "parameter ''")
-                name = "";
+            argument_name = "parameter '<param>'";
+            string_replace(argument_name, "<param>", _sym.GetName(param_descs[idx].Name));
+            if (argument_name == "parameter ''")
+                argument_name = "";
         }
 
-        if ("" == name)
+        if ("" == argument_name)
         {
-            name = "argument #<arg>";
-            string_replace(name, "<arg>", std::to_string(idx));
+            argument_name = "argument #<arg>";
+            string_replace(argument_name, "<arg>", std::to_string(idx));
         }
 
-        string_replace(ctfp, "<name>", name);
+        string_replace(ctfp, "<name>", argument_name);
 
         FuncParameterDesc const &param_desc =
             (idx < param_descs.size()) ? param_descs[idx] : no_desc;
+
+        Symbol arg_vartype = kKW_NoSymbol;
 
         if (idx < arg_exprs.size() && arg_exprs[idx].Length() > 0u) // Argument passed
         {
@@ -3034,6 +3146,7 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bo
             EvaluationResult eres;
             ParseExpression_Term(arg_expr, eres, true, true);
             EvaluationResultToAx(eres);
+            arg_vartype = eres.Vartype;
             if (idx < param_descs.size())
             {
                 if (IsVartypeMismatch_Oneway(eres.Vartype, param_desc.Vartype))
@@ -3050,6 +3163,7 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bo
                     // Must make sure that NULL isn't passed at runtime
                     WriteCmd(SCMD_CHECKNULLREG, SREG_AX);
             }
+
         }
         else // No argument or empty argument passed
         {
@@ -3058,14 +3172,54 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bo
             if (kKW_NoSymbol == deflt)
                 UserError(
                     ReferenceMsgLoc(
-                        (ctfp +
-                            "Argument isn't passed and parameter doesn't have a default").c_str(),
+                        (ctfp + "Argument isn't passed and parameter doesn't have a default").c_str(),
                         param_desc.Declared).c_str());
 
             if (!_sym.IsLiteral(deflt))
                 InternalError("Parameter default symbol isn't literal");
+            arg_vartype = _sym[deflt].LiteralD->Vartype;
             CodeCell value = _sym[deflt].LiteralD->Value;
             WriteCmd(SCMD_LITTOREG, SREG_AX, value);
+        }
+
+        if (check_format && idx >= param_descs.size())
+        {
+            size_t const format_idx = idx - first_variadic_idx;
+            auto &format = formats[format_idx];
+            int const fletter = format.back();
+            switch (fletter)
+            {
+            default:
+                InternalError("Cannot process format letter '%c'", fletter);
+
+            case 'c':
+            case 'd':
+                if (!_sym.IsAnyIntegerVartype(arg_vartype))
+                    UserError(
+                        (ctfp + "Argument has type '%s' and doesn't match the format specifier '%s' for integer types").c_str(),
+                        _sym.GetName(arg_vartype).c_str(),
+                        format.c_str());
+                break;
+
+            case 'f':
+                if (kKW_Float != arg_vartype)
+                    UserError(
+                        (ctfp + "Argument has type '%s' and doesn't match the format specifier '%s' for type 'float'").c_str(),
+                        _sym.GetName(arg_vartype).c_str(),
+                        format.c_str());
+                break;
+
+            case 's':
+                // Also let through one-dimensional classic arrays of 'char'
+                if (!_sym.IsAnyStringVartype(arg_vartype) &&
+                    !(  _sym[arg_vartype].VartypeD->Type == VTT::kArray &&
+                        _sym[arg_vartype].VartypeD->Dims.size() == 1u &&
+                        _sym[arg_vartype].VartypeD->BaseVartype == kKW_Char))
+                    UserError(
+                        (ctfp + "Argument has type '%s' and doesn't match the format specifier '%s' for string types").c_str(),
+                        _sym.GetName(arg_vartype).c_str(),
+                        format.c_str());
+            }
         }
 
         if (func_is_import)
@@ -3075,7 +3229,7 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bo
     }
 }
 
-void AGS::Parser::AccessData_FunctionCall_Arguments(Symbol const name_of_func, bool const func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool const is_variadic, SrcList &arguments, size_t &args_count)
+void AGS::Parser::AccessData_FunctionCall_Arguments(Symbol const name_of_func, bool const func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool const is_variadic, SrcList &arguments, size_t &args_size)
 {
     // Parse the arguments into expressions that match 'param_descs'
     std::vector<SrcList> arg_exprs = {};
@@ -3085,20 +3239,25 @@ void AGS::Parser::AccessData_FunctionCall_Arguments(Symbol const name_of_func, b
         _sym.IsIdentifier(arguments[1u]) &&
         kKW_Colon == arguments[2u];
     if (use_named_args)
-        AccessData_FunctionCall_Arguments_Named(name_of_func, param_descs, is_variadic, arguments, arg_exprs);
+        AccessData_FunctionCall_Arguments_Named(name_of_func, param_descs, arguments, arg_exprs);
     else
-        AccessData_FunctionCall_Arguments_Sequence(name_of_func, param_descs, is_variadic, arguments, arg_exprs);
+        AccessData_FunctionCall_Arguments_Sequence(name_of_func, param_descs, arguments, arg_exprs);
 
-    args_count = std::max(param_descs.size(), arg_exprs.size()) - 1u; // '- 1u' due to the unused '[0u]'
-    if (args_count > param_descs.size() - 1u && !is_variadic)
+    args_size = std::max(param_descs.size(), arg_exprs.size()); 
+    if (args_size > param_descs.size() && !is_variadic)
         UserError(
             ReferenceMsgSym(
                 "Call to function '%s': Expected at most %u arguments, found more",
                 name_of_func).c_str(),
             _sym.GetName(name_of_func).c_str(),
-            param_descs.size() - 1u);
+            param_descs.size() - 1u); // '-1u' because 'param_descs[0]' is the return parameter
 
-    AccessData_FunctionCall_Arguments_Push(name_of_func, func_is_import, args_count, arg_exprs, use_named_args, param_descs);
+    bool check_vartypes_by_format = false;
+    std::vector<std::string> format_strings = {};
+    if (_sym[name_of_func].FunctionD->IsFormat)
+        AccessData_FunctionCall_AnalyseFormatString(param_descs, arg_exprs, check_vartypes_by_format, format_strings);
+    AccessData_FunctionCall_Arguments_Push(name_of_func, func_is_import, args_size, arg_exprs, use_named_args, param_descs,
+        check_vartypes_by_format, format_strings);
     
     // Move cursor to the end of the arguments, they have been used up
     arguments.SetCursor(arguments.Length());
@@ -3147,14 +3306,17 @@ void AGS::Parser::AccessData_FunctionCall(Symbol name_of_func, SrcList &expressi
         mar_pushed = true;
     }
 
-    size_t args_count;
+    size_t args_size;
     AccessData_FunctionCall_Arguments(
         name_of_func,
         func_is_import,
         _sym[name_of_func].FunctionD->Parameters,
         _sym.IsVariadicFunc(name_of_func),
         arguments,
-        args_count);
+        args_size);
+
+    // Get the 'net' number of arguments, without the return parameter in '[0]'
+    size_t const args_count = args_size - 1u; 
     
       if (called_func_uses_this)
       {

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1046,7 +1046,6 @@ void AGS::Parser::ParseVarname0(bool const accept_member_access, Symbol &structn
 
 void AGS::Parser::ParseFuncdecl_Parameters_Param(Symbol const name_of_func, bool const body_follows, bool const read_only, size_t const param_idx)
 {
-    auto &parameters = _sym[name_of_func].FunctionD->Parameters;
     size_t const declared = _src.GetCursor();
 
     bool const is_format_param = (kKW_Format == _src.PeekNext());
@@ -1100,6 +1099,8 @@ void AGS::Parser::ParseFuncdecl_Parameters_Param(Symbol const name_of_func, bool
     ParseDynArrayMarkersIfPresent(_src, param_vartype);
     Symbol const param_default =
         ParseFuncdecl_Parameters_ParamDefaultValue(param_vartype, param_idx);
+
+    auto &parameters = _sym[name_of_func].FunctionD->Parameters;
 
     if (!body_follows &&
         kKW_NoSymbol == param_default &&

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3071,15 +3071,12 @@ void AGS::Parser::AccessData_FunctionCall_AnalyseFormatString(std::vector<FuncPa
         for (size_t format_idx2 = format_idx1 + 1u; format_idx2 < format.length(); format_idx2++)
         {
             char const ch = format[format_idx2];
-            if (!('a' <= ch && ch <= 'z') && !('A' <= ch && ch <= 'Z'))
-            {
-                if ('0' <= ch && ch <= '9')
-                    continue;
-                if (std::string::npos != legal_symbols.find(ch))
-                    continue;
-                if (std::string::npos != modifiers.find(ch))
-                    continue;
-            }
+            if ('0' <= ch && ch <= '9')
+                continue;
+            if (std::string::npos != legal_symbols.find(ch))
+                continue;
+            if (std::string::npos != modifiers.find(ch))
+                continue;
 
             auto const spec = format.substr(format_idx1, format_idx2 - format_idx1 + 1u);
             if (std::string::npos != format_letters.find(ch))

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -555,13 +555,20 @@ private:
     // and add it to the symbol table
     void AccessData_GenerateDynarrayLengthAttrib(EvaluationResult &eres);
 
-    void AccessData_FunctionCall_Arguments_Named(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool is_variadic, SrcList &arguments, std::vector<SrcList> &arg_exprs);
-    void AccessData_FunctionCall_Arguments_Sequence(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, bool is_variadic, SrcList &arguments, std::vector<SrcList> &arg_exprs);
+    void AccessData_FunctionCall_Arguments_Named(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, SrcList &arguments, std::vector<SrcList> &arg_exprs);
+    void AccessData_FunctionCall_Arguments_Sequence(Symbol name_of_func, std::vector<FuncParameterDesc> const &param_desc, SrcList &arguments, std::vector<SrcList> &arg_exprs);
 
-    void AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bool func_is_import, size_t args_count, std::vector<SrcList> arg_exprs, bool named_args, std::vector<AGS::FuncParameterDesc> const &param_descs);
+    // Find the format string of the function; find its formats and write them to 'format_strings'
+    void AccessData_FunctionCall_AnalyseFormatString(std::vector<FuncParameterDesc> const &param_descs, std::vector<SrcList> &arg_exprs, bool &check_vartypes_by_format, std::vector<std::string> &format_strings);
+
+    // Push the arguments onto the stack, including the default ones.
+    // Note, 'args_size' counts the return parameter in '[0]'. (This return parameter is NOT pushed.)
+    void AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bool func_is_import, size_t args_size, std::vector<SrcList> arg_exprs, bool use_named_args,
+        std::vector<AGS::FuncParameterDesc> const &param_descs, bool check_format, std::vector<std::string> const formats);
 
     // Parse the arguments 'args_list' of a function call
-    void AccessData_FunctionCall_Arguments(Symbol name_of_func, bool func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool is_variadic, SrcList &arguments, size_t &args_count);
+    // Note, 'args_size' counts the return parameter in [0]
+    void AccessData_FunctionCall_Arguments(Symbol name_of_func, bool func_is_import, std::vector<FuncParameterDesc> const &param_descs, bool is_variadic, SrcList &arguments, size_t &args_size);
 
     // Process a function call. 
     void AccessData_FunctionCall(Symbol name_of_func, SrcList &arguments, EvaluationResult &eres);

--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -626,7 +626,9 @@ void AGS::Scanner::ReadInStringLit(std::string &symstring, std::string &valstrin
             lineno_before_skip = _lineno;
             Get(); // Eat leading '"'
             char tbuffer[kNewSectionLitPrefixSize + 1u];
-            _inputStream.get(tbuffer, kNewSectionLitPrefixSize + 1u, 0);
+            // Shut up a stupid warning for arg #2, brought about by the standard requiring
+            // a ‘size’ that can be negative in theory, but not actually so in the current circumstances
+            _inputStream.get(tbuffer, static_cast<std::streamsize>(kNewSectionLitPrefixSize + 1u), 0);
             _eofReached |= _inputStream.eof();
             _failed |= _inputStream.fail();
             // Undo the reading

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -307,6 +307,7 @@ TEST_F(Bytecode0, Float01) {
 TEST_F(Bytecode0, Float02) {
 
     // Positive and negative float parameter defaults
+    // Processing must be correct for the _last_ default parameter
 
     char const *inpl = "\
         float sub (float p1 = 7.2,          \n\
@@ -2055,38 +2056,41 @@ TEST_F(Bytecode0, FreeLocalPtr_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("FreeLocalPtr_Rtti", scrip);
-    size_t const codesize = 85;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 85;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,   74,    3,    // 7
-      92,    4,   51,    0,           47,    3,    1,    1,    // 15
+     100,    4,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   10,    6,            3,    0,   29,    3,    // 23
       31,   11,   36,   10,           51,    4,    7,    3,    // 31
        1,    3,    1,    8,            3,   36,   10,   51,    // 39
        4,    7,    3,   29,            3,    6,    3,   10,    // 47
       30,    4,   18,    4,            3,    3,    4,    3,    // 55
-      28,   12,   36,   11,           74,    3,   92,    4,    // 63
+      28,   12,   36,   11,           74,    3,  100,    4,    // 63
       51,    8,   47,    3,           31,  -44,    2,    1,    // 71
        4,   36,   12,   51,            4,   49,    2,    1,    // 79
        4,    6,    3,    0,            5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct01) {
@@ -2409,17 +2413,18 @@ TEST_F(Bytecode0, Struct04_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Struct04_Rtti", scrip);
-    size_t const codesize = 108;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 108;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   13,   38,    0,           36,   14,   51,    0,    // 7
       63,   16,    1,    1,           16,   36,   15,   74,    // 15
-       3,   92,    4,   51,           16,   47,    3,   36,    // 23
+       3,  100,    4,   51,           16,   47,    3,   36,    // 23
       16,   51,   16,   48,            2,   52,    6,    3,    // 31
     12345,    8,    3,   36,           17,   51,    0,   63,    // 39
       48,    1,    1,   48,           36,   18,   74,    3,    // 47
-      92,    4,   51,   16,           47,    3,   36,   19,    // 55
+     100,    4,   51,   16,           47,    3,   36,   19,    // 55
       51,   64,   49,    1,            2,    4,   49,    1,    // 63
        2,    4,   49,    1,            2,    4,   49,   51,    // 71
       48,    6,    3,    3,           29,    2,   49,    1,    // 79
@@ -2428,22 +2433,24 @@ TEST_F(Bytecode0, Struct04_RTTI) {
        2,    3,    1,   70,          -25,    2,    1,   64,    // 103
        6,    3,    0,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct05) {
@@ -2545,35 +2552,38 @@ TEST_F(Bytecode0, Struct06) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Struct06", scrip);
-    size_t const codesize = 59;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 59;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   14,   38,    0,           36,   15,    6,    3,    // 7
        0,   29,    3,   36,           16,    6,    3,    5,    // 15
-      75,    3,   92,    4,           51,    4,   47,    3,    // 23
+      75,    3,  100,    4,           51,    4,   47,    3,    // 23
       36,   17,   51,    4,           48,    2,   52,    6,    // 31
        3,   15,   71,    3,            1,    2,   12,   48,    // 39
        2,   52,    6,    3,           77,    8,    3,   36,    // 47
       18,   51,    4,   49,            2,    1,    4,    6,    // 55
        3,    0,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct07) {
@@ -2883,86 +2893,6 @@ TEST_F(Bytecode0, Struct10) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode0, Struct11_NoRTTI) {
-
-    // Structs may contain variables that are structs themselves.
-    // Since 'Inner1' is managed, 'In1' will convert into an 'Inner1 *'.
-
-    char const *inpl = "\
-        managed struct Inner1                               \n\
-        {                                                   \n\
-            short Fluff;                                    \n\
-            int Payload;                                    \n\
-        };                                                  \n\
-        struct Inner2                                       \n\
-        {                                                   \n\
-            short Fluff;                                    \n\
-            int Payload;                                    \n\
-        };                                                  \n\
-        import int Foo;                                     \n\
-        import struct Struct                                \n\
-        {                                                   \n\
-            Inner1 In1;                                     \n\
-            Inner2 In2;                                     \n\
-        } SS;                                               \n\
-                                                            \n\
-        int main()                                          \n\
-        {                                                   \n\
-            SS.In1 = new Inner1;                            \n\
-            SS.In1.Payload = 77;                            \n\
-            SS.In2.Payload = 777;                           \n\
-            return SS.In1.Payload + SS.In2.Payload;         \n\
-        }                                                   \n\
-    ";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Struct11_NoRtti", scrip);
-
-    size_t const code_size = 75;
-    EXPECT_EQ(code_size, scrip.code.size());
-
-    int32_t code[] = {
-      36,   19,   38,    0,           36,   20,   73,    3,    // 7
-       8,    6,    2,    1,           47,    3,   36,   21,    // 15
-       6,    2,    1,   48,            2,   52,    6,    3,    // 23
-      77,    1,    2,    2,            8,    3,   36,   22,    // 31
-       6,    3,  777,    6,            2,    1,    1,    2,    // 39
-       6,    8,    3,   36,           23,    6,    2,    1,    // 47
-      48,    2,   52,    1,            2,    2,    7,    3,    // 55
-      29,    3,    6,    2,            1,    1,    2,    6,    // 63
-       7,    3,   30,    4,           11,    4,    3,    3,    // 71
-       4,    3,    5,  -999
-    };
-    CompareCode(&scrip, code_size, code);
-
-    size_t const fixups_size = 5;
-    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
-    EXPECT_EQ(fixups_size, scrip.fixups.size());
-
-    int32_t fixups[] = {
-      11,   18,   37,   47,         60, };
-    char fixuptypes[] = {
-       4,    4,    4,    4,          4, };
-    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
-
-    int const non_empty_imports_count = 1;
-    std::string imports[] = {
-    "SS", };
-    CompareImports(&scrip, non_empty_imports_count, imports);
-
-    size_t const exports_size = 0;
-    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
-    EXPECT_EQ(exports_size, scrip.exports.size());
-
-    size_t const strings_size = 0;
-    EXPECT_EQ(strings_size, scrip.strings.size());
-
-    size_t const globaldata_size = 0;
-    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
-}
 
 TEST_F(Bytecode0, Struct11_RTTI) {
 
@@ -3003,12 +2933,13 @@ TEST_F(Bytecode0, Struct11_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Struct11_Rtti", scrip);
+
     size_t const code_size = 76;
     EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   19,   38,    0,           36,   20,   74,    3,    // 7
-      92,    8,    6,    2,            1,   47,    3,   36,    // 15
+     100,    8,    6,    2,            1,   47,    3,   36,    // 15
       21,    6,    2,    1,           48,    2,   52,    6,    // 23
        3,   77,    1,    2,            2,    8,    3,   36,    // 31
       22,    6,    3,  777,            6,    2,    1,    1,    // 39
@@ -3150,56 +3081,6 @@ TEST_F(Bytecode0, Struct12) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode0, Struct13_NoRTTI) {
-
-    char const *inpl = "\
-    managed struct Struct                \n\
-    {                                    \n\
-        int Int[10];                     \n\
-    };                                   \n\
-                                         \n\
-    int main()                           \n\
-    {                                    \n\
-        Struct *S = new Struct;          \n\
-        S.Int[4] =  1;                   \n\
-    }                                    \n\
-    ";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Struct13_NoRtti", scrip);
-
-    size_t const codesize = 43;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,    7,   38,    0,           36,    8,   73,    3,    // 7
-      40,   51,    0,   47,            3,    1,    1,    4,    // 15
-      36,    9,   51,    4,           48,    2,   52,    6,    // 23
-       3,    1,    1,    2,           16,    8,    3,   36,    // 31
-      10,   51,    4,   49,            2,    1,    4,    6,    // 39
-       3,    0,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
-
 TEST_F(Bytecode0, Struct13_RTTI) {
 
     char const *inpl = "\
@@ -3222,90 +3103,36 @@ TEST_F(Bytecode0, Struct13_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Struct13_Rtti", scrip);
-    size_t const codesize = 44;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 44;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,   74,    3,    // 7
-      92,   40,   51,    0,           47,    3,    1,    1,    // 15
+     100,   40,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,    9,   51,            4,   48,    2,   52,    // 23
        6,    3,    1,    1,            2,   16,    8,    3,    // 31
       36,   10,   51,    4,           49,    2,    1,    4,    // 39
        6,    3,    0,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
 
-TEST_F(Bytecode0, Struct14_NoRTTI) {
-
-    // Static arrays can be multidimensional
-
-    char const *inpl = "\
-    managed struct Struct                \n\
-    {                                    \n\
-        int Int1[5, 4];                  \n\
-        int Int2[2][3];                  \n\
-    };                                   \n\
-                                         \n\
-    int main()                           \n\
-    {                                    \n\
-        Struct S = new Struct;           \n\
-        S.Int1[4, 2] = 1;                \n\
-        S.Int2[1][2] = S.Int1[4, 2];     \n\
-    }                                    \n\
-    ";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Struct14_NoRtti", scrip);
-
-    size_t const codesize = 65;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,    8,   38,    0,           36,    9,   73,    3,    // 7
-     104,   51,    0,   47,            3,    1,    1,    4,    // 15
-      36,   10,   51,    4,           48,    2,   52,    6,    // 23
-       3,    1,    1,    2,           72,    8,    3,   36,    // 31
-      11,   51,    4,   48,            2,   52,    1,    2,    // 39
-      72,    7,    3,   51,            4,   48,    2,   52,    // 47
-       1,    2,  100,    8,            3,   36,   12,   51,    // 55
-       4,   49,    2,    1,            4,    6,    3,    0,    // 63
-       5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Struct14_RTTI) {
@@ -3334,12 +3161,13 @@ TEST_F(Bytecode0, Struct14_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Struct14_Rtti", scrip);
-    size_t const codesize = 66;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 66;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    8,   38,    0,           36,    9,   74,    3,    // 7
-      92,  104,   51,    0,           47,    3,    1,    1,    // 15
+     100,  104,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   10,   51,            4,   48,    2,   52,    // 23
        6,    3,    1,    1,            2,   72,    8,    3,    // 31
       36,   11,   51,    4,           48,    2,   52,    1,    // 39
@@ -3348,22 +3176,24 @@ TEST_F(Bytecode0, Struct14_RTTI) {
       51,    4,   49,    2,            1,    4,    6,    3,    // 63
        0,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Func01) {
@@ -3710,8 +3540,9 @@ TEST_F(Bytecode0, Func05_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Func05_Rtti", scrip);
-    size_t const codesize = 49;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 49;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,    6,    3,    // 7
@@ -3719,33 +3550,33 @@ TEST_F(Bytecode0, Func05_RTTI) {
        2,    1,    4,   51,            0,   47,    3,    1,    // 23
        1,    4,   36,    9,            6,    3,   -1,   51,    // 31
        4,   49,    2,    1,            4,    5,   36,   13,    // 39
-      38,   38,   36,   14,           74,    3,   92,    4,    // 47
+      38,   38,   36,   14,           74,    3,  100,    4,    // 47
        5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 1;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 1;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      13,  -999
-    };
+      13, };
     char fixuptypes[] = {
-      2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       2, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Func06) {
@@ -5053,8 +4884,9 @@ TEST_F(Bytecode0, ArrayOfPointers1_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("ArrayOfPointers1_Rtti", scrip);
-    size_t const codesize = 109;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 109;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    9,   38,    0,           36,   10,    6,    3,    // 7
@@ -5063,7 +4895,7 @@ TEST_F(Bytecode0, ArrayOfPointers1_RTTI) {
       36,   10,   51,    4,            7,    3,   29,    3,    // 31
        6,    3,    9,   30,            4,   18,    4,    3,    // 39
        3,    4,    3,   28,           30,   36,   11,   74,    // 47
-       3,   92,    8,   29,            3,   51,    8,    7,    // 55
+       3,  100,    8,   29,            3,   51,    8,    7,    // 55
        3,   46,    3,   50,           32,    3,    4,    6,    // 63
        2,    0,   11,    2,            3,   30,    3,   47,    // 71
        3,   31,  -62,    2,            1,    4,   36,   13,    // 79
@@ -5072,30 +4904,34 @@ TEST_F(Bytecode0, ArrayOfPointers1_RTTI) {
        4,    3,   29,    3,           36,   14,    2,    1,    // 103
        4,    6,    3,    0,            5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 2;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      65,   82,  -999
-    };
+      65,   82, };
     char fixuptypes[] = {
-      1,   1,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       1,    1, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 200;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
+
+    CharRun global_runs[] = {
+    { 200, 0x00}, {0, 0x00} };
+    CompareGlobalRuns(&scrip, global_runs);
 }
 
 TEST_F(Bytecode0, ArrayOfPointers2_NoRTTI) {
@@ -5193,8 +5029,9 @@ TEST_F(Bytecode0, ArrayOfPointers2_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("ArrayOfPointers2_RTTI", scrip);
-    size_t const codesize = 132;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 132;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    8,   38,    0,           36,    9,   51,    0,    // 7
@@ -5204,7 +5041,7 @@ TEST_F(Bytecode0, ArrayOfPointers2_RTTI) {
        3,   36,   10,   51,            4,    7,    3,   29,    // 39
        3,    6,    3,   20,           30,    4,   18,    4,    // 47
        3,    3,    4,    3,           28,   29,   36,   11,    // 55
-      74,    3,   92,    8,           29,    3,   51,    8,    // 63
+      74,    3,  100,    8,           29,    3,   51,    8,    // 63
        7,    3,   46,    3,           50,   32,    3,    4,    // 71
       51,  208,   11,    2,            3,   30,    3,   47,    // 79
        3,   31,  -61,   36,           12,    2,    1,    4,    // 87
@@ -5215,22 +5052,24 @@ TEST_F(Bytecode0, ArrayOfPointers2_RTTI) {
        2,    3,    1,   70,           -9,    2,    1,  200,    // 127
        6,    3,    0,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, DynarrayOfDynarray1) {
@@ -5262,15 +5101,15 @@ TEST_F(Bytecode0, DynarrayOfDynarray1) {
 
     // WriteOutput("DynarrayOfDynarray1", scrip);
 
-    size_t const codesize = 114;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 114;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    8,   38,    0,           36,    9,    6,    3,    // 7
        2,   29,    3,   36,           10,   51,    0,   49,    // 15
        1,    1,    4,   36,           11,    6,    3,    3,    // 23
-      75,    3,   92,    4,           51,    4,   47,    3,    // 31
-      36,   12,    6,    3,            5,   75,    3,   92,    // 39
+      75,    3,  100,    4,           51,    4,   47,    3,    // 31
+      36,   12,    6,    3,            5,   75,    3,  100,    // 39
       24,   29,    3,   51,            8,   48,    2,   52,    // 47
        6,    3,   11,   71,            3,   30,    3,    1,    // 55
        2,    8,   47,    3,           36,   13,   51,    4,    // 63
@@ -5282,23 +5121,24 @@ TEST_F(Bytecode0, DynarrayOfDynarray1) {
       51,    4,   49,    2,            1,    8,    6,    3,    // 111
        0,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
 
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, DynarrayOfDynarray2) {
@@ -5397,18 +5237,19 @@ TEST_F(Bytecode0, DynarrayOfDynarray3) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("DynarrayOfDynarray3", scrip);
-    size_t const codesize = 156;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 156;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    9,   38,    0,           36,   10,   51,    0,    // 7
       49,    1,    1,    4,           36,   11,    6,    3,    // 15
-       3,   75,    3,   92,            4,   51,    4,   47,    // 23
+       3,   75,    3,  100,            4,   51,    4,   47,    // 23
        3,   36,   12,    6,            3,    5,   75,    3,    // 31
-      92,    4,   29,    3,           51,    8,   48,    2,    // 39
+     100,    4,   29,    3,           51,    8,   48,    2,    // 39
       52,    6,    3,   11,           71,    3,   30,    3,    // 47
        1,    2,    8,   47,            3,   36,   13,   74,    // 55
-       3,   92,   24,   29,            3,   51,    8,   48,    // 63
+       3,  100,   24,   29,            3,   51,    8,   48,    // 63
        2,   52,    6,    3,           11,   71,    3,    1,    // 71
        2,    8,   48,    2,           52,   29,    2,    6,    // 79
        2,    0,    7,    3,           30,    2,   32,    3,    // 87
@@ -5422,30 +5263,34 @@ TEST_F(Bytecode0, DynarrayOfDynarray3) {
       36,   15,   51,    4,           49,    2,    1,    4,    // 151
        6,    3,    0,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 2;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      81,  120,  -999
-    };
+      81,  120, };
     char fixuptypes[] = {
-      1,   1,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       1,    1, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 4;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
+
+    unsigned char globaldata[] = {
+    0x02, 0x00, 0x00, 0x00, };
+    CompareGlobalData(&scrip, globaldata_size, globaldata);
 }
 
 
@@ -5683,12 +5528,13 @@ TEST_F(Bytecode0, DynarrayOfNonManaged_Rtti) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("DynarrayOfNonManaged_Rtti", scrip);
-    size_t const codesize = 101;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 101;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   16,   38,    0,           36,   17,    6,    3,    // 7
-      17,   75,    3,   96,           20,   51,    0,   47,    // 15
+      17,   75,    3,  104,           20,   51,    0,   47,    // 15
        3,    1,    1,    4,           36,   18,    6,    3,    // 23
        7,   29,    3,   36,           19,   51,    8,   48,    // 31
        2,   52,    6,    3,           79,   71,    3,    6,    // 39
@@ -5701,22 +5547,24 @@ TEST_F(Bytecode0, DynarrayOfNonManaged_Rtti) {
        3,   36,   21,   51,            8,   49,    2,    1,    // 95
        8,    6,    3,    0,            5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, DynarrayOfPrimitives) {
@@ -5811,33 +5659,35 @@ TEST_F(Bytecode0, DynpointerDynamicCast1)
 
     // WriteOutput("DynpointerDynamicCast1", scrip);
 
-    size_t const codesize = 47;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 47;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   18,   38,    0,           36,   19,   74,    3,    // 7
-      94,   12,   51,    0,           47,    3,    1,    1,    // 15
+     102,   12,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   20,   51,            4,   48,    3,   76,    // 23
-      94,   51,    0,   47,            3,    1,    1,    4,    // 31
+     102,   51,    0,   47,            3,    1,    1,    4,    // 31
       36,   21,   51,    8,           49,   51,    4,   49,    // 39
        2,    1,    8,    6,            3,    0,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 0;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode0, Writeprotected) {

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -28,7 +28,7 @@
 */
 
 
-// The vars defined here are provided in each test that is in category "Bytecode0"
+// The vars defined here are provided in each test that is in category "Bytecode1"
 class Bytecode1 : public ::testing::Test
 {
 public:
@@ -1016,96 +1016,6 @@ TEST_F(Bytecode1, Attributes01) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode1, Attributes02_NoRTTI) {
-
-    // The getter and setter functions are defined locally, so
-    // they ought to be exported instead of imported.
-    // Assigning to the attribute should generate the same call
-    // as calling the setter; reading the same as calling the getter.
-    // 'Armor::' functions should be allowed to access '_Damage'.
-
-    char const *inpl = "\
-        managed struct Armor {                          \n\
-            attribute int Damage;                       \n\
-            writeprotected short _Aura;                 \n\
-            protected int _Damage;                      \n\
-        };                                              \n\
-                                                        \n\
-        int main()                                      \n\
-        {                                               \n\
-            Armor *armor = new Armor;                   \n\
-            armor.Damage = 17;                          \n\
-            return (armor.Damage > 10);                 \n\
-        }                                               \n\
-                                                        \n\
-        void Armor::set_Damage(int damage)              \n\
-        {                                               \n\
-            if (damage >= 0)                            \n\
-                _Damage = damage;                       \n\
-        }                                               \n\
-                                                        \n\
-        int Armor::get_Damage()                         \n\
-        {                                               \n\
-            return _Damage;                             \n\
-        }                                               \n\
-        ";
-
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Attributes02_NoRtti", scrip);
-
-    size_t const codesize = 139;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,    8,   38,    0,           36,    9,   73,    3,    // 7
-       8,   51,    0,   47,            3,    1,    1,    4,    // 15
-      36,   10,   51,    4,           48,    2,   52,    6,    // 23
-       3,   17,   29,    6,           29,    3,   45,    2,    // 31
-       6,    3,   80,   23,            3,    2,    1,    4,    // 39
-      30,    6,   36,   11,           51,    4,   48,    2,    // 47
-      52,   29,    6,   45,            2,    6,    3,  123,    // 55
-      23,    3,   30,    6,           29,    3,    6,    3,    // 63
-      10,   30,    4,   17,            4,    3,    3,    4,    // 71
-       3,   51,    4,   49,            2,    1,    4,    5,    // 79
-      36,   15,   38,   80,           36,   16,   51,    8,    // 87
-       7,    3,   29,    3,            6,    3,    0,   30,    // 95
-       4,   19,    4,    3,            3,    4,    3,   28,    // 103
-      15,   36,   17,   51,            8,    7,    3,    3,    // 111
-       6,    2,   52,    1,            2,    2,    8,    3,    // 119
-      36,   18,    5,   36,           21,   38,  123,   36,    // 127
-      22,    3,    6,    2,           52,    1,    2,    2,    // 135
-       7,    3,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int32_t fixups[] = {
-      34,   55,  -999
-    };
-    char fixuptypes[] = {
-      2,   2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
-
 TEST_F(Bytecode1, Attributes02_RTTI) {
 
     // The getter and setter functions are defined locally, so
@@ -1147,12 +1057,13 @@ TEST_F(Bytecode1, Attributes02_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Attributes02_Rtti", scrip);
-    size_t const codesize = 140;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 140;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    8,   38,    0,           36,    9,   74,    3,    // 7
-      92,    8,   51,    0,           47,    3,    1,    1,    // 15
+     100,    8,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   10,   51,            4,   48,    2,   52,    // 23
        6,    3,   17,   29,            6,   29,    3,   45,    // 31
        2,    6,    3,   81,           23,    3,    2,    1,    // 39
@@ -1170,98 +1081,30 @@ TEST_F(Bytecode1, Attributes02_RTTI) {
       36,   22,    3,    6,            2,   52,    1,    2,    // 135
        2,    7,    3,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int32_t fixups[] = {
-      35,   56,  -999
-    };
-    char fixuptypes[] = {
-      2,   2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
-
-TEST_F(Bytecode1, Attributes03_NoRTTI) {
-
-    // The getters and setters are NOT defined locally here, 
-    // so import decls should be generated for them.
-    // The getters and setters should be called as import funcs.
-
-    char const *inpl = "\
-        managed struct Armor {                          \n\
-            attribute int Damage;                       \n\
-            writeprotected short _aura;                 \n\
-            protected int _damage;                      \n\
-        };                                              \n\
-                                                        \n\
-        int main()                                      \n\
-        {                                               \n\
-            Armor *armor = new Armor;                   \n\
-            armor.Damage = 17;                          \n\
-            return (armor.Damage > 10);                 \n\
-        }";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Attributes03_NoRtti", scrip);
-
-    size_t const codesize = 83;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,    8,   38,    0,           36,    9,   73,    3,    // 7
-       8,   51,    0,   47,            3,    1,    1,    4,    // 15
-      36,   10,   51,    4,           48,    2,   52,    6,    // 23
-       3,   17,   29,    6,           34,    3,   45,    2,    // 31
-      39,    1,    6,    3,            1,   33,    3,   35,    // 39
-       1,   30,    6,   36,           11,   51,    4,   48,    // 47
-       2,   52,   29,    6,           45,    2,   39,    0,    // 55
-       6,    3,    0,   33,            3,   30,    6,   29,    // 63
-       3,    6,    3,   10,           30,    4,   17,    4,    // 71
-       3,    3,    4,    3,           51,    4,   49,    2,    // 79
-       1,    4,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 2;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      36,   58,  -999
-    };
+      35,   56, };
     char fixuptypes[] = {
-      4,   4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       2,    2, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 2;
-    std::string imports[] = {
-    "Armor::get_Damage^0",        "Armor::set_Damage^1",         "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode1, Attributes03_RTTI) {
@@ -1291,12 +1134,13 @@ TEST_F(Bytecode1, Attributes03_RTTI) {
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("Attributes03_Rtti", scrip);
-    size_t const codesize = 84;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 84;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    8,   38,    0,           36,    9,   74,    3,    // 7
-      92,    8,   51,    0,           47,    3,    1,    1,    // 15
+     100,    8,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   10,   51,            4,   48,    2,   52,    // 23
        6,    3,   17,   29,            6,   34,    3,   45,    // 31
        2,   39,    1,    6,            3,    1,   33,    3,    // 39
@@ -1307,30 +1151,32 @@ TEST_F(Bytecode1, Attributes03_RTTI) {
        4,    3,    3,    4,            3,   51,    4,   49,    // 79
        2,    1,    4,    5,          -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 2;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 2;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      37,   59,  -999
-    };
+      37,   59, };
     char fixuptypes[] = {
-      4,   4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       4,    4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 2;
+    int const non_empty_imports_count = 2;
     std::string imports[] = {
-    "Armor::get_Damage^0",        "Armor::set_Damage^1",         "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "Armor::get_Damage^0",        "Armor::set_Damage^1", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode1, Attributes04) {
@@ -2027,88 +1873,6 @@ TEST_F(Bytecode1, ManagedDerefZerocheck) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode1, MemInitPtr1_NoRTTI) {
-
-    // Check that pointer vars are pushed correctly in func calls
-
-    char const *inpl = "\
-        managed struct Struct1              \n\
-        {                                   \n\
-            float Payload1;                 \n\
-        };                                  \n\
-        managed struct Struct2              \n\
-        {                                   \n\
-            char Payload2;                  \n\
-        };                                  \n\
-                                            \n\
-        int main()                          \n\
-        {                                   \n\
-            Struct1 SS1 = new Struct1;      \n\
-            SS1.Payload1 = 0.7;             \n\
-            Struct2 SS2 = new Struct2;      \n\
-            SS2.Payload2 = 4;               \n\
-            int Val = Func(SS1, SS2);       \n\
-        }                                   \n\
-                                            \n\
-        int Func(Struct1 S1, Struct2 S2)    \n\
-        {                                   \n\
-            return S2.Payload2;             \n\
-        }                                   \n\
-        ";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    EXPECT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("MemInitPtr1_NoRTTI", scrip);
-
-    size_t const codesize = 123;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,   11,   38,    0,           36,   12,   73,    3,    // 7
-       4,   51,    0,   47,            3,    1,    1,    4,    // 15
-      36,   13,   51,    4,           48,    2,   52,    6,    // 23
-       3, 1060320051,    8,    3,           36,   14,   73,    3,    // 31
-       4,   51,    0,   47,            3,    1,    1,    4,    // 39
-      36,   15,   51,    4,           48,    2,   52,    6,    // 47
-       3,    4,   26,    3,           36,   16,   51,    4,    // 55
-      48,    3,   29,    3,           51,   12,   48,    3,    // 63
-      29,    3,    6,    3,           91,   23,    3,    2,    // 71
-       1,    8,   29,    3,           36,   17,   51,   12,    // 79
-      49,   51,    8,   49,            2,    1,   12,    6,    // 87
-       3,    0,    5,   36,           20,   38,   91,   51,    // 95
-       8,    7,    3,   50,            3,   51,   12,    7,    // 103
-       3,   50,    3,   36,           21,   51,   12,   48,    // 111
-       2,   52,   24,    3,           51,    8,   49,   51,    // 119
-      12,   49,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 1;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int32_t fixups[] = {
-      68,  -999
-    };
-    char fixuptypes[] = {
-      2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
-
 TEST_F(Bytecode1, MemInitPtr1_RTTI) {
 
     // Check that pointer vars are pushed correctly in func calls
@@ -2146,15 +1910,15 @@ TEST_F(Bytecode1, MemInitPtr1_RTTI) {
 
     // WriteOutput("MemInitPtr1_RTTI", scrip);
 
-    size_t const codesize = 125;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 125;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,   11,   38,    0,           36,   12,   74,    3,    // 7
-      92,    4,   51,    0,           47,    3,    1,    1,    // 15
+     100,    4,   51,    0,           47,    3,    1,    1,    // 15
        4,   36,   13,   51,            4,   48,    2,   52,    // 23
        6,    3, 1060320051,    8,            3,   36,   14,   74,    // 31
-       3,   94,    4,   51,            0,   47,    3,    1,    // 39
+       3,  102,    4,   51,            0,   47,    3,    1,    // 39
        1,    4,   36,   15,           51,    4,   48,    2,    // 47
       52,    6,    3,    4,           26,    3,   36,   16,    // 55
       51,    4,   48,    3,           29,    3,   51,   12,    // 63
@@ -2167,30 +1931,30 @@ TEST_F(Bytecode1, MemInitPtr1_RTTI) {
       12,   48,    2,   52,           24,    3,   51,    8,    // 119
       49,   51,   12,   49,            5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 1;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 1;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      70,  -999
-    };
+      70, };
     char fixuptypes[] = {
-      2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       2, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }
 
 TEST_F(Bytecode1, Ternary1) {
@@ -2248,70 +2012,6 @@ TEST_F(Bytecode1, Ternary1) {
     EXPECT_EQ(stringssize, scrip.strings.size());
 }
 
-TEST_F(Bytecode1, Ternary2_NoRTTI) {
-
-    // Accept Elvis operator expression
-
-    char const *inpl = "\
-    managed struct Struct       \n\
-    {                           \n\
-        int Payload;            \n\
-    } S, T;                     \n\
-                                \n\
-    void main()                 \n\
-    {                           \n\
-        S = null;               \n\
-        T = new Struct;         \n\
-        Struct Res = S          \n\
-                       ?:       \n\
-                          T;    \n\
-    }                           \n\
-    ";
-
-    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
-    std::string const &err_msg = mh.GetError().Message;
-    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
-
-    // WriteOutput("Ternary2_NoRTTI", scrip);
-
-    size_t const codesize = 58;
-    EXPECT_EQ(codesize, scrip.code.size());
-
-    int32_t code[] = {
-      36,    7,   38,    0,           36,    8,    6,    3,    // 7
-       0,    6,    2,    0,           47,    3,   36,    9,    // 15
-      73,    3,    4,    6,            2,    4,   47,    3,    // 23
-      36,   10,    6,    2,            0,   48,    3,   70,    // 31
-       7,   36,   12,    6,            2,    4,   48,    3,    // 39
-      36,   12,   51,    0,           47,    3,    1,    1,    // 47
-       4,   36,   13,   51,            4,   49,    2,    1,    // 55
-       4,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 4;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
-
-    int32_t fixups[] = {
-      11,   21,   28,   37,        -999
-    };
-    char fixuptypes[] = {
-      1,   1,   1,   1,     '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
-}
 
 TEST_F(Bytecode1, Ternary2_RTTI) {
 
@@ -2341,43 +2041,47 @@ TEST_F(Bytecode1, Ternary2_RTTI) {
 
     // WriteOutput("Ternary2_RTTI", scrip);
 
-    size_t const codesize = 59;
-    EXPECT_EQ(codesize, scrip.code.size());
+    size_t const code_size = 59;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,    6,    3,    // 7
        0,    6,    2,    0,           47,    3,   36,    9,    // 15
-      74,    3,   92,    4,            6,    2,    4,   47,    // 23
+      74,    3,  100,    4,            6,    2,    4,   47,    // 23
        3,   36,   10,    6,            2,    0,   48,    3,    // 31
       70,    7,   36,   12,            6,    2,    4,   48,    // 39
        3,   36,   12,   51,            0,   47,    3,    1,    // 47
        1,    4,   36,   13,           51,    4,   49,    2,    // 55
        1,    4,    5,  -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 4;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 4;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      11,   22,   29,   38,        -999
-    };
+      11,   22,   29,   38, };
     char fixuptypes[] = {
-      1,   1,   1,   1,     '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       1,    1,    1,    1, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    int const non_empty_imports_count = 0;
+    CompareImports(&scrip, non_empty_imports_count, nullptr);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 8;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
+
+    CharRun global_runs[] = {
+    {   8, 0x00}, {0, 0x00} };
+    CompareGlobalRuns(&scrip, global_runs);
 }
 
 TEST_F(Bytecode1, Ternary3) {
@@ -3467,41 +3171,48 @@ TEST_F(Bytecode1, DynarrayLength1_RTTI) {
     EXPECT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     // WriteOutput("DynarrayLength1_Rtti", scrip);
-    size_t const codesize = 40;
-    EXPECT_EQ(codesize, scrip.code.size());
+
+    size_t const code_size = 40;
+    EXPECT_EQ(code_size, scrip.code.size());
 
     int32_t code[] = {
       36,    7,   38,    0,           36,    8,    6,    3,    // 7
-       5,   75,    3,   92,            4,    6,    2,    0,    // 15
+       5,   75,    3,  100,            4,    6,    2,    0,    // 15
       47,    3,   36,    9,            6,    2,    0,   48,    // 23
        2,   52,   29,    6,           45,    2,   39,    0,    // 31
        6,    3,    0,   33,            3,   30,    6,    5,    // 39
      -999
     };
-    CompareCode(&scrip, codesize, code);
+    CompareCode(&scrip, code_size, code);
 
-    size_t const numfixups = 3;
-    EXPECT_EQ(numfixups, scrip.fixups.size());
+    size_t const fixups_size = 3;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
 
     int32_t fixups[] = {
-      15,   22,   34,  -999
-    };
+      15,   22,   34, };
     char fixuptypes[] = {
-      1,   1,   4,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+       1,    1,    4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
 
-    int const numimports = 1;
+    int const non_empty_imports_count = 1;
     std::string imports[] = {
-    "__Builtin_DynamicArray::get_Length",         "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
+    "__Builtin_DynamicArray::get_Length", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
 
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.exports.size());
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
 
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.strings.size());
+    size_t const strings_size = 0;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    size_t const globaldata_size = 4;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
+
+    CharRun global_runs[] = {
+    {   4, 0x00}, {0, 0x00} };
+    CompareGlobalRuns(&scrip, global_runs);
 }
 
 TEST_F(Bytecode1, DynarrayLength2_NoRTTI) {
@@ -4150,4 +3861,85 @@ TEST_F(Bytecode1, StaticFuncImpliedTypename)
 
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.strings.size());
+}
+
+TEST_F(Bytecode1, FormatFunc01)
+{
+    // One function parameter that can accept a string literal
+    // can be marked with '__format'. In this case, the variadic
+    // arguments are checked whether they fit the format string.
+
+    char const *inpl = R"%&/(
+        import void foo(int dummy1, __format const string f, const string dummy2, ...);
+
+        int game_start()
+        {
+            foo(15,
+                "%d nuns carrying %05d grade-%c hammers shouted, \"%s %%\"."
+                "They were hot, at %f °F.",
+                "dummy",
+                150, 25, 'A', "Huzza!", 96.8);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+
+    // WriteOutput("FormatFunc01", scrip);
+    size_t const code_size = 69;
+    EXPECT_EQ(code_size, scrip.code.size());
+
+    int32_t code[] = {
+      36,    5,   38,    0,           36,   10,    6,    3,    // 7
+    1119984026,   34,    3,    6,            3,   87,   34,    3,    // 15
+       6,    3,   65,   34,            3,    6,    3,   25,    // 23
+      34,    3,    6,    3,          150,   34,    3,   36,    // 31
+       9,    6,    3,   81,           34,    3,   36,    8,    // 39
+       6,    3,    0,   34,            3,   36,    6,    6,    // 47
+       3,   15,   34,    3,           36,   10,   39,    8,    // 55
+       6,    3,    0,   33,            3,   35,    8,   36,    // 63
+      11,    6,    3,    0,            5,  -999
+    };
+    CompareCode(&scrip, code_size, code);
+
+    size_t const fixups_size = 4;
+    ASSERT_EQ(scrip.fixups.size(), scrip.fixuptypes.size());
+    EXPECT_EQ(fixups_size, scrip.fixups.size());
+
+    int32_t fixups[] = {
+      13,   35,   42,   58, };
+    char fixuptypes[] = {
+       3,    3,    3,    4, };
+    CompareFixups(&scrip, fixups_size, fixups, fixuptypes);
+
+    int const non_empty_imports_count = 1;
+    std::string imports[] = {
+    "foo^103", };
+    CompareImports(&scrip, non_empty_imports_count, imports);
+
+    size_t const exports_size = 0;
+    ASSERT_EQ(scrip.exports.size(), scrip.export_addr.size());
+    EXPECT_EQ(exports_size, scrip.exports.size());
+
+    size_t const strings_size = 94;
+    EXPECT_EQ(strings_size, scrip.strings.size());
+
+    char strings[] = {
+    '%',  'd',  ' ',  'n',          'u',  'n',  's',  ' ',     // 7
+    'c',  'a',  'r',  'r',          'y',  'i',  'n',  'g',     // 15
+    ' ',  '%',  '0',  '5',          'd',  ' ',  'g',  'r',     // 23
+    'a',  'd',  'e',  '-',          '%',  'c',  ' ',  'h',     // 31
+    'a',  'm',  'm',  'e',          'r',  's',  ' ',  's',     // 39
+    'h',  'o',  'u',  't',          'e',  'd',  ',',  ' ',     // 47
+    '"',  '%',  's',  ' ',          '%',  '%',  '"',  '.',     // 55
+    'T',  'h',  'e',  'y',          ' ',  'w',  'e',  'r',     // 63
+    'e',  ' ',  'h',  'o',          't',  ',',  ' ',  'a',     // 71
+    't',  ' ',  '%',  'f',          ' ',  '\xb0',  'F',  '.',     // 79
+      0,  'd',  'u',  'm',          'm',  'y',    0,  'H',     // 87
+    'u',  'z',  'z',  'a',          '!',    0, };
+    CompareStrings(&scrip, strings_size, strings);
+
+    size_t const globaldata_size = 0;
+    EXPECT_EQ(globaldata_size, scrip.globaldata.size());
 }

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -1103,3 +1103,22 @@ TEST_F(Compile2, FormatFunction06)
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("variadic arg"));
 }
+
+TEST_F(Compile2, FormatFunction07)
+{
+    // Modifiers and new format specifiers
+
+    char const *inpl = R"%&/(
+        import void foo(__format const string f, ...);
+
+        int game_start()
+        {
+            foo("%u %3i %X %.3e", 3, 99, 0xaf, 3.14);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+}


### PR DESCRIPTION
This partially addresses #2739.

Introduce a new keyword `__format`. 

This can adorn one string parameter of a variadic function. This will declare the function, such as `Character.Say`, as a _format function_ and the adorned parameter as the _format parameter_ of that function.
```
managed struct Character {
    import void Say(__format string fmt, ...);
}
```

I'm envisioning that end users don't use the keyword, hence the leading `__`. It's very improbable that there is pre-existing code that has used `__format` in some (incompatible) way.

Whenever the compiler sees a call to a format function where the format parameter is passed a string literal, the compiler will check whether the variadic arguments of that call match the specifications in the format parameter.
```
cEgo.Say("Your backpack contains %s items", InvWindow.ItemCount); // ← Error, an 'int' is passed where a kind of string is expected
cEgo.Say("Don't forget your %10s, Red Riding Hood!") // ← Error, not enough variadic arguments passed to satisfy `%10s`

String msg = "Your backpack contains %s items";
cEgo.Say(msg, InvWindow.ItemCount); // ← Sorry, no error, compiler doesn't attempt to check format _variables_
```

**Note** This is the work on the compiler side. To make this work in practice, the system must also be modified:
– The AGS definitions must be changed to mark the respective format parameters of all relevant functions (`String.Format`etc.)
– A way must be provided to differentiate whether the 'old' or the 'new' compiler will compile the code.
– When the 'old' compiler (that doesn't know `__format`)  will run, it must be shown a line `#define __format`.

Nitty gritty details: 
– The code assumes that the format parameter describes the _variadic_ arguments. The first format specification pertains to the first _variadic_ argument, etc. So in a function `int f(__format string fmt, int i, ...)`, the parameter `i` is not considered to satisfy the first spec in the format parameter `fmt`.