### PR TITLE
Editor: support a include/exclude file when making templates

### DIFF
--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -165,8 +165,8 @@ public:
     inline bool Equals(const char *cstr) const { return Compare(cstr) == 0; }
     inline bool StartsWith(const String &str) const { return CompareLeft(str) == 0; }
     inline bool StartsWith(const char *cstr) const { return CompareLeft(cstr) == 0; }
-    inline bool EndsWidth(const String &str) const { return CompareRight(str) == 0; }
-    inline bool EndsWidth(const char *cstr) const { return CompareRight(cstr) == 0; }
+    inline bool EndsWith(const String &str) const { return CompareRight(str) == 0; }
+    inline bool EndsWith(const char *cstr) const { return CompareRight(cstr) == 0; }
 
     // These functions search for character or substring inside this string
     // and return the index of the (first) character, or NoIndex if nothing found.

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Editor\AutoComplete\AutoCompleteTests.cs" />
     <Compile Include="Editor\BuildTargets\BuildTargetBaseTests.cs" />
     <Compile Include="Editor\Panes\FreePanControlTests.cs" />
+    <Compile Include="Editor\Utilities\IncludeUtilsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScriptCompiler\PreprocessorTests.cs" />
     <Compile Include="Types\RuntimeSetupTests.cs" />

--- a/Editor/AGS.Editor.Tests/Editor/Utilities/IncludeUtilsTests.cs
+++ b/Editor/AGS.Editor.Tests/Editor/Utilities/IncludeUtilsTests.cs
@@ -1,0 +1,294 @@
+﻿using NUnit.Framework;
+
+namespace AGS.Editor
+{
+    [TestFixture]
+    public class IncludeUtilsTests
+    {
+        [Test]
+        public void CreatePatternList_ReadPatternsFromString()
+        {
+            string patternInput = @"
+*.asc
+!ignoreme.asc
+folder/*
+";
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+
+            Assert.That(patterns.Length, Is.EqualTo(3));
+            Assert.That(patterns[0].OriginalPattern, Is.EqualTo("*.asc"));
+            Assert.That(patterns[1].OriginalPattern, Is.EqualTo("ignoreme.asc"));
+            Assert.That(patterns[2].OriginalPattern, Is.EqualTo("folder/*"));
+        }
+
+        [Test]
+        public void CreatePatternList_ParsePatterns()
+        {
+            string[] patternInput =
+            {
+                "*.asc",
+                "!ignoreme.asc",
+                "folder/*"
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+
+            Assert.That(patterns.Length, Is.EqualTo(3));
+            Assert.That(patterns[0].Type, Is.EqualTo(IncludeUtils.PatternType.Include));
+            Assert.That(patterns[1].Type, Is.EqualTo(IncludeUtils.PatternType.Exclude));
+            Assert.That(patterns[2].Type, Is.EqualTo(IncludeUtils.PatternType.Include));
+
+            Assert.That(patterns[0].OriginalPattern, Is.EqualTo("*.asc"));
+            Assert.That(patterns[1].OriginalPattern, Is.EqualTo("ignoreme.asc"));
+            Assert.That(patterns[2].OriginalPattern, Is.EqualTo("folder/*"));
+
+            // NOTE: IncludeUtils encloses the pattern into (^|/)...($|/) pair
+            Assert.That(patterns[0].RegexPattern, Is.EqualTo("(^|/).*\\.asc($|/)"));
+            Assert.That(patterns[1].RegexPattern, Is.EqualTo("(^|/)ignoreme\\.asc($|/)"));
+            Assert.That(patterns[2].RegexPattern, Is.EqualTo("(^|/)folder\\/.*($|/)"));
+        }
+
+        [Test]
+        public void FilterItemList_CaseInsensitiveMatch()
+        {
+            string[] items = new string[]
+            {
+                "file1.txt",
+                "file2.TXT",
+                "file3.TxT"
+            };
+
+            string[] patternInput =
+            {
+                "*.TXT"
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput, IncludeUtils.MatchOption.CaseInsensitive);
+            var result = IncludeUtils.FilterItemList(items, patterns, IncludeUtils.MatchOption.CaseInsensitive);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void FilterItemList_InclusionAndExclusion()
+        {
+            string[] items =
+            {
+                "a.txt",
+                "b.txt",
+                "include_me/c.txt",
+                "include_me/d.txt",
+                "include_me/exclude_me_anyway.dat",
+                "exclude_me/file1.dat",
+                "exclude_me/file2.dat",
+                "exclude_me/e.txt",
+                "exclude_me/f.txt",
+                "exclude_me/include_me_anyway.dat",
+            };
+
+            string[] patternInput =
+            {
+                "*.txt",
+                "!exclude_me_anyway.dat",
+                "!exclude_me/",
+                "include_me_anyway.dat"
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+            var result = IncludeUtils.FilterItemList(items, patterns, IncludeUtils.MatchOption.CaseInsensitive);
+
+            Assert.That(result.Length, Is.EqualTo(5));
+            Assert.That(result, Does.Contain("a.txt"));
+            Assert.That(result, Does.Contain("b.txt"));
+            Assert.That(result, Does.Contain("include_me/c.txt"));
+            Assert.That(result, Does.Contain("include_me/d.txt"));
+            Assert.That(result, Does.Contain("exclude_me/include_me_anyway.dat"));
+            Assert.That(result, Does.Not.Contain("include_me/exclude_me_anyway.dat"));
+            Assert.That(result, Does.Not.Contain("exclude_me/file1.dat"));
+            Assert.That(result, Does.Not.Contain("exclude_me/file2.dat"));
+            Assert.That(result, Does.Not.Contain("exclude_me/e.txt"));
+            Assert.That(result, Does.Not.Contain("exclude_me/f.txt"));
+        }
+
+        [Test]
+        public void FilterItemList_PatternOrderMatters()
+        {
+            string[] items = new string[]
+            {
+                "file.txt",
+                "exclude.txt"
+            };
+
+            string[] patternInput =
+            {
+                "*.txt",
+                "!exclude.txt",
+                "*.txt"
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+            var result = IncludeUtils.FilterItemList(items, patterns);
+
+            Assert.That(result, Does.Contain("file.txt"));
+            Assert.That(result, Does.Contain("exclude.txt"));
+        }
+
+        [Test]
+        public void FilterItemList_IgnoreEmptyOrCommentLines()
+        {
+            string patternInput = @"
+# This is a comment
+*.dat
+
+!ignore.dat
+";
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+
+            Assert.That(patterns.Length, Is.EqualTo(2));
+            Assert.That(patterns[0].OriginalPattern, Is.EqualTo("*.dat"));
+            Assert.That(patterns[1].OriginalPattern, Is.EqualTo("ignore.dat"));
+        }
+
+        [Test]
+        public void FilterItemList_MatchAnySectionOfThePath()
+        {
+            string[] files =
+            {
+                "name",
+                "name/file1.dat",
+                "name/file2.dat",
+                "name/file3.dat",
+                "name.dir/file4.dat",
+                "dir/name",
+                "dir/name/file5.dat",
+                "dir/name.dat"
+            };
+
+            string[] patternInput =
+            {
+                "name"
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput);
+            var outFiles = IncludeUtils.FilterItemList(files, patterns, IncludeUtils.MatchOption.CaseInsensitive);
+
+            Assert.That(outFiles.Length, Is.EqualTo(6));
+            Assert.That(outFiles, Does.Contain("name"));
+            Assert.That(outFiles, Does.Contain("name/file1.dat"));
+            Assert.That(outFiles, Does.Contain("name/file2.dat"));
+            Assert.That(outFiles, Does.Contain("name/file3.dat"));
+            Assert.That(outFiles, Does.Contain("dir/name"));
+            Assert.That(outFiles, Does.Contain("dir/name/file5.dat"));
+            Assert.That(outFiles, Does.Not.Contain("name.dir/file4.dat"));
+            Assert.That(outFiles, Does.Not.Contain("dir/name.dat"));
+        }
+
+        [Test]
+        public void FilterItemList_ExampleTemplate()
+        {
+            string[] exampleGameFiles = 
+            {
+                "acsprset.spr",
+                "AGSFNT0.WFN",
+                "AGSFNT1.WFN",
+                "AGSFNT2.WFN",
+                "AudioCache",
+                "Compiled",
+                "Compiled/Data",
+                "Game.agf",
+                "Game.agf.bak",
+                "Game.agf.user",
+                "GlobalScript.asc",
+                "GlobalScript.ash",
+                "KeyboardMovement.asc",
+                "KeyboardMovement.ash",
+                "KeyboardMovement.txt",
+                "room1.asc",
+                "room1.crm",
+                "Speech",
+                "sprindex.dat",
+                "Sprites",
+                "Sprites/bluecup0.png",
+                "Sprites/Defaults",
+                "Sprites/Defaults/Cursors",
+                "Sprites/Defaults/Cursors/cursor_interact.png",
+                "Sprites/Defaults/ico_bluecup.png",
+                "Sprites/Defaults/ico_key.png",
+                "Sprites/Defaults/ico_x.png",
+                "Sprites/Defaults/UI",
+                "Sprites/Defaults/UI/background_inventory.png",
+                "Sprites/Defaults/Verbs",
+                "Sprites/Defaults/Verbs/btn_arrowdown_normal.png",
+                "Sprites/Defaults/Verbs/btn_arrowdown_over.png",
+                "template.files",
+                "template.ico",
+                "template.txt",
+                "_Debug",
+                "_Debug/acsetup.cfg",
+                "_Debug/SDL2.dll",
+                "_Debug/Sierra-style.exe"
+            };
+
+            string[] patternInput =
+            {
+                "*.asc",
+                "*.ash",
+                "*.crm",
+                "*.ttf",
+                "*.wfn",
+                "*.txt",
+                "Game.agf",
+                "template.files",
+                "template.ico",
+                "Speech/",
+                "Sprites/",
+                "!_Debug/",
+                "!*.bak",
+                "!*.user",
+            };
+
+            var patterns = IncludeUtils.CreatePatternList(patternInput, IncludeUtils.MatchOption.CaseInsensitive);
+            var result = IncludeUtils.FilterItemList(exampleGameFiles, patterns, IncludeUtils.MatchOption.CaseInsensitive);
+
+            Assert.That(result, Does.Contain("AGSFNT0.WFN"));
+            Assert.That(result, Does.Contain("AGSFNT1.WFN"));
+            Assert.That(result, Does.Contain("AGSFNT2.WFN"));
+            Assert.That(result, Does.Contain("Game.agf"));
+            Assert.That(result, Does.Contain("GlobalScript.asc"));
+            Assert.That(result, Does.Contain("GlobalScript.ash"));
+            Assert.That(result, Does.Contain("KeyboardMovement.asc"));
+            Assert.That(result, Does.Contain("KeyboardMovement.ash"));
+            Assert.That(result, Does.Contain("KeyboardMovement.txt"));
+            Assert.That(result, Does.Contain("room1.asc"));
+            Assert.That(result, Does.Contain("room1.crm"));
+            Assert.That(result, Does.Contain("Sprites/bluecup0.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/Cursors"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/Cursors/cursor_interact.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/ico_bluecup.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/ico_key.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/ico_x.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/UI"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/UI/background_inventory.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/Verbs"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/Verbs/btn_arrowdown_normal.png"));
+            Assert.That(result, Does.Contain("Sprites/Defaults/Verbs/btn_arrowdown_over.png"));
+            Assert.That(result, Does.Contain("template.files"));
+            Assert.That(result, Does.Contain("template.ico"));
+            Assert.That(result, Does.Contain("template.txt"));
+            Assert.That(result, Does.Not.Contain("Game.agf.bak"));
+            Assert.That(result, Does.Not.Contain("Game.agf.user"));
+
+            Assert.That(result, Does.Not.Contain("_Debug"));
+            Assert.That(result, Does.Not.Contain("_Debug/acsetup.cfg"));
+            Assert.That(result, Does.Not.Contain("_Debug/SDL2.dll"));
+            Assert.That(result, Does.Not.Contain("_Debug/Sierra-style.exe"));
+            Assert.That(result, Does.Not.Contain("AudioCache"));
+            Assert.That(result, Does.Not.Contain("Compiled"));
+            Assert.That(result, Does.Not.Contain("Compiled/Data"));
+
+            Assert.That(result.Length, Is.EqualTo(26));
+        }
+    }
+}

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -47,6 +47,7 @@ namespace AGS.Editor
         public const string GAME_FILE_NAME = "Game.agf";
 		public const string BACKUP_EXTENSION = "bak";
         public const string OLD_GAME_FILE_NAME = "ac2game.dta";
+        public const string TEMPLATE_INCLUDE_FILE = "template.files";
         public const string TEMPLATES_DIRECTORY_NAME = "Templates";
         public const string AGS_REGISTRY_KEY = @"SOFTWARE\Adventure Game Studio\AGS Editor";
         public const string SPRITE_FILE_NAME = "acsprset.spr";

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -446,6 +446,7 @@
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\Debounce.cs" />
+    <Compile Include="Utils\IncludeUtils.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\TickOnceTimer.cs">
       <SubType>Component</SubType>

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -41,6 +41,29 @@ namespace AGS.Editor
             }
         }
 
+        private void ConstructFileListUsingIncludeFile(List<string> filesToInclude, string fileDir, string includeFile)
+        {
+            using (Stream s = File.OpenRead(includeFile))
+            {
+                var patterns = 
+                    IncludeUtils.CreatePatternList(s, IncludeUtils.MatchOption.CaseInsensitive);
+                if (patterns.Length == 0)
+                    return;
+
+                string[] files = Utilities.GetDirectoryFileList(fileDir, "*.*", SearchOption.AllDirectories);
+                if (files.Length == 0)
+                    return;
+
+                for (int i = 0; i < files.Length; ++i)
+                {
+                    files[i] = files[i].Substring(fileDir.Length + 1);
+                }
+
+                files = IncludeUtils.FilterItemList(files, patterns, IncludeUtils.MatchOption.CaseInsensitive);
+                filesToInclude.AddRange(files);
+            }
+        }
+
         private void ConstructBasicFileListForTemplate(List<string> filesToInclude, List<string> filesToDeleteAfterwards)
         {
             Utilities.AddAllMatchingFiles(filesToInclude, "*.ico");
@@ -66,6 +89,8 @@ namespace AGS.Editor
 
                 GetFilesForInclusionInTemplate(extraFiles);
 
+                // FIXME: remind why do we have to copy these files into the current directory?!
+                // there has to be a way to avoid doing this!
                 foreach (string fullFileName in extraFiles)
                 {
                     string baseFileName = Path.GetFileName(fullFileName);
@@ -77,7 +102,6 @@ namespace AGS.Editor
                     filesToInclude.Add(baseFileName);
                 }
             }
-
         }
 
         public void CreateTemplateFromCurrentGame(string templateFileName)
@@ -85,7 +109,15 @@ namespace AGS.Editor
             List<string> files = new List<string>();
             List<string> filesToDeleteAfterwards = new List<string>();
 
-            ConstructBasicFileListForTemplate(files, filesToDeleteAfterwards);
+            string templateIncludeFile = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, AGSEditor.TEMPLATE_INCLUDE_FILE);
+            if (File.Exists(templateIncludeFile))
+            {
+                ConstructFileListUsingIncludeFile(files, Factory.AGSEditor.CurrentGame.DirectoryPath, templateIncludeFile);
+            }
+            else
+            {
+                ConstructBasicFileListForTemplate(files, filesToDeleteAfterwards);
+            }
 
             Utilities.TryDeleteFile(templateFileName);
 

--- a/Editor/AGS.Editor/Utils/IncludeUtils.cs
+++ b/Editor/AGS.Editor/Utils/IncludeUtils.cs
@@ -167,8 +167,20 @@ namespace AGS.Editor
                 parseLine = NormalizePathSeparatorsInPattern(parseLine);
                 string regexString = PatternToRegexString(parseLine, option);
 
-                Pattern p = new Pattern(type, new Regex(regexString, RegexOptions.None), parseLine, regexString);
-                patterns.Add(p);
+                Regex rx = null;
+                try
+                {
+                    rx = new Regex(regexString, RegexOptions.None);
+                }
+                catch (Exception)
+                {
+                }
+
+                if (rx != null)
+                {
+                    Pattern p = new Pattern(type, rx, parseLine, regexString);
+                    patterns.Add(p);
+                }
             }
             return patterns;
         }
@@ -268,7 +280,7 @@ namespace AGS.Editor
                 }
                 else
                 {
-                    if (char.IsLetterOrDigit(c))
+                    if (char.IsLetterOrDigit(c) || c == '_')
                     {
                         result.Append(c);
                     }

--- a/Editor/AGS.Editor/Utils/IncludeUtils.cs
+++ b/Editor/AGS.Editor/Utils/IncludeUtils.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// IncludeUtils deal with the include/exclude list, containing patterns
+    /// in the .gitignore format, which may instruct to either include or
+    /// exclude particular file path.
+    /// The code is based on the Python's fnmatch, and a gist demonstrating
+    /// its port to C++, see:
+    /// https://github.com/python/cpython/blob/main/Lib/fnmatch.py
+    /// https://gist.github.com/alco/1869512
+    /// NOTE: the level of support for .gitignore format is not clear,
+    /// maybe not all of the possible edge cases are handled here.
+    /// For the reference, .gitignore specs:
+    /// https://git-scm.com/docs/gitignore
+    /// </summary>
+    public static class IncludeUtils
+    {
+        public enum PatternType
+        {
+            Include,
+            Exclude
+        };
+
+        /// <summary>
+        /// MatchOption flags tell how to interpret pattern and item contents.
+        /// </summary>
+        [Flags]
+        public enum MatchOption
+        {
+            None = 0,
+            /// <summary>
+            /// Will ignore item's letter case
+            /// </summary>
+            CaseInsensitive = 0x0001
+        }
+
+        /// <summary>
+        /// Describes a single match pattern, which instructs to either include
+        /// or excluding matching items. Contains a prepared Regex object.
+        /// </summary>
+        public struct Pattern
+        {
+            public readonly PatternType Type;
+            public readonly Regex Regex;
+            public readonly string OriginalPattern;
+            public readonly string RegexPattern;
+
+            public Pattern(PatternType type, Regex rx, string originalPattern, string regexPattern)
+            {
+                Type = type;
+                Regex = rx;
+                OriginalPattern = originalPattern;
+                RegexPattern = regexPattern;
+            }
+        }
+
+        /// <summary>
+        /// Creates a list of Patterns by parsing Stream contents as a text.
+        /// </summary>
+        public static Pattern[] CreatePatternList(Stream stream, MatchOption option = MatchOption.None)
+        {
+            var lines = ReadPatternLines(stream);
+            return ParsePatterns(lines, option).ToArray();
+        }
+
+        /// <summary>
+        /// Creates a list of Patterns by parsing a string.
+        /// </summary>
+        public static Pattern[] CreatePatternList(string str, MatchOption option = MatchOption.None)
+        {
+            var lines = ReadPatternLines(str);
+            return ParsePatterns(lines, option).ToArray();
+        }
+
+        /// <summary>
+        /// Filters a list of items using a list of patterns.
+        /// Returns a filtered list.
+        /// </summary>
+        public static string[] FilterItemList(string[] items, Pattern[] patterns, MatchOption option = MatchOption.None)
+        {
+            // if a file entry matches no pattern of the include type it should not be included in the list
+            // if a file entry matches a pattern of the include type it should be included unless a pattern of exclude type will match it after
+            // if a pattern of exclude type exists but a later pattern causes it to be included, it should be included.
+            List<string> matches = new List<string>();
+            foreach (string item in items)
+            {
+                bool include = false;
+                string matchItem = item;
+                if (option.HasFlag(MatchOption.CaseInsensitive))
+                    matchItem = matchItem.ToLowerInvariant();
+                matchItem = NormalizePathSeparatorsInItem(matchItem);
+
+                foreach (var pattern in patterns)
+                {
+                    if (pattern.Regex.IsMatch(matchItem))
+                    {
+                        if (pattern.Type == PatternType.Include)
+                        {
+                            include = true;
+                        }
+                        else if (pattern.Type == PatternType.Exclude)
+                        {
+                            include = false;
+                        }
+                    }
+                }
+
+                if (include)
+                {
+                    matches.Add(item);
+                }
+            }
+            return matches.ToArray();
+        }
+
+        private static List<string> ReadPatternLines(Stream stream)
+        {
+            using (TextReader textReader = new StreamReader(stream))
+                return ReadPatternLines(textReader);
+        }
+
+        private static List<string> ReadPatternLines(string str)
+        {
+            using (TextReader textReader = new StringReader(str))
+                return ReadPatternLines(textReader);
+        }
+
+        private static List<string> ReadPatternLines(TextReader textReader)
+        {
+            List<string> lines = new List<string>();
+            for (string line = textReader.ReadLine(); line != null; line = textReader.ReadLine())
+            {
+                lines.Add(line);
+            }
+            return lines;
+        }
+
+        /// <summary>
+        /// Parses the given list of lines and creates a list of Patterns.
+        /// </summary>
+        private static List<Pattern> ParsePatterns(List<string> lines, MatchOption option)
+        {
+            List<Pattern> patterns = new List<Pattern>();
+            foreach (string line in lines)
+            {
+                string parseLine = line.Trim();
+
+                // line is empty or a comment
+                if (string.IsNullOrEmpty(parseLine) || parseLine.StartsWith("#"))
+                    continue;
+
+                PatternType type = PatternType.Include;
+                if (parseLine.StartsWith("!"))
+                {
+                    type = PatternType.Exclude;
+                    parseLine = parseLine.Substring(1);
+                }
+
+                if (option.HasFlag(MatchOption.CaseInsensitive))
+                    parseLine = parseLine.ToLowerInvariant();
+                parseLine = NormalizePathSeparatorsInPattern(parseLine);
+                string regexString = PatternToRegexString(parseLine);
+
+                Pattern p = new Pattern(type, new Regex(regexString, RegexOptions.None), parseLine, regexString);
+                patterns.Add(p);
+            }
+            return patterns;
+        }
+
+        /// <summary>
+        /// Normalizes path separators in a input filepath item.
+        /// </summary>
+        private static string NormalizePathSeparatorsInItem(string pattern)
+        {
+            return pattern.Replace("\\", "/"); // convert to UNIX paths
+        }
+
+        /// <summary>
+        /// Normalizes path separators in the pattern string.
+        /// </summary>
+        private static string NormalizePathSeparatorsInPattern(string pattern)
+        {
+            return pattern.Replace("\\\\", "/"); // convert to UNIX paths
+        }
+
+        /// <summary>
+        /// Converts a include/exclude pattern string into the regex string,
+        /// which may be used to construct a Regex object.
+        /// </summary>
+        private static string PatternToRegexString(string pattern)
+        {
+            StringBuilder result = new StringBuilder();
+
+            int i = 0;
+            int n = pattern.Length;
+            while (i < n)
+            {
+                char c = pattern[i++];
+                if (c == '*')
+                {
+                    result.Append(".*");
+                }
+                else if (c == '?')
+                {
+                    result.Append('.');
+                }
+                else if (c == '[')
+                {
+                    int j = i;
+                    /*
+                     * The following two statements check if the sequence we stumbled
+                     * upon is '[]' or '[!]' because those are not valid character
+                     * classes.
+                     */
+                    if (j < n && pattern[j] == '!')
+                        ++j;
+                    if (j < n && pattern[j] == ']')
+                        ++j;
+                    /*
+                     * Look for the closing ']' right off the bat. If one is not found,
+                     * escape the opening '[' and continue.  If it is found, process
+                     * the contents of '[...]'.
+                     */
+                    while (j < n && pattern[j] != ']')
+                        ++j;
+
+                    if (j >= n)
+                    {
+                        result.Append("\\[");
+                    }
+                    else
+                    {
+                        String part = pattern.Substring(i, j - i);
+                        part.Replace("\\", " \\\\");
+                        char first_char = pattern[i];
+                        i = j + 1;
+                        result.Append("[");
+                        if (first_char == '!')
+                        {
+                            result.Append("^");
+                            result.Append(part.Substring(1));
+                        }
+                        else if (first_char == '^')
+                        {
+                            result.Append("\\");
+                            result.Append(part);
+                        }
+                        else
+                        {
+                            result.Append(part);
+                        }
+                        result.Append("]");
+                    }
+                }
+                else
+                {
+                    if (char.IsLetterOrDigit(c))
+                    {
+                        result.Append(c);
+                    }
+                    else
+                    {
+                        // The python approach is to escape all characters that are not alphanumeric
+                        result.Append("\\");
+                        result.Append(c);
+                    }
+                }
+            }
+            return result.ToString();
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/IncludeUtils.cs
+++ b/Editor/AGS.Editor/Utils/IncludeUtils.cs
@@ -165,7 +165,7 @@ namespace AGS.Editor
                 if (option.HasFlag(MatchOption.CaseInsensitive))
                     parseLine = parseLine.ToLowerInvariant();
                 parseLine = NormalizePathSeparatorsInPattern(parseLine);
-                string regexString = PatternToRegexString(parseLine);
+                string regexString = PatternToRegexString(parseLine, option);
 
                 Pattern p = new Pattern(type, new Regex(regexString, RegexOptions.None), parseLine, regexString);
                 patterns.Add(p);
@@ -193,9 +193,17 @@ namespace AGS.Editor
         /// Converts a include/exclude pattern string into the regex string,
         /// which may be used to construct a Regex object.
         /// </summary>
-        private static string PatternToRegexString(string pattern)
+        private static string PatternToRegexString(string pattern, MatchOption option)
         {
+            if (string.IsNullOrEmpty(pattern))
+                return string.Empty;
+
             StringBuilder result = new StringBuilder();
+            // The pattern must match the path section either at the beginning or right after the path separator
+            if (!pattern.StartsWith("/"))
+            {
+                result.Append("(^|/)");
+            }
 
             int i = 0;
             int n = pattern.Length;
@@ -271,6 +279,12 @@ namespace AGS.Editor
                         result.Append(c);
                     }
                 }
+            }
+
+            // The pattern must match the path section either at the end or right before the path separator
+            if (!pattern.EndsWith("/"))
+            {
+                result.Append("($|/)");
             }
             return result.ToString();
         }

--- a/Editor/AGS.Editor/Utils/IncludeUtils.cs
+++ b/Editor/AGS.Editor/Utils/IncludeUtils.cs
@@ -66,7 +66,7 @@ namespace AGS.Editor
         public static Pattern[] CreatePatternList(Stream stream, MatchOption option = MatchOption.None)
         {
             var lines = ReadPatternLines(stream);
-            return ParsePatterns(lines, option).ToArray();
+            return ParsePatterns(lines, option);
         }
 
         /// <summary>
@@ -75,7 +75,15 @@ namespace AGS.Editor
         public static Pattern[] CreatePatternList(string str, MatchOption option = MatchOption.None)
         {
             var lines = ReadPatternLines(str);
-            return ParsePatterns(lines, option).ToArray();
+            return ParsePatterns(lines, option);
+        }
+
+        /// <summary>
+        /// Creates a list of Patterns by parsing an array of strings, where each element is a pattern.
+        /// </summary>
+        public static Pattern[] CreatePatternList(string[] patternStrings, MatchOption option = MatchOption.None)
+        {
+            return ParsePatterns(patternStrings, option);
         }
 
         /// <summary>
@@ -119,32 +127,32 @@ namespace AGS.Editor
             return matches.ToArray();
         }
 
-        private static List<string> ReadPatternLines(Stream stream)
+        private static string[] ReadPatternLines(Stream stream)
         {
             using (TextReader textReader = new StreamReader(stream))
                 return ReadPatternLines(textReader);
         }
 
-        private static List<string> ReadPatternLines(string str)
+        private static string[] ReadPatternLines(string str)
         {
             using (TextReader textReader = new StringReader(str))
                 return ReadPatternLines(textReader);
         }
 
-        private static List<string> ReadPatternLines(TextReader textReader)
+        private static string[] ReadPatternLines(TextReader textReader)
         {
             List<string> lines = new List<string>();
             for (string line = textReader.ReadLine(); line != null; line = textReader.ReadLine())
             {
                 lines.Add(line);
             }
-            return lines;
+            return lines.ToArray();
         }
 
         /// <summary>
         /// Parses the given list of lines and creates a list of Patterns.
         /// </summary>
-        private static List<Pattern> ParsePatterns(List<string> lines, MatchOption option)
+        private static Pattern[] ParsePatterns(string[] lines, MatchOption option)
         {
             List<Pattern> patterns = new List<Pattern>();
             foreach (string line in lines)
@@ -182,7 +190,7 @@ namespace AGS.Editor
                     patterns.Add(p);
                 }
             }
-            return patterns;
+            return patterns.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
Resolve #2063

1. Implemented "IncludeUtils" class, porting existing code from agspak (see #2505).
2. Editor looks for the "template.files" file when making a template. If such file is present, then it will read a list of include/exclude patterns and use these to gather a list of files to package. If it's not present, then it will fall back to using standard list.
3. Editor matches the files found in the project folder and all the subfolders (of any nesting), but never any outside files.

NOTE: I only made a quick test with one-level subfolder, need to test that it can pack AND unpack multiple nesting levels properly.

NOTE: there's some strange logic with the standard file list, where Editor will make temporary file copies in order to package a template and later delete them. I can't remember what is that for, may be worth investigating, and redoing that if it's not necessary.