### PR TITLE
Editor: Welcome pane links to AGS 4 help topics

### DIFF
--- a/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
@@ -170,7 +170,7 @@ namespace AGS.Editor
             this.pnlRight.Margin = new System.Windows.Forms.Padding(10);
             this.pnlRight.MinimumSize = new System.Drawing.Size(443, 362);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(612, 362);
+            this.pnlRight.Size = new System.Drawing.Size(608, 362);
             this.pnlRight.TabIndex = 2;
             // 
             // tableRight
@@ -192,7 +192,7 @@ namespace AGS.Editor
             this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableRight.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableRight.Size = new System.Drawing.Size(612, 362);
+            this.tableRight.Size = new System.Drawing.Size(608, 362);
             this.tableRight.TabIndex = 6;
             // 
             // lblUpgradingInfo3
@@ -202,7 +202,7 @@ namespace AGS.Editor
             this.lblUpgradingInfo3.MaximumSize = new System.Drawing.Size(600, 0);
             this.lblUpgradingInfo3.Name = "lblUpgradingInfo3";
             this.lblUpgradingInfo3.Padding = new System.Windows.Forms.Padding(3);
-            this.lblUpgradingInfo3.Size = new System.Drawing.Size(438, 244);
+            this.lblUpgradingInfo3.Size = new System.Drawing.Size(275, 146);
             this.lblUpgradingInfo3.TabIndex = 3;
             this.lblUpgradingInfo3.Text = resources.GetString("lblUpgradingInfo3.Text");
             // 
@@ -213,7 +213,7 @@ namespace AGS.Editor
             this.label5.Location = new System.Drawing.Point(6, 3);
             this.label5.Name = "label5";
             this.label5.Padding = new System.Windows.Forms.Padding(3);
-            this.label5.Size = new System.Drawing.Size(172, 20);
+            this.label5.Size = new System.Drawing.Size(160, 20);
             this.label5.TabIndex = 0;
             this.label5.Text = "What\'s new in AGS 4.0?";
             // 
@@ -225,7 +225,7 @@ namespace AGS.Editor
             this.lnkUpgrading.MaximumSize = new System.Drawing.Size(600, 0);
             this.lnkUpgrading.Name = "lnkUpgrading";
             this.lnkUpgrading.Padding = new System.Windows.Forms.Padding(3);
-            this.lnkUpgrading.Size = new System.Drawing.Size(600, 48);
+            this.lnkUpgrading.Size = new System.Drawing.Size(596, 48);
             this.lnkUpgrading.TabIndex = 1;
             this.lnkUpgrading.Text = resources.GetString("lnkUpgrading.Text");
             this.lnkUpgrading.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkUpgrading_LinkClicked);
@@ -237,7 +237,7 @@ namespace AGS.Editor
             this.lblUpgradingInfo.MaximumSize = new System.Drawing.Size(600, 0);
             this.lblUpgradingInfo.Name = "lblUpgradingInfo";
             this.lblUpgradingInfo.Padding = new System.Windows.Forms.Padding(3);
-            this.lblUpgradingInfo.Size = new System.Drawing.Size(531, 20);
+            this.lblUpgradingInfo.Size = new System.Drawing.Size(367, 20);
             this.lblUpgradingInfo.TabIndex = 2;
             this.lblUpgradingInfo.Text = "With AGS 4.0 you can make use of the new extended compiler!";
             // 

--- a/Editor/AGS.Editor/Panes/WelcomePane.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.cs
@@ -32,6 +32,8 @@ namespace AGS.Editor
         {
             _guiContoller = guiContoller;
             InitializeComponent();
+            lnkUpgrading.Links.Add(65, 23, "What's new in AGS 4.0");
+            lnkUpgrading.Links.Add(212, 22, "Upgrading to AGS 4.0");
         }
 
         protected override string OnGetHelpKeyword()

--- a/Editor/AGS.Editor/Panes/WelcomePane.resx
+++ b/Editor/AGS.Editor/Panes/WelcomePane.resx
@@ -130,6 +130,6 @@
 * And loads more!</value>
   </data>
   <data name="lnkUpgrading.Text" xml:space="preserve">
-    <value>If you've come from an older version of AGS be sure to read "Upgrading to ..." articles in the manual. "Upgrading to AGS 4.0" page gives insight into most important changes in current version.</value>
+    <value>If you've come from an older version of AGS, be sure to read the "What's New In AGS 4.0" page, which describes the main changes in the current version. If you are upgrading a project from a previous version, the "Upgrading To AGS 4.0" page gives you a walkthrough.</value>
   </data>
 </root>


### PR DESCRIPTION
Very minimal change, the idea here is just to have links to the proper AGS 4.0 help topic in the Welcome Pane.

- [What's new in AGS 4.0](https://github.com/adventuregamestudio/ags-manual-source/blob/ags4/WhatsNewIn40.md)
- [Upgrading to AGS 4.0](https://github.com/adventuregamestudio/ags-manual-source/blob/ags4/UpgradingTo40.md)

![image](https://github.com/user-attachments/assets/6595abf8-065b-445c-9ec5-1f15659ccc45)

Because we are already building from the ags4 manual source branch and getting it here from the CI, this should just work.