### PR TITLE
Engine and Editor: Add support to set character spacing in fonts

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -124,7 +124,7 @@ OPT_SAVESCREENSHOTLAYER, CHF_TURNWHENFACE. Button's WrapText and padding.
 Few minor behavior changes.
 3.6.3:
 OPT_GUICONTROLMOUSEBUT
-
+Font.CharacterSpacing
 */
 
 enum GameDataVersion

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -100,8 +100,6 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             fonts[i].Outline = in->ReadInt32();
             fonts[i].YOffset = in->ReadInt32();
             fonts[i].LineSpacing = std::max(0, in->ReadInt32());
-            // Character spacing added in a future version, use 0 for older games
-            fonts[i].CharacterSpacing = (data_ver >= kGameVersion_Current) ? in->ReadInt32() : 0;
             AdjustFontInfoUsingFlags(fonts[i], flags);
         }
     }

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -100,6 +100,8 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             fonts[i].Outline = in->ReadInt32();
             fonts[i].YOffset = in->ReadInt32();
             fonts[i].LineSpacing = std::max(0, in->ReadInt32());
+            // Character spacing added in a future version, use 0 for older games
+            fonts[i].CharacterSpacing = (data_ver >= kGameVersion_Current) ? in->ReadInt32() : 0;
             AdjustFontInfoUsingFlags(fonts[i], flags);
         }
     }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -310,6 +310,8 @@ struct FontInfo
     int           YOffset;
     // Custom line spacing between two lines of text (0 = use font height)
     int           LineSpacing;
+    // Horizontal spacing between individual characters, in pixels
+    int           CharacterSpacing;
     // When automatic outlining, style of the outline
     AutoOutlineStyle AutoOutlineStyle;
     // When automatic outlining, thickness of the outline (0 = no auto outline)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -75,6 +75,7 @@ FontInfo::FontInfo()
     , Outline(FONT_OUTLINE_NONE)
     , YOffset(0)
     , LineSpacing(0)
+    , CharacterSpacing(0)
     , AutoOutlineStyle(kSquared)
     , AutoOutlineThickness(0)
 {}
@@ -175,6 +176,12 @@ static void font_post_init(int font_number)
             font.Info.Flags |= FFLG_DEFLINESPACING;
             font.LineSpacingCalc = font.Metrics.CompatHeight + 2 * font.Info.AutoOutlineThickness;
         }
+    }
+    
+    // Apply character spacing if it's a TTF font
+    if (font.RendererInt == ttfRenderer.get())
+    {
+        static_cast<TTFFontRenderer*>(font.RendererInt)->SetCharacterSpacing(font_number, font.Info.CharacterSpacing);
     }
 }
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -183,6 +183,11 @@ static void font_post_init(int font_number)
     {
         static_cast<TTFFontRenderer*>(font.RendererInt)->SetCharacterSpacing(font_number, font.Info.CharacterSpacing);
     }
+    // Apply character spacing if it's a WFN font
+    else if (font.RendererInt == wfnRenderer.get())
+    {
+        static_cast<WFNFontRenderer*>(font.RendererInt)->SetCharacterSpacing(font_number, font.Info.CharacterSpacing);
+    }
 }
 
 static void font_replace_renderer(int font_number,

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -181,6 +181,14 @@ void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
   }
 }
 
+void TTFFontRenderer::SetCharacterSpacing(int fontNumber, int spacing)
+{
+    if (_fontData.find(fontNumber) != _fontData.end())
+    {
+        alfont_set_char_extra_spacing(_fontData[fontNumber].AlFont, spacing);
+    }
+}
+
 void TTFFontRenderer::FreeMemory(int fontNumber)
 {
   alfont_destroy_font(_fontData[fontNumber].AlFont);

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -46,6 +46,7 @@ public:
       const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
+  void SetCharacterSpacing(int fontNumber, int spacing);
 
   TTFFontRenderer(AGS::Common::AssetManager *amgr);
   virtual ~TTFFontRenderer();

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -36,12 +36,20 @@ int WFNFontRenderer::GetTextWidth(const char *text, int fontNumber)
 {
     const WFNFont* font = _fontData[fontNumber].Font;
     const FontRenderParams &params = _fontData[fontNumber].Params;
+    const int charSpacing = _fontData[fontNumber].CharacterSpacing;
     int text_width = 0;
+    int char_count = 0;
 
     for (int code = ugetxc(&text); code; code = ugetxc(&text))
     {
         text_width += font->GetChar(code).Width;
+        char_count++;
     }
+    
+    // Add character spacing between characters (but not after the last character)
+    if (char_count > 1)
+        text_width += charSpacing * (char_count - 1);
+        
     return text_width * params.SizeMultiplier;
 }
 
@@ -69,13 +77,22 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 
   const WFNFont* font = _fontData[fontNumber].Font;
   const FontRenderParams &params = _fontData[fontNumber].Params;
+  const int charSpacing = _fontData[fontNumber].CharacterSpacing;
   Bitmap ds(destination, true);
 
   // NOTE: allegro's putpixel ignores clipping (optimization),
   // so we'll have to accomodate for that ourselves
   Rect clip = ds.GetClip();
+  bool first_char = true;
   for (int code = ugetxc(&text); code; code = ugetxc(&text))
+  {
+    if (!first_char)
+    {
+      x += charSpacing * params.SizeMultiplier;
+    }
     x += RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
+    first_char = false;
+  }
 
   set_our_eip(oldeip);
 }
@@ -145,6 +162,7 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
   }
   _fontData[fontNumber].Font = font;
   _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+  _fontData[fontNumber].CharacterSpacing = 0;
   if (src_filename)
     *src_filename = file_name;
   if (metrics)
@@ -161,4 +179,12 @@ void WFNFontRenderer::FreeMemory(int fontNumber)
 bool WFNFontRenderer::SupportsExtendedCharacters(int fontNumber)
 {
   return _fontData[fontNumber].Font->GetCharCount() > 128;
+}
+
+void WFNFontRenderer::SetCharacterSpacing(int fontNumber, int spacing)
+{
+    if (_fontData.find(fontNumber) != _fontData.end())
+    {
+        _fontData[fontNumber].CharacterSpacing = spacing;
+    }
 }

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -77,7 +77,7 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 
   const WFNFont* font = _fontData[fontNumber].Font;
   const FontRenderParams &params = _fontData[fontNumber].Params;
-  const int charSpacing = _fontData[fontNumber].CharacterSpacing;
+  const int charSpacing = _fontData[fontNumber].CharacterSpacing * params.SizeMultiplier;
   Bitmap ds(destination, true);
 
   // NOTE: allegro's putpixel ignores clipping (optimization),
@@ -86,12 +86,7 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
   bool first_char = true;
   for (int code = ugetxc(&text); code; code = ugetxc(&text))
   {
-    if (!first_char)
-    {
-      x += charSpacing * params.SizeMultiplier;
-    }
-    x += RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
-    first_char = false;
+    x += charSpacing + RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
   }
 
   set_our_eip(oldeip);

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -45,6 +45,7 @@ public:
       const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override { *metrics = FontMetrics(); }
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
+  void SetCharacterSpacing(int fontNumber, int spacing);
 
   WFNFontRenderer(AGS::Common::AssetManager *mgr)
       : _amgr(mgr) {}
@@ -55,6 +56,7 @@ private:
   {
     WFNFont         *Font;
     FontRenderParams Params;
+    int              CharacterSpacing;
   };
   std::map<int, FontData> _fontData;
   AGS::Common::AssetManager *_amgr = nullptr;

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -962,6 +962,13 @@ HError GameDataExtReader::ReadBlock(Stream *in, int /*block_id*/, const String &
             in->ReadInt32();
         }
     }
+    else if (ext_id.CompareNoCase("v363_charspacing") == 0)
+    {
+        for (FontInfo &finfo : _ents.Game.fonts)
+        {
+            finfo.CharacterSpacing = in->ReadInt32();
+        }
+    }
     else
     {
         return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -114,7 +114,7 @@ namespace AGS.Editor
          * 3.6.2.2        - Button.WrapText, TextPadding.
          * 3.6.2.6        - Settings.GameFPS.
          * 3.6.2.9        - Sprite.TransparentColorIndex (can select transparent palette index).
-         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton.
+         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton, Font.CharacterSpacing.
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060300;
         /*

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1503,6 +1503,7 @@ namespace AGS.Editor
 
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
+                writer.Write(game.Fonts[i].CharacterSpacing);
             }
             int topmostSprite;
             byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -384,7 +384,7 @@ namespace AGS.Editor
             {
                 if (makeFileNameAssumptions)
                 {
-                    ourlib.DataFilenames.Add(baseFileName + "." + 
+                    ourlib.DataFilenames.Add(baseFileName + "." +
                         (i == 0 ? "ags" : i.ToString("D3")));
                 }
                 else
@@ -1503,7 +1503,6 @@ namespace AGS.Editor
 
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
-                writer.Write(game.Fonts[i].CharacterSpacing);
             }
             int topmostSprite;
             byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];
@@ -1818,6 +1817,7 @@ namespace AGS.Editor
             WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, gameEnts, errors);
             WriteExtension("v362_interevent2", WriteExt_362InteractionEvents, writer, gameEnts, errors);
             WriteExtension("v362_guictrls", WriteExt_362GUIControls, writer, gameEnts, errors);
+            WriteExtension("v363_charspacing", WriteExt_363CharSpacing, writer, gameEnts, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1943,6 +1943,14 @@ namespace AGS.Editor
             }
         }
 
+        private static void WriteExt_363CharSpacing(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
+        {
+            foreach (var font in ents.Game.Fonts)
+            {
+                writer.Write(font.CharacterSpacing);
+            }
+        }
+
         /// <summary>
         /// Helper struct for gathering objects that may be useful when writing extensions.
         /// </summary>
@@ -1962,6 +1970,11 @@ namespace AGS.Editor
 
         private static void WriteExtension(string ext_id, WriteExtensionProc proc, BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            if (ext_id == null)
+                throw new ArgumentNullException(nameof(ext_id));
+            if (ext_id.Length > 16)
+                throw new ArgumentException($"Data file extension ID cannot be longer than 16 characters: {ext_id}");
+            
             // The block meta format:
             //    - 1 byte - an old-style unsigned numeric ID, for compatibility with room file format:
             //               where 0 would indicate following string ID,

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2154,6 +2154,7 @@ void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate)
     font_info.SizeMultiplier = font->SizeMultiplier;
     font_info.YOffset = font->VerticalOffset;
     font_info.LineSpacing = font->LineSpacing;
+    font_info.CharacterSpacing = font->CharacterSpacing;
     if (game->Settings->TTFHeightDefinedBy == FontHeightDefinition::PixelHeight)
         font_info.Flags &= ~FFLG_REPORTNOMINALHEIGHT;
     else

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -21,6 +21,7 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
+        private int _characterSpacing;
         private int _autoOutlineThickness = 1;
         private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Squared;
         private FontMetricsFixup _ttfMetricsFixup = FontMetricsFixup.None;
@@ -33,6 +34,7 @@ namespace AGS.Types
             _outlineStyle = FontOutlineStyle.None;
             _fontHeight = 0;
             _lineSpacing = 0;
+            _characterSpacing = 0;
         }
 
         [Description("The ID number of the font")]
@@ -216,6 +218,15 @@ namespace AGS.Types
         {
             get { return _lineSpacing; }
             set { _lineSpacing = value; }
+        }
+
+        [DisplayName("Character Spacing")]
+        [Description("Horizontal spacing between characters, in pixels")]
+        [Category("Appearance")]
+        public int CharacterSpacing
+        {
+            get { return _characterSpacing; }
+            set { _characterSpacing = value; }
         }
 
 		[Browsable(false)]


### PR DESCRIPTION
## Overview

Resolves #2766 

This change enables game authors to set character spacing in fonts. Supports both TTF and WFN fonts, as well as outlines (for WFN fonts, the spacing must match the outline). I did this in master because I have someone interested in using this for a project this year, but they are not ready to take the risk with 4.0.x 

## Screen Shots
TTF
![Screenshot 2025-07-01 221150](https://github.com/user-attachments/assets/497ae270-b2d3-42a4-af89-05bd220b3b4f)

WFN
![Screenshot 2025-07-01 221323](https://github.com/user-attachments/assets/a30ec617-0848-4439-a204-0411019cc340)

Editor
![image](https://github.com/user-attachments/assets/b15db568-f521-40ef-8ff8-e7a0a23e67bf)


## TODO
- [ ] "Character Spacing" or "Letter Spacing" (to avoid term overloading?)
- [ ] Test with RTL fonts, and CJK fonts
- [ ] Changes.txt