### PR TITLE
Add game description properties into the compiled game, available in script

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -83,6 +83,9 @@ struct GameSetupStruct : public GameSetupStructBase
     int               numGameChannels = 0;
     // backward-compatible channel limit that may be exported to script and reserved by audiotypes
     int               numCompatGameChannels = 0;
+
+    // A dictionary of semi-arbitrary game info properties: title, developer's name, etc
+    AGS::Common::StringMap GameInfo;
     
     // TODO: I converted original array of sprite infos to vector here, because
     // statistically in most games sprites go in long continious sequences with minimal

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -962,6 +962,11 @@ HError GameDataExtReader::ReadBlock(Stream *in, int /*block_id*/, const String &
             in->ReadInt32();
         }
     }
+    else if (ext_id.CompareNoCase("v363_gameinfo") == 0)
+    {
+        // Read a dictionary of strings
+        StrUtil::ReadStringMap(_ents.Game.GameInfo, in);
+    }
     else
     {
         return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1817,6 +1817,7 @@ namespace AGS.Editor
             WriteExtension("v361_objnames", WriteExt_361ObjNames, writer, gameEnts, errors);
             WriteExtension("v362_interevent2", WriteExt_362InteractionEvents, writer, gameEnts, errors);
             WriteExtension("v362_guictrls", WriteExt_362GUIControls, writer, gameEnts, errors);
+            WriteExtension("v363_gameinfo", WriteExt_363GameInfo, writer, gameEnts, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1942,6 +1943,25 @@ namespace AGS.Editor
             }
         }
 
+        private static void WriteExt_363GameInfo(BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
+        {
+            var gameinfo = new Dictionary<string, string>();
+            gameinfo.Add("title", ents.Game.Settings.GameName);
+            gameinfo.Add("description", ents.Game.Settings.Description);
+            gameinfo.Add("dev_name", ents.Game.Settings.DeveloperName);
+            gameinfo.Add("dev_url", ents.Game.Settings.DeveloperURL);
+            gameinfo.Add("genre", ents.Game.Settings.Genre);
+            gameinfo.Add("release_date", ents.Game.Settings.ReleaseDate.ToString("dd.MM.yyyy"));
+            gameinfo.Add("version", ents.Game.Settings.Version);
+
+            writer.Write(gameinfo.Count);
+            foreach (var item in gameinfo)
+            {
+                FilePutString(item.Key, writer);
+                FilePutString(item.Value, writer);
+            }
+        }
+
         /// <summary>
         /// Helper struct for gathering objects that may be useful when writing extensions.
         /// </summary>
@@ -1961,6 +1981,11 @@ namespace AGS.Editor
 
         private static void WriteExtension(string ext_id, WriteExtensionProc proc, BinaryWriter writer, WriteExtEntities ents, CompileMessages errors)
         {
+            if (string.IsNullOrWhiteSpace(ext_id))
+                throw new ArgumentException("Invalid data file extension ID");
+            if (ext_id.Length > 16)
+                throw new ArgumentException($"Data file extension ID cannot be longer than 16 characters: {ext_id}");
+
             // The block meta format:
             //    - 1 byte - an old-style unsigned numeric ID, for compatibility with room file format:
             //               where 0 would indicate following string ID,

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3213,6 +3213,20 @@ builtin struct Game {
   /// Gets whether the game is currently in a blocking state, that is during a blocking action or a Wait() call.
   import static readonly attribute bool InBlockingWait;
 #endif // SCRIPT_API_v362
+#ifdef SCRIPT_API_v363
+  /// Gets the game's description
+  import static readonly attribute String Description;
+  /// Gets the game's developer's name
+  import static readonly attribute String DeveloperName;
+  /// Gets the game's developer's URL string
+  import static readonly attribute String DeveloperURL;
+  /// Gets the game's genre description
+  import static readonly attribute String Genre;
+  /// Gets the game's release date as a DateTime instance
+  import static readonly attribute DateTime* ReleaseDate;
+  /// Gets the game's release version, represented as "X.Y.Z.W" string
+  import static readonly attribute String Version;
+#endif
 };
 
 builtin struct GameState {

--- a/Engine/ac/datetime.h
+++ b/Engine/ac/datetime.h
@@ -21,6 +21,8 @@
 #include "ac/dynobj/scriptdatetime.h"
 
 ScriptDateTime* DateTime_Now();
+ScriptDateTime *DateTime_CreateFromDate(int year, int month, int day, int hour, int minute, int second);
+ScriptDateTime *DateTime_CreateFromRawTime(int raw_time);
 int             DateTime_GetYear(ScriptDateTime *sdt);
 int             DateTime_GetMonth(ScriptDateTime *sdt);
 int             DateTime_GetDayOfMonth(ScriptDateTime *sdt);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -781,6 +781,50 @@ void Game_SetName(const char *newName) {
     GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Gamename);
 }
 
+const char *Game_GetDescription()
+{
+    return CreateNewScriptString(game.GameInfo["description"]);
+}
+
+const char *Game_GetDeveloperName()
+{
+    return CreateNewScriptString(game.GameInfo["dev_name"]);
+}
+
+const char *Game_GetDeveloperURL()
+{
+    return CreateNewScriptString(game.GameInfo["dev_url"]);
+}
+
+const char *Game_GetGenre()
+{
+    return CreateNewScriptString(game.GameInfo["genre"]);
+}
+
+ScriptDateTime *Game_GetReleaseDate()
+{
+    String release_date = game.GameInfo["release_date"];
+    if (release_date.IsEmpty())
+        return nullptr; // not available
+    std::vector<String> parts = release_date.Split('.');
+    if (parts.size() == 0 || parts.size() > 3)
+        return nullptr; // malformed date
+    int year = 0, month = 0, day = 0;
+    year = StrUtil::StringToInt(parts[parts.size() - 1], -1);
+    if (parts.size() > 1)
+        month = StrUtil::StringToInt(parts[parts.size() - 2], -1);
+    if (parts.size() > 2)
+        day = StrUtil::StringToInt(parts[parts.size() - 3], -1);
+    if (year < 0 || month < 0 || day < 0)
+        return nullptr; // malformed date
+    return DateTime_CreateFromDate(year, month, day, 0, 0, 0);
+}
+
+const char *Game_GetVersion()
+{
+    return CreateNewScriptString(game.GameInfo["version"]);
+}
+
 int Game_GetSkippingCutscene()
 {
     if (play.fast_forward)
@@ -1804,6 +1848,21 @@ RuntimeScriptValue Sc_Game_GetCharacterCount(const RuntimeScriptValue *params, i
     API_SCALL_INT(Game_GetCharacterCount);
 }
 
+RuntimeScriptValue Sc_Game_GetDescription(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetDescription);
+}
+
+RuntimeScriptValue Sc_Game_GetDeveloperName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetDeveloperName);
+}
+
+RuntimeScriptValue Sc_Game_GetDeveloperURL(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetDeveloperURL);
+}
+
 // int ()
 RuntimeScriptValue Sc_Game_GetDialogCount(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1820,6 +1879,11 @@ RuntimeScriptValue Sc_Game_GetFileName(const RuntimeScriptValue *params, int32_t
 RuntimeScriptValue Sc_Game_GetFontCount(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_INT(Game_GetFontCount);
+}
+
+RuntimeScriptValue Sc_Game_GetGenre(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetGenre);
 }
 
 // const char* (int index)
@@ -1912,6 +1976,11 @@ RuntimeScriptValue Sc_SetNormalFont(const RuntimeScriptValue *params, int32_t pa
     API_SCALL_VOID_PINT(SetNormalFont);
 }
 
+RuntimeScriptValue Sc_Game_GetReleaseDate(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptDateTime, Game_GetReleaseDate);
+}
+
 // int ()
 RuntimeScriptValue Sc_Game_GetSkippingCutscene(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1969,6 +2038,11 @@ RuntimeScriptValue Sc_Game_GetSpeechVoxFilename(const RuntimeScriptValue *params
 RuntimeScriptValue Sc_Game_GetUseNativeCoordinates(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_INT(Game_GetUseNativeCoordinates);
+}
+
+RuntimeScriptValue Sc_Game_GetVersion(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetVersion);
 }
 
 // int ()
@@ -2077,16 +2151,27 @@ void RegisterGameAPI()
         { "Game::PrecacheView",                           API_FN_PAIR(Game_PrecacheView) },
         { "Game::GetSaveSlots^4",                         API_FN_PAIR(Game_GetSaveSlots) },
         { "Game::ScanSaveSlots^6",                        API_FN_PAIR(Game_ScanSaveSlots) },
+        { "Game::get_AudioClipCount",                     API_FN_PAIR(Game_GetAudioClipCount) },
+        { "Game::geti_AudioClips",                        API_FN_PAIR(Game_GetAudioClip) },
+        { "Game::get_BlockingWaitSkipped",                API_FN_PAIR(Game_BlockingWaitSkipped) },
+        { "Game::get_Camera",                             API_FN_PAIR(Game_GetCamera) },
+        { "Game::get_CameraCount",                        API_FN_PAIR(Game_GetCameraCount) },
+        { "Game::geti_Cameras",                           API_FN_PAIR(Game_GetAnyCamera) },
         { "Game::get_CharacterCount",                     API_FN_PAIR(Game_GetCharacterCount) },
+        { "Game::get_Description",                        API_FN_PAIR(Game_GetDescription) },
+        { "Game::get_DeveloperName",                      API_FN_PAIR(Game_GetDeveloperName) },
+        { "Game::get_DeveloperURL",                       API_FN_PAIR(Game_GetDeveloperURL) },
         { "Game::get_DialogCount",                        API_FN_PAIR(Game_GetDialogCount) },
         { "Game::get_FileName",                           API_FN_PAIR(Game_GetFileName) },
         { "Game::get_FontCount",                          API_FN_PAIR(Game_GetFontCount) },
+        { "Game::get_Genre",                              API_FN_PAIR(Game_GetGenre) },
         { "Game::geti_GlobalMessages",                    API_FN_PAIR(Game_GetGlobalMessages) },
         { "Game::geti_GlobalStrings",                     API_FN_PAIR(Game_GetGlobalStrings) },
         { "Game::seti_GlobalStrings",                     API_FN_PAIR(SetGlobalString) },
         { "Game::get_GUICount",                           API_FN_PAIR(Game_GetGUICount) },
         { "Game::get_IgnoreUserInputAfterTextTimeoutMs",  API_FN_PAIR(Game_GetIgnoreUserInputAfterTextTimeoutMs) },
         { "Game::set_IgnoreUserInputAfterTextTimeoutMs",  API_FN_PAIR(Game_SetIgnoreUserInputAfterTextTimeoutMs) },
+        { "Game::get_InBlockingWait",                     API_FN_PAIR(Game_InBlockingWait) },
         { "Game::get_InSkippableCutscene",                API_FN_PAIR(Game_GetInSkippableCutscene) },
         { "Game::get_InventoryItemCount",                 API_FN_PAIR(Game_GetInventoryItemCount) },
         { "Game::get_MinimumTextDisplayTimeMs",           API_FN_PAIR(Game_GetMinimumTextDisplayTimeMs) },
@@ -2096,24 +2181,19 @@ void RegisterGameAPI()
         { "Game::set_Name",                               API_FN_PAIR(Game_SetName) },
         { "Game::get_NormalFont",                         API_FN_PAIR(Game_GetNormalFont) },
         { "Game::set_NormalFont",                         API_FN_PAIR(SetNormalFont) },
+        { "Game::get_ReleaseDate",                        API_FN_PAIR(Game_GetReleaseDate) },
         { "Game::get_SkippingCutscene",                   API_FN_PAIR(Game_GetSkippingCutscene) },
         { "Game::get_SpeechFont",                         API_FN_PAIR(Game_GetSpeechFont) },
         { "Game::set_SpeechFont",                         API_FN_PAIR(SetSpeechFont) },
+        { "Game::get_SpeechVoxFilename",                  API_FN_PAIR(Game_GetSpeechVoxFilename) },
         { "Game::geti_SpriteWidth",                       API_FN_PAIR(Game_GetSpriteWidth) },
         { "Game::geti_SpriteHeight",                      API_FN_PAIR(Game_GetSpriteHeight) },
         { "Game::get_TextReadingSpeed",                   API_FN_PAIR(Game_GetTextReadingSpeed) },
         { "Game::set_TextReadingSpeed",                   API_FN_PAIR(Game_SetTextReadingSpeed) },
         { "Game::get_TranslationFilename",                API_FN_PAIR(Game_GetTranslationFilename) },
         { "Game::get_UseNativeCoordinates",               API_FN_PAIR(Game_GetUseNativeCoordinates) },
+        { "Game::get_Version",                            API_FN_PAIR(Game_GetVersion) },
         { "Game::get_ViewCount",                          API_FN_PAIR(Game_GetViewCount) },
-        { "Game::get_AudioClipCount",                     API_FN_PAIR(Game_GetAudioClipCount) },
-        { "Game::geti_AudioClips",                        API_FN_PAIR(Game_GetAudioClip) },
-        { "Game::get_BlockingWaitSkipped",                API_FN_PAIR(Game_BlockingWaitSkipped) },
-        { "Game::get_InBlockingWait",                     API_FN_PAIR(Game_InBlockingWait) },
-        { "Game::get_SpeechVoxFilename",                  API_FN_PAIR(Game_GetSpeechVoxFilename) },
-        { "Game::get_Camera",                             API_FN_PAIR(Game_GetCamera) },
-        { "Game::get_CameraCount",                        API_FN_PAIR(Game_GetCameraCount) },
-        { "Game::geti_Cameras",                           API_FN_PAIR(Game_GetAnyCamera) },
     };
 
     ccAddExternalFunctions(game_api);


### PR DESCRIPTION
This is an intermediate step for the #2729, but also may be used e.g. in savegame upgrading process, and perhaps for other things.

Editor writes the "game information" properties as a bundle into the compiled game, as a single extension.
Added following properties in script:
```
  /// Gets the game's description
  static readonly String Game.Description;
  /// Gets the game's developer's name
  static readonly String Game.DeveloperName;
  /// Gets the game's developer's URL string
  static readonly String Game.DeveloperURL;
  /// Gets the game's genre description
  static readonly String Game.Genre;
  /// Gets the game's release date as a DateTime instance
  static readonly DateTime* Game.ReleaseDate;
  /// Gets the game's release version, represented as "X.Y.Z.W" string
  static readonly String Game.Version;
```