### PR TITLE
AGS 4: reimplement Character waiting 1 frame before moving to let animation advance

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -142,7 +142,8 @@ struct CharacterInfo
     int16_t walkspeed_y = 0;
     int16_t pic_yoffs   = 0; // this is fixed in screen coordinates
     int     z           = 0; // z-location, for flying etc
-    int     walkwait    = 0;
+    int     walkwait    = 0; // number of frames to wait before advancing a move;
+                             // also used as a turning counter
     int16_t speech_anim_speed = 0;
     int16_t idle_anim_speed = 0;
     int16_t blocking_width = 0;

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -70,7 +70,7 @@ public:
     short tint_light = 0;
     char  process_idle_this_time = 0;
     char  slow_move_counter = 0;
-    short animwait = 0;
+    short animwait = 0; // number of frames to wait before advancing a animation
     int   anim_volume = 100; // default animation volume (relative factor)
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
     int   following = -1; // whom do we follow (character id)

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -173,6 +173,8 @@ bool UpdateCharacterTurning(CharacterInfo *chi, CharacterExtras *chex)
         // if still turning, wait for next frame
         if (chex->turns > 0)
           chi->walkwait = chi->animspeed;
+        else
+          chi->walkwait = 1; // wait 1 frame to let walking animation advance once
         chex->animwait = 0;
       }
 

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -84,14 +84,6 @@ void MoveList::SetStageProgress(float progress)
     curpos = CalcCurrentPos();
 }
 
-// for do_movelist_move, that needs to elbaorate the current step before moving to the next
-bool MoveList::GetAndForward()
-{
-    bool progressChanged = OnProgressChanged();
-    onpart += 1.f;
-    return progressChanged;
-}
-
 bool MoveList::Forward()
 {
     onpart += 1.f;

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -107,11 +107,6 @@ public:
     void SetStageDoneSteps(float parts);
     // Set MoveList's progress within the current stage [0.0; 1.0)
     void SetStageProgress(float progress);
-    // Elaborates current step before incrementing stage progress, for do_movelist_move()
-    // FIXME: this method is a part of a hotfix, but it should not exist, because it brings
-    // MoveList object to an inconsistent state. Devise a better solution, keep any necessary
-    // fixups outside of the MoveList instead.
-    bool GetAndForward();
     // Increment current stage's progress, update object position;
     // if the stage is complete, then progress to the next stage;
     // returns if there's a new stage available

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -74,7 +74,7 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     // TODO: find out what this value means and refactor
     int need_to_fix_sprite = 0;
     const int old_stage = cmls.GetStage();
-    if (cmls.GetAndForward())
+    if (cmls.Forward())
     {
         pos_x = cmls.GetCurrentPos().X;
         pos_y = cmls.GetCurrentPos().Y;


### PR DESCRIPTION
Fix #2744

This reimplements a default AGS behavior where character will keep at the previous position for 1 frame more before starting to move along the path.
Previously this worked because MoveList returned a *previous* position when updating. It is now returning a *new* position after a MoveList refactor and a introduction of MotionPath api. Therefore the "animation first" behavior has to be implemented in another way.
IMHO it's reasonable to not have this logic inside MoveList, as that makes MoveList having inconsistent state; instead this logic shall be a part of the Character which decides when to animate and when to move along the path.
Users of the MotionPath api can do according to their desire in script.

@AlanDrake , please try this and tell if this seems working to you. I checked that it does 1 walk frame before starting to move, and right after turning, but I could have missed something.