### PR TITLE
AGS 4: support creating ShaderProgram from a string in script

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -663,6 +663,15 @@ enum StringSplitOptions {
 };
 #endif // SCRIPT_API_v400
 
+#ifdef SCRIPT_API_v400_18
+enum ShaderLanguageType {
+    eShaderNotSupported = 0,
+    eShaderGLSL = 1,
+    eShaderHLSL = 2
+};
+#endif // SCRIPT_API_v400_18
+
+
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
   import static String Format(__format const string format, ...);    // $AUTOCOMPLETESTATICONLY$
@@ -2372,6 +2381,10 @@ builtin struct System {
   /// Gets/sets whether the engine displays the FPS counter
   import static attribute bool DisplayFPS; // $AUTOCOMPLETESTATICONLY$
 #endif // SCRIPT_API_v362
+#ifdef SCRIPT_API_v400_18
+  /// Gets a shader language type supported by the active graphics driver
+  import static readonly attribute ShaderLanguageType ShaderLanguage;
+#endif // SCRIPT_API_v400_18
 };
 
 builtin managed struct Object {
@@ -3384,6 +3397,10 @@ builtin managed struct MotionPath {
 builtin managed struct ShaderProgram {
   /// Creates a new ShaderProgram by either loading a precompiled shader, or reading source code and compiling one.
   import static ShaderProgram* CreateFromFile(const string filename); // $AUTOCOMPLETESTATICONLY$
+  /// Creates a new ShaderProgram by compiling a shader from the given script, using an optional shader definition config in INI format
+  import static ShaderProgram* CreateFromString(const string name, const string shaderScript, const string shaderDef); // $AUTOCOMPLETESTATICONLY$
+  // Creates a new "stub" ShaderProgram that does nothing
+  import static ShaderProgram* CreateShaderStub(const string name); // $AUTOCOMPLETESTATICONLY$
   /// Creates a new shader instance of this shader program.
   import ShaderInstance* CreateInstance();
   /// Gets the default shader instance of this shader program.

--- a/Engine/ac/dynobj/scriptshader.h
+++ b/Engine/ac/dynobj/scriptshader.h
@@ -38,10 +38,14 @@ public:
     static void ResetFreeIndexes();
 
     ScriptShaderProgram() = default;
-    ScriptShaderProgram(const String &filename);
+
+    static ScriptShaderProgram *CreateFileBased(const String &filename);
+    static ScriptShaderProgram *CreateScriptBased(const String &name, const String &script, const String &def_script);
 
     const String &GetName() const { return _name; }
     const String &GetFilename() const { return _filename; }
+    const String &GetShaderScript() const { return _script; }
+    const String &GetDefinitionScript() const { return _defScript; }
     uint32_t GetID() const { return _id; }
     int GetDefaultInstanceHandle() const { return _defaultInstanceHandle; }
     ScriptShaderInstance *GetDefaultInstance() const;
@@ -62,11 +66,16 @@ public:
     void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
 
 private:
+    size_t CalcHeaderSize();
     size_t CalcSerializeSize(const void *address) override;
     void   Serialize(const void *address, AGS::Common::Stream *out) override;
 
     String _name;
     String _filename;
+    // Script is saved for shaders created from the script string
+    String _script;
+    // Definition script is saved for shaders created from the script string
+    String _defScript;
     uint32_t _id = NullShaderID;
     int _defaultInstanceHandle = 0;
     mutable ScriptShaderInstance *_defaultInstance = nullptr;

--- a/Engine/ac/shader_script.h
+++ b/Engine/ac/shader_script.h
@@ -20,8 +20,11 @@
 
 #include "ac/dynobj/scriptshader.h"
 
-// Creates a new shader and registers a ScriptShaderProgram object
-ScriptShaderProgram *CreateScriptShaderProgram(const char *filename);
+// Creates a new shader by reading either a precompiled shader object,
+// or reading and compiling a script; registers a ScriptShaderProgram object
+ScriptShaderProgram *CreateScriptShaderProgramFromFile(const char *filename);
+// Creates a new shader by compiling a script; registers a ScriptShaderProgram object
+ScriptShaderProgram *CreateScriptShaderProgramFromScript(const char *shader_scr);
 // Creates a new shader instance and registers a ScriptShaderInstance object
 ScriptShaderInstance *ShaderProgram_CreateInstance(ScriptShaderProgram *sc_shader);
 // Restore shaders and shader instances after loading a save

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -93,6 +93,16 @@ int System_GetScrollLock()
     return (state[SDL_SCANCODE_SCROLLLOCK]) ? 1 : 0;
 }
 
+int System_GetShaderLanguage()
+{
+    const String &drv_name = gfxDriver->GetDriverID();
+    if (drv_name.CompareNoCase("ogl") == 0)
+        return kShaderLang_GLSL;
+    if (drv_name.CompareNoCase("d3d9") == 0)
+        return kShaderLang_HLSL;
+    return kShaderLang_NotSupported;
+}
+
 int System_GetVsync() {
     return scsystem.vsync;
 }
@@ -389,6 +399,11 @@ RuntimeScriptValue Sc_System_GetScrollLock(const RuntimeScriptValue *params, int
     API_SCALL_INT(System_GetScrollLock);
 }
 
+RuntimeScriptValue Sc_System_GetShaderLanguage(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(System_GetShaderLanguage);
+}
+
 // int ()
 RuntimeScriptValue Sc_System_GetSupportsGammaControl(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -513,6 +528,7 @@ void RegisterSystemAPI()
         { "System::set_RenderAtScreenResolution", API_FN_PAIR(System_SetRenderAtScreenResolution) },
         { "System::get_RuntimeInfo",          API_FN_PAIR(System_GetRuntimeInfo) },
         { "System::get_ScrollLock",           API_FN_PAIR(System_GetScrollLock) },
+        { "System::get_ShaderLanguage",       API_FN_PAIR(System_GetShaderLanguage) },
         { "System::get_SupportsGammaControl", API_FN_PAIR(System_GetSupportsGammaControl) },
         { "System::get_Version",              API_FN_PAIR(System_GetVersion) },
         { "SystemInfo::get_Version",          API_FN_PAIR(System_GetVersion) },

--- a/Engine/ac/system.h
+++ b/Engine/ac/system.h
@@ -20,6 +20,15 @@
 
 #include "ac/dynobj/scriptobjects.h"
 
+// ShaderLanguageType defines the type of the shader language used by
+// the active graphics renderer. This corresponds to the enum in script API.
+enum ShaderLanguageType
+{
+    kShaderLang_NotSupported = 0,
+    kShaderLang_GLSL = 1,
+    kShaderLang_HLSL = 2
+};
+
 int     System_GetColorDepth();
 int     System_GetOS();
 const char *System_GetVersion();


### PR DESCRIPTION
Implements following api:

`static ShaderProgram.CreateFromString(name, shaderScript, shaderDef)`

creates a ShaderProgram compiled from the given shaderScript string, optionally using a "shader definition" config in INI format (currently only used by Direct3D).

`static ShaderProgram.CreateShaderStub(name)`

creates a ShaderProgram that does nothing (no-op).

`static readonly ShaderLanguageType System.ShaderLanguage`

returns the shader language type used by the active gfx driver

The ShaderLanguageType is defined as:
```
enum ShaderLanguageType {
    eShaderNotSupported = 0,
    eShaderGLSL = 1,
    eShaderHLSL = 2
};
```

**NOTES:**

The ShaderProgram created from string will keep the whole shader script in memory and serialize one into game saves in order to recreate itself after save's restoration.
However, since it has only a string in language used at a time when it was created, so unlike the shaders created from file, it won't be able to automatically re-initialize if the gfx driver changes.
That is something that the user has to resolve in script. I suppose, they might save the ShaderLanguageType in a variable and check that variable's value after the save is restored.

In summary, on upside this api lets to create custom shaders programmatically in script, but on a downside user has to also script switching shaders if a gfx driver have changed in between the game sessions.