### PR TITLE
Doc: Create RFCs doc structure with template and example

### DIFF
--- a/RFCs/QUICK_REFERENCE.md
+++ b/RFCs/QUICK_REFERENCE.md
@@ -1,0 +1,151 @@
+# AGS RFC Quick Reference
+
+## TL;DR - How to Submit an RFC
+
+1. **Copy the template**: `cp RFCs/templates/rfc-template.md RFCs/drafts/0000-my-feature.md`
+2. **Fill it out**: Replace placeholder text with your proposal details
+3. **Choose component type**: Mark as `[EDITOR]`, `[ENGINE]`, `[EDITOR AND ENGINE]`, `[INFRASTRUCTURE]`, or `[DOCUMENTATION]`
+4. **Submit PR**: Open a pull request with your RFC
+5. **Iterate**: Respond to feedback and refine your proposal
+
+## RFC Types & Examples
+
+| Type | When to Use | Example |
+|------|-------------|---------|
+| `[EDITOR]` | Changes to AGS Editor interface, tools, or functionality | New room editor features, plugin system changes |
+| `[ENGINE]` | Changes to AGS runtime, scripting, or game execution | New script functions, graphics features, platform support |
+| `[EDITOR AND ENGINE]` | Changes affecting both Editor and Engine | File format changes, cross-component architecture |
+| `[INFRASTRUCTURE]` | Build system, CI/CD, project structure | CMake changes, new deployment processes |
+| `[DOCUMENTATION]` | Major documentation initiatives | API documentation overhaul, tutorial series |
+
+## Common Mistakes to Avoid
+
+❌ **Too vague**: "Make AGS better"  
+✅ **Specific**: "Add real-time lighting system to AGS Engine"
+
+❌ **No motivation**: Jumping straight to technical details  
+✅ **Clear motivation**: Explain the problem you're solving
+
+❌ **Missing alternatives**: Only one solution considered  
+✅ **Consider alternatives**: Compare different approaches
+
+❌ **No backwards compatibility plan**: Breaking changes without migration path  
+✅ **Migration strategy**: How existing users adapt to changes
+
+## Template Checklist
+
+### Required Sections
+
+- [ ] **Summary**: One paragraph overview
+- [ ] **Motivation**: Why this change is needed
+- [ ] **Detailed Design**: Technical specification
+- [ ] **Component Impact**: Editor/Engine changes
+- [ ] **Backwards Compatibility**: Breaking changes and migration
+- [ ] **Alternatives Considered**: Other approaches evaluated
+
+### Recommended Sections
+
+- [ ] **Implementation Plan**: Phased development approach
+- [ ] **Testing Strategy**: How to verify correctness
+- [ ] **Performance Impact**: Resource consumption changes
+- [ ] **Security Considerations**: Security implications
+- [ ] **Community Impact**: Effect on users and ecosystem
+- [ ] **Disclosures**: External references, Stack Overflow answers, AI assistance used
+
+## Review Process
+
+```txt
+Draft → Active → FCP → Accepted → Implemented
+  ↓       ↓       ↓       ↓
+Rejected/Postponed (any stage)
+```
+
+### Status Meanings
+
+- **Draft**: Initial submission, gathering feedback
+- **Active**: Under active discussion and refinement
+- **FCP**: Final Comment Period - last chance for feedback
+- **Accepted**: Approved for implementation
+- **Implemented**: Successfully implemented and deployed
+- **Rejected**: Not moving forward
+- **Postponed**: Valid but not current priority
+
+## File Organization
+
+```txt
+RFCs/
+├── drafts/           # Your RFC starts here
+├── active/           # Under discussion
+├── accepted/         # Approved, awaiting implementation
+├── implemented/      # Completed RFCs
+│   ├── editor/      # Editor-specific
+│   └── engine/      # Engine-specific
+├── rejected/         # Not accepted
+└── postponed/       # Future consideration
+```
+
+## Writing Tips
+
+### Structure Your Argument
+
+1. **Problem Statement**: What's broken or missing?
+2. **Solution Overview**: High-level approach
+3. **Technical Details**: Implementation specifics
+4. **Trade-offs**: Why this approach vs alternatives
+5. **Migration**: How users adapt to changes
+
+### Code Examples
+
+Include code snippets for:
+
+- API changes (C++, C#, AGS Script)
+- Data structure modifications
+- File format changes
+- Configuration examples
+
+### Be Specific
+
+- Use concrete examples over abstract descriptions
+- Include measurable success criteria
+- Specify version targets and timelines
+- Consider edge cases and error scenarios
+
+## Common RFC Patterns
+
+### New Feature RFCs
+
+Focus on: User scenarios, API design, integration points
+
+### Performance RFCs
+
+Focus on: Benchmarks, metrics, trade-offs, profiling
+
+### Breaking Change RFCs
+
+Focus on: Migration path, deprecation timeline, tooling support
+
+### Architecture RFCs
+
+Focus on: System design, component interactions, future extensibility
+
+## Getting Help
+
+- **Template Questions**: Check `RFCs/templates/example-rfc.md`
+- **Process Questions**: See main `RFCs/README.md`
+- **Technical Questions**: Open GitHub issue or discuss with maintainers
+- **Community Discussion**: Use AGS forums or Discord
+
+## Quick Start Commands
+
+```bash
+# Create new RFC
+cp RFCs/templates/rfc-template.md RFCs/drafts/0000-my-feature.md
+
+# Edit your RFC
+$EDITOR RFCs/drafts/0000-my-feature.md
+
+# Check against example
+diff RFCs/templates/example-rfc.md RFCs/drafts/0000-my-feature.md
+```
+
+Remember: RFCs are conversations, not demands. Be open to feedback and iteration!

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,0 +1,156 @@
+# AGS Request for Comments (RFC) Process
+
+## What is an RFC?
+
+Request for Comments (RFC) is a process for proposing major changes to the AGS (Adventure Game Studio) project. RFCs provide a consistent and controlled path for new features and significant changes to enter the project, so that all stakeholders can be confident about the direction AGS is evolving in.
+
+## When to Submit an RFC
+
+You should consider writing an RFC if you intend to make "substantial" changes to AGS or its documentation. What constitutes a "substantial" change is evolving based on community norms and varies depending on what part of the ecosystem you are proposing to change, but may include the following:
+
+### AGS Editor RFCs
+
+- New major features or significant changes to the Editor UI/UX
+- Changes to the Editor's plugin system
+- New file formats or major changes to existing formats
+- Significant changes to the build system or project structure
+- Major refactoring of Editor architecture
+
+### AGS Engine RFCs
+
+- New runtime features that affect game behavior
+- Changes to the scripting language syntax or semantics
+- New platform support or significant platform-specific changes
+- Performance improvements that change APIs or behavior
+- Changes to the save/load system or compatibility
+- New graphics, audio, or input features
+
+### General AGS RFCs
+
+- Cross-cutting changes that affect both Editor and Engine
+- Changes to development processes or project governance
+- Major dependency updates or architectural decisions
+
+## RFC Lifecycle
+
+### 1. Pre-RFC Discussion
+
+Before submitting an RFC, consider discussing your idea in:
+
+- GitHub Issues for initial feedback
+- Community forums or Discord channels
+- Direct discussion with maintainers
+
+### 2. RFC Submission
+
+1. Fork the AGS repository
+2. Copy `RFCs/templates/rfc-template.md` to `RFCs/drafts/0000-my-feature.md`
+3. Fill in the RFC template with your proposal
+4. Submit a pull request
+
+### 3. RFC Review Process
+
+- **Draft**: Initial submission and community feedback
+- **Active**: RFC is being actively discussed and refined
+- **Final Comment Period (FCP)**: Last chance for feedback before decision
+- **Accepted**: RFC is approved for implementation
+- **Implemented**: RFC has been successfully implemented
+- **Rejected**: RFC is not moving forward
+- **Postponed**: RFC is valid but not prioritized currently
+
+### 4. Implementation
+
+- Accepted RFCs move to implementation phase
+- Implementation details may evolve during development
+- RFCs are moved to appropriate folders based on status
+
+## Directory Structure
+
+```sh
+RFCs/
+├── README.md                 # This file
+├── templates/
+│   └── rfc-template.md      # RFC template
+├── drafts/                  # RFCs under initial development
+├── active/                  # RFCs under active discussion
+├── accepted/                # Accepted RFCs awaiting implementation
+├── implemented/             # Successfully implemented RFCs
+│   ├── editor/             # Editor-specific implementations
+│   └── engine/             # Engine-specific implementations
+├── rejected/                # RFCs that were not accepted
+└── postponed/              # RFCs postponed for future consideration
+```
+
+## RFC Numbering
+
+RFCs are numbered sequentially starting from 0001. The number is assigned when the RFC is first created. The format is:
+
+- `NNNN-brief-description.md` (e.g., `0001-new-scripting-features.md`)
+
+## Component Classification
+
+Each RFC must clearly identify which components it affects:
+
+- **`[EDITOR]`**: Changes primarily affecting the AGS Editor
+- **`[ENGINE]`**: Changes primarily affecting the AGS Engine/Runtime
+- **`[BOTH]`**: Changes affecting both Editor and Engine
+- **`[INFRASTRUCTURE]`**: Changes to build systems, CI/CD, or project structure
+- **`[DOCUMENTATION]`**: Significant documentation changes or proposals
+
+## Quality Guidelines
+
+### Writing Style
+
+- Be clear and concise
+- Use proper grammar and spelling
+- Include code examples where appropriate
+- Consider multiple perspectives and use cases
+
+### Technical Depth
+
+- Provide sufficient detail for implementation
+- Consider backwards compatibility
+- Address performance implications
+- Include testing strategies
+
+### Community Consideration
+
+- Acknowledge alternative approaches
+- Consider impact on existing users
+- Be open to feedback and iteration
+
+## Decision Making
+
+- RFCs require consensus from core maintainers
+- Community feedback is highly valued and considered
+- Technical merit and project alignment are key factors
+- Backwards compatibility is a strong consideration
+
+## FAQ
+
+### How long does the RFC process take?
+
+The process varies based on complexity and consensus. Simple RFCs might be resolved in weeks, while complex architectural changes could take months.
+
+### Can I implement before RFC acceptance?
+
+You can create proof-of-concept implementations to support your RFC, but substantial implementation work should wait for acceptance.
+
+### What if my RFC is rejected?
+
+Rejection doesn't mean the idea is bad. Common reasons include timing, resource constraints, or need for more development. You can revise and resubmit.
+
+### How do I get feedback on my RFC?
+
+- Comment on the RFC pull request
+- Engage in community forums
+- Reach out to relevant maintainers
+- Present at community meetings if available
+
+## Contributing
+
+We encourage participation from all community members. Whether you're proposing changes, reviewing RFCs, or providing feedback, your involvement helps shape AGS's future.
+
+---
+
+For questions about the RFC process, please open an issue or reach out to the maintainers.

--- a/RFCs/accepted/.gitkeep
+++ b/RFCs/accepted/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the accepted directory is tracked by git
+# Accepted RFCs awaiting implementation are placed here 

--- a/RFCs/active/.gitkeep
+++ b/RFCs/active/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the active directory is tracked by git
+# RFCs under active discussion are placed here 

--- a/RFCs/drafts/.gitkeep
+++ b/RFCs/drafts/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the drafts directory is tracked by git
+# RFCs in draft status are placed here during initial development 

--- a/RFCs/implemented/editor/.gitkeep
+++ b/RFCs/implemented/editor/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the implemented/editor directory is tracked by git
+# Implemented Editor-specific RFCs are archived here 

--- a/RFCs/implemented/engine/.gitkeep
+++ b/RFCs/implemented/engine/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the implemented/engine directory is tracked by git
+# Implemented Engine-specific RFCs are archived here 

--- a/RFCs/postponed/.gitkeep
+++ b/RFCs/postponed/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the postponed directory is tracked by git
+# RFCs postponed for future consideration are placed here 

--- a/RFCs/rejected/.gitkeep
+++ b/RFCs/rejected/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the rejected directory is tracked by git
+# RFCs that were not accepted are archived here for future reference 

--- a/RFCs/templates/example-rfc.md
+++ b/RFCs/templates/example-rfc.md
@@ -1,0 +1,434 @@
+# RFC 0001: Engine Log Panel Integration for AGS Editor
+
+- **RFC Number**: 0001
+- **Title**: Engine Log Panel Integration for AGS Editor
+- **Author(s)**: Erico Porto (@ericoporto)
+- **Status**: Implemented
+- **Type**: EDITOR AND ENGINE
+- **Created**: 2023-05-08
+- **AGS Version Target**: 3.6.1
+
+## Summary
+
+Add a log panel to the AGS Editor that displays real-time engine log output during game testing and debugging. This panel integrates engine logging directly into the Editor interface, providing developers with immediate access to game runtime information without requiring external tools or file monitoring.
+
+## Motivation
+
+Game developers frequently need to monitor log output during development and debugging. Currently, AGS logs are written to files or console output, requiring developers to switch between the Editor and external tools to view runtime information. This creates a fragmented debugging experience and slows down the development workflow.
+
+### Problems Addressed
+
+- Developers must monitor separate log files or console windows during debugging
+- No integrated way to view engine log output within the Editor
+- Difficult to correlate Editor actions with engine log messages
+- Limited filtering and search capabilities for log analysis
+- No persistent log viewing configuration across Editor sessions
+
+### Success Criteria
+
+- Log messages appear in real-time within the Editor during game testing
+- Developers can filter log messages by level and category
+- Log panel integrates seamlessly with Editor's docking system
+- Minimal performance impact on both Editor and Engine
+- Configuration persists across Editor sessions
+
+## Detailed Design
+
+### Overview
+
+The log panel feature creates a bidirectional communication channel between the AGS Engine and Editor. The Engine sends log messages through a new debugger interface, while the Editor displays these messages in a dockable panel with filtering, search, and management capabilities.
+
+### Component Impact
+
+#### AGS Editor Changes
+
+- **UI/UX Changes**: New dockable Log Panel with toolbar and rich text display
+- **File Format Changes**: Log configuration stored in Game.agf.user file
+- **Plugin System**: New DebugLogComponent for panel management
+- **Build System**: Integration with existing debugger interface
+
+#### AGS Engine Changes
+
+- **Runtime Behavior**: New DebuggerLogOutputTarget sends messages to Editor
+- **Scripting API**: No changes to script API - transparent logging
+- **Platform Support**: Available on all platforms where Editor debugging is supported
+- **Performance**: Minimal impact - only active during Editor debugging sessions
+- **Save/Load**: No impact on game save/load functionality
+
+#### Cross-Component Changes
+
+- **Communication Protocol**: Extension of existing IDE debugger interface
+- **Shared Data Structures**: Log message format and filtering parameters
+- **Build Pipeline**: Coordinated logging initialization during game testing
+
+### Technical Specification
+
+#### API Changes
+
+##### Engine API (C++)
+
+```cpp
+// Engine: New log output target
+class DebuggerLogOutputTarget : public IOutputTarget {
+public:
+    void PrintMessage(const LogMessage &msg) override;
+    void Initialize(const ConfigNode &config) override;
+    void Shutdown() override;
+};
+
+// Command line argument support
+// --log-debugger=OUTPUT_LEVEL
+```
+
+##### Editor API (C#)
+
+```csharp
+// Editor: New debug log component
+public class DebugLogComponent : IEditorComponent {
+    public void Initialize(AGSEditor editor);
+    public void GameSettingsChanged();
+    public void RefreshDataFromGame();
+    // ... other IEditorComponent members
+}
+
+// Editor: Log panel dockable content
+public class LogPanel : DockContent {
+    public LogBuffer LogBuffer { get; }
+    public LogFilterConfig FilterConfig { get; set; }
+    public void UpdateLogDisplay();
+    public void ClearLog();
+}
+```
+
+##### AGS Script API
+
+```cpp
+// New LogLevel enum added in SCRIPT_API_v360
+enum LogLevel {
+  eLogAlert = 1,
+  eLogFatal = 2,
+  eLogError = 3,
+  eLogWarn = 4,
+  eLogInfo = 5,
+  eLogDebug = 6
+};
+
+// New function added to System struct in SCRIPT_API_v360:
+// builtin struct System {
+//   import static void Log(LogLevel level, const string format, ...);
+// }
+
+// Usage examples:
+System.Log(LogLevel.Info, "This message appears in Editor log panel");
+System.Log(LogLevel.Warn, "Warning message with formatting: %d", someValue);
+System.Log(LogLevel.Error, "Error occurred in function %s", functionName);
+
+// All existing AbortGame calls with messages also appear in log panel
+AbortGame("Game aborted - message appears in log panel");
+```
+
+**Script API Impact:**
+
+- **New Functions**: `System.Log(LogLevel level, const string format, ...)` - added to System struct for structured logging
+- **New Enums**: `LogLevel` enum with six severity levels (Alert, Fatal, Error, Warn, Info, Debug)
+- **Modified Structs**: `System` struct extended with new `Log` function in SCRIPT_API_v360
+- **Modified Functions**: Existing `AbortGame()` messages now also appear in Editor log panel
+- **Deprecated Functions**: None
+- **Breaking Changes**: None - fully backwards compatible
+- **Backwards Compatibility**: All existing scripts work unchanged; new `System.Log` provides enhanced logging capabilities
+
+#### Data Structures
+
+```csharp
+// Circular buffer for efficient log storage
+public class LogBuffer {
+    private readonly ConcurrentCircularBuffer<LogEntry> _buffer;
+    public int Capacity { get; }
+    public void AddEntry(LogEntry entry);
+    public IEnumerable<LogEntry> GetEntries();
+}
+
+// Log filtering configuration
+public class LogFilterConfig {
+    public LogLevel MinLevel { get; set; }
+    public Dictionary<LogGroup, LogLevel> GroupLevels { get; set; }
+    public bool EnableTimestamps { get; set; }
+}
+```
+
+#### File Format Changes
+
+```xml
+<!-- Game.agf.user - Log panel configuration -->
+<GameSettings>
+  <LogPanel>
+    <MinLevel>Info</MinLevel>
+    <GroupLevels>
+      <Main>Debug</Main>
+      <Game>Info</Game>
+      <Script>Warn</Script>
+    </GroupLevels>
+    <AutoGlue>true</AutoGlue>
+    <Font>Consolas</Font>
+    <FontSize>9</FontSize>
+  </LogPanel>
+</GameSettings>
+```
+
+### Implementation Plan
+
+#### Phase 1: Core Infrastructure
+
+- [x] Create DebuggerLogOutputTarget in Engine
+- [x] Implement basic message passing through debugger interface
+- [x] Add LogBuffer with circular buffer implementation
+- [x] Create basic LogPanel UI structure
+
+#### Phase 2: Panel Integration
+
+- [x] Integrate LogPanel as DockContent for window management
+- [x] Add toolbar with Run, Pause, Clear functionality
+- [x] Implement log filtering system
+- [x] Add configuration persistence to Game.agf.user
+
+#### Phase 3: Enhanced Features
+
+- [x] Add "Glue" mode for automatic scrolling
+- [x] Implement Copy and Copy All functionality
+- [x] Add font and font size preferences
+- [x] Optimize panel redrawing and text updates
+
+### Testing Strategy
+
+#### Unit Tests
+
+- LogBuffer circular buffer functionality
+- Log message filtering and level checking
+- Configuration serialization/deserialization
+
+#### Integration Tests
+
+- Engine-to-Editor log message transmission
+- Panel UI responsiveness during high-frequency logging
+- Configuration persistence across Editor sessions
+
+#### User Acceptance Tests
+
+- Usability testing with game developers
+- Performance impact during extended debugging sessions
+- Integration with existing Editor workflow
+
+## Backwards Compatibility
+
+### Breaking Changes
+
+None - this is an additive feature that doesn't affect existing functionality.
+
+### Migration Path
+
+Not applicable - purely additive feature. Existing projects work unchanged.
+
+### Deprecation Timeline
+
+Not applicable.
+
+## Alternatives Considered
+
+### Alternative 1: File-Based Log Monitoring
+
+**Pros:**
+
+- Simpler implementation
+- No need for debugger interface changes
+- Works with existing log files
+
+**Cons:**
+
+- File I/O overhead and locking issues
+- Delayed log updates due to file buffering
+- No real-time filtering capabilities
+- Platform-specific file monitoring APIs
+
+**Why not chosen:** Real-time integration provides better developer experience.
+
+### Alternative 2: Separate Log Viewer Application
+
+**Pros:**
+
+- Independent development and deployment
+- Could support multiple AGS versions
+- Potentially more advanced log analysis features
+
+**Cons:**
+
+- Additional tool to install and manage
+- No integration with Editor workflow
+- Requires separate communication protocol
+- Complex synchronization with Editor state
+
+**Why not chosen:** Integrated solution provides seamless workflow.
+
+### Alternative 3: Console Window Integration
+
+**Pros:**
+
+- Reuses existing console output infrastructure
+- Familiar to developers from other environments
+
+**Cons:**
+
+- Platform-specific console handling
+- Limited formatting and filtering options
+- Cannot integrate with Editor's docking system
+- Poor user experience on some platforms
+
+**Why not chosen:** Dockable panel provides better integration and usability.
+
+## Dependencies
+
+### External Dependencies
+
+- Windows Forms RichTextBox for log display
+- .NET concurrent collections for thread-safe buffering
+
+### Internal Dependencies
+
+- Existing AGS Editor debugger interface
+- Editor's docking panel system (WeifenLuo.WinFormsUI.Docking)
+- Engine's logging system and IOutputTarget interface
+
+### Platform Dependencies
+
+- Windows: Full feature support
+- Linux/macOS: Limited to platforms where Editor runs
+
+## Security Considerations
+
+- **Attack Vectors**: Log messages could potentially contain sensitive game data
+- **Mitigation Strategies**: Only enabled during debugging sessions, not in release builds
+- **Trust Boundaries**: Log panel has access to all engine log output during debugging
+
+## Performance Impact
+
+### Memory Usage
+
+- Fixed-size circular buffer (configurable, default ~1000 entries)
+- Approximately 100KB additional memory per active debugging session
+- Automatic cleanup when buffer is full
+
+### CPU Usage
+
+- Minimal impact during normal operation
+- Text rendering optimization to prevent UI freezing
+- Background thread for log message processing
+
+### Storage
+
+- Configuration stored in Game.agf.user (few KB)
+- No persistent log storage - runtime only
+
+### Network
+
+Not applicable - local communication only.
+
+## Documentation Impact
+
+### User Documentation
+
+- New section in AGS Editor manual covering log panel usage
+- Tutorial on debugging workflow with integrated logging
+- Configuration options and filtering documentation
+
+### Developer Documentation
+
+- API documentation for DebuggerLogOutputTarget
+- Integration guide for custom log output targets
+- Panel customization and extension examples
+
+### Examples and Tutorials
+
+- Sample debugging scenarios using log panel
+- Log filtering best practices
+- Integration with existing debugging workflows
+
+## Community Impact
+
+### User Experience
+
+Significantly improved debugging experience with integrated log viewing and real-time filtering.
+
+### Learning Curve
+
+Minimal - uses familiar logging concepts with intuitive panel interface.
+
+### Ecosystem Impact
+
+- Enables better debugging practices in AGS community
+- May inspire additional Editor panel integrations
+- Provides foundation for future debugging tools
+
+## Open Questions
+
+- ~~Should the log panel support custom color themes?~~ (Resolved: Uses Editor's existing theme system)
+- ~~What should be the default buffer size for the circular buffer?~~ (Resolved: 1000 entries)
+- ~~Should there be keyboard shortcuts for log panel operations?~~ (Resolved: Standard Editor shortcuts apply)
+
+## Future Possibilities
+
+This RFC enables future enhancements like:
+
+- Advanced log search and filtering capabilities
+- Log message bookmarking and annotations
+- Export functionality for log analysis
+- Integration with external debugging tools
+- Performance profiling based on log timing data
+
+## References
+
+- [PR #1999: Editor: feature log panel](https://github.com/adventuregamestudio/ags/pull/1999)
+- [Issue #1362: Read engine Log in the Editor](https://github.com/adventuregamestudio/ags/issues/1362)
+- [Previous attempt PR #1518](https://github.com/adventuregamestudio/ags/pull/1518)
+- [Previous attempt PR #1989](https://github.com/adventuregamestudio/ags/pull/1989)
+- [WeifenLuo.WinFormsUI.Docking Documentation](https://github.com/dockpanelsuite/dockpanelsuite)
+
+## Disclosures
+
+### External References
+
+- **Documentation**: AGS Editor documentation, WeifenLuo.WinFormsUI.Docking library documentation
+- **Stack Overflow**: [C# RichTextBox performance optimization](https://stackoverflow.com/questions/1259355/how-to-prevent-flickering-in-listview-when-updating-a-single-listviewitems-text) - for UI optimization techniques
+- **Other Sources**: Microsoft .NET Framework documentation for concurrent collections and WinForms components
+
+### AI Assistance
+
+- **AI Used**: Yes
+- **Application/Service**: Claude (Anthropic)
+- **Model Version**: Claude 3.5 Sonnet
+- **Usage Description**: AI was used to help structure and write portions of this example RFC document, including technical sections, formatting, and documentation best practices. The AI analyzed the actual PR #1999 implementation details and AGS script definitions to create accurate technical content.
+- **Human Review**: All AI-generated content was reviewed for technical accuracy against the actual implementation, with corrections made for API details, script function signatures, and implementation specifics.
+
+*Note: This disclosure helps maintain transparency about the sources and methods used in creating this RFC, ensuring proper attribution and allowing reviewers to assess the content appropriately.*
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2023-05-08 | Erico Porto | Initial draft based on previous attempts |
+| 2023-05-25 | Erico Porto | Updated with DockContent implementation and panel integration |
+| 2023-05-27 | Erico Porto | Final implementation notes and Wine compatibility fixes |
+
+## Implementation Tracking
+
+### Implementation Status
+
+- [x] Design finalized
+- [x] Core implementation
+- [x] Testing complete
+- [x] Documentation updated
+- [x] Released
+
+### Implementation Notes
+
+Successfully implemented in AGS 3.6.1. The log panel integrates seamlessly with the Editor's docking system and provides real-time log viewing during game testing. Some minor Wine-specific issues were discovered but don't affect the core functionality on supported platforms.

--- a/RFCs/templates/rfc-template.md
+++ b/RFCs/templates/rfc-template.md
@@ -1,0 +1,326 @@
+# RFC NNNN: [Title]
+
+- **RFC Number**: NNNN
+- **Title**: [Brief, descriptive title]
+- **Author(s)**: [Your name and contact info]
+- **Status**: Draft
+- **Type**: [EDITOR | ENGINE | EDITOR AND ENGINE | INFRASTRUCTURE | DOCUMENTATION]
+- **Created**: [YYYY-MM-DD]
+- **AGS Version Target**: [e.g., 4.x, 3.x]
+
+## Summary
+
+[One paragraph explanation of the feature or change being proposed.]
+
+## Motivation
+
+[Why are we doing this? What use cases does it support? What is the expected outcome?]
+
+### Problems Addressed
+
+- [Problem 1]
+- [Problem 2]
+- [Problem 3]
+
+### Success Criteria
+
+- [Measurable success criterion 1]
+- [Measurable success criterion 2]
+
+## Detailed Design
+
+### Overview
+
+[High-level architectural overview of the proposed changes.]
+
+### Component Impact
+
+#### AGS Editor Changes
+
+[If applicable, describe changes to the Editor]
+
+- **UI/UX Changes**: [Describe any user interface modifications]
+- **File Format Changes**: [Any new or modified file formats]
+- **Plugin System**: [Impact on plugin architecture]
+- **Build System**: [Changes to compilation or packaging]
+
+#### AGS Engine Changes
+
+[If applicable, describe changes to the Engine]
+
+- **Runtime Behavior**: [How game execution is affected]
+- **Scripting API**: [New or modified script functions/properties]
+- **Platform Support**: [Platform-specific considerations]
+- **Performance**: [Expected performance impact]
+- **Save/Load**: [Impact on game state persistence]
+
+#### Cross-Component Changes
+
+[If applicable, describe changes that affect both Editor and Engine]
+
+- **Communication Protocol**: [How Editor and Engine interact]
+- **Shared Data Structures**: [Common formats or APIs]
+- **Build Pipeline**: [Integration between components]
+
+### Technical Specification
+
+#### API Changes
+
+##### Engine API (C++)
+
+```cpp
+// Example C++ API changes for Engine
+class NewFeature {
+public:
+    void DoSomething(int param);
+    int GetValue() const;
+};
+```
+
+##### Editor API (C#)
+
+```csharp
+// Example C# API changes for Editor
+public class EditorFeature
+{
+    public void ProcessData(string input);
+    public bool IsEnabled { get; set; }
+}
+```
+
+##### AGS Script API
+
+```cpp
+builtin struct System {
+  import void Example(int param);
+}
+```
+
+**Script API Impact:**
+
+- **New Functions**: List any new script functions added
+- **Modified Functions**: List functions with changed behavior or parameters
+- **Deprecated Functions**: List functions being deprecated
+- **Breaking Changes**: List any script-breaking changes
+- **Backwards Compatibility**: How existing scripts are affected
+
+#### Data Structures
+
+[Define new data structures or modifications to existing ones]
+
+#### File Format Changes
+
+[If applicable, document changes to .agf, .crm, or other file formats]
+
+```json
+{
+  "newField": "value",
+  "existingField": "modified_structure"
+}
+```
+
+### Implementation Plan
+
+#### Phase 1: [Foundation]
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+#### Phase 2: [Core Implementation]
+
+- [ ] Task 1
+- [ ] Task 2
+
+#### Phase 3: [Integration & Polish]
+
+- [ ] Task 1
+- [ ] Task 2
+
+### Testing Strategy
+
+#### Unit Tests
+
+- [Describe unit testing approach]
+
+#### Integration Tests
+
+- [Describe integration testing approach]
+
+#### User Acceptance Tests
+
+- [Describe user testing scenarios]
+
+#### Regression Tests
+
+- [Describe backwards compatibility testing]
+
+## Backwards Compatibility
+
+### Breaking Changes
+
+[List any breaking changes and their justification]
+
+### Migration Path
+
+[Describe how existing projects/users can migrate]
+
+### Deprecation Timeline
+
+[If applicable, outline deprecation schedule]
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+**Pros:**
+
+- [Advantage 1]
+- [Advantage 2]
+
+**Cons:**
+
+- [Disadvantage 1]
+- [Disadvantage 2]
+
+**Why not chosen:** [Explanation]
+
+### Alternative 2: [Name]
+
+[Similar structure as above]
+
+### Do Nothing
+
+**Pros:**
+
+- [Advantage of status quo]
+
+**Cons:**
+
+- [Problems that remain unsolved]
+
+## Dependencies
+
+### External Dependencies
+
+- [New libraries or tools required]
+
+### Internal Dependencies
+
+- [Dependencies on other AGS components or RFCs]
+
+### Platform Dependencies
+
+- [Platform-specific requirements]
+
+## Security Considerations
+
+[Analyze any security implications of the proposed changes]
+
+- **Attack Vectors**: [Potential security risks]
+- **Mitigation Strategies**: [How risks are addressed]
+- **Trust Boundaries**: [Changes to security model]
+
+## Performance Impact
+
+### Memory Usage
+
+[Expected impact on memory consumption]
+
+### CPU Usage
+
+[Expected impact on processing performance]
+
+### Storage
+
+[Expected impact on file sizes or disk usage]
+
+### Network
+
+[If applicable, network performance considerations]
+
+## Documentation Impact
+
+### User Documentation
+
+- [Documentation that needs to be updated]
+
+### Developer Documentation
+
+- [API documentation updates]
+
+### Examples and Tutorials
+
+- [New examples or tutorial updates needed]
+
+## Community Impact
+
+### User Experience
+
+[How this affects game developers using AGS]
+
+### Learning Curve
+
+[Complexity added or removed for users]
+
+### Ecosystem Impact
+
+[Effect on plugins, tools, or community resources]
+
+## Open Questions
+
+- [Unresolved question 1]
+- [Unresolved question 2]
+- [Decision point that needs community input]
+
+## Future Possibilities
+
+[What this RFC makes possible in the future, without committing to implementation]
+
+## References
+
+- [Link to relevant discussions]
+- [Related RFCs or issues]
+- [External documentation or standards]
+
+## Disclosures
+
+### External References
+
+- **Documentation**: [List any official documentation, manuals, or specifications consulted]
+- **Stack Overflow**: [List any Stack Overflow questions/answers referenced, with links]
+- **Other Sources**: [Books, articles, blog posts, or other materials referenced]
+
+### AI Assistance
+
+- **AI Used**: [Yes/No - if Yes, complete the following]
+- **Application/Service**: [e.g., ChatGPT, Claude, GitHub Copilot, etc.]
+- **Model Version**: [e.g., GPT-4, Claude 3.5 Sonnet, etc.]
+- **Usage Description**: [How AI was used - e.g., "Used for initial draft writing", "Code review and optimization suggestions", "Research assistance", "Technical explanation clarification", etc.]
+- **Human Review**: [Describe how AI-generated content was reviewed, validated, and modified by human authors]
+
+*Note: This disclosure helps maintain transparency about the sources and methods used in creating this RFC, ensuring proper attribution and allowing reviewers to assess the content appropriately.*
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| YYYY-MM-DD | [Author] | Initial draft |
+
+## Implementation Tracking
+
+[This section is updated during implementation]
+
+### Implementation Status
+
+- [ ] Design finalized
+- [ ] Core implementation
+- [ ] Testing complete
+- [ ] Documentation updated
+- [ ] Released
+
+### Implementation Notes
+
+[Notes about implementation decisions that differ from the RFC]


### PR DESCRIPTION
## Background

Significant changes to the AGS source code are currently a bit convoluted to discuss. Sometimes it happens in GitHub issues, the AGS Forum, Discord, or directly in the PR. The PR can be the most dangerous because the change can be rejected, causing the most expensive work—writing actual code — to be lost.

As one example, I'd like to significantly change the Editor code to make it more flexible, maintainable, and adaptable for future cross-platform development or potential UI library changes. However, I'd like to get some feedback and talk about my plans before making code changes, so I don't surprise anyone when the PRs start appearing.

## Enter the RFC

Request For Comments, or RFCs, are a good way to accomplish this. The user creates a document that can be commented on via the regular PR review process, and then the outcome can be tracked and logged for historical reasons. This also allows developers to gather feedback and gauge the appetite for a change.

## This change

This provides a template based on best practices, along with an example of how the Log Panel could have been proposed. The initial submission is extensive and is open to feedback and changes to adjust the requirements for the RFC, as well as the process.

## AI Disclosure

I used Anthropic's Claude Sonnet 4 to generate this change, and then manually reviewed and made some adjustments. I've reviewed the generated structure and agreed that this is a typical pattern I've seen in other RFCs; I did my best to ensure that it didn't introduce any hallucinations. If you notice anything unusual, I can always edit it out or make changes.