### PR TITLE
New compiler: Fix bugs around `null` as an argument for a function parameter

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1729,9 +1729,10 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
         return false;
 
 
-    // Can convert 'null' to dynpointer or dynarray
+    // Can convert 'null' to dynpointer or dynarray or 'const string'
     if (kKW_Null == vartype_is)
         return
+            _sym.VartypeWithout(VTT::kConst, vartype_wants_to_be) != kKW_String &&
             !_sym.IsDynpointerVartype(vartype_wants_to_be) &&
             !_sym.IsDynarrayVartype(vartype_wants_to_be);
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3062,7 +3062,7 @@ void AGS::Parser::AccessData_FunctionCall_AnalyseFormatString(std::vector<FuncPa
         }
 
         // Letters that define a format  to be printed
-        static std::string const format_letters = "AEFGXacdefgiosux";
+        static std::string const format_letters = "AEFGXacdefgiopsux";
         // Modifiers that can be in beween '%' and the respective format letter
         static std::string const modifiers = "hjLltz";
         // Symbols that can be in beween '%' and the respective format letter

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3248,8 +3248,10 @@ void AGS::Parser::AccessData_FunctionCall_Arguments_Push(Symbol name_of_func, bo
                 break;
 
             case 's':
+                // Also let through 'null'
                 // Also let through one-dimensional classic arrays of 'char'
-                if (!_sym.IsAnyStringVartype(arg_vartype) &&
+                if (arg_vartype != kKW_Null &&
+                    !_sym.IsAnyStringVartype(arg_vartype) &&
                     !(  _sym[arg_vartype].VartypeD->Type == VTT::kArray &&
                         _sym[arg_vartype].VartypeD->Dims.size() == 1u &&
                         _sym[arg_vartype].VartypeD->BaseVartype == kKW_Char))

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -1139,3 +1139,23 @@ TEST_F(Compile2, NullAsConstOldstringArgument) {
 
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 }
+
+TEST_F(Compile2, NullAsStringArgument) {
+
+    // Must be able to assign 'null' to a String parameter
+
+    std::string inpl = R"%&/(
+        int func(__format String s, ...)
+        {
+            func(null);
+            func("%s", null);
+        }
+        )%&/";
+
+    inpl = kAgsHeaderBool + (kAgsHeaderString + inpl);
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -1122,3 +1122,20 @@ TEST_F(Compile2, FormatFunction07)
 
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 }
+
+TEST_F(Compile2, NullAsConstOldstringArgument) {
+
+    // Must be able to assign 'null' to a "const string" parameter
+
+    char const *inpl = R"%&/(
+        int func(const string s)
+        {
+            func(null);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+}

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -1123,6 +1123,29 @@ TEST_F(Compile2, FormatFunction07)
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 }
 
+
+TEST_F(Compile2, FormatFunction08)
+{
+    // Modifiers and new format specifiers
+
+    char const *inpl = R"%&/(
+        import void foo(__format const string f, ...);
+        managed struct str { int Payload; };
+
+        int game_start()
+        {
+            str *s = new str;
+            str s_array[] = new str[10];
+            foo("%p %p", s_array, s);
+        }
+        )%&/";
+
+    int compile_result = cc_compile(inpl, kNoOptions, scrip, mh);
+    std::string const &err_msg = mh.GetError().Message;
+
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
+}
+
 TEST_F(Compile2, NullAsConstOldstringArgument) {
 
     // Must be able to assign 'null' to a "const string" parameter


### PR DESCRIPTION
Fixes #2781

Fix a bug where the compiler wouldn't accept `null` as an argument for a `string` or `const string` parameter.

Typical code:
```
int func(const string s)
{
    func(null); // ← Erroneous error message here
}
```

I'm taking this as an opportunity to also fix a bug where the compiler wouldn't accept `null` as a variadic argument in a format function for a `%s` format.

Typical code:
```
import int func(__format String s, ...);

void game_start()
{
    func("%s", null);
}
```