### PR TITLE
Engine: fix check for asset existence

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -175,7 +175,8 @@ bool AssetManager::DoesAssetExist(const String &asset_name, const String &filter
         }
         else
         {
-            return lib->Lookup.count(asset_name) > 0;
+            if (lib->Lookup.count(asset_name) > 0)
+                return true;
         }
     }
     return false;


### PR DESCRIPTION
The check for asset existence can return too early without checking all libs.

To reproduce, start from BASS template, add a Music file, and check if it's Available. The problem only appears in compiled game, not in editor.

```
function room_FirstLoad()
{
 if(aMusic1.IsAvailable)
 {
  player.Say("It's available.");
 }
 else
 {
  player.Say("It's NOT available.");
 }
}
```

Looks like this got broken here:
https://github.com/adventuregamestudio/ags/commit/5cb40d3b371ffc31e3ec6eb71656716ff11f63d2

