### PR TITLE
ci: add Arm64 builds for Linux and Windows MinGW

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows-mingw64, os: windows-latest, artifact: 'ags-mingw64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",       msystem: mingw64, msys-env: mingw-w64-x86_64 }
-        - { name: Windows,         os: windows-latest, artifact: 'ags-windows', shell: cmd,         runbin: ".\\ags.exe", bindir: "Release" }
-        - { name: Ubuntu,          os: ubuntu-latest,  artifact: 'ags-linux',   shell: sh,          runbin: "./ags",      bindir: ""        }
-        - { name: macOS,           os: macos-latest,   artifact: 'ags-macos',   shell: sh,          runbin: "./ags",      bindir: ""        }
+        - { name: Windows-mingw-x86_64, os: windows-latest,   artifact: 'ags-mingw-x86_64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",       msystem: mingw64, msys-env: mingw-w64-x86_64 }
+        - { name: Windows-mingw-arm64,  os: windows-11-arm,   artifact: 'ags-mingw-arm64',  shell: 'msys2 {0}', runbin: "./ags",      bindir: "",       msystem: clangarm64, msys-env: mingw-w64-clang-aarch64 }
+        - { name: Windows,              os: windows-latest,   artifact: 'ags-windows',      shell: cmd,         runbin: ".\\ags.exe", bindir: "Release" }
+        - { name: Ubuntu-x86_64,        os: ubuntu-latest,    artifact: 'ags-linux-x86_64', shell: sh,          runbin: "./ags",      bindir: ""        }
+        - { name: Ubuntu-Arm64,         os: ubuntu-22.04-arm, artifact: 'ags-linux-Arm64',  shell: sh,          runbin: "./ags",      bindir: ""        }
+        - { name: macOS,                os: macos-latest,     artifact: 'ags-macos',        shell: sh,          runbin: "./ags",      bindir: ""        }
 
     steps:
     - name: Set up MSYS2

--- a/Engine/platform/windows/setup/advancedpagedialog.cpp
+++ b/Engine/platform/windows/setup/advancedpagedialog.cpp
@@ -346,6 +346,9 @@ void GameFilesPageDialog::SaveSetup()
 //
 //=============================================================================
 
+const int AccessibilityPageDialog::TextReadSpeedMin;
+const int AccessibilityPageDialog::TextReadSpeedMax;
+
 INT_PTR AccessibilityPageDialog::OnInitDialog()
 {
     _hEnableAccess          = GetDlgItem(_hwnd, IDC_ACCESSENABLECHECK);


### PR DESCRIPTION
This adds some cool experimental ci runs from the public beta arm64 partner images.

I think these are fun, and also I have a raspiberry pi arriving tomorrow I want to play with. But the real reason I am doing this PR here (and leaving it in draft) is the error that will happen in the Windows Arm64 MinGW build, [on ci here](
const int AccessibilityPageDialog::TextReadSpeedMin;
const int AccessibilityPageDialog::TextReadSpeedMax;), highlighted below:

```
ld.lld: error: undefined symbol: AGS::Engine::AccessibilityPageDialog::TextReadSpeedMin
>>> referenced by C:/a/ags/ags/Engine/platform/windows/setup/advancedpagedialog.cpp
>>>               libengine.a(advancedpagedialog.cpp.obj)

ld.lld: error: undefined symbol: AGS::Engine::AccessibilityPageDialog::TextReadSpeedMax

>>> referenced by C:/a/ags/ags/Engine/platform/windows/setup/advancedpagedialog.cpp

>>>               libengine.a(advancedpagedialog.cpp.obj)

c++: error: linker command failed with exit code 1 (use -v to see invocation)
```

I don't understand what that error is, but I had the same error locally when I was trying to build @ivan-mogilko ags4-SDL_ttf branch until I did a rebase and it disappeared. So my guess is whatever is this error we (may?) have already fixed it in the ags4 branch. But I don't know what that is.