### PR TITLE
View Editor: "Copy/Paste" frames and "Reverse Frames" commands

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Panes\ScriptEditorBase.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="Panes\ViewEditClipboard.cs" />
     <Compile Include="Panes\ViewLoopContextMenuArgs.cs" />
     <Compile Include="Panes\ZoomTrackbar.cs">
       <SubType>UserControl</SubType>

--- a/Editor/AGS.Editor/Panes/ViewEditClipboard.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditClipboard.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// ViewEditClipboard shares copied data among the ViewLoopEditor instances.
+    /// </summary>
+    public class ViewEditClipboard
+    {
+        /// <summary>
+        /// Last sprite selected to be assigned to the view's frame.
+        /// </summary>
+        public int LastSelectedSprite { get; set; }
+
+        /// <summary>
+        /// A copied loop, can be pasted into the ViewLoopEditor.
+        /// </summary>
+        public ViewLoop CopiedLoop { get; set; }
+    }
+}

--- a/Editor/AGS.Editor/Panes/ViewEditClipboard.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditClipboard.cs
@@ -17,5 +17,10 @@ namespace AGS.Editor
         /// A copied loop, can be pasted into the ViewLoopEditor.
         /// </summary>
         public ViewLoop CopiedLoop { get; set; }
+
+        /// <summary>
+        /// A copied set of frames, can be pasted into the ViewLoopEditor.
+        /// </summary>
+        public ViewFrame[] CopiedFrames { get; set; }
     }
 }

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -23,6 +23,9 @@ namespace AGS.Editor
         private int _lastSelectedLoop = -1;
         private int _lastSelectedFrame = -1;
 
+        // A clipboard shared among all the view editors and view loop editors
+        private static ViewEditClipboard _clipboard = new ViewEditClipboard();
+
         public ViewEditor(AGS.Types.View viewToEdit)
         {
             _guiController = Factory.GUIController;
@@ -106,7 +109,7 @@ namespace AGS.Editor
 
         private ViewLoopEditor AddNewLoopPane(ViewLoop loop)
         {
-            ViewLoopEditor loopPane = new ViewLoopEditor(loop, _guiController);
+            ViewLoopEditor loopPane = new ViewLoopEditor(loop, _guiController, _clipboard);
             loopPane.Left = 10 + editorPanel.AutoScrollPosition.X;
             loopPane.ZoomLevel = sldZoomLevel.ZoomScale;
             loopPane.Top = 10 + _loopPanes.Count * loopPane.Height + editorPanel.AutoScrollPosition.Y;
@@ -294,10 +297,9 @@ namespace AGS.Editor
             {
                 var menu = e.Menu;
                 EventHandler onClick = new EventHandler(ContextMenuEventHandler);
+                // NOTE: 'F' does not work as a menu item shortkey for some reason, so we handle it in OnKeyPressed
                 menu.Items.Add(new ToolStripMenuItem("&Flip selected frame(s)", null, onClick, MENU_ITEM_FLIP_FRAMES));
-                ToolStripMenuItem deleteOption = new ToolStripMenuItem("Delete selected frame(s)", null, onClick, MENU_ITEM_DELETE_FRAMES);
-                deleteOption.ShortcutKeys = Keys.Delete;
-                menu.Items.Add(deleteOption);
+                menu.Items.Add(ToolStripExtensions.CreateMenuItem("Delete selected frame(s)", null, onClick, MENU_ITEM_DELETE_FRAMES, Keys.Delete));
             }
         }
 

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -9,6 +9,8 @@ namespace AGS.Editor
 {
     public partial class ViewEditor : EditorContentPanel
     {
+        private const string MENU_ITEM_COPY_FRAME = "CopyFrame";
+        private const string MENU_ITEM_CUT_FRAME = "CutFrame";
         private const string MENU_ITEM_DELETE_FRAMES = "DeleteFrames";
         private const string MENU_ITEM_FLIP_FRAMES = "FlipFrames";
 
@@ -297,10 +299,23 @@ namespace AGS.Editor
             {
                 var menu = e.Menu;
                 EventHandler onClick = new EventHandler(ContextMenuEventHandler);
+                menu.Items.Add(ToolStripExtensions.CreateMenuItem("Copy frame(s)", null, OnCopyFrames, MENU_ITEM_COPY_FRAME, Keys.Control | Keys.C));
+                menu.Items.Add(ToolStripExtensions.CreateMenuItem("Cut frame(s)", null, OnCutFrames, MENU_ITEM_CUT_FRAME, Keys.Control | Keys.X));
                 // NOTE: 'F' does not work as a menu item shortkey for some reason, so we handle it in OnKeyPressed
                 menu.Items.Add(new ToolStripMenuItem("&Flip selected frame(s)", null, onClick, MENU_ITEM_FLIP_FRAMES));
                 menu.Items.Add(ToolStripExtensions.CreateMenuItem("Delete selected frame(s)", null, onClick, MENU_ITEM_DELETE_FRAMES, Keys.Delete));
             }
+        }
+
+        private void OnCopyFrames(object sender, EventArgs e)
+        {
+            _clipboard.CopiedFrames = _selectedFrames.Select(f => f.Clone()).ToArray();
+        }
+
+        private void OnCutFrames(object sender, EventArgs e)
+        {
+            _clipboard.CopiedFrames = _selectedFrames.Select(f => f.Clone()).ToArray();
+            DeleteSelectedFrames();
         }
 
         private void ContextMenuEventHandler(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -301,7 +301,7 @@ namespace AGS.Editor
                 EventHandler onClick = new EventHandler(ContextMenuEventHandler);
                 menu.Items.Add(ToolStripExtensions.CreateMenuItem("Copy frame(s)", null, OnCopyFrames, MENU_ITEM_COPY_FRAME, Keys.Control | Keys.C));
                 menu.Items.Add(ToolStripExtensions.CreateMenuItem("Cut frame(s)", null, OnCutFrames, MENU_ITEM_CUT_FRAME, Keys.Control | Keys.X));
-                // NOTE: 'F' does not work as a menu item shortkey for some reason, so we handle it in OnKeyPressed
+                // NOTE: Simple keys like 'F' or 'R' does not work as a menu item shortkey for some reason, so we handle it in OnKeyPressed
                 menu.Items.Add(new ToolStripMenuItem("&Flip selected frame(s)", null, onClick, MENU_ITEM_FLIP_FRAMES));
                 menu.Items.Add(ToolStripExtensions.CreateMenuItem("Delete selected frame(s)", null, onClick, MENU_ITEM_DELETE_FRAMES, Keys.Delete));
             }
@@ -363,6 +363,14 @@ namespace AGS.Editor
             foreach (ViewLoopEditor loopPane in _loopPanes)
             {
                 loopPane.FlipSelectedFrames();
+            }
+        }
+
+        private void ReverseSelectedFrames()
+        {
+            foreach (ViewLoopEditor loopPane in _loopPanes)
+            {
+                loopPane.ReverseSelectedFrames();
             }
         }
 
@@ -457,6 +465,10 @@ namespace AGS.Editor
 			{
                 FlipSelectedFrames();
 			}
+            else if (keyData == Keys.R)
+            {
+                ReverseSelectedFrames();
+            }
         }
 
 		private void UpdateWhetherPreviewIsShown()

--- a/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
@@ -449,18 +449,18 @@ namespace AGS.Editor
                 }
                 menu.Items.Add(new ToolStripSeparator());
             }
-            menu.Items.Add(new ToolStripMenuItem("Cut loop", null, onCutLoopClicked, MENU_ITEM_CUT_LOOP));
-            menu.Items.Add(new ToolStripMenuItem("Copy loop", null, onCopyLoopClicked, MENU_ITEM_COPY_LOOP));
+            menu.Items.Add(new ToolStripMenuItem("Cut loop", null, OnCutLoopClicked, MENU_ITEM_CUT_LOOP));
+            menu.Items.Add(new ToolStripMenuItem("Copy loop", null, OnCopyLoopClicked, MENU_ITEM_COPY_LOOP));
             if (_clipboard.CopiedLoop != null || _clipboard.CopiedFrames != null)
             {
-                menu.Items.Add(new ToolStripMenuItem("Paste over this loop", null, onPasteLoopClicked, MENU_ITEM_PASTE_OVER_LOOP));
-                menu.Items.Add(new ToolStripMenuItem("Paste over this loop flipped", null, onPasteFlippedClicked, MENU_ITEM_PASTE_OVER_LOOP_FLIPPED));
+                menu.Items.Add(new ToolStripMenuItem("Paste over this loop", null, OnPasteLoopClicked, MENU_ITEM_PASTE_OVER_LOOP));
+                menu.Items.Add(new ToolStripMenuItem("Paste over this loop flipped", null, OnPasteFlippedClicked, MENU_ITEM_PASTE_OVER_LOOP_FLIPPED));
                 menu.Items.Add(new ToolStripMenuItem("Paste over this loop reversed", null, OnPasteReversedClicked, MENU_ITEM_PASTE_OVER_LOOP_REVERSED));
             }
-            menu.Items.Add(new ToolStripMenuItem("Flip all frames in loop", null, onFlipAllClicked, MENU_ITEM_FLIP_ALL));
+            menu.Items.Add(new ToolStripMenuItem("Flip all frames in loop", null, OnFlipAllClicked, MENU_ITEM_FLIP_ALL));
             menu.Items.Add(new ToolStripMenuItem("Reverse all frames in loop", null, OnReverseAllClicked, MENU_ITEM_REVERSE_ALL));
-            menu.Items.Add(new ToolStripMenuItem("Add all sprites from folder...", null, onQuickImportFromFolderClicked, MENU_ITEM_QUICK_IMPORT));
-            menu.Items.Add(new ToolStripMenuItem("Replace with all sprites from folder...", null, onQuickImportReplaceFromFolderClicked, MENU_ITEM_QUICK_IMPORT_REPLACE));
+            menu.Items.Add(new ToolStripMenuItem("Add all sprites from folder...", null, OnQuickImportFromFolderClicked, MENU_ITEM_QUICK_IMPORT));
+            menu.Items.Add(new ToolStripMenuItem("Replace with all sprites from folder...", null, OnQuickImportReplaceFromFolderClicked, MENU_ITEM_QUICK_IMPORT_REPLACE));
 
             menu.Show(this, menuPosition);
         }
@@ -520,19 +520,19 @@ namespace AGS.Editor
             ReverseSelectedFrames();
         }
 
-        private void copyLoop()
+        private void CopyLoop()
         {
             _clipboard.CopiedLoop = _loop.Clone();
         }
 
-        private void onCopyLoopClicked(object sender, EventArgs e)
+        private void OnCopyLoopClicked(object sender, EventArgs e)
         {
-            copyLoop();
+            CopyLoop();
         }
 
-        private void onCutLoopClicked(object sender, EventArgs e)
+        private void OnCutLoopClicked(object sender, EventArgs e)
         {
-            copyLoop();
+            CopyLoop();
             if (_loop.Frames.Count > 0)
             {
                 _selectedFrames.Clear();
@@ -545,7 +545,7 @@ namespace AGS.Editor
             }
         }
 
-        private void pasteLoop(bool flipped)
+        private void PasteLoop(bool flipped)
         {
             if (_clipboard.CopiedLoop != null)
             {
@@ -560,23 +560,23 @@ namespace AGS.Editor
             this.Invalidate();
         }
 
-        private void onPasteLoopClicked(object sender, EventArgs e)
+        private void OnPasteLoopClicked(object sender, EventArgs e)
         {
-            pasteLoop(false);
+            PasteLoop(false);
         }
 
-        private void onPasteFlippedClicked(object sender, EventArgs e)
+        private void OnPasteFlippedClicked(object sender, EventArgs e)
         {
-            pasteLoop(true);
+            PasteLoop(true);
         }
 
         private void OnPasteReversedClicked(object sender, EventArgs e)
         {
-            pasteLoop(false);
+            PasteLoop(false);
             ReverseAllFrames();
         }
 
-        private void onFlipAllClicked(object sender, EventArgs e)
+        private void OnFlipAllClicked(object sender, EventArgs e)
         {            
             _loop.Frames.ForEach(c => c.Flipped = !c.Flipped);
             this.Invalidate();
@@ -614,12 +614,12 @@ namespace AGS.Editor
             }
         }
 
-        private void onQuickImportFromFolderClicked(object sender, EventArgs e)
+        private void OnQuickImportFromFolderClicked(object sender, EventArgs e)
         {
             QuickImportFromFolder(false);
         }
 
-        private void onQuickImportReplaceFromFolderClicked(object sender, EventArgs e)
+        private void OnQuickImportReplaceFromFolderClicked(object sender, EventArgs e)
         {
             QuickImportFromFolder(true);
         }

--- a/Editor/AGS.Types/ViewFrame.cs
+++ b/Editor/AGS.Types/ViewFrame.cs
@@ -95,5 +95,15 @@ namespace AGS.Types
             };
         }
 
+        /// <summary>
+        /// Copies properties to another ViewFrame, *except* for an ID
+        /// </summary>
+        public void CopyTo(ViewFrame other)
+        {
+            other.Image = Image;
+            other.Flipped = Flipped;
+            other.Delay = Delay;
+            other.Sound = Sound;
+        }
     }
 }


### PR DESCRIPTION
Resolve #2792

Adds following commands to the ViewEditor:
* Copy frame(s) (Ctrl+C) - works if selection is across multiple loops too
* Cut frame(s) (Ctrl+X) - works if selection is across multiple loops too
* Paste frame(s) before - pastes copied number of frames *before* the selected frame in a single loop
* Paste frame(s) after (Ctrl+V) - pastes copied number of frames *after* the selected frame in a single loop

Also
* Paste over loop - now works if clipboard has copied frames, not whole loop.

More commands:
* Reverse frames (R) - reverses an order of selected frames within a single loop. Selection may have gaps in it (i think).
* Reverse all frames - reverses all frames in a loop.
* Paste over loop reversed - pastes a copied loop or frames over the loop and then reverts frames.