### PR TITLE
Bugfix: Avoid buffer overflow with unicode in source for (old) compiler 

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3930,14 +3930,15 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                             memberPart += 2;
 
                             // declare the imports for the Get and Setters
-                            char propFuncName[200];
-                            sprintf(propFuncName, "%s::get%s_%s", sym.get_name(stname), namePrefix, memberPart);
+                            const int propFuncNameLen = 200;
+                            char propFuncName[propFuncNameLen];
+                            snprintf(propFuncName, propFuncNameLen, "%s::get%s_%s", sym.get_name(stname), namePrefix, memberPart);
 
                             int propGet = scrip->add_new_import(propFuncName);
                             int propSet = 0xffff;
                             if (!member_is_readonly) {
                                 // setter only if it's not read-only
-                                sprintf(propFuncName, "%s::set%s_%s", sym.get_name(stname), namePrefix, memberPart);
+                                snprintf(propFuncName, propFuncNameLen, "%s::set%s_%s", sym.get_name(stname), namePrefix, memberPart);
                                 propSet = scrip->add_new_import(propFuncName);
                             }
                             sym.entries[vname].set_propfuncs(propGet, propSet);
@@ -4428,10 +4429,11 @@ startvarbit:
             return -1;
         }
         else if (symType == 0) {
-            char extratex[20] = "";
+            const int extratex_len = 40;
+            char extratex[extratex_len] = "";
             const char *symname = sym.get_name(cursym);
             if ((symname[0] <= 32) || (symname[0] >= 128))
-                sprintf (extratex, " (ASCII index %02X)", symname[0]);
+                snprintf (extratex, extratex_len, " (ASCII index %02X)", (unsigned char) symname[0]);
 
             cc_error("Undefined token '%s' %s", symname, extratex);
             return -1;

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -63,6 +63,23 @@ TEST(Compile, UnknownKeywordAfterReadonly) {
     EXPECT_STREQ("Syntax error at 'MyStruct::int2'; expected variable type", last_seen_cc_error());
 }
 
+TEST(Compile, UnExpectedUnicodeChar) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    const char *inpl = " \
+        int game_start()    \n\
+        {                   \n\
+            ¨               \n\
+        }";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_EQ(-1, compileResult);
+    std::string err = last_seen_cc_error();
+    EXPECT_NE(std::string::npos, err.find("A8"));
+}
+
 TEST(Compile, DynamicArrayReturnValueErrorText) {
     ccCompiledScript *scrip = newScriptFixture();
 


### PR DESCRIPTION
Fixes #2799

Avoid a buffer overflow from a call to `sprintf()` when AGS source contains unicode characters (outside of string literals).

Typical code: 
```
int game_start()
{
    ¨
}";
```

I'm using this as an opportunity to also convert two other `sprintf()`calls to `snprintf()` calls that were in the same file `cs_parser.cpp`