### PR TITLE
Editor: hide certain properties when multiple objects are selected for editing.

### DIFF
--- a/Editor/AGS.Editor/GUI/PropertiesPanel.cs
+++ b/Editor/AGS.Editor/GUI/PropertiesPanel.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Windows.Forms;
 using WeifenLuo.WinFormsUI.Docking;
 using System.Windows.Forms.Design;
+using AGS.Types;
 
 namespace AGS.Editor
 {
@@ -103,6 +104,7 @@ namespace AGS.Editor
             {
                 propertiesGrid.SelectedObject = value;
                 propertiesGrid.ExpandAllGridItems();
+                propertiesGrid.BrowsableAttributes = null; // reset to defaults
             }
         }
 
@@ -112,6 +114,15 @@ namespace AGS.Editor
             set 
             {
                 propertiesGrid.SelectedObjects = value;
+                if (value == null)
+                {
+                    propertiesGrid.BrowsableAttributes = null; // reset to defaults
+                }
+                else
+                {
+                    propertiesGrid.BrowsableAttributes = new AttributeCollection(
+                        new Attribute[] { BrowsableAttribute.Yes, BrowsableMultieditAttribute.Yes });
+                }
                 propertiesGrid.ExpandAllGridItems();
             }
         }

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -110,6 +110,7 @@
   <ItemGroup>
     <Compile Include="Attributes\AGSNoSerializeAttribute.cs" />
     <Compile Include="Attributes\AGSSerializeClassAttribute.cs" />
+    <Compile Include="Attributes\BrowsableMultieditAttribute.cs" />
     <Compile Include="Attributes\ScriptFunctionParametersAttribute.cs" />
     <Compile Include="AudioClip.cs" />
     <Compile Include="AudioClipFolder.cs" />

--- a/Editor/AGS.Types/Attributes/BrowsableMultieditAttribute.cs
+++ b/Editor/AGS.Types/Attributes/BrowsableMultieditAttribute.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace AGS.Types
+{
+    /// <summary>
+    /// BrowsableMultiedit attribute defines whether the property should be
+    /// displayed in the PropertyGrid when the multiple objects are edited at once.
+    /// Default is true (BrowsableMultieditAttribute.Yes).
+    /// Setting [BrowsableMultiedit(false)] will make properties hidden
+    /// in case multiple objects are selected for edit.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class BrowsableMultieditAttribute : Attribute
+    {
+        public static BrowsableMultieditAttribute Yes = new BrowsableMultieditAttribute(true);
+        public static BrowsableMultieditAttribute No = new BrowsableMultieditAttribute(false);
+        public static BrowsableMultieditAttribute Default = Yes;
+
+        private bool _isBrowseableWhenMultiedit;
+
+        public BrowsableMultieditAttribute(bool isBrowseableWhenMultiedit)
+        {
+            _isBrowseableWhenMultiedit = isBrowseableWhenMultiedit;
+        }
+
+        public bool Browsable { get { return _isBrowseableWhenMultiedit; } }
+
+        public override bool Equals(object obj)
+        {
+            var otherAttr = obj as BrowsableMultieditAttribute;
+            return otherAttr != null && otherAttr.Browsable == Browsable;
+        }
+
+        public override int GetHashCode()
+        {
+            return _isBrowseableWhenMultiedit.GetHashCode();
+        }
+
+        public override bool IsDefaultAttribute()
+        {
+            return _isBrowseableWhenMultiedit == true;
+        }
+    }
+}

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -58,6 +58,7 @@ namespace AGS.Types
         [DisplayName("ID")]
         [Description("The ID number of the clip")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -74,6 +75,7 @@ namespace AGS.Types
         }
 
         [Description("The name by which this audio clip can be referenced in the script")]
+        [BrowsableMultiedit(false)]
         public string ScriptName
         {
             get { return _scriptName; }

--- a/Editor/AGS.Types/AudioClipType.cs
+++ b/Editor/AGS.Types/AudioClipType.cs
@@ -15,6 +15,7 @@ namespace AGS.Types
         [Description("The name of this audio type")]
         [Category("Design")]
         [RefreshProperties(RefreshProperties.All)]
+        [BrowsableMultiedit(false)]
         public string Name { get; set; }
 
         [Description("The maximum number of clips of this type that can play at the same time (0=unlimited)")]
@@ -37,6 +38,7 @@ namespace AGS.Types
         [AGSNoSerialize]
         [Description("The name by which the script will know this audio type")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string ScriptID
         {
             get

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -67,6 +67,7 @@ namespace AGS.Types
         [Description("The ID number of the character")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -76,6 +77,7 @@ namespace AGS.Types
         [DisplayName(PROPERTY_NAME_SCRIPTNAME)]
         [Description("The script name of the character")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string ScriptName
         {
             get { return _scriptName; }

--- a/Editor/AGS.Types/Dialog.cs
+++ b/Editor/AGS.Types/Dialog.cs
@@ -32,6 +32,7 @@ namespace AGS.Types
         [Description("The ID number of the dialog")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -40,6 +41,7 @@ namespace AGS.Types
 
         [Description("The script name of the dialog")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -38,6 +38,7 @@ namespace AGS.Types
         [Description("The ID number of the font")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -79,6 +80,7 @@ namespace AGS.Types
 
         [Description("The name of the font")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }
@@ -88,7 +90,8 @@ namespace AGS.Types
         [AGSNoSerialize]
         [Description("The name with which the script will access this font")]
 		[Category("Design")]
-		public string ScriptID
+        [BrowsableMultiedit(false)]
+        public string ScriptID
 		{
 			get
 			{

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -85,6 +85,7 @@ namespace AGS.Types
         [Description("The ID number of the GUI")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -93,6 +94,7 @@ namespace AGS.Types
 
         [Description("The script name of the GUI")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -129,6 +129,7 @@ namespace AGS.Types
         [Description("The ID number of the control")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -137,6 +138,7 @@ namespace AGS.Types
 
         [Description("The script name of the control")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -47,6 +47,7 @@ namespace AGS.Types
         [Description("The ID number of the item")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -117,6 +118,7 @@ namespace AGS.Types
 
         [Description("The script name of the item")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/MouseCursor.cs
+++ b/Editor/AGS.Types/MouseCursor.cs
@@ -27,6 +27,7 @@ namespace AGS.Types
         [Description("The ID number of the cursor")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -120,6 +121,7 @@ namespace AGS.Types
 
         [Description("The name of the cursor")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }
@@ -142,8 +144,10 @@ namespace AGS.Types
             get { return TypesHelper.MakePropertyGridTitle("Character", _name, _id); }
         }
 
+        [AGSNoSerialize]
         [Description("The script ID of the cursor")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string ScriptID
         {
 			get

--- a/Editor/AGS.Types/PaletteEntry.cs
+++ b/Editor/AGS.Types/PaletteEntry.cs
@@ -44,6 +44,7 @@ namespace AGS.Types
 
         [Description("The colour number of this colour")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public int Index
         {
             get { return _index; }

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -46,6 +46,7 @@ namespace AGS.Types
         [Description("The ID number of the hotspot")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -64,6 +65,7 @@ namespace AGS.Types
 		[DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
 		[Description("The script name of the hotspot")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -49,6 +49,7 @@ namespace AGS.Types
         [Description("The ID number of the object")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -142,6 +143,7 @@ namespace AGS.Types
 		[DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
         [Description("The script name of the object")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -36,6 +36,7 @@ namespace AGS.Types
         [Description("The ID number of the region")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }

--- a/Editor/AGS.Types/RoomWalkBehind.cs
+++ b/Editor/AGS.Types/RoomWalkBehind.cs
@@ -15,6 +15,7 @@ namespace AGS.Types
         [Description("The ID number of the walk-behind area")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }

--- a/Editor/AGS.Types/RoomWalkableArea.cs
+++ b/Editor/AGS.Types/RoomWalkableArea.cs
@@ -19,6 +19,7 @@ namespace AGS.Types
         [Description("The ID number of the walkable area")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -62,6 +62,7 @@ namespace AGS.Types
         [Category("Design")]
         [ReadOnly(true)]
         [DisplayName(PROPERTY_SPRITE_NUMBER)]
+        [BrowsableMultiedit(false)]
         public int Number 
         { 
             get { return _number; } 

--- a/Editor/AGS.Types/View.cs
+++ b/Editor/AGS.Types/View.cs
@@ -23,6 +23,7 @@ namespace AGS.Types
         [Description("The ID number of the view")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }
@@ -31,6 +32,7 @@ namespace AGS.Types
 
         [Description("The script name of the view")]
         [Category("Design")]
+        [BrowsableMultiedit(false)]
         public string Name
         {
             get { return _name; }

--- a/Editor/AGS.Types/ViewFrame.cs
+++ b/Editor/AGS.Types/ViewFrame.cs
@@ -27,6 +27,7 @@ namespace AGS.Types
         [Description("The ID number of the frame")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }

--- a/Editor/AGS.Types/ViewLoop.cs
+++ b/Editor/AGS.Types/ViewLoop.cs
@@ -26,6 +26,7 @@ namespace AGS.Types
         [Description("The ID number of the loop")]
         [Category("Design")]
         [ReadOnly(true)]
+        [BrowsableMultiedit(false)]
         public int ID
         {
             get { return _id; }


### PR DESCRIPTION
Fix #2802

Implemented BrowsableMultieditAttribute that marks properties that should or should not be displayed whenever multiple objects are selected for edit in PropertyGrid.

When PropertiesPanel.SelectedObjects is set, check whether there are multiple objects, and if yes then assign this custom attribute to the propertiesGrid.BrowsableAttributes collection. If a single object is selected, then reset BrowsableAttributes to defaults.

This allows to hide properties that must have unique values, such as Name, so that user won't try to edit them.