### PR TITLE
ci: add Emscripten builds to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows-mingw-x86_64, os: windows-latest,   artifact: 'ags-mingw-x86_64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: mingw64, msys-env: mingw-w64-x86_64 }
-        - { name: Windows-mingw-arm64,  os: windows-11-arm,   artifact: 'ags-mingw-arm64',  shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: clangarm64, msys-env: mingw-w64-clang-aarch64 }
-        - { name: Windows,              os: windows-latest,   artifact: 'ags-windows',      shell: cmd,         runbin: ".\\ags.exe", bindir: "Release", cmakecmd: "cmake" }
-        - { name: Ubuntu-x86_64,        os: ubuntu-latest,    artifact: 'ags-linux-x86_64', shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
-        - { name: Ubuntu-Arm64,         os: ubuntu-22.04-arm, artifact: 'ags-linux-Arm64',  shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
-        - { name: macOS,                os: macos-latest,     artifact: 'ags-macos',        shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
-        - { name: Emscripten,           os: ubuntu-latest,    artifact: 'ags-emscripten',   shell: sh,          runbin: "",           bindir: ""       , cmakecmd: "emcmake cmake" }
+        - { name: Windows-mingw-x86_64, os: windows-latest,   sys: Windows, gfx: D3D9, artifact: 'ags-mingw-x86_64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: mingw64, msys-env: mingw-w64-x86_64 }
+        - { name: Windows-mingw-arm64,  os: windows-11-arm,   sys: Windows, gfx: D3D9, artifact: 'ags-mingw-arm64',  shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: clangarm64, msys-env: mingw-w64-clang-aarch64 }
+        - { name: Windows,              os: windows-latest,   sys: Windows, gfx: D3D9, artifact: 'ags-windows',      shell: cmd,         runbin: ".\\ags.exe", bindir: "Release", cmakecmd: "cmake" }
+        - { name: Ubuntu-x86_64,        os: ubuntu-latest,    sys: Ubuntu,  gfx: OGL,  artifact: 'ags-linux-x86_64', shell: sh,          runbin: "./ags",      bindir: "",        cmakecmd: "cmake" }
+        - { name: Ubuntu-Arm64,         os: ubuntu-22.04-arm, sys: Ubuntu,  gfx: OGL,  artifact: 'ags-linux-Arm64',  shell: sh,          runbin: "./ags",      bindir: "",        cmakecmd: "cmake" }
+        - { name: macOS,                os: macos-latest,     sys: macOS,   gfx: OGL,  artifact: 'ags-macos',        shell: sh,          runbin: "./ags",      bindir: "",        cmakecmd: "cmake" }
+        - { name: Emscripten,           os: ubuntu-latest,    sys: Web,     gfx: OGL,  artifact: 'ags-emscripten',   shell: sh,          runbin: "",           bindir: ""       , cmakecmd: "emcmake cmake" }
 
     steps:
     - name: Set up MSYS2
@@ -40,6 +40,16 @@ jobs:
           ${{ matrix.platform.msys-env }}-pkg-config
           ${{ matrix.platform.msys-env }}-clang-tools-extra
           unzip
+
+    - name: Set up SDL dependencies on Linux (ensures OpenGL)
+      if: matrix.platform.sys == 'Ubuntu'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y \
+          gnome-desktop-testing libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev \
+          libusb-1.0-0-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev \
+          libxss-dev libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+          libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
 
     - name: Set up Tappy
       run: pip install tap.py
@@ -95,14 +105,28 @@ jobs:
         unzip auto-test.zip
         rm auto-test.zip
 
-    - name: Run auto-test
+    - name: Run auto-test (Hardware GFX)
       if: ${{ matrix.platform.name != 'Emscripten' }}
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
-        ${{matrix.platform.runbin}} --no-message-box --log-stdout=script:info,main:info --user-data-dir . ags3-auto-test.ags
+        ${{matrix.platform.runbin}} --gfxdriver ${{matrix.platform.gfx}} --no-message-box --log-stdout=script:info,main:info --user-data-dir . ags3-auto-test.ags
+        mv agstest.tap agstest_hardware.tap
 
-    - name: Check auto-test  # we are using tap.py so that the pipeline fails if a test fails
+    - name: Check auto-test (Hardware GFX) # we are using tap.py so that the pipeline fails if a test fails
       if: ${{ matrix.platform.name != 'Emscripten' }}
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
-        tappy agstest.tap
+        tappy agstest_hardware.tap
+
+    - name: Run auto-test (Software GFX)
+      if: ${{ matrix.platform.name != 'Emscripten' }}
+      working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
+      run: |
+        ${{matrix.platform.runbin}} --gfxdriver Software --no-message-box --log-stdout=script:info,main:info --user-data-dir . ags3-auto-test.ags
+        mv agstest.tap agstest_software.tap
+
+    - name: Check auto-test (Software GFX) # we are using tap.py so that the pipeline fails if a test fails
+      if: ${{ matrix.platform.name != 'Emscripten' }}
+      working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
+      run: |
+        tappy agstest_software.tap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows-mingw-x86_64, os: windows-latest,   artifact: 'ags-mingw-x86_64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",       msystem: mingw64, msys-env: mingw-w64-x86_64 }
-        - { name: Windows-mingw-arm64,  os: windows-11-arm,   artifact: 'ags-mingw-arm64',  shell: 'msys2 {0}', runbin: "./ags",      bindir: "",       msystem: clangarm64, msys-env: mingw-w64-clang-aarch64 }
-        - { name: Windows,              os: windows-latest,   artifact: 'ags-windows',      shell: cmd,         runbin: ".\\ags.exe", bindir: "Release" }
-        - { name: Ubuntu-x86_64,        os: ubuntu-latest,    artifact: 'ags-linux-x86_64', shell: sh,          runbin: "./ags",      bindir: ""        }
-        - { name: Ubuntu-Arm64,         os: ubuntu-22.04-arm, artifact: 'ags-linux-Arm64',  shell: sh,          runbin: "./ags",      bindir: ""        }
-        - { name: macOS,                os: macos-latest,     artifact: 'ags-macos',        shell: sh,          runbin: "./ags",      bindir: ""        }
+        - { name: Windows-mingw-x86_64, os: windows-latest,   artifact: 'ags-mingw-x86_64', shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: mingw64, msys-env: mingw-w64-x86_64 }
+        - { name: Windows-mingw-arm64,  os: windows-11-arm,   artifact: 'ags-mingw-arm64',  shell: 'msys2 {0}', runbin: "./ags",      bindir: "",        cmakecmd: "cmake", msystem: clangarm64, msys-env: mingw-w64-clang-aarch64 }
+        - { name: Windows,              os: windows-latest,   artifact: 'ags-windows',      shell: cmd,         runbin: ".\\ags.exe", bindir: "Release", cmakecmd: "cmake" }
+        - { name: Ubuntu-x86_64,        os: ubuntu-latest,    artifact: 'ags-linux-x86_64', shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
+        - { name: Ubuntu-Arm64,         os: ubuntu-22.04-arm, artifact: 'ags-linux-Arm64',  shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
+        - { name: macOS,                os: macos-latest,     artifact: 'ags-macos',        shell: sh,          runbin: "./ags",      bindir: ""       , cmakecmd: "cmake" }
+        - { name: Emscripten,           os: ubuntu-latest,    artifact: 'ags-emscripten',   shell: sh,          runbin: "",           bindir: ""       , cmakecmd: "emcmake cmake" }
 
     steps:
     - name: Set up MSYS2
@@ -45,15 +46,21 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - uses: mymindstorm/setup-emsdk@v14
+      if: ${{ matrix.platform.name == 'Emscripten' }}
+      with:
+        version: 3.1.74
+
     - name: Configure CMake
       run: |
         cmake --version
-        cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DAGS_BUILD_TOOLS=1 -DAGS_TESTS=1 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        ${{ matrix.platform.cmakecmd }} -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DAGS_BUILD_TOOLS=1 -DAGS_TESTS=1 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       run: cmake --build "${{github.workspace}}/build" --config ${{env.BUILD_TYPE}} --parallel 2
 
     - name: Test
+      if: ${{ matrix.platform.name != 'Emscripten' }}
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
@@ -65,6 +72,9 @@ jobs:
           ${{github.workspace}}/build/${{env.BUILD_TYPE}}/ags.exe
           ${{github.workspace}}/build/ags
           ${{github.workspace}}/build/ags.exe
+          ${{github.workspace}}/build/ags.html
+          ${{github.workspace}}/build/ags.wasm
+          ${{github.workspace}}/build/ags.js
 
     - name: Download auto-test
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
@@ -86,11 +96,13 @@ jobs:
         rm auto-test.zip
 
     - name: Run auto-test
+      if: ${{ matrix.platform.name != 'Emscripten' }}
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
         ${{matrix.platform.runbin}} --no-message-box --log-stdout=script:info,main:info --user-data-dir . ags3-auto-test.ags
 
     - name: Check auto-test  # we are using tap.py so that the pipeline fails if a test fails
+      if: ${{ matrix.platform.name != 'Emscripten' }}
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
         tappy agstest.tap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ if(EMSCRIPTEN)
         -s FULL_ES2=1 \
         -s FORCE_FILESYSTEM=1 -lidbfs.js \
         --post-js ${CMAKE_SOURCE_DIR}/Emscripten/post.js \
-        -s EXPORTED_FUNCTIONS=['_main','_ext_syncfs_done','_ext_toggle_fullscreen','_ext_get_windowed','_ext_gfxmode_get_width','_ext_gfxmode_get_height'] \
+        -s EXPORTED_FUNCTIONS=['_main'] \
         -s EXPORTED_RUNTIME_METHODS=['ccall','callMain']")
 
     set(EMSDK_FLAGS_LINKER "${EMSDK_FLAGS_LINKER} ${EMSDK_DEBUG_LINKER_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/Emscripten/launcher_index.html ")

--- a/Common/util/string_compat.c
+++ b/Common/util/string_compat.c
@@ -17,6 +17,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "core/platform.h"
+#if !AGS_PLATFORM_OS_WINDOWS
+#include <strings.h>
+#endif
 #include "debug/assert.h"
 
 char *ags_strlwr(char *s)


### PR DESCRIPTION
This adds Emscripten builds to GitHub Actions. The Emscripten builds don't run either the tests or the auto-tests yet, the regular test require some changes to be js and wasm only that could be run using node, and the `auto-test.ags` game will require a headless browser that can output the `console.log()` to the command line.

The difference between this build and the Cirrus one is mostly that even if not run, the Tools and the Tests are built.