### PR TITLE
Editor: Font preview redesign

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -298,7 +298,7 @@ struct FontInfo
         kRounded = 1,
     };
 
-    // General font's loading and rendering flags
+    // General font's loading and rendering flags (FFLG_*)
     uint32_t      Flags;
     // Nominal font import size (in pixels)
     int           Size;

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -117,6 +117,8 @@ public:
     virtual void GetFontMetrics(int fontNumber, FontMetrics *metrics) = 0;
     // Perform any necessary adjustments when the AA mode is toggled
     virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
+    // Get a range of supported character codes (first and last present in the font)
+    virtual void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) = 0;
 
 protected:
     IAGSFontRendererInternal() = default;

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -119,6 +119,8 @@ public:
     virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
     // Get a range of supported character codes (first and last present in the font)
     virtual void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) = 0;
+    // Get a list of supported character codes
+    virtual void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) = 0;
 
 protected:
     IAGSFontRendererInternal() = default;

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -14,6 +14,7 @@
 #ifndef __AC_AGSFONTRENDERER_H
 #define __AC_AGSFONTRENDERER_H
 
+#include "util/geometry.h"
 #include "util/string.h"
 
 struct BITMAP;
@@ -86,14 +87,17 @@ struct FontMetrics
     // selected depending on the game settings.
     // This property is used in calculating linespace, etc.
     int CompatHeight = 0;
-    // Maximal vertical extent of a font (top; bottom), this tells the actual
-    // graphical bounds that may be occupied by font's glyphs.
+    // Maximal bounding rectangle of a font's glyph, this tells the actual
+    // graphical bounds that may be occupied by any font's glyphs.
+    // BBox is given in pixels, relative to our "pen" position (top-left).
+    Rect BBox;
+    // Maximal vertical extent of a font (top; bottom).
     // In a "proper" font this extent is (0; RealHeight-1), but "bad" fonts may
     // have individual glyphs exceeding these bounds, in both directions.
     // Note that "top" may be negative!
     std::pair<int, int> VExtent;
 
-    inline int ExtentHeight() const { return VExtent.second - VExtent.first; }
+    inline int ExtentHeight() const { return VExtent.second - VExtent.first + 1; }
 };
 
 // The strictly internal font renderer interface, not to use in plugin API.

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -54,6 +54,8 @@ struct Font
     // First and last character code supported in this font; -1 if not initialized
     int                 FirstCharCode = -1;
     int                 LastCharCode = -1;
+    // Cached list of valid character codes in this font
+    std::vector<int>    ValidCharCodes;
 
     // Outline buffers
     Bitmap TextStencil, TextStencilSub;
@@ -257,6 +259,18 @@ int get_font_topmost_char_code(int font_number)
         fonts[font_number].LastCharCode = range.second;
     }
     return fonts[font_number].LastCharCode;
+}
+
+void get_font_valid_char_codes(int font_number, std::vector<int> &charcodes)
+{
+    if (!assert_font_number(font_number) || !fonts[font_number].RendererInt)
+        return;
+
+    if (fonts[font_number].ValidCharCodes.size() == 0)
+    {
+        fonts[font_number].RendererInt->GetValidCharCodes(font_number, fonts[font_number].ValidCharCodes);
+    }
+    charcodes = fonts[font_number].ValidCharCodes;
 }
 
 const char *get_font_name(int font_number)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -148,7 +148,7 @@ static void font_post_init(int font_number)
 
         font.Metrics.NominalHeight = std::max(0, height);
         font.Metrics.RealHeight = font.Metrics.NominalHeight;
-        font.Metrics.VExtent = std::make_pair(0, font.Metrics.RealHeight);
+        font.Metrics.VExtent = std::make_pair(0, font.Metrics.RealHeight - 1);
     }
     // Use either nominal or real pixel height to define font's logical height
     // and default linespacing; logical height = nominal height is compatible with the old games
@@ -609,9 +609,10 @@ bool load_font_size(int font_number, const String &filename, const FontInfo &fon
     font.Metrics = metrics;
     font_post_init(font_number);
 
-    Debug::Printf("Loaded font %d: %s, req size: %d; nominal h: %d, real h: %d, extent: %d,%d",
+    Debug::Printf("Loaded font %d: %s, req size: %d; nominal h: %d, real h: %d, vextent: %d,%d, aabb: %d,%d - %d,%d",
         font_number, src_filename.GetCStr(), font_info.Size, font.Metrics.NominalHeight, font.Metrics.RealHeight,
-    font.Metrics.VExtent.first, font.Metrics.VExtent.second);
+        font.Metrics.VExtent.first, font.Metrics.VExtent.second,
+        font.Metrics.BBox.Left, font.Metrics.BBox.Top, font.Metrics.BBox.Right, font.Metrics.BBox.Bottom);
     return true;
 }
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -261,16 +261,16 @@ int get_font_topmost_char_code(int font_number)
     return fonts[font_number].LastCharCode;
 }
 
-void get_font_valid_char_codes(int font_number, std::vector<int> &charcodes)
+const std::vector<int> *get_font_valid_char_codes(int font_number)
 {
     if (!assert_font_number(font_number) || !fonts[font_number].RendererInt)
-        return;
+        return nullptr;
 
     if (fonts[font_number].ValidCharCodes.size() == 0)
     {
         fonts[font_number].RendererInt->GetValidCharCodes(font_number, fonts[font_number].ValidCharCodes);
     }
-    charcodes = fonts[font_number].ValidCharCodes;
+    return &fonts[font_number].ValidCharCodes;
 }
 
 const char *get_font_name(int font_number)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -51,6 +51,9 @@ struct Font
     FontMetrics         Metrics;
     // Precalculated linespacing, based on font properties and compat settings
     int                 LineSpacingCalc = 0;
+    // First and last character code supported in this font; -1 if not initialized
+    int                 FirstCharCode = -1;
+    int                 LastCharCode = -1;
 
     // Outline buffers
     Bitmap TextStencil, TextStencilSub;
@@ -242,6 +245,20 @@ bool font_supports_extended_characters(int font_number)
     return fonts[font_number].Renderer->SupportsExtendedCharacters(font_number);
 }
 
+int get_font_topmost_char_code(int font_number)
+{
+    if (!assert_font_number(font_number) || !fonts[font_number].RendererInt)
+        return -1;
+    if (fonts[font_number].LastCharCode == -1)
+    {
+        std::pair<int, int> range;
+        fonts[font_number].RendererInt->GetCharCodeRange(font_number, &range);
+        fonts[font_number].FirstCharCode = range.first;
+        fonts[font_number].LastCharCode = range.second;
+    }
+    return fonts[font_number].LastCharCode;
+}
+
 const char *get_font_name(int font_number)
 {
     if (!assert_font_number(font_number) || !fonts[font_number].Renderer2)
@@ -377,6 +394,13 @@ std::pair<int, int> get_font_surface_extent(int font_number)
     if (!assert_font_number(font_number))
         return std::make_pair(0, 0);
     return fonts[font_number].Metrics.VExtent;
+}
+
+Rect get_font_glyph_bbox(int font_number)
+{
+    if (!assert_font_number(font_number))
+        return Rect();
+    return fonts[font_number].Metrics.BBox;
 }
 
 int get_font_linespacing(int font_number)

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -147,7 +147,7 @@ public:
 
 private:
     std::vector<AGS::Common::String> _pool;
-    size_t _count; // actual number of lines in use
+    size_t _count = 0; // actual number of lines in use
 };
 
 // Break up the text into lines restricted by the given width;

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -44,6 +44,9 @@ bool font_supports_extended_characters(int font_number);
 // Gets font's topmost available char code;
 // returns -1 if this information is not available
 int get_font_topmost_char_code(int font_number);
+// Gets font's valid character codes;
+// this means character codes for which this font has glyphs
+void get_font_valid_char_codes(int font_number, std::vector<int> &charcodes);
 // Get font's name, if it's available, otherwise returns empty string
 const char *get_font_name(int font_number);
 // Get a collection of FFLG_* flags corresponding to this font

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -41,6 +41,9 @@ bool font_first_renderer_loaded();
 bool is_font_loaded(int font_number);
 bool is_bitmap_font(int font_number);
 bool font_supports_extended_characters(int font_number);
+// Gets font's topmost available char code;
+// returns -1 if this information is not available
+int get_font_topmost_char_code(int font_number);
 // Get font's name, if it's available, otherwise returns empty string
 const char *get_font_name(int font_number);
 // Get a collection of FFLG_* flags corresponding to this font
@@ -69,6 +72,8 @@ int get_font_surface_height_outlined(int font_number);
 // relative to the "pen" position. Besides letting to calculate the surface height,
 // this information also lets to detect if some of the glyphs may appear above y0.
 std::pair<int, int> get_font_surface_extent(int font_number);
+// Get font's glyphs max bounding box, in pixels relative to the "pen" position.
+Rect get_font_glyph_bbox(int font_number);
 // Get font's line spacing
 int get_font_linespacing(int font_number);
 // Set font's line spacing

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -46,7 +46,7 @@ bool font_supports_extended_characters(int font_number);
 int get_font_topmost_char_code(int font_number);
 // Gets font's valid character codes;
 // this means character codes for which this font has glyphs
-void get_font_valid_char_codes(int font_number, std::vector<int> &charcodes);
+const std::vector<int> *get_font_valid_char_codes(int font_number);
 // Get font's name, if it's available, otherwise returns empty string
 const char *get_font_name(int font_number);
 // Get a collection of FFLG_* flags corresponding to this font

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -203,8 +203,23 @@ void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
 void TTFFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes)
 {
     int first_charcode = -1, last_charcode = -1;
-    alfont_get_charcode_range(_fontData[fontNumber].AlFont, &first_charcode, &last_charcode);
+    alfont_get_charcode_range(_fontData[fontNumber].AlFont, &first_charcode, &last_charcode, nullptr);
     *char_codes = std::make_pair(first_charcode, last_charcode);
+}
+
+void TTFFontRenderer::GetValidCharCodes(int fontNumber, std::vector<int> &char_codes)
+{
+    int *charcodes = nullptr;
+    int count = alfont_get_valid_charcodes(_fontData[fontNumber].AlFont, &charcodes);
+    if (!charcodes)
+        return;
+
+    char_codes.reserve(count);
+    for (int i = 0; i < count; ++i)
+    {
+        char_codes.push_back(charcodes[i]);
+    }
+    free(charcodes);
 }
 
 void TTFFontRenderer::FreeMemory(int fontNumber)

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -115,10 +115,23 @@ static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics)
     metrics->NominalHeight = alfont_get_font_height(alfptr);
     metrics->RealHeight = alfont_get_font_real_height(alfptr);
     metrics->CompatHeight = metrics->NominalHeight; // just set to default here
-    alfont_get_font_real_vextent(alfptr, &metrics->VExtent.first, &metrics->VExtent.second);
-    // fixup vextent to be *not less* than realheight
+    {
+        Rect ttf_bbox;
+        alfont_get_font_bbox(alfptr, &ttf_bbox.Left, &ttf_bbox.Top, &ttf_bbox.Right, &ttf_bbox.Bottom);
+        // Remember that FreeType has Y axis pointing bottom->up
+        int real_face_extent_asc = (int)ttf_bbox.Top;
+        int real_face_extent_desc = -(int)ttf_bbox.Bottom;
+        int face_ascent = alfont_get_font_ascent(alfptr);
+        int top    = face_ascent - real_face_extent_asc; // may be negative
+        int bottom = face_ascent + real_face_extent_desc;
+        // Get real vertical extent, relative to the ascent (y pen position)
+        metrics->VExtent = std::make_pair(top, bottom);
+        // Recalc bbox, from the top-left "pen" position, and match our Y axis pointing down
+        metrics->BBox = Rect(ttf_bbox.Left, top, ttf_bbox.Right, bottom);
+    }
+    // Fix vertical extent to be *not less* than realheight
     metrics->VExtent.first = std::min(0, metrics->VExtent.first);
-    metrics->VExtent.second = std::max(metrics->RealHeight, metrics->VExtent.second);
+    metrics->VExtent.second = std::max(metrics->RealHeight - 1, metrics->VExtent.second);
 }
 
 ALFONT_FONT *TTFFontRenderer::LoadTTF(const AGS::Common::String &filename, int font_size, int alfont_flags)

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -200,6 +200,13 @@ void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
   }
 }
 
+void TTFFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes)
+{
+    int first_charcode = -1, last_charcode = -1;
+    alfont_get_charcode_range(_fontData[fontNumber].AlFont, &first_charcode, &last_charcode);
+    *char_codes = std::make_pair(first_charcode, last_charcode);
+}
+
 void TTFFontRenderer::FreeMemory(int fontNumber)
 {
   alfont_destroy_font(_fontData[fontNumber].AlFont);

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -46,6 +46,7 @@ public:
       const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
+  void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
 
   TTFFontRenderer(AGS::Common::AssetManager *amgr);
   virtual ~TTFFontRenderer();

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -47,6 +47,7 @@ public:
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
   void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
+  void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) override;
 
   TTFFontRenderer(AGS::Common::AssetManager *amgr);
   virtual ~TTFFontRenderer();

--- a/Common/font/wfnfont.cpp
+++ b/Common/font/wfnfont.cpp
@@ -44,6 +44,8 @@ void WFNFont::Clear()
     _refs.clear();
     _items.clear();
     _pixelData.clear();
+    _height = 0;
+    _bbox = Rect();
 }
 
 WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
@@ -124,6 +126,9 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
         init_ch.Height = Memory::ReadInt16LE(p_data + sizeof(uint16_t));
         total_pixel_size += init_ch.GetRequiredPixelSize();
         _items[i] = init_ch;
+
+        _bbox.Right = std::max(_bbox.Right, init_ch.Width - 1);
+        _bbox.Bottom = std::max(_bbox.Bottom, init_ch.Height - 1);
     }
 
     // Now that we know actual size of pixels in use, create pixel data array;
@@ -190,6 +195,9 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
             }
         }
     }
+
+    // Save font metrics
+    _height = _bbox.GetHeight();
 
     return err;
 }

--- a/Common/font/wfnfont.h
+++ b/Common/font/wfnfont.h
@@ -38,6 +38,7 @@
 
 #include <vector>
 #include "core/types.h"
+#include "util/geometry.h"
 
 namespace AGS { namespace Common { class Stream; } }
 
@@ -86,15 +87,20 @@ public:
         return code < _refs.size() ? *_refs[code] : _emptyChar;
     }
 
+    inline int GetHeight() const { return _height; }
+    inline const Rect &GetBBox() const { return _bbox; }
+
     void Clear();
     // Reads WFNFont object, using data_size bytes from stream; if data_size = 0,
     // the available stream's length is used instead. Returns error code.
     WFNError ReadFromFile(AGS::Common::Stream *in, const soff_t data_size = 0);
 
-protected:
+private:
     std::vector<const WFNChar*> _refs;      // reference array, contains pointers to elements of _items
     std::vector<WFNChar>        _items;     // actual character items
     std::vector<uint8_t>        _pixelData; // pixel data array
+    int  _height = 0;   // font's height (calculated from the max glyph's height)
+    Rect _bbox;         // bounding box (maximal glyphs extent)
 
     static const WFNChar        _emptyChar; // a dummy character to substitute bad symbols
 };

--- a/Common/font/wfnfont.h
+++ b/Common/font/wfnfont.h
@@ -58,6 +58,11 @@ struct WFNChar
 
     WFNChar();
 
+    inline bool IsValid() const
+    {
+        return Width != 0 && Height != 0;
+    }
+
     inline size_t GetRowByteCount() const
     {
         return (Width + 7) / 8;

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -178,6 +178,16 @@ void WFNFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char
             static_cast<int>(_fontData[fontNumber].Font->GetCharCount() - 1));
 }
 
+void WFNFontRenderer::GetValidCharCodes(int fontNumber, std::vector<int> &char_codes)
+{
+    const WFNFont *font = _fontData[fontNumber].Font;
+    for (int i = 0; i < font->GetCharCount(); ++i)
+    {
+        if (font->GetChar(i).IsValid())
+            char_codes.push_back(i);
+    }
+}
+
 void WFNFontRenderer::FreeMemory(int fontNumber)
 {
   delete _fontData[fontNumber].Font;

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -171,8 +171,11 @@ void WFNFontRenderer::GetFontMetrics(int fontNumber, FontMetrics *metrics)
 
 void WFNFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes)
 {
-    *char_codes = std::make_pair(0,
-        static_cast<int>(_fontData[fontNumber].Font->GetCharCount()));
+    if (_fontData[fontNumber].Font->GetCharCount() == 0)
+        *char_codes = std::make_pair(0, 0);
+    else
+        *char_codes = std::make_pair(0,
+            static_cast<int>(_fontData[fontNumber].Font->GetCharCount() - 1));
 }
 
 void WFNFontRenderer::FreeMemory(int fontNumber)

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -122,6 +122,19 @@ bool WFNFontRenderer::IsBitmapFont()
     return true;
 }
 
+// Fill the FontMetrics struct from the given WFNFont
+static void FillMetrics(const WFNFont *font, FontMetrics *metrics)
+{
+    metrics->NominalHeight = font->GetHeight();
+    metrics->RealHeight = font->GetHeight();
+    metrics->CompatHeight = metrics->NominalHeight; // just set to default here
+    metrics->BBox = font->GetBBox();
+    metrics->VExtent = std::make_pair(metrics->BBox.Top, metrics->BBox.Bottom);
+    // fix it up to be *not less* than realheight
+    metrics->VExtent.first = std::min(0, metrics->VExtent.first);
+    metrics->VExtent.second = std::max(metrics->RealHeight - 1, metrics->VExtent.second);
+}
+
 bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/, const String &filename,
     String *src_filename, const FontRenderParams *params, FontMetrics *metrics)
 {
@@ -147,8 +160,13 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/, const Str
   if (src_filename)
     *src_filename = use_filename;
   if (metrics)
-    *metrics = FontMetrics();
+    FillMetrics(font, metrics);
   return true;
+}
+
+void WFNFontRenderer::GetFontMetrics(int fontNumber, FontMetrics *metrics)
+{
+    FillMetrics(_fontData[fontNumber].Font, metrics);
 }
 
 void WFNFontRenderer::FreeMemory(int fontNumber)

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -169,6 +169,12 @@ void WFNFontRenderer::GetFontMetrics(int fontNumber, FontMetrics *metrics)
     FillMetrics(_fontData[fontNumber].Font, metrics);
 }
 
+void WFNFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes)
+{
+    *char_codes = std::make_pair(0,
+        static_cast<int>(_fontData[fontNumber].Font->GetCharCount()));
+}
+
 void WFNFontRenderer::FreeMemory(int fontNumber)
 {
   delete _fontData[fontNumber].Font;

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -45,6 +45,7 @@ public:
       const FontRenderParams *params, FontMetrics *metrics) override;
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
+  void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
 
   WFNFontRenderer(AGS::Common::AssetManager *mgr)
       : _amgr(mgr) {}

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -43,7 +43,7 @@ public:
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const String &filename, String *src_filename,
       const FontRenderParams *params, FontMetrics *metrics) override;
-  void GetFontMetrics(int fontNumber, FontMetrics *metrics) override { *metrics = FontMetrics(); }
+  void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
 
   WFNFontRenderer(AGS::Common::AssetManager *mgr)

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -46,6 +46,7 @@ public:
   void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
   void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
+  void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) override;
 
   WFNFontRenderer(AGS::Common::AssetManager *mgr)
       : _amgr(mgr) {}

--- a/Common/libsrc/alfont-2.0.9/alfont.c
+++ b/Common/libsrc/alfont-2.0.9/alfont.c
@@ -36,6 +36,12 @@ struct ALFONT_FONT {
   int face_ascender;      /* face ascender */
   int real_face_extent_asc; /* calculated max extent of glyphs (ascender) */
   int real_face_extent_desc; /* calculated max extent of glyphs (descender) */
+  struct _ALFONT_BBOX {
+    int xmin;
+    int xmax;
+    int ymin;
+    int ymax;
+  } face_bbox;            /* glyph's bounding box, in pixels */
   char *data;             /* if loaded from memory, the data chunk */
   int data_size;          /* and its size */
   int ch_spacing;         /* extra spacing */
@@ -409,14 +415,13 @@ static void _alfont_new_cache_glyph(ALFONT_FONT *f) {
   }
 }
 
-static void _alfont_calculate_max_cbox(ALFONT_FONT *f, int max_glyphs) {
-  (void)max_glyphs; // kept just in case, but this was used to load N glyphs
-
-  FT_Long bbox_ymin = FT_MulFix( FT_DivFix( f->face->bbox.yMin, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
-  FT_Long bbox_ymax = FT_MulFix( FT_DivFix( f->face->bbox.yMax, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
-
-  f->real_face_extent_asc = (int)bbox_ymax;
-  f->real_face_extent_desc = -(int)bbox_ymin;
+static void _alfont_calculate_max_cbox(ALFONT_FONT *f) {
+  f->face_bbox.xmin = (int)FT_MulFix( FT_DivFix( f->face->bbox.xMin, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
+  f->face_bbox.xmax = (int)FT_MulFix( FT_DivFix( f->face->bbox.xMax, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
+  f->face_bbox.ymin = (int)FT_MulFix( FT_DivFix( f->face->bbox.yMin, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
+  f->face_bbox.ymax = (int)FT_MulFix( FT_DivFix( f->face->bbox.yMax, f->face->units_per_EM ), f->face->size->metrics.y_ppem );
+  f->real_face_extent_asc = f->face_bbox.ymax;
+  f->real_face_extent_desc = -f->face_bbox.ymin;
 }
 
 
@@ -494,9 +499,9 @@ int alfont_set_font_size_ex(ALFONT_FONT *f, int h, int flags) {
     f->real_face_h = real_height;
     f->face_ascender = f->face->size->metrics.ascender >> 6;
 
-    /* Precalculate actual glyphs vertical extent */
+    /* Precalculate actual glyphs extent */
     if ((flags & ALFONT_FLG_PRECALC_MAX_CBOX) != 0) {
-      _alfont_calculate_max_cbox(f, 256);
+      _alfont_calculate_max_cbox(f);
     }
 
     /* AGS COMPAT HACK: set ascender to the formal font height */
@@ -514,6 +519,10 @@ int alfont_set_font_size_ex(ALFONT_FONT *f, int h, int flags) {
 }
 
 
+int alfont_get_font_ascent(ALFONT_FONT *f) {
+  return f->face_ascender;
+}
+
 int alfont_get_font_height(ALFONT_FONT *f) {
   return f->face_h;
 }
@@ -523,9 +532,11 @@ int alfont_get_font_real_height(ALFONT_FONT *f) {
   return f->real_face_h;
 }
 
-ALFONT_DLL_DECLSPEC void alfont_get_font_real_vextent(ALFONT_FONT *f, int *top, int *bottom) {
-  *top = f->face_ascender - f->real_face_extent_asc; // may be negative
-  *bottom = f->face_ascender + f->real_face_extent_desc;
+ALFONT_DLL_DECLSPEC void alfont_get_font_bbox(ALFONT_FONT *f, int *left, int *top, int *right, int *bottom) {
+  *left = f->face_bbox.xmin;
+  *right = f->face_bbox.xmax;
+  *top = f->face_bbox.ymax;
+  *bottom = f->face_bbox.ymin;
 }
 
 void alfont_exit(void) {

--- a/Common/libsrc/alfont-2.0.9/alfont.c
+++ b/Common/libsrc/alfont-2.0.9/alfont.c
@@ -539,6 +539,24 @@ ALFONT_DLL_DECLSPEC void alfont_get_font_bbox(ALFONT_FONT *f, int *left, int *to
   *bottom = f->face_bbox.ymin;
 }
 
+ALFONT_DLL_DECLSPEC void alfont_get_charcode_range(ALFONT_FONT *f, int *first_charcode, int *last_charcode) {
+  /* See: https://freetype.sourceforge.net/freetype2/docs/reference/ft2-base_interface.html#FT_Get_First_Char */
+  FT_ULong  charcode;
+  FT_UInt   gindex;
+  
+  charcode = FT_Get_First_Char(f->face, &gindex);
+  if (first_charcode)
+    *first_charcode = charcode;
+  while (gindex != 0) {
+    FT_ULong next_charcode = FT_Get_Next_Char(f->face, charcode, &gindex);
+    if (next_charcode) {
+      charcode = next_charcode;
+    }
+  }
+  if (last_charcode)
+    *last_charcode = charcode;
+}
+
 void alfont_exit(void) {
   if (alfont_inited) {
     alfont_inited = 0;

--- a/Common/libsrc/alfont-2.0.9/alfont.h
+++ b/Common/libsrc/alfont-2.0.9/alfont.h
@@ -78,8 +78,12 @@ ALFONT_DLL_DECLSPEC int alfont_get_font_height(ALFONT_FONT *f);
 ALFONT_DLL_DECLSPEC int alfont_get_font_real_height(ALFONT_FONT *f);
 /* Returns the font's glyph maximal bound box */
 ALFONT_DLL_DECLSPEC void alfont_get_font_bbox(ALFONT_FONT *f, int *left, int *top, int *right, int *bottom);
-/* Returns first and last character codes found in the font */
-ALFONT_DLL_DECLSPEC void alfont_get_charcode_range(ALFONT_FONT *f, int *first_charcode, int *last_charcode);
+/* Returns first and last character codes found in the font, and number of valid character codes */
+ALFONT_DLL_DECLSPEC void alfont_get_charcode_range(ALFONT_FONT *f, int *first_charcode, int *last_charcode, int *num_charcodes);
+/* Creates an array containing all the valid character codes found in this font,
+*  returns the length of array.
+   The array is created with malloc() and must be disposed using free(). */
+ALFONT_DLL_DECLSPEC int alfont_get_valid_charcodes(ALFONT_FONT *f, int **charcodes);
 
 ALFONT_DLL_DECLSPEC int alfont_text_mode(int mode);
 

--- a/Common/libsrc/alfont-2.0.9/alfont.h
+++ b/Common/libsrc/alfont-2.0.9/alfont.h
@@ -50,7 +50,6 @@ extern "C" {
 #define ALFONT_FLG_SELECT_NOMINAL_SZ  0x04
 // Precalculate maximal glyph control box, that is maximal graphical
 // extent of any glyph in the font (which may exceed font's height).
-// Note that this requires FreeType to load each glyph one by one.
 #define ALFONT_FLG_PRECALC_MAX_CBOX   0x08
 
 
@@ -73,11 +72,12 @@ ALFONT_DLL_DECLSPEC void alfont_destroy_font(ALFONT_FONT *f);
 
 ALFONT_DLL_DECLSPEC int alfont_set_font_size(ALFONT_FONT *f, int h);
 ALFONT_DLL_DECLSPEC int alfont_set_font_size_ex(ALFONT_FONT *f, int h, int flags);
+ALFONT_DLL_DECLSPEC int alfont_get_font_ascent(ALFONT_FONT *f);
 ALFONT_DLL_DECLSPEC int alfont_get_font_height(ALFONT_FONT *f);
 /* Returns the real font graphical height */
 ALFONT_DLL_DECLSPEC int alfont_get_font_real_height(ALFONT_FONT *f);
-/* Returns the real font graphical extent (top, bottom) */
-ALFONT_DLL_DECLSPEC void alfont_get_font_real_vextent(ALFONT_FONT *f, int *top, int *bottom);
+/* Returns the font's glyph maximal bound box */
+ALFONT_DLL_DECLSPEC void alfont_get_font_bbox(ALFONT_FONT *f, int *left, int *top, int *right, int *bottom);
 
 ALFONT_DLL_DECLSPEC int alfont_text_mode(int mode);
 

--- a/Common/libsrc/alfont-2.0.9/alfont.h
+++ b/Common/libsrc/alfont-2.0.9/alfont.h
@@ -78,6 +78,8 @@ ALFONT_DLL_DECLSPEC int alfont_get_font_height(ALFONT_FONT *f);
 ALFONT_DLL_DECLSPEC int alfont_get_font_real_height(ALFONT_FONT *f);
 /* Returns the font's glyph maximal bound box */
 ALFONT_DLL_DECLSPEC void alfont_get_font_bbox(ALFONT_FONT *f, int *left, int *top, int *right, int *bottom);
+/* Returns first and last character codes found in the font */
+ALFONT_DLL_DECLSPEC void alfont_get_charcode_range(ALFONT_FONT *f, int *first_charcode, int *last_charcode);
 
 ALFONT_DLL_DECLSPEC int alfont_text_mode(int mode);
 

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -293,6 +293,9 @@
       <DependentUpon>NumberEntryDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="Entities\LogBuffer.cs" />
+    <Compile Include="Panes\FontPreviewGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Panes\Room\RoomEditFilters\BaseRoomEditorFilter.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\BaseThingEditorFilter.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\CharactersEditorFilter.cs" />

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -224,6 +224,7 @@ namespace AGS.Editor.Components
                 var fontEditor = doc.Control as FontEditor;
                 if (fontEditor != null)
                 {
+                    fontEditor.OnTextFormatUpdated();
                     fontEditor.UpdatePreviewScaling();
                 }
             }

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -164,10 +164,11 @@ namespace AGS.Editor.Components
                 return;
             }
 
-            bool shouldRepaint = (propertyName == "SourceFilename" || propertyName == "Font Size" || propertyName == "SizeMultiplier");
+            bool fontStyleChanged = (propertyName == "SourceFilename" || propertyName == "Font Size" || propertyName == "SizeMultiplier");
+            bool fontGlyphPositionChanged = true; // any other property changes this
             Factory.NativeProxy.OnFontUpdated(Factory.AGSEditor.CurrentGame, itemBeingEdited.ID, (propertyName == "SourceFilename"));
-            if (shouldRepaint)
-                editor.OnFontUpdated();
+            if (fontStyleChanged || fontGlyphPositionChanged)
+                editor.OnFontUpdated(fontStyleChanged, fontGlyphPositionChanged);
         }
 
         public override IList<MenuCommand> GetContextMenu(string controlID)

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -217,6 +217,18 @@ namespace AGS.Editor.Components
             FontTypeConverter.SetFontList(_agsEditor.CurrentGame.Fonts);
         }
 
+        public override void GameSettingsChanged()
+        {
+            foreach (ContentDocument doc in _documents.Values)
+            {
+                var fontEditor = doc.Control as FontEditor;
+                if (fontEditor != null)
+                {
+                    fontEditor.UpdatePreviewScaling();
+                }
+            }
+        }
+
         private string GetNodeID(AGS.Types.Font item)
         {
             return "Fnt" + item.ID;

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -164,7 +164,9 @@ namespace AGS.Editor.Components
                 return;
             }
 
-            bool fontStyleChanged = (propertyName == "SourceFilename" || propertyName == "Font Size" || propertyName == "SizeMultiplier");
+            bool fontStyleChanged =
+                (propertyName == "SourceFilename" || propertyName == "Font Size"
+                || propertyName == "SizeMultiplier" || propertyName == "TTF font adjustment");
             bool fontGlyphPositionChanged = true; // any other property changes this
             Factory.NativeProxy.OnFontUpdated(Factory.AGSEditor.CurrentGame, itemBeingEdited.ID, (propertyName == "SourceFilename"));
             if (fontStyleChanged || fontGlyphPositionChanged)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -115,11 +115,18 @@ namespace AGS.Editor
             return _native.GetFontMetrics(fontNum);
         }
 
-        public void DrawFont(IntPtr hdc, int fontNum, bool ansi_mode, int dc_atx, int dc_aty, int dc_width, int dc_height,
+        public int[] GetFontValidCharacters(int fontNum)
+        {
+            return _native.GetFontValidCharacters(fontNum);
+        }
+
+        public void DrawFont(IntPtr hdc, int fontNum, bool ansi_mode, bool only_valid_chars,
+                int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y)
         {
-            _native.DrawFont((int)hdc, fontNum, ansi_mode, dc_atx, dc_aty, dc_width, dc_height,
+            _native.DrawFont((int)hdc, fontNum, ansi_mode, only_valid_chars,
+                dc_atx, dc_aty, dc_width, dc_height,
                 cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                 scroll_y);
         }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -115,11 +115,11 @@ namespace AGS.Editor
             return _native.GetFontMetrics(fontNum);
         }
 
-        public void DrawFont(IntPtr hdc, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+        public void DrawFont(IntPtr hdc, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y)
         {
-            _native.DrawFont((int)hdc, fontNum, dc_atx, dc_aty, dc_width, dc_height, padding,
+            _native.DrawFont((int)hdc, fontNum, dc_atx, dc_aty, dc_width, dc_height,
                 cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                 scroll_y);
         }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -121,14 +121,15 @@ namespace AGS.Editor
         }
 
         public void DrawFont(IntPtr hdc, int fontNum, bool ansi_mode, bool only_valid_chars,
-                int dc_atx, int dc_aty, int dc_width, int dc_height,
-                int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
-                int scroll_y)
+                int dc_atx, int dc_aty, int draw_atx, int draw_aty,
+                int cell_w, int cell_h, int cell_space_x, int cell_space_y,
+                int col_count, int row_count, int first_cell,
+                float scaling)
         {
             _native.DrawFont((int)hdc, fontNum, ansi_mode, only_valid_chars,
-                dc_atx, dc_aty, dc_width, dc_height,
-                cell_w, cell_h, cell_space_x, cell_space_y, scaling,
-                scroll_y);
+                dc_atx, dc_aty, draw_atx, draw_aty,
+                cell_w, cell_h, cell_space_x, cell_space_y,
+                col_count, row_count, first_cell, scaling);
         }
 
         public void DrawTextUsingFont(IntPtr hdc, string text, int fontNum,

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -115,6 +115,13 @@ namespace AGS.Editor
             return _native.DrawFont((int)hdc, fontNum, x, y, width, height, scroll_y);
         }
 
+        public void DrawTextUsingFont(IntPtr hdc, string text, int fontNum,
+            int dc_atx, int dc_aty, int dc_width, int dc_height,
+            int text_atx, int text_aty, int max_width)
+        {
+            _native.DrawTextUsingFont((int)hdc, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width);
+        }
+
         public void DrawSprite(IntPtr hdc, int x, int y, int width, int height, int spriteNum, bool flipImage = false)
         {
 			lock (_spriteSetLock)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -115,11 +115,11 @@ namespace AGS.Editor
             return _native.GetFontMetrics(fontNum);
         }
 
-        public void DrawFont(IntPtr hdc, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height,
+        public void DrawFont(IntPtr hdc, int fontNum, bool ansi_mode, int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y)
         {
-            _native.DrawFont((int)hdc, fontNum, dc_atx, dc_aty, dc_width, dc_height,
+            _native.DrawFont((int)hdc, fontNum, ansi_mode, dc_atx, dc_aty, dc_width, dc_height,
                 cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                 scroll_y);
         }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -110,16 +110,25 @@ namespace AGS.Editor
 			}
         }
 
-        public int DrawFont(IntPtr hdc, int fontNum, int x, int y, int width, int height, int scroll_y)
+        public Native.FontMetrics GetFontMetrics(int fontNum)
         {
-            return _native.DrawFont((int)hdc, fontNum, x, y, width, height, scroll_y);
+            return _native.GetFontMetrics(fontNum);
+        }
+
+        public void DrawFont(IntPtr hdc, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+                int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
+                int scroll_y)
+        {
+            _native.DrawFont((int)hdc, fontNum, dc_atx, dc_aty, dc_width, dc_height, padding,
+                cell_w, cell_h, cell_space_x, cell_space_y, scaling,
+                scroll_y);
         }
 
         public void DrawTextUsingFont(IntPtr hdc, string text, int fontNum,
             int dc_atx, int dc_aty, int dc_width, int dc_height,
-            int text_atx, int text_aty, int max_width)
+            int text_atx, int text_aty, int max_width, float scaling)
         {
-            _native.DrawTextUsingFont((int)hdc, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width);
+            _native.DrawTextUsingFont((int)hdc, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width, scaling);
         }
 
         public void DrawSprite(IntPtr hdc, int x, int y, int width, int height, int spriteNum, bool flipImage = false)

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -33,6 +33,11 @@ namespace AGS.Editor
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
             this.textPreviewPanel = new AGS.Editor.BufferedPanel();
+            this.btnGotoChar = new System.Windows.Forms.Button();
+            this.tbCharInput = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.udCharCode = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
             this.fontViewPanel = new AGS.Editor.BufferedPanel();
             this.btnImportFont = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
@@ -42,6 +47,7 @@ namespace AGS.Editor
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udCharCode)).BeginInit();
             this.SuspendLayout();
             // 
             // currentItemGroupBox
@@ -55,7 +61,7 @@ namespace AGS.Editor
             this.currentItemGroupBox.Controls.Add(this.label1);
             this.currentItemGroupBox.Location = new System.Drawing.Point(13, 13);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
-            this.currentItemGroupBox.Size = new System.Drawing.Size(505, 467);
+            this.currentItemGroupBox.Size = new System.Drawing.Size(550, 467);
             this.currentItemGroupBox.TabIndex = 3;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected font settings";
@@ -68,7 +74,7 @@ namespace AGS.Editor
             this.panel1.Controls.Add(this.splitContainer1);
             this.panel1.Location = new System.Drawing.Point(6, 72);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(493, 389);
+            this.panel1.Size = new System.Drawing.Size(538, 389);
             this.panel1.TabIndex = 5;
             // 
             // splitContainer1
@@ -88,9 +94,14 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
+            this.splitContainer1.Panel2.Controls.Add(this.btnGotoChar);
+            this.splitContainer1.Panel2.Controls.Add(this.tbCharInput);
+            this.splitContainer1.Panel2.Controls.Add(this.label3);
+            this.splitContainer1.Panel2.Controls.Add(this.udCharCode);
+            this.splitContainer1.Panel2.Controls.Add(this.label2);
             this.splitContainer1.Panel2.Controls.Add(this.fontViewPanel);
             this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(7);
-            this.splitContainer1.Size = new System.Drawing.Size(493, 389);
+            this.splitContainer1.Size = new System.Drawing.Size(538, 389);
             this.splitContainer1.SplitterDistance = 120;
             this.splitContainer1.TabIndex = 5;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
@@ -99,11 +110,11 @@ namespace AGS.Editor
             // 
             this.tbTextPreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbTextPreview.Location = new System.Drawing.Point(10, 64);
+            this.tbTextPreview.Location = new System.Drawing.Point(10, 62);
             this.tbTextPreview.Multiline = true;
             this.tbTextPreview.Name = "tbTextPreview";
             this.tbTextPreview.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.tbTextPreview.Size = new System.Drawing.Size(471, 44);
+            this.tbTextPreview.Size = new System.Drawing.Size(516, 44);
             this.tbTextPreview.TabIndex = 5;
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
@@ -116,9 +127,62 @@ namespace AGS.Editor
             this.textPreviewPanel.AutoScroll = true;
             this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
             this.textPreviewPanel.Name = "textPreviewPanel";
-            this.textPreviewPanel.Size = new System.Drawing.Size(471, 45);
+            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
             this.textPreviewPanel.TabIndex = 4;
             this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
+            // btnGotoChar
+            // 
+            this.btnGotoChar.Location = new System.Drawing.Point(313, 6);
+            this.btnGotoChar.Name = "btnGotoChar";
+            this.btnGotoChar.Size = new System.Drawing.Size(75, 23);
+            this.btnGotoChar.TabIndex = 8;
+            this.btnGotoChar.Text = "Go To...";
+            this.btnGotoChar.UseVisualStyleBackColor = true;
+            this.btnGotoChar.Click += new System.EventHandler(this.btnGotoChar_Click);
+            // 
+            // tbCharInput
+            // 
+            this.tbCharInput.Location = new System.Drawing.Point(231, 8);
+            this.tbCharInput.MaxLength = 1;
+            this.tbCharInput.Name = "tbCharInput";
+            this.tbCharInput.Size = new System.Drawing.Size(60, 20);
+            this.tbCharInput.TabIndex = 7;
+            this.tbCharInput.TextChanged += new System.EventHandler(this.tbCharInput_TextChanged);
+            this.tbCharInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbCharInput_KeyDown);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(169, 11);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(56, 13);
+            this.label3.TabIndex = 6;
+            this.label3.Text = "Character:";
+            // 
+            // udCharCode
+            // 
+            this.udCharCode.Hexadecimal = true;
+            this.udCharCode.Location = new System.Drawing.Point(65, 7);
+            this.udCharCode.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+            this.udCharCode.Name = "udCharCode";
+            this.udCharCode.Size = new System.Drawing.Size(87, 20);
+            this.udCharCode.TabIndex = 5;
+            this.udCharCode.ValueChanged += new System.EventHandler(this.udCharCode_ValueChanged);
+            this.udCharCode.KeyDown += new System.Windows.Forms.KeyEventHandler(this.udCharCode_KeyDown);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(11, 11);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(52, 13);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "Code: U+";
             // 
             // fontViewPanel
             // 
@@ -126,12 +190,12 @@ namespace AGS.Editor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.fontViewPanel.AutoScroll = true;
-            this.fontViewPanel.Location = new System.Drawing.Point(10, 10);
+            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
             this.fontViewPanel.Name = "fontViewPanel";
-            this.fontViewPanel.Size = new System.Drawing.Size(471, 243);
+            this.fontViewPanel.Size = new System.Drawing.Size(516, 203);
             this.fontViewPanel.TabIndex = 3;
-            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.imagePanel_Scroll);
-            this.fontViewPanel.SizeChanged += new System.EventHandler(this.imagePanel_SizeChanged);
+            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.fontViewPanel_Scroll);
+            this.fontViewPanel.SizeChanged += new System.EventHandler(this.fontViewPanel_SizeChanged);
             this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
             // 
             // btnImportFont
@@ -159,7 +223,7 @@ namespace AGS.Editor
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.currentItemGroupBox);
             this.Name = "FontEditor";
-            this.Size = new System.Drawing.Size(534, 493);
+            this.Size = new System.Drawing.Size(579, 493);
             this.Load += new System.EventHandler(this.FontEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.currentItemGroupBox.PerformLayout();
@@ -167,8 +231,10 @@ namespace AGS.Editor
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.udCharCode)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -183,5 +249,10 @@ namespace AGS.Editor
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TextBox tbTextPreview;
         private BufferedPanel textPreviewPanel;
+        private System.Windows.Forms.TextBox tbCharInput;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.NumericUpDown udCharCode;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button btnGotoChar;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -131,6 +131,7 @@ namespace AGS.Editor
             this.textPreviewPanel.Name = "textPreviewPanel";
             this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
             this.textPreviewPanel.TabIndex = 0;
+            this.textPreviewPanel.SizeChanged += new System.EventHandler(this.textPreviewPanel_SizeChanged);
             this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
             // 
             // chkDisplayCodes

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -82,6 +82,7 @@ namespace AGS.Editor
             // 
             this.splitContainer1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -33,6 +33,7 @@ namespace AGS.Editor
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
             this.textPreviewPanel = new AGS.Editor.BufferedPanel();
+            this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
@@ -62,7 +63,7 @@ namespace AGS.Editor
             this.currentItemGroupBox.Location = new System.Drawing.Point(13, 13);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
             this.currentItemGroupBox.Size = new System.Drawing.Size(550, 467);
-            this.currentItemGroupBox.TabIndex = 3;
+            this.currentItemGroupBox.TabIndex = 0;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected font settings";
             // 
@@ -94,6 +95,7 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
+            this.splitContainer1.Panel2.Controls.Add(this.chkDisplayCodes);
             this.splitContainer1.Panel2.Controls.Add(this.btnGotoChar);
             this.splitContainer1.Panel2.Controls.Add(this.tbCharInput);
             this.splitContainer1.Panel2.Controls.Add(this.label3);
@@ -103,7 +105,7 @@ namespace AGS.Editor
             this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(7);
             this.splitContainer1.Size = new System.Drawing.Size(538, 389);
             this.splitContainer1.SplitterDistance = 120;
-            this.splitContainer1.TabIndex = 5;
+            this.splitContainer1.TabIndex = 0;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
             // 
             // tbTextPreview
@@ -115,7 +117,7 @@ namespace AGS.Editor
             this.tbTextPreview.Name = "tbTextPreview";
             this.tbTextPreview.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.tbTextPreview.Size = new System.Drawing.Size(516, 44);
-            this.tbTextPreview.TabIndex = 5;
+            this.tbTextPreview.TabIndex = 1;
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
             // 
@@ -128,15 +130,26 @@ namespace AGS.Editor
             this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
             this.textPreviewPanel.Name = "textPreviewPanel";
             this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
-            this.textPreviewPanel.TabIndex = 4;
+            this.textPreviewPanel.TabIndex = 0;
             this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
+            // chkDisplayCodes
+            // 
+            this.chkDisplayCodes.AutoSize = true;
+            this.chkDisplayCodes.Location = new System.Drawing.Point(408, 10);
+            this.chkDisplayCodes.Name = "chkDisplayCodes";
+            this.chkDisplayCodes.Size = new System.Drawing.Size(92, 17);
+            this.chkDisplayCodes.TabIndex = 5;
+            this.chkDisplayCodes.Text = "Display codes";
+            this.chkDisplayCodes.UseVisualStyleBackColor = true;
+            this.chkDisplayCodes.CheckedChanged += new System.EventHandler(this.chkDisplayCodes_CheckedChanged);
             // 
             // btnGotoChar
             // 
             this.btnGotoChar.Location = new System.Drawing.Point(313, 6);
             this.btnGotoChar.Name = "btnGotoChar";
             this.btnGotoChar.Size = new System.Drawing.Size(75, 23);
-            this.btnGotoChar.TabIndex = 8;
+            this.btnGotoChar.TabIndex = 4;
             this.btnGotoChar.Text = "Go To...";
             this.btnGotoChar.UseVisualStyleBackColor = true;
             this.btnGotoChar.Click += new System.EventHandler(this.btnGotoChar_Click);
@@ -147,7 +160,7 @@ namespace AGS.Editor
             this.tbCharInput.MaxLength = 1;
             this.tbCharInput.Name = "tbCharInput";
             this.tbCharInput.Size = new System.Drawing.Size(60, 20);
-            this.tbCharInput.TabIndex = 7;
+            this.tbCharInput.TabIndex = 3;
             this.tbCharInput.TextChanged += new System.EventHandler(this.tbCharInput_TextChanged);
             this.tbCharInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbCharInput_KeyDown);
             // 
@@ -157,7 +170,7 @@ namespace AGS.Editor
             this.label3.Location = new System.Drawing.Point(169, 11);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(56, 13);
-            this.label3.TabIndex = 6;
+            this.label3.TabIndex = 2;
             this.label3.Text = "Character:";
             // 
             // udCharCode
@@ -171,7 +184,7 @@ namespace AGS.Editor
             0});
             this.udCharCode.Name = "udCharCode";
             this.udCharCode.Size = new System.Drawing.Size(87, 20);
-            this.udCharCode.TabIndex = 5;
+            this.udCharCode.TabIndex = 1;
             this.udCharCode.ValueChanged += new System.EventHandler(this.udCharCode_ValueChanged);
             this.udCharCode.KeyDown += new System.Windows.Forms.KeyEventHandler(this.udCharCode_KeyDown);
             // 
@@ -181,7 +194,7 @@ namespace AGS.Editor
             this.label2.Location = new System.Drawing.Point(11, 11);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(52, 13);
-            this.label2.TabIndex = 4;
+            this.label2.TabIndex = 0;
             this.label2.Text = "Code: U+";
             // 
             // fontViewPanel
@@ -193,7 +206,7 @@ namespace AGS.Editor
             this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
             this.fontViewPanel.Name = "fontViewPanel";
             this.fontViewPanel.Size = new System.Drawing.Size(516, 203);
-            this.fontViewPanel.TabIndex = 3;
+            this.fontViewPanel.TabIndex = 6;
             this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.fontViewPanel_Scroll);
             this.fontViewPanel.SizeChanged += new System.EventHandler(this.fontViewPanel_SizeChanged);
             this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
@@ -203,7 +216,7 @@ namespace AGS.Editor
             this.btnImportFont.Location = new System.Drawing.Point(13, 40);
             this.btnImportFont.Name = "btnImportFont";
             this.btnImportFont.Size = new System.Drawing.Size(132, 26);
-            this.btnImportFont.TabIndex = 4;
+            this.btnImportFont.TabIndex = 1;
             this.btnImportFont.Text = "Import over this font...";
             this.btnImportFont.UseVisualStyleBackColor = true;
             this.btnImportFont.Click += new System.EventHandler(this.btnImportFont_Click);
@@ -254,5 +267,6 @@ namespace AGS.Editor
         private System.Windows.Forms.NumericUpDown udCharCode;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button btnGotoChar;
+        private System.Windows.Forms.CheckBox chkDisplayCodes;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -29,10 +29,19 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.currentItemGroupBox = new System.Windows.Forms.GroupBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.tbTextPreview = new System.Windows.Forms.TextBox();
+            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
+            this.fontViewPanel = new AGS.Editor.BufferedPanel();
             this.btnImportFont = new System.Windows.Forms.Button();
-            this.imagePanel = new AGS.Editor.BufferedPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.currentItemGroupBox.SuspendLayout();
+            this.panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             this.SuspendLayout();
             // 
             // currentItemGroupBox
@@ -41,8 +50,8 @@ namespace AGS.Editor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.currentItemGroupBox.BackColor = System.Drawing.SystemColors.Control;
+            this.currentItemGroupBox.Controls.Add(this.panel1);
             this.currentItemGroupBox.Controls.Add(this.btnImportFont);
-            this.currentItemGroupBox.Controls.Add(this.imagePanel);
             this.currentItemGroupBox.Controls.Add(this.label1);
             this.currentItemGroupBox.Location = new System.Drawing.Point(13, 13);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
@@ -50,6 +59,80 @@ namespace AGS.Editor
             this.currentItemGroupBox.TabIndex = 3;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected font settings";
+            // 
+            // panel1
+            // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panel1.Controls.Add(this.splitContainer1);
+            this.panel1.Location = new System.Drawing.Point(6, 72);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(493, 389);
+            this.panel1.TabIndex = 5;
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.tbTextPreview);
+            this.splitContainer1.Panel1.Controls.Add(this.textPreviewPanel);
+            this.splitContainer1.Panel1.Padding = new System.Windows.Forms.Padding(7);
+            this.splitContainer1.Panel1MinSize = 120;
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.fontViewPanel);
+            this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(7);
+            this.splitContainer1.Size = new System.Drawing.Size(493, 389);
+            this.splitContainer1.SplitterDistance = 120;
+            this.splitContainer1.TabIndex = 5;
+            this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
+            // 
+            // tbTextPreview
+            // 
+            this.tbTextPreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbTextPreview.Location = new System.Drawing.Point(10, 64);
+            this.tbTextPreview.Multiline = true;
+            this.tbTextPreview.Name = "tbTextPreview";
+            this.tbTextPreview.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.tbTextPreview.Size = new System.Drawing.Size(471, 44);
+            this.tbTextPreview.TabIndex = 5;
+            this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
+            this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
+            // 
+            // textPreviewPanel
+            // 
+            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textPreviewPanel.AutoScroll = true;
+            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
+            this.textPreviewPanel.Name = "textPreviewPanel";
+            this.textPreviewPanel.Size = new System.Drawing.Size(471, 45);
+            this.textPreviewPanel.TabIndex = 4;
+            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
+            // fontViewPanel
+            // 
+            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fontViewPanel.AutoScroll = true;
+            this.fontViewPanel.Location = new System.Drawing.Point(10, 10);
+            this.fontViewPanel.Name = "fontViewPanel";
+            this.fontViewPanel.Size = new System.Drawing.Size(471, 243);
+            this.fontViewPanel.TabIndex = 3;
+            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.imagePanel_Scroll);
+            this.fontViewPanel.SizeChanged += new System.EventHandler(this.imagePanel_SizeChanged);
+            this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
             // 
             // btnImportFont
             // 
@@ -60,20 +143,6 @@ namespace AGS.Editor
             this.btnImportFont.Text = "Import over this font...";
             this.btnImportFont.UseVisualStyleBackColor = true;
             this.btnImportFont.Click += new System.EventHandler(this.btnImportFont_Click);
-            // 
-            // imagePanel
-            // 
-            this.imagePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.imagePanel.AutoScroll = true;
-            this.imagePanel.Location = new System.Drawing.Point(13, 80);
-            this.imagePanel.Name = "imagePanel";
-            this.imagePanel.Size = new System.Drawing.Size(477, 370);
-            this.imagePanel.TabIndex = 3;
-            this.imagePanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.imagePanel_Scroll);
-            this.imagePanel.SizeChanged += new System.EventHandler(this.imagePanel_SizeChanged);
-            this.imagePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.imagePanel_Paint);
             // 
             // label1
             // 
@@ -94,6 +163,12 @@ namespace AGS.Editor
             this.Load += new System.EventHandler(this.FontEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.currentItemGroupBox.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -103,6 +178,10 @@ namespace AGS.Editor
         private System.Windows.Forms.GroupBox currentItemGroupBox;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnImportFont;
-        private BufferedPanel imagePanel;
+        private BufferedPanel fontViewPanel;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.TextBox tbTextPreview;
+        private BufferedPanel textPreviewPanel;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -213,6 +213,7 @@ namespace AGS.Editor
             this.fontViewPanel.SelectedCharCode = -1;
             this.fontViewPanel.Size = new System.Drawing.Size(516, 209);
             this.fontViewPanel.TabIndex = 6;
+            this.fontViewPanel.TabStop = true;
             // 
             // btnImportFont
             // 

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -32,16 +32,16 @@ namespace AGS.Editor
             this.panel1 = new System.Windows.Forms.Panel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
-            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
             this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.udCharCode = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
-            this.fontViewPanel = new AGS.Editor.BufferedPanel();
             this.btnImportFont = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
+            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
+            this.fontViewPanel = new AGS.Editor.BufferedPanel();
             this.currentItemGroupBox.SuspendLayout();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -121,18 +121,6 @@ namespace AGS.Editor
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
             // 
-            // textPreviewPanel
-            // 
-            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textPreviewPanel.AutoScroll = true;
-            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
-            this.textPreviewPanel.Name = "textPreviewPanel";
-            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
-            this.textPreviewPanel.TabIndex = 0;
-            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
-            // 
             // chkDisplayCodes
             // 
             this.chkDisplayCodes.AutoSize = true;
@@ -197,20 +185,6 @@ namespace AGS.Editor
             this.label2.TabIndex = 0;
             this.label2.Text = "Code: U+";
             // 
-            // fontViewPanel
-            // 
-            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.fontViewPanel.AutoScroll = true;
-            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
-            this.fontViewPanel.Name = "fontViewPanel";
-            this.fontViewPanel.Size = new System.Drawing.Size(516, 203);
-            this.fontViewPanel.TabIndex = 6;
-            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.fontViewPanel_Scroll);
-            this.fontViewPanel.SizeChanged += new System.EventHandler(this.fontViewPanel_SizeChanged);
-            this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
-            // 
             // btnImportFont
             // 
             this.btnImportFont.Location = new System.Drawing.Point(13, 40);
@@ -229,6 +203,33 @@ namespace AGS.Editor
             this.label1.Size = new System.Drawing.Size(282, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
+            // 
+            // textPreviewPanel
+            // 
+            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textPreviewPanel.AutoScroll = true;
+            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
+            this.textPreviewPanel.Name = "textPreviewPanel";
+            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
+            this.textPreviewPanel.TabIndex = 0;
+            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
+            // fontViewPanel
+            // 
+            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fontViewPanel.AutoScroll = true;
+            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
+            this.fontViewPanel.Name = "fontViewPanel";
+            this.fontViewPanel.Size = new System.Drawing.Size(516, 203);
+            this.fontViewPanel.TabIndex = 6;
+            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.fontViewPanel_Scroll);
+            this.fontViewPanel.SizeChanged += new System.EventHandler(this.fontViewPanel_SizeChanged);
+            this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
+            this.fontViewPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.fontViewPanel_MouseClick);
             // 
             // FontEditor
             // 

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -32,16 +32,16 @@ namespace AGS.Editor
             this.panel1 = new System.Windows.Forms.Panel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
+            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
             this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.udCharCode = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
+            this.fontViewPanel = new AGS.Editor.FontPreviewGrid();
             this.btnImportFont = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
-            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
-            this.fontViewPanel = new AGS.Editor.BufferedPanel();
             this.currentItemGroupBox.SuspendLayout();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -121,6 +121,18 @@ namespace AGS.Editor
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
             // 
+            // textPreviewPanel
+            // 
+            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textPreviewPanel.AutoScroll = true;
+            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
+            this.textPreviewPanel.Name = "textPreviewPanel";
+            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
+            this.textPreviewPanel.TabIndex = 0;
+            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
             // chkDisplayCodes
             // 
             this.chkDisplayCodes.AutoSize = true;
@@ -185,6 +197,21 @@ namespace AGS.Editor
             this.label2.TabIndex = 0;
             this.label2.Text = "Code: U+";
             // 
+            // fontViewPanel
+            // 
+            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fontViewPanel.AutoScroll = true;
+            this.fontViewPanel.DisplayCodes = false;
+            this.fontViewPanel.GameFontNumber = -1;
+            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
+            this.fontViewPanel.Name = "fontViewPanel";
+            this.fontViewPanel.Scaling = 1F;
+            this.fontViewPanel.SelectedCharCode = -1;
+            this.fontViewPanel.Size = new System.Drawing.Size(516, 209);
+            this.fontViewPanel.TabIndex = 6;
+            // 
             // btnImportFont
             // 
             this.btnImportFont.Location = new System.Drawing.Point(13, 40);
@@ -203,33 +230,6 @@ namespace AGS.Editor
             this.label1.Size = new System.Drawing.Size(282, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
-            // 
-            // textPreviewPanel
-            // 
-            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textPreviewPanel.AutoScroll = true;
-            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
-            this.textPreviewPanel.Name = "textPreviewPanel";
-            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
-            this.textPreviewPanel.TabIndex = 0;
-            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
-            // 
-            // fontViewPanel
-            // 
-            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.fontViewPanel.AutoScroll = true;
-            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
-            this.fontViewPanel.Name = "fontViewPanel";
-            this.fontViewPanel.Size = new System.Drawing.Size(516, 203);
-            this.fontViewPanel.TabIndex = 6;
-            this.fontViewPanel.Scroll += new System.Windows.Forms.ScrollEventHandler(this.fontViewPanel_Scroll);
-            this.fontViewPanel.SizeChanged += new System.EventHandler(this.fontViewPanel_SizeChanged);
-            this.fontViewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.fontViewPanel_Paint);
-            this.fontViewPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.fontViewPanel_MouseClick);
             // 
             // FontEditor
             // 
@@ -258,7 +258,7 @@ namespace AGS.Editor
         private System.Windows.Forms.GroupBox currentItemGroupBox;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnImportFont;
-        private BufferedPanel fontViewPanel;
+        private FontPreviewGrid fontViewPanel;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TextBox tbTextPreview;

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -32,16 +32,19 @@ namespace AGS.Editor
             this.panel1 = new System.Windows.Forms.Panel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
-            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
             this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.udCharCode = new System.Windows.Forms.NumericUpDown();
-            this.label2 = new System.Windows.Forms.Label();
-            this.fontViewPanel = new AGS.Editor.FontPreviewGrid();
+            this.lblCharCode = new System.Windows.Forms.Label();
             this.btnImportFont = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.rbUnicode = new System.Windows.Forms.RadioButton();
+            this.rbANSI = new System.Windows.Forms.RadioButton();
+            this.textPreviewPanel = new AGS.Editor.BufferedPanel();
+            this.fontViewPanel = new AGS.Editor.FontPreviewGrid();
             this.currentItemGroupBox.SuspendLayout();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -96,18 +99,23 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
+            this.splitContainer1.Panel2.Controls.Add(this.rbANSI);
+            this.splitContainer1.Panel2.Controls.Add(this.rbUnicode);
+            this.splitContainer1.Panel2.Controls.Add(this.label2);
             this.splitContainer1.Panel2.Controls.Add(this.chkDisplayCodes);
             this.splitContainer1.Panel2.Controls.Add(this.btnGotoChar);
             this.splitContainer1.Panel2.Controls.Add(this.tbCharInput);
             this.splitContainer1.Panel2.Controls.Add(this.label3);
             this.splitContainer1.Panel2.Controls.Add(this.udCharCode);
-            this.splitContainer1.Panel2.Controls.Add(this.label2);
+            this.splitContainer1.Panel2.Controls.Add(this.lblCharCode);
             this.splitContainer1.Panel2.Controls.Add(this.fontViewPanel);
             this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(7);
+            this.splitContainer1.Panel2MinSize = 120;
             this.splitContainer1.Size = new System.Drawing.Size(538, 389);
             this.splitContainer1.SplitterDistance = 120;
             this.splitContainer1.TabIndex = 0;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
+            this.splitContainer1.Resize += new System.EventHandler(this.splitContainer1_Resize);
             // 
             // tbTextPreview
             // 
@@ -122,63 +130,50 @@ namespace AGS.Editor
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
             // 
-            // textPreviewPanel
-            // 
-            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textPreviewPanel.AutoScroll = true;
-            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
-            this.textPreviewPanel.Name = "textPreviewPanel";
-            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
-            this.textPreviewPanel.TabIndex = 0;
-            this.textPreviewPanel.SizeChanged += new System.EventHandler(this.textPreviewPanel_SizeChanged);
-            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
-            // 
             // chkDisplayCodes
             // 
             this.chkDisplayCodes.AutoSize = true;
-            this.chkDisplayCodes.Location = new System.Drawing.Point(408, 10);
+            this.chkDisplayCodes.Location = new System.Drawing.Point(408, 33);
             this.chkDisplayCodes.Name = "chkDisplayCodes";
             this.chkDisplayCodes.Size = new System.Drawing.Size(92, 17);
-            this.chkDisplayCodes.TabIndex = 5;
+            this.chkDisplayCodes.TabIndex = 8;
             this.chkDisplayCodes.Text = "Display codes";
             this.chkDisplayCodes.UseVisualStyleBackColor = true;
             this.chkDisplayCodes.CheckedChanged += new System.EventHandler(this.chkDisplayCodes_CheckedChanged);
             // 
             // btnGotoChar
             // 
-            this.btnGotoChar.Location = new System.Drawing.Point(313, 6);
+            this.btnGotoChar.Location = new System.Drawing.Point(313, 29);
             this.btnGotoChar.Name = "btnGotoChar";
             this.btnGotoChar.Size = new System.Drawing.Size(75, 23);
-            this.btnGotoChar.TabIndex = 4;
+            this.btnGotoChar.TabIndex = 7;
             this.btnGotoChar.Text = "Go To...";
             this.btnGotoChar.UseVisualStyleBackColor = true;
             this.btnGotoChar.Click += new System.EventHandler(this.btnGotoChar_Click);
             // 
             // tbCharInput
             // 
-            this.tbCharInput.Location = new System.Drawing.Point(231, 8);
+            this.tbCharInput.Location = new System.Drawing.Point(231, 31);
             this.tbCharInput.MaxLength = 1;
             this.tbCharInput.Name = "tbCharInput";
             this.tbCharInput.Size = new System.Drawing.Size(60, 20);
-            this.tbCharInput.TabIndex = 3;
+            this.tbCharInput.TabIndex = 6;
             this.tbCharInput.TextChanged += new System.EventHandler(this.tbCharInput_TextChanged);
             this.tbCharInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbCharInput_KeyDown);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(169, 11);
+            this.label3.Location = new System.Drawing.Point(169, 34);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(56, 13);
-            this.label3.TabIndex = 2;
+            this.label3.TabIndex = 5;
             this.label3.Text = "Character:";
             // 
             // udCharCode
             // 
             this.udCharCode.Hexadecimal = true;
-            this.udCharCode.Location = new System.Drawing.Point(65, 7);
+            this.udCharCode.Location = new System.Drawing.Point(65, 30);
             this.udCharCode.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -186,34 +181,18 @@ namespace AGS.Editor
             0});
             this.udCharCode.Name = "udCharCode";
             this.udCharCode.Size = new System.Drawing.Size(87, 20);
-            this.udCharCode.TabIndex = 1;
+            this.udCharCode.TabIndex = 4;
             this.udCharCode.ValueChanged += new System.EventHandler(this.udCharCode_ValueChanged);
             this.udCharCode.KeyDown += new System.Windows.Forms.KeyEventHandler(this.udCharCode_KeyDown);
             // 
-            // label2
+            // lblCharCode
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(11, 11);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(52, 13);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Code: U+";
-            // 
-            // fontViewPanel
-            // 
-            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.fontViewPanel.AutoScroll = true;
-            this.fontViewPanel.DisplayCodes = false;
-            this.fontViewPanel.GameFontNumber = -1;
-            this.fontViewPanel.Location = new System.Drawing.Point(10, 44);
-            this.fontViewPanel.Name = "fontViewPanel";
-            this.fontViewPanel.Scaling = 1F;
-            this.fontViewPanel.SelectedCharCode = -1;
-            this.fontViewPanel.Size = new System.Drawing.Size(516, 209);
-            this.fontViewPanel.TabIndex = 6;
-            this.fontViewPanel.TabStop = true;
+            this.lblCharCode.AutoSize = true;
+            this.lblCharCode.Location = new System.Drawing.Point(11, 34);
+            this.lblCharCode.Name = "lblCharCode";
+            this.lblCharCode.Size = new System.Drawing.Size(52, 13);
+            this.lblCharCode.TabIndex = 3;
+            this.lblCharCode.Text = "Code: U+";
             // 
             // btnImportFont
             // 
@@ -233,6 +212,69 @@ namespace AGS.Editor
             this.label1.Size = new System.Drawing.Size(282, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(10, 7);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(77, 13);
+            this.label2.TabIndex = 0;
+            this.label2.Text = "Preview mode:";
+            // 
+            // rbUnicode
+            // 
+            this.rbUnicode.AutoSize = true;
+            this.rbUnicode.Checked = true;
+            this.rbUnicode.Location = new System.Drawing.Point(93, 6);
+            this.rbUnicode.Name = "rbUnicode";
+            this.rbUnicode.Size = new System.Drawing.Size(65, 17);
+            this.rbUnicode.TabIndex = 1;
+            this.rbUnicode.TabStop = true;
+            this.rbUnicode.Text = "Unicode";
+            this.rbUnicode.UseVisualStyleBackColor = true;
+            this.rbUnicode.CheckedChanged += new System.EventHandler(this.rbUnicode_CheckedChanged);
+            // 
+            // rbANSI
+            // 
+            this.rbANSI.AutoSize = true;
+            this.rbANSI.Location = new System.Drawing.Point(164, 6);
+            this.rbANSI.Name = "rbANSI";
+            this.rbANSI.Size = new System.Drawing.Size(88, 17);
+            this.rbANSI.TabIndex = 2;
+            this.rbANSI.Text = "ASCII / ANSI";
+            this.rbANSI.UseVisualStyleBackColor = true;
+            this.rbANSI.CheckedChanged += new System.EventHandler(this.rbANSI_CheckedChanged);
+            // 
+            // textPreviewPanel
+            // 
+            this.textPreviewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textPreviewPanel.AutoScroll = true;
+            this.textPreviewPanel.Location = new System.Drawing.Point(10, 13);
+            this.textPreviewPanel.Name = "textPreviewPanel";
+            this.textPreviewPanel.Size = new System.Drawing.Size(516, 44);
+            this.textPreviewPanel.TabIndex = 0;
+            this.textPreviewPanel.SizeChanged += new System.EventHandler(this.textPreviewPanel_SizeChanged);
+            this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
+            // 
+            // fontViewPanel
+            // 
+            this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fontViewPanel.ANSIMode = false;
+            this.fontViewPanel.AutoScroll = true;
+            this.fontViewPanel.DisplayCodes = false;
+            this.fontViewPanel.GameFontNumber = -1;
+            this.fontViewPanel.Location = new System.Drawing.Point(6, 57);
+            this.fontViewPanel.Name = "fontViewPanel";
+            this.fontViewPanel.Scaling = 1F;
+            this.fontViewPanel.SelectedCharCode = -1;
+            this.fontViewPanel.Size = new System.Drawing.Size(520, 196);
+            this.fontViewPanel.TabIndex = 9;
+            this.fontViewPanel.TabStop = true;
             // 
             // FontEditor
             // 
@@ -269,8 +311,11 @@ namespace AGS.Editor
         private System.Windows.Forms.TextBox tbCharInput;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.NumericUpDown udCharCode;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblCharCode;
         private System.Windows.Forms.Button btnGotoChar;
         private System.Windows.Forms.CheckBox chkDisplayCodes;
+        private System.Windows.Forms.RadioButton rbANSI;
+        private System.Windows.Forms.RadioButton rbUnicode;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -32,6 +32,9 @@ namespace AGS.Editor
             this.panel1 = new System.Windows.Forms.Panel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
+            this.rbANSI = new System.Windows.Forms.RadioButton();
+            this.rbUnicode = new System.Windows.Forms.RadioButton();
+            this.label2 = new System.Windows.Forms.Label();
             this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
@@ -40,9 +43,7 @@ namespace AGS.Editor
             this.lblCharCode = new System.Windows.Forms.Label();
             this.btnImportFont = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.rbUnicode = new System.Windows.Forms.RadioButton();
-            this.rbANSI = new System.Windows.Forms.RadioButton();
+            this.rbPreviewAuto = new System.Windows.Forms.RadioButton();
             this.textPreviewPanel = new AGS.Editor.BufferedPanel();
             this.fontViewPanel = new AGS.Editor.FontPreviewGrid();
             this.currentItemGroupBox.SuspendLayout();
@@ -99,6 +100,7 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
+            this.splitContainer1.Panel2.Controls.Add(this.rbPreviewAuto);
             this.splitContainer1.Panel2.Controls.Add(this.rbANSI);
             this.splitContainer1.Panel2.Controls.Add(this.rbUnicode);
             this.splitContainer1.Panel2.Controls.Add(this.label2);
@@ -129,6 +131,38 @@ namespace AGS.Editor
             this.tbTextPreview.TabIndex = 1;
             this.tbTextPreview.Text = "The quick brown fox jumps over the lazy dog.";
             this.tbTextPreview.TextChanged += new System.EventHandler(this.tbTextPreview_TextChanged);
+            // 
+            // rbANSI
+            // 
+            this.rbANSI.AutoSize = true;
+            this.rbANSI.Location = new System.Drawing.Point(306, 6);
+            this.rbANSI.Name = "rbANSI";
+            this.rbANSI.Size = new System.Drawing.Size(88, 17);
+            this.rbANSI.TabIndex = 2;
+            this.rbANSI.Text = "ASCII / ANSI";
+            this.rbANSI.UseVisualStyleBackColor = true;
+            this.rbANSI.CheckedChanged += new System.EventHandler(this.rbANSI_CheckedChanged);
+            // 
+            // rbUnicode
+            // 
+            this.rbUnicode.AutoSize = true;
+            this.rbUnicode.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.rbUnicode.Location = new System.Drawing.Point(235, 6);
+            this.rbUnicode.Name = "rbUnicode";
+            this.rbUnicode.Size = new System.Drawing.Size(65, 17);
+            this.rbUnicode.TabIndex = 1;
+            this.rbUnicode.Text = "Unicode";
+            this.rbUnicode.UseVisualStyleBackColor = true;
+            this.rbUnicode.CheckedChanged += new System.EventHandler(this.rbUnicode_CheckedChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(10, 7);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(77, 13);
+            this.label2.TabIndex = 0;
+            this.label2.Text = "Preview mode:";
             // 
             // chkDisplayCodes
             // 
@@ -213,38 +247,18 @@ namespace AGS.Editor
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
             // 
-            // label2
+            // rbPreviewAuto
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 7);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(77, 13);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Preview mode:";
-            // 
-            // rbUnicode
-            // 
-            this.rbUnicode.AutoSize = true;
-            this.rbUnicode.Checked = true;
-            this.rbUnicode.Location = new System.Drawing.Point(93, 6);
-            this.rbUnicode.Name = "rbUnicode";
-            this.rbUnicode.Size = new System.Drawing.Size(65, 17);
-            this.rbUnicode.TabIndex = 1;
-            this.rbUnicode.TabStop = true;
-            this.rbUnicode.Text = "Unicode";
-            this.rbUnicode.UseVisualStyleBackColor = true;
-            this.rbUnicode.CheckedChanged += new System.EventHandler(this.rbUnicode_CheckedChanged);
-            // 
-            // rbANSI
-            // 
-            this.rbANSI.AutoSize = true;
-            this.rbANSI.Location = new System.Drawing.Point(164, 6);
-            this.rbANSI.Name = "rbANSI";
-            this.rbANSI.Size = new System.Drawing.Size(88, 17);
-            this.rbANSI.TabIndex = 2;
-            this.rbANSI.Text = "ASCII / ANSI";
-            this.rbANSI.UseVisualStyleBackColor = true;
-            this.rbANSI.CheckedChanged += new System.EventHandler(this.rbANSI_CheckedChanged);
+            this.rbPreviewAuto.AutoSize = true;
+            this.rbPreviewAuto.Checked = true;
+            this.rbPreviewAuto.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.rbPreviewAuto.Location = new System.Drawing.Point(91, 6);
+            this.rbPreviewAuto.Name = "rbPreviewAuto";
+            this.rbPreviewAuto.Size = new System.Drawing.Size(138, 17);
+            this.rbPreviewAuto.TabIndex = 10;
+            this.rbPreviewAuto.Text = "Auto (use Game setting)";
+            this.rbPreviewAuto.UseVisualStyleBackColor = true;
+            this.rbPreviewAuto.CheckedChanged += new System.EventHandler(this.rbPreviewAuto_CheckedChanged);
             // 
             // textPreviewPanel
             // 
@@ -268,6 +282,7 @@ namespace AGS.Editor
             this.fontViewPanel.AutoScroll = true;
             this.fontViewPanel.DisplayCodes = false;
             this.fontViewPanel.GameFontNumber = -1;
+            this.fontViewPanel.HideMissingCharacters = true;
             this.fontViewPanel.Location = new System.Drawing.Point(6, 57);
             this.fontViewPanel.Name = "fontViewPanel";
             this.fontViewPanel.Scaling = 1F;
@@ -317,5 +332,6 @@ namespace AGS.Editor
         private System.Windows.Forms.RadioButton rbANSI;
         private System.Windows.Forms.RadioButton rbUnicode;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.RadioButton rbPreviewAuto;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -26,7 +26,7 @@ namespace AGS.Editor
         public delegate void ImportFont(AGS.Types.Font font);
 
         private AGS.Types.Font _item;
-        private int _previewHeight;
+        private int _previewHeight; // a virtual preview height
 
         public AGS.Types.Font ItemToEdit
         {
@@ -69,47 +69,8 @@ namespace AGS.Editor
             try
             {
                 Factory.NativeProxy.DrawTextUsingFont(g.GetHdc(), tbTextPreview.Text, _item.ID,
-                    0, 0, g_width, g_height, 5, 5, g_width - 5);
-                g.ReleaseHdc();
-                hdcReleased = true;
-            }
-            catch (Exception ex)
-            {
-                int a = 0;
-            }
-            finally
-            {
-                if (!hdcReleased)
-                    g.ReleaseHdc();
-            }
-        }
-
-        // TODO: reimplement this to e.g. only have a bitmap of the panel's size,
-        // and draw a visible portion of the font preview.
-        private void PaintFont(Graphics g)
-        {
-            if (_item == null)
-                return;
-
-            if (fontViewPanel.ClientSize.Width <= 0 || fontViewPanel.ClientSize.Height <= 0)
-                return; // sometimes occurs during automatic rearrangement of controls
-
-            int width = fontViewPanel.ClientSize.Width;
-            int height = fontViewPanel.ClientSize.Height;
-            int full_height = Factory.NativeProxy.DrawFont(IntPtr.Zero, _item.ID, 0, 0, width, 0, 0);
-            if (full_height <= 0)
-            {
-                SetPreviewHeight(0);
-                return; // something went wrong when calculating needed height
-            }
-
-            SetPreviewHeight(full_height);
-
-            int scroll_y = -fontViewPanel.AutoScrollPosition.Y;
-            bool hdcReleased = false;
-            try
-            {
-                Factory.NativeProxy.DrawFont(g.GetHdc(), _item.ID, 0, 0, width, height, scroll_y);
+                    0, 0, g_width, g_height, 5, 5, g_width - 5,
+                    Factory.AGSEditor.CurrentGame.GUIScaleFactor);
                 g.ReleaseHdc();
                 hdcReleased = true;
             }
@@ -123,6 +84,56 @@ namespace AGS.Editor
             }
         }
 
+        private void PaintFont(Graphics g)
+        {
+            if (_item == null)
+                return;
+
+            if (fontViewPanel.ClientSize.Width <= 0 || fontViewPanel.ClientSize.Height <= 0)
+                return; // sometimes occurs during automatic rearrangement of controls
+
+            int scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
+            int width = fontViewPanel.ClientSize.Width;
+            int height = fontViewPanel.ClientSize.Height;
+            int grid_width = width / scaling;
+            int grid_height = height / scaling;
+            var fontMetrics = Factory.NativeProxy.GetFontMetrics(_item.ID);
+            Rectangle bbox = fontMetrics.CharBBox;
+            int padding = 5;
+            int cell_w = Math.Max(10, bbox.Width);
+            int cell_h = Math.Max(10, bbox.Height);
+            int cell_space_x = Math.Max(4, cell_w / 4);
+            int cell_space_y = Math.Max(4, cell_h / 4);
+
+            // Precalculate full height
+            int chars_per_row = Math.Max(1, (grid_width - (padding * 2)) / (cell_w + cell_space_x));
+            int first_char = 0; // we draw starting with char 0 always, just as a convention
+            int last_char = fontMetrics.LastCharCode;
+            int char_count = (last_char - first_char + 1);
+            int full_height = (char_count / chars_per_row + 1) * (cell_h + cell_space_y);
+
+            SetPreviewHeight(full_height);
+
+            int scroll_y = -fontViewPanel.AutoScrollPosition.Y;
+            bool hdcReleased = false;
+            try
+            {
+                Factory.NativeProxy.DrawFont(g.GetHdc(), _item.ID, 0, 0, width, height,
+                    padding, cell_w, cell_h, cell_space_x, cell_space_y, scaling, scroll_y);
+                g.ReleaseHdc();
+                hdcReleased = true;
+            }
+            catch (Exception)
+            {
+            }
+            finally
+            {
+                if (!hdcReleased)
+                    g.ReleaseHdc();
+            }
+        }
+
+        // Sets a virtual preview height (the virtual size of the contents within the font preview)
         private void SetPreviewHeight(int height)
         {
             _previewHeight = height;

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -51,7 +51,7 @@ namespace AGS.Editor
             UpdateCharInput();
 
             if (fontStyle)
-                fontViewPanel.UpdateAndRepaint();
+                fontViewPanel.UpdateAndRepaint(true);
             if (fontStyle || fontGlyphPosition)
                 textPreviewPanel.Invalidate();
         }

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -56,6 +56,11 @@ namespace AGS.Editor
                 textPreviewPanel.Invalidate();
         }
 
+        public void OnTextFormatUpdated()
+        {
+            SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
+        }
+
         public void UpdatePreviewScaling()
         {
             fontViewPanel.Scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
@@ -120,18 +125,35 @@ namespace AGS.Editor
             textPreviewPanel.Invalidate();
         }
 
+        private void SetFontPreviewMode(bool unicodeMode)
+        {
+            if (unicodeMode)
+            {
+                fontViewPanel.ANSIMode = false;
+                lblCharCode.Text = "Code: U+";
+                udCharCode.Hexadecimal = true;
+            }
+            else
+            {
+                fontViewPanel.ANSIMode = true;
+                lblCharCode.Text = "Code:";
+                udCharCode.Hexadecimal = false;
+            }
+        }
+
+        private void rbPreviewAuto_CheckedChanged(object sender, EventArgs e)
+        {
+            SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
+        }
+
         private void rbUnicode_CheckedChanged(object sender, EventArgs e)
         {
-            fontViewPanel.ANSIMode = false;
-            lblCharCode.Text = "Code: U+";
-            udCharCode.Hexadecimal = true;
+            SetFontPreviewMode(true);
         }
 
         private void rbANSI_CheckedChanged(object sender, EventArgs e)
         {
-            fontViewPanel.ANSIMode = true;
-            lblCharCode.Text = "Code:";
-            udCharCode.Hexadecimal = false;
+            SetFontPreviewMode(false);
         }
 
         private void fontViewPanel_CharacterSelected(object sender, FontPreviewGrid.CharacterSelectedEventArgs args)
@@ -252,11 +274,7 @@ namespace AGS.Editor
             if (!DesignMode)
             {
                 Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
-
-                if (Factory.AGSEditor.CurrentGame.UnicodeMode)
-                    rbUnicode.Checked = true;
-                else
-                    rbANSI.Checked = false;
+                SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -210,6 +210,10 @@ namespace AGS.Editor
             t.ControlHelper(this, "font-editor");
             t.GroupBoxHelper(currentItemGroupBox, "font-editor/box");
             t.ButtonHelper(btnImportFont, "font-editor/btn-import");
+            t.ButtonHelper(btnGotoChar, "font-editor/btn-gotochar");
+            t.TextBoxHelper(tbTextPreview, "font-editor/text-box-preview");
+            // FIXME: color theme is not applied to the "character code" and "character" textboxes atm,
+            // because there's no implementation for "up-down-control", so no way to color them consistently.
         }
 
         private void FontEditor_Load(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -16,12 +16,14 @@ namespace AGS.Editor
         {
             InitializeComponent();
             udCharCode.TextChanged += udCharCode_TextChanged;
+            fontViewPanel.CharacterSelected += fontViewPanel_CharacterSelected;
         }
 
         public FontEditor(AGS.Types.Font selectedFont) : this()
         {
             _item = selectedFont;
-            fontViewPanel.Invalidate();
+            fontViewPanel.GameFontNumber = _item.ID;
+            fontViewPanel.Scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
         }
 
         public delegate void ImportFont(AGS.Types.Font font);
@@ -34,28 +36,27 @@ namespace AGS.Editor
             set
             {
                 _item = value;
-                fontViewPanel.Invalidate();
+                fontViewPanel.GameFontNumber = _item.ID;
             }
         }
 
         public ImportFont ImportOverFont { get; set; }
-
-        /// <summary>
-        /// Tells if the character codes should be displayed in preview
-        /// </summary>
-        public bool DisplayCodes { get; set; }
 
         public void OnFontUpdated(bool fontStyle = true, bool fontGlyphPosition = true)
         {
             Factory.GUIController.RefreshPropertyGrid();
 
             UpdateCharInput();
-            PrecalculatePreviewGrid();
 
             if (fontStyle)
-                fontViewPanel.Invalidate();
+                fontViewPanel.UpdateAndRepaint();
             if (fontStyle || fontGlyphPosition)
                 textPreviewPanel.Invalidate();
+        }
+
+        public void UpdatePreviewScaling()
+        {
+            fontViewPanel.Scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
         }
 
         protected override string OnGetHelpKeyword()
@@ -93,166 +94,6 @@ namespace AGS.Editor
             }
         }
 
-        struct PreviewGrid
-        {
-            // The size and font of a "character code" cue, optionally drawn below characters
-            public int CodeCueWidth;
-            public int CodeCueHeight;
-            public System.Drawing.Font CodeCueFont;
-
-            // All of the following "grid" sizes are defined in non-scaled grid coordinates,
-            // which must be scaled by a chosen factor when converting to the real
-            // client control coordinates.
-            public float Scaling;
-            public int GridWidth; // visible grid width
-            public int GridHeight; // visible grid height
-            public int Padding;
-            public int CellWidth;
-            public int CellHeight;
-            public int CellSpaceX;
-            public int CellSpaceY;
-            public int CharsPerRow;
-
-            public int PreviewHeight; // a virtual full preview height
-            public int PreviewScrollY; // a virtual scroll y
-
-            public int SelectedChar; // a character to display a selection rect around
-        };
-
-        PreviewGrid _previewGrid = new PreviewGrid();
-
-        private void PrecalculatePreviewGrid()
-        {
-            if (_item == null)
-                return;
-
-            if (fontViewPanel.ClientSize.Width <= 0 || fontViewPanel.ClientSize.Height <= 0)
-                return; // sometimes occurs during automatic rearrangement of controls
-
-            int scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
-            int width = fontViewPanel.ClientSize.Width;
-            int height = fontViewPanel.ClientSize.Height;
-            int grid_width = width / scaling;
-            int grid_height = height / scaling;
-            var fontMetrics = Factory.NativeProxy.GetFontMetrics(_item.ID);
-            Rectangle bbox = fontMetrics.CharBBox;
-            int padding = 5;
-            int cell_w = Math.Max(10, bbox.Width);
-            int cell_h = Math.Max(10, bbox.Height);
-            // We want cell spacing to include a place for printing character codes;
-            // remember that the cue sizes are in unscaled coords, so pre-unscale them here
-            int cell_space_x = Math.Max(cell_w / 4, 4); // 4 min pixels is arbitrary
-            int cell_space_y = Math.Max(cell_h / 4, _previewGrid.CodeCueHeight / scaling + 1);
-
-            // Precalculate full height
-            int chars_per_row = Math.Max(1, (grid_width - (padding * 2)) / (cell_w + cell_space_x));
-            int first_char = 0; // we draw starting with char 0 always, just as a convention
-            int last_char = fontMetrics.LastCharCode;
-            int char_count = (last_char - first_char + 1);
-            int full_height = (char_count / chars_per_row + 1) * (cell_h + cell_space_y);
-
-            _previewGrid.Scaling = scaling;
-            _previewGrid.GridWidth = grid_width;
-            _previewGrid.GridHeight = grid_height;
-            _previewGrid.Padding = padding;
-            _previewGrid.CellWidth = cell_w;
-            _previewGrid.CellHeight = cell_h;
-            _previewGrid.CellSpaceX = cell_space_x;
-            _previewGrid.CellSpaceY = cell_space_y;
-            _previewGrid.CharsPerRow = chars_per_row;
-            _previewGrid.PreviewHeight = full_height;
-
-            SetPreviewHeight(full_height);
-        }
-
-        private void PaintFont(Graphics g)
-        {
-            if (_item == null)
-                return;
-
-            if (fontViewPanel.ClientSize.Width <= 0 || fontViewPanel.ClientSize.Height <= 0)
-                return; // sometimes occurs during automatic rearrangement of controls
-
-            if (_previewGrid.PreviewHeight == 0)
-            {
-                PrecalculatePreviewGrid();
-            }
-
-            int width = fontViewPanel.ClientSize.Width;
-            int height = fontViewPanel.ClientSize.Height;
-            int scaling = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
-
-            int scroll_y = _previewGrid.PreviewScrollY;
-            bool hdcReleased = false;
-            try
-            {
-                Factory.NativeProxy.DrawFont(g.GetHdc(), _item.ID, 0, 0, width, height,
-                    _previewGrid.Padding, _previewGrid.CellWidth, _previewGrid.CellHeight,
-                    _previewGrid.CellSpaceX, _previewGrid.CellSpaceY, scaling, scroll_y);
-                g.ReleaseHdc();
-                hdcReleased = true;
-            }
-            catch (Exception)
-            {
-            }
-            finally
-            {
-                if (!hdcReleased)
-                    g.ReleaseHdc();
-            }
-
-            // Additional visual cues
-            if (_previewGrid.SelectedChar > 0)
-            {
-                int code = _previewGrid.SelectedChar;
-                int row = code / _previewGrid.CharsPerRow;
-                int y = row * (_previewGrid.CellHeight + _previewGrid.CellSpaceY) + _previewGrid.Padding;
-                int col = code % _previewGrid.CharsPerRow;
-                int x = col * (_previewGrid.CellWidth + _previewGrid.CellSpaceX) + _previewGrid.Padding;
-                Rectangle pos;
-                if (DisplayCodes)
-                    pos = new Rectangle(x * scaling, (y - scroll_y) * scaling, _previewGrid.CellWidth * scaling, (_previewGrid.CellHeight + _previewGrid.CellSpaceY) * scaling);
-                else
-                    pos = new Rectangle(x * scaling, (y - scroll_y) * scaling, _previewGrid.CellWidth * scaling, (_previewGrid.CellHeight) * scaling);
-                g.DrawRectangle(Pens.Yellow, pos);
-            }
-
-            // Print char codes
-            if (DisplayCodes)
-            {
-                int firstVisibleRow = (scroll_y - _previewGrid.Padding) / (_previewGrid.CellHeight + _previewGrid.CellSpaceY);
-                int firstVisibleChar = firstVisibleRow * _previewGrid.CharsPerRow;
-                int lastVisibleRow = firstVisibleRow + (_previewGrid.GridHeight / (_previewGrid.CellHeight + _previewGrid.CellSpaceY));
-                int lastVisibleChar = lastVisibleRow * _previewGrid.CharsPerRow + _previewGrid.CharsPerRow;
-                for (int code = firstVisibleChar, row = firstVisibleRow; row <= lastVisibleRow; ++row)
-                {
-                    for (int col = 0; col < _previewGrid.CharsPerRow; ++col, ++code)
-                    {
-                        int x = col * (_previewGrid.CellWidth + _previewGrid.CellSpaceX) + _previewGrid.Padding;
-                        int y = row * (_previewGrid.CellHeight + _previewGrid.CellSpaceY) + _previewGrid.Padding;
-                        // x,y and cell sizes are in scaled grid coordinates, but cue size is not scaled
-                        Rectangle pos = new Rectangle(
-                            x * scaling,
-                            (y - scroll_y + _previewGrid.CellHeight + _previewGrid.CellSpaceY) * scaling - _previewGrid.CodeCueHeight,
-                            _previewGrid.CodeCueWidth, _previewGrid.CodeCueHeight);
-                        g.FillRectangle(Brushes.LightGray, pos);
-                        g.DrawString(code.ToString("X4"), _previewGrid.CodeCueFont, Brushes.Black, pos.X + 1, pos.Y + 1);
-                    }
-                }
-            }
-        }
-
-        // Sets a virtual preview height (the virtual size of the contents within the font preview)
-        private void SetPreviewHeight(int height)
-        {
-            fontViewPanel.AutoScrollMinSize = new Size(0, height);
-        }
-
-        private void fontViewPanel_Paint(object sender, PaintEventArgs e)
-        {
-            PaintFont(e.Graphics);
-        }
-
         private void btnImportFont_Click(object sender, EventArgs e)
         {
             if (_item != null && ImportOverFont != null)
@@ -265,16 +106,9 @@ namespace AGS.Editor
             }
         }
 
-        private void fontViewPanel_SizeChanged(object sender, EventArgs e)
+        private void fontViewPanel_CharacterSelected(object sender, FontPreviewGrid.CharacterSelectedEventArgs args)
         {
-            PrecalculatePreviewGrid();
-            fontViewPanel.Invalidate();
-        }
-
-        private void fontViewPanel_Scroll(object sender, ScrollEventArgs e)
-        {
-            _previewGrid.PreviewScrollY = -fontViewPanel.AutoScrollPosition.Y;
-            fontViewPanel.Invalidate();
+            udCharCode.Value = args.CharacterCode;
         }
 
         private void tbTextPreview_TextChanged(object sender, EventArgs e)
@@ -310,47 +144,11 @@ namespace AGS.Editor
             UpdateCharCode();
         }
 
-        private void GotoChar(int code)
-        {
-            if (_item == null)
-                return;
-
-            if (_previewGrid.PreviewHeight == 0)
-            {
-                PrecalculatePreviewGrid();
-            }
-
-            // Try to calculate the necessary scroll Y which lets us see the wanted character
-            int row = code / _previewGrid.CharsPerRow;
-            int y = row * (_previewGrid.CellHeight + _previewGrid.CellSpaceY) /*+ _previewGrid.Padding*/;
-
-            _previewGrid.SelectedChar = code;
-
-            // If y is NOT within the visible range, then do the minimal necessary scroll
-            bool do_scroll = false;
-            if (y < _previewGrid.PreviewScrollY)
-            {
-                do_scroll = true;
-            }
-            else if ((y + _previewGrid.CellHeight + _previewGrid.CellSpaceY) > (_previewGrid.PreviewScrollY + _previewGrid.GridHeight))
-            {
-                y = (y + _previewGrid.CellHeight + _previewGrid.CellSpaceY) - _previewGrid.GridHeight;
-                do_scroll = true;
-            }
-
-            if (do_scroll)
-            {
-                _previewGrid.PreviewScrollY = y;
-                fontViewPanel.AutoScrollPosition = new Point(0, y);
-            }
-            fontViewPanel.Invalidate();
-        }
-
         private void udCharCode_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
             {
-                GotoChar((int)udCharCode.Value);
+                fontViewPanel.SelectedCharCode = (int)udCharCode.Value;
                 e.Handled = true;
             }
         }
@@ -359,46 +157,19 @@ namespace AGS.Editor
         {
             if (e.KeyCode == Keys.Enter)
             {
-                GotoChar((int)udCharCode.Value);
+                fontViewPanel.SelectedCharCode = (int)udCharCode.Value;
                 e.Handled = true;
             }
         }
 
         private void btnGotoChar_Click(object sender, EventArgs e)
         {
-            GotoChar((int)udCharCode.Value);
+            fontViewPanel.SelectedCharCode = (int)udCharCode.Value;
         }
 
         private void chkDisplayCodes_CheckedChanged(object sender, EventArgs e)
         {
-            DisplayCodes = chkDisplayCodes.Checked;
-            fontViewPanel.Invalidate();
-        }
-
-        private void SelectCharacterAt(Point pt)
-        {
-            if (_item == null)
-                return;
-
-            if (_previewGrid.GridHeight == 0)
-            {
-                PrecalculatePreviewGrid();
-            }
-
-            int x = (int)(pt.X / _previewGrid.Scaling);
-            int y = (int)(pt.Y / _previewGrid.Scaling) + _previewGrid.PreviewScrollY;
-            int row = (y - _previewGrid.Padding) / (_previewGrid.CellHeight + _previewGrid.CellSpaceY);
-            int col = (x - _previewGrid.Padding) / (_previewGrid.CellWidth + _previewGrid.CellSpaceX);
-            int code = row * _previewGrid.CharsPerRow + col;
-
-            GotoChar(code);
-
-            udCharCode.Value = code;
-        }
-
-        private void fontViewPanel_MouseClick(object sender, MouseEventArgs e)
-        {
-            SelectCharacterAt(e.Location);
+            fontViewPanel.DisplayCodes = chkDisplayCodes.Checked;
         }
 
         private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
@@ -419,12 +190,6 @@ namespace AGS.Editor
             if (!DesignMode)
             {
                 Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
-
-                // Assign some "static" preview grid properties
-                _previewGrid.CodeCueFont = fontViewPanel.Font;
-                Size size = TextRenderer.MeasureText("0000", _previewGrid.CodeCueFont);
-                _previewGrid.CodeCueWidth = size.Width + 2;
-                _previewGrid.CodeCueHeight = size.Height + 2;
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -205,6 +205,13 @@ namespace AGS.Editor
             textPreviewPanel.Invalidate();
         }
 
+        private void splitContainer1_Resize(object sender, EventArgs e)
+        {
+            // HACK: Fix the size of the preview panel.
+            // For some reason, when done automatically, the preview panel's bottom gets too far down.
+            fontViewPanel.SetBounds(fontViewPanel.Left, fontViewPanel.Top, fontViewPanel.Width, splitContainer1.Panel2.Height - splitContainer1.Panel2.Padding.Bottom - fontViewPanel.Top);
+        }
+
         private void LoadColorTheme(ColorTheme t)
         {
             t.ControlHelper(this, "font-editor");

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -120,6 +120,20 @@ namespace AGS.Editor
             textPreviewPanel.Invalidate();
         }
 
+        private void rbUnicode_CheckedChanged(object sender, EventArgs e)
+        {
+            fontViewPanel.ANSIMode = false;
+            lblCharCode.Text = "Code: U+";
+            udCharCode.Hexadecimal = true;
+        }
+
+        private void rbANSI_CheckedChanged(object sender, EventArgs e)
+        {
+            fontViewPanel.ANSIMode = true;
+            lblCharCode.Text = "Code:";
+            udCharCode.Hexadecimal = false;
+        }
+
         private void fontViewPanel_CharacterSelected(object sender, FontPreviewGrid.CharacterSelectedEventArgs args)
         {
             udCharCode.Value = args.CharacterCode;
@@ -132,7 +146,17 @@ namespace AGS.Editor
                 _updatingCharCode = true;
                 int code = 0;
                 if (tbCharInput.Text.Length > 0)
-                    code = tbCharInput.Text[0];
+                {
+                    if (fontViewPanel.ANSIMode)
+                    {
+                        var ansiBytes = Encoding.Default.GetBytes(tbCharInput.Text);
+                        code = ansiBytes[0];
+                    }
+                    else
+                    {
+                        code = tbCharInput.Text[0];
+                    }
+                }
                 udCharCode.Value = (code >= udCharCode.Minimum && code <= udCharCode.Maximum) ? code : 0;
 
                 // Automatically scroll the preview to the selected character
@@ -228,6 +252,11 @@ namespace AGS.Editor
             if (!DesignMode)
             {
                 Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+
+                if (Factory.AGSEditor.CurrentGame.UnicodeMode)
+                    rbUnicode.Checked = true;
+                else
+                    rbANSI.Checked = false;
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/FontEditor.resx
+++ b/Editor/AGS.Editor/Panes/FontEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -1,0 +1,463 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public class FontPreviewGrid : BufferedPanel
+    {
+        private int _fontNumber = -1;
+        private Native.FontMetrics _fontMetrics;
+        private float _scaling = 1.0f;
+        private int _selectedChar = -1;
+        private bool _displayCodes = false;
+
+        public FontPreviewGrid()
+        {
+            // Assign some default preview grid properties
+            _codeCue.Font = Font;
+            Size size = TextRenderer.MeasureText("0000", _codeCue.Font);
+            _codeCue.Width = size.Width + 2;
+            _codeCue.Height = size.Height + 2;
+
+            PrecalculatePreviewGrid();
+        }
+
+        /// <summary>
+        /// Game font to display.
+        /// </summary>
+        [Browsable(false)]
+        public int GameFontNumber
+        {
+            get
+            {
+                return _fontNumber;
+            }
+            set
+            {
+                _fontNumber = value;
+                if (DesignMode)
+                    return;
+
+                if (_fontNumber >= 0 && _fontNumber < Factory.AGSEditor.CurrentGame.Fonts.Count)
+                {
+                    _fontMetrics = Factory.NativeProxy.GetFontMetrics(_fontNumber);
+                }
+                else
+                {
+                    _fontNumber = -1;
+                    _fontMetrics = Native.FontMetrics.Empty;
+                }
+                UpdateAndRepaint();
+            }
+        }
+
+        public float Scaling
+        {
+            get
+            {
+                return _scaling;
+            }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException();
+
+                _scaling = value;
+                if (!DesignMode)
+                {
+                    UpdateAndRepaint();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        public int SelectedCharCode
+        {
+            get
+            {
+                return _selectedChar;
+            }
+            set
+            {
+                if (!DesignMode)
+                {
+                    // Any out of range value (negative too) will act as "no selection"
+                    SelectAndScrollToCharacter(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tells if the character codes should be displayed in preview
+        /// </summary>
+        public bool DisplayCodes
+        {
+            get
+            {
+                return _displayCodes;
+            }
+            set
+            {
+                _displayCodes = value;
+                if (!DesignMode)
+                {
+                    UpdateAndRepaint();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        public bool GameFontValid
+        {
+            get { return !DesignMode && _fontNumber >= 0 && _fontNumber < Factory.AGSEditor.CurrentGame.Fonts.Count; }
+        }
+
+        public class CharacterSelectedEventArgs : EventArgs
+        {
+            public int CharacterCode { get; private set; }
+
+            public CharacterSelectedEventArgs(int characterCode)
+            {
+                CharacterCode = characterCode;
+            }
+        }
+
+        public delegate void CharacterSelectedHandler(object sender, CharacterSelectedEventArgs args);
+        public event CharacterSelectedHandler CharacterSelected;
+
+        /// <summary>
+        /// Parameters of the character code cue, optionally drawn below characters.
+        /// </summary>
+        struct CodeCue
+        {
+            public int Width;
+            public int Height;
+            public System.Drawing.Font Font;
+        };
+
+        private CodeCue _codeCue;
+
+        /// <summary>
+        /// Measurements of the character grid itself.
+        /// Note that all of the grid sizes are defined in "local" grid coordinates,
+        /// which must be scaled by the chosen factor when translating to the control's
+        /// client area.
+        /// </summary>
+        struct PreviewGrid
+        {
+            public int GridWidth; // visible grid width
+            public int GridHeight; // visible grid height
+            public int CellWidth;
+            public int CellHeight;
+            public int CellSpaceX; // horizontal spacing between character cells
+            public int CellSpaceY; // vertical spacing between character cells
+            public int CharsPerRow; // how many characters fit a single row
+
+            public int FullHeight; // a virtual full preview height
+            public int ScrollY; // a virtual scroll y
+        };
+
+        private PreviewGrid _grid;
+
+        public void UpdateAndRepaint()
+        {
+            PrecalculatePreviewGrid();
+            Invalidate();
+        }
+
+        private void PrecalculatePreviewGrid()
+        {
+            if (!GameFontValid)
+                return;
+
+            if (ClientSize.Width <= 0 || ClientSize.Height <= 0)
+                return; // sometimes occurs during automatic rearrangement of controls
+
+            int width = ClientSize.Width;
+            int height = ClientSize.Height;
+            Rectangle bbox = _fontMetrics.CharBBox;
+            int cell_w = Math.Max(10, bbox.Width);
+            int cell_h = Math.Max(10, bbox.Height);
+            // We want cell spacing to include a place for printing character codes;
+            // remember that the cue sizes are in unscaled coords, so pre-unscale them here
+            int cell_space_x = Math.Max(cell_w / 4, (int)(_codeCue.Width / _scaling) + 1 - cell_w);
+            int cell_space_y = Math.Max(cell_h / 4, (int)(_codeCue.Height / _scaling) + 1);
+            int grid_width = (int)(width / _scaling);
+            int grid_height = (int)(height / _scaling);
+
+            // Precalculate full height
+            // Chars per row do not include partially visible ones, unless there's just 1 column
+            int chars_per_row = Math.Max(1, (grid_width - cell_space_x) / (cell_w + cell_space_x));
+            int first_char = 0; // we draw starting with char 0 always, just as a convention
+            int last_char = _fontMetrics.LastCharCode;
+            int char_count = (last_char - first_char + 1);
+            int full_height = (char_count / chars_per_row + 1) * (cell_h + cell_space_y)
+                 + cell_space_y;
+
+            _grid.GridWidth = grid_width;
+            _grid.GridHeight = grid_height;
+            _grid.CellWidth = cell_w;
+            _grid.CellHeight = cell_h;
+            _grid.CellSpaceX = cell_space_x;
+            _grid.CellSpaceY = cell_space_y;
+            _grid.CharsPerRow = chars_per_row;
+            _grid.FullHeight = full_height;
+
+            // Set virtual preview height (the virtual size of the contents within the font preview)
+            AutoScrollMinSize = new Size(0, full_height);
+        }
+
+        private Point ControlToGrid(int x, int y)
+        {
+            return new Point(
+                (int)(x / _scaling),
+                (int)(y / _scaling) + _grid.ScrollY);
+        }
+
+        private Point ControlToGrid(Point pt)
+        {
+            return ControlToGrid(pt.X, pt.Y);
+        }
+
+        private Point GridToControl(int x, int y)
+        {
+            return new Point(
+                (int)((x) * _scaling),
+                (int)((y - _grid.ScrollY) * _scaling));
+        }
+
+        private Point GridToControl(Point pt)
+        {
+            return GridToControl(pt.X, pt.Y);
+        }
+
+        private Rectangle GridToControl(Rectangle rect)
+        {
+            return new Rectangle(
+                GridToControl(rect.X, rect.Y),
+                new Size((int)(rect.Width * _scaling), (int)(rect.Height * _scaling))
+                );
+        }
+
+        private bool CharCodeToColRow(int code, out int col, out int row)
+        {
+            if (code < 0 || _grid.CharsPerRow == 0)
+            {
+                col = -1;
+                row = -1;
+                return false;
+            }
+
+            col = code % _grid.CharsPerRow;
+            row = code / _grid.CharsPerRow;
+            return true;
+        }
+
+        private Point CharCodePosition(int code)
+        {
+            if (code < 0 || _grid.CharsPerRow == 0)
+            {
+                return new Point(-1, -1);
+            }
+
+            return CellPosition(
+                code % _grid.CharsPerRow,
+                code / _grid.CharsPerRow);
+        }
+
+        private bool PointToColRow(Point pt, out int col, out int row)
+        {
+            if (pt.X < 0 || pt.Y < 0 || _grid.CharsPerRow == 0)
+            {
+                col = -1;
+                row = -1;
+                return false;
+            }
+
+            col = Math.Min((pt.X - _grid.CellSpaceX) / (_grid.CellWidth + _grid.CellSpaceX), _grid.CharsPerRow - 1);
+            row = (pt.Y - _grid.CellSpaceY) / (_grid.CellHeight + _grid.CellSpaceY);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns left-top position of a cell in grid's coordinates
+        /// </summary>
+        private Point CellPosition(int col, int row)
+        {
+            return new Point(
+                col * (_grid.CellWidth + _grid.CellSpaceX) + _grid.CellSpaceX,
+                row * (_grid.CellHeight + _grid.CellSpaceY) + _grid.CellSpaceY);
+        }
+
+        private int CharCodeAtCell(int col, int row)
+        {
+            return row * _grid.CharsPerRow + col;
+        }
+
+        private void SelectAndScrollToCharacter(int code)
+        {
+            if (!GameFontValid ||
+                code < 0 || code > _fontMetrics.LastCharCode)
+            {
+                _selectedChar = -1;
+                Invalidate(); // might need to erase selection box
+                return;
+            }
+
+            if (_grid.FullHeight == 0)
+            {
+                PrecalculatePreviewGrid();
+            }
+
+            // Try to calculate the necessary scroll Y which lets us see the wanted character
+            var pos = CharCodePosition(code);
+
+            // If y is NOT within the visible range, then do the minimal necessary scroll
+            bool do_scroll = false;
+            if (pos.Y < _grid.ScrollY)
+            {
+                do_scroll = true;
+            }
+            else
+            {
+                if ((pos.Y + _grid.CellHeight + _grid.CellSpaceY) > (_grid.ScrollY + _grid.GridHeight))
+                {
+                    pos.Y = (pos.Y + _grid.CellHeight + _grid.CellSpaceY) - _grid.GridHeight;
+                    do_scroll = true;
+                }
+            }
+
+            _selectedChar = code;
+            if (do_scroll)
+            {
+                _grid.ScrollY = pos.Y;
+                AutoScrollPosition = new Point(0, pos.Y);
+            }
+            CharacterSelected?.Invoke(this, new CharacterSelectedEventArgs(_selectedChar));
+            Invalidate();
+        }
+
+        private void SelectCharacterAt(Point pt)
+        {
+            if (!GameFontValid)
+                return;
+
+            if (_grid.GridHeight == 0)
+            {
+                PrecalculatePreviewGrid();
+            }
+
+            Point gridPt = ControlToGrid(pt);
+            if (gridPt.X < 0 || gridPt.Y < 0 || gridPt.X >= _grid.GridWidth || gridPt.Y >= _grid.FullHeight)
+                return;
+
+            int col, row;
+            PointToColRow(gridPt, out col, out row);
+            SelectAndScrollToCharacter(CharCodeAtCell(col, row));
+        }
+
+        private void PaintFont(Graphics g)
+        {
+            if (DesignMode)
+                return;
+
+            if (ClientSize.Width <= 0 || ClientSize.Height <= 0)
+                return; // sometimes occurs during automatic rearrangement of controls
+
+            if (!GameFontValid)
+            {
+                g.Clear(Color.Black);
+                return;
+            }
+
+            if (_grid.FullHeight == 0)
+            {
+                PrecalculatePreviewGrid();
+            }
+
+            int width = ClientSize.Width;
+            int height = ClientSize.Height;
+            int scroll_y = _grid.ScrollY;
+
+            g.Clear(Color.Black);
+            bool hdcReleased = false;
+            try
+            {
+                Factory.NativeProxy.DrawFont(g.GetHdc(), _fontNumber, 0, 0, width, height,
+                    _grid.CellWidth, _grid.CellHeight, _grid.CellSpaceX, _grid.CellSpaceY,
+                    _scaling, scroll_y);
+                g.ReleaseHdc();
+                hdcReleased = true;
+            }
+            catch (Exception)
+            {
+            }
+            finally
+            {
+                if (!hdcReleased)
+                    g.ReleaseHdc();
+            }
+
+            // Additional visual cues
+            if (_selectedChar >= 0)
+            {
+                Point cellPos = CharCodePosition(_selectedChar);
+                Rectangle pos = new Rectangle(cellPos,
+                    new Size(
+                        DisplayCodes ? Math.Max(_grid.CellWidth, (int)(_codeCue.Width / _scaling)) : _grid.CellWidth,
+                        DisplayCodes ? (_grid.CellHeight + _grid.CellSpaceY) : _grid.CellHeight));
+                pos = GridToControl(pos);
+                g.DrawRectangle(Pens.Yellow, pos);
+            }
+
+            // Print char codes
+            if (DisplayCodes)
+            {
+                int firstVisibleRow = (scroll_y) / (_grid.CellHeight + _grid.CellSpaceY);
+                int firstVisibleChar = firstVisibleRow * _grid.CharsPerRow;
+                int lastVisibleRow = firstVisibleRow + (_grid.GridHeight / (_grid.CellHeight + _grid.CellSpaceY));
+                int lastVisibleChar = lastVisibleRow * _grid.CharsPerRow + _grid.CharsPerRow;
+                lastVisibleChar = Math.Min(lastVisibleChar, _fontMetrics.LastCharCode);
+                for (int code = firstVisibleChar, row = firstVisibleRow; row <= lastVisibleRow && code <= lastVisibleChar; ++row)
+                {
+                    for (int col = 0; col < _grid.CharsPerRow && code <= lastVisibleChar; ++col, ++code)
+                    {
+                        // x,y and cell sizes are in scaled grid coordinates, but cue size is not scaled
+                        Point cellLeftBottom = GridToControl(CellPosition(col, row + 1));
+                        Rectangle pos = new Rectangle(cellLeftBottom.X, cellLeftBottom.Y - _codeCue.Height,
+                            _codeCue.Width, _codeCue.Height);
+                        g.FillRectangle(Brushes.LightGray, pos);
+                        g.DrawString(code.ToString("X4"), _codeCue.Font, Brushes.Black, pos.X + 1, pos.Y + 1);
+                    }
+                }
+            }
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            UpdateAndRepaint();
+        }
+
+        protected override void OnScroll(ScrollEventArgs se)
+        {
+            base.OnScroll(se);
+            _grid.ScrollY = -AutoScrollPosition.Y;
+            UpdateAndRepaint();
+        }
+
+        protected override void OnMouseClick(MouseEventArgs e)
+        {
+            base.OnMouseClick(e);
+            SelectCharacterAt(e.Location);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            PaintFont(e.Graphics);
+        }
+    }
+}

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -40,15 +40,11 @@ namespace AGS.Editor
                 if (DesignMode)
                     return;
 
-                if (_fontNumber >= 0 && _fontNumber < Factory.AGSEditor.CurrentGame.Fonts.Count)
-                {
-                    _fontMetrics = Factory.NativeProxy.GetFontMetrics(_fontNumber);
-                }
-                else
+                if (_fontNumber < 0 || _fontNumber >= Factory.AGSEditor.CurrentGame.Fonts.Count)
                 {
                     _fontNumber = -1;
-                    _fontMetrics = Native.FontMetrics.Empty;
                 }
+
                 UpdateAndRepaint();
             }
         }
@@ -163,6 +159,15 @@ namespace AGS.Editor
 
         public void UpdateAndRepaint()
         {
+            if (_fontNumber >= 0 && _fontNumber < Factory.AGSEditor.CurrentGame.Fonts.Count)
+            {
+                _fontMetrics = Factory.NativeProxy.GetFontMetrics(_fontNumber);
+            }
+            else
+            {
+                _fontMetrics = Native.FontMetrics.Empty;
+            }
+
             PrecalculatePreviewGrid();
             Invalidate();
         }

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -206,7 +206,7 @@ namespace AGS.Editor
             _grid.FullHeight = full_height;
 
             // Set virtual preview height (the virtual size of the contents within the font preview)
-            AutoScrollMinSize = new Size(0, full_height);
+            AutoScrollMinSize = new Size(0, (int)(full_height * _scaling));
         }
 
         private Point ControlToGrid(int x, int y)
@@ -332,8 +332,8 @@ namespace AGS.Editor
             _selectedChar = code;
             if (do_scroll)
             {
-                _grid.ScrollY = pos.Y;
-                AutoScrollPosition = new Point(0, pos.Y);
+                _grid.ScrollY = MathExtra.Clamp(pos.Y, 0, _grid.FullHeight - _grid.GridHeight);
+                AutoScrollPosition = new Point(0, (int)(pos.Y * _scaling));
             }
             CharacterSelected?.Invoke(this, new CharacterSelectedEventArgs(_selectedChar));
             Invalidate();
@@ -438,14 +438,22 @@ namespace AGS.Editor
         protected override void OnSizeChanged(EventArgs e)
         {
             base.OnSizeChanged(e);
-            UpdateAndRepaint();
+
+            PrecalculatePreviewGrid();
+            if (_grid.ScrollY + _grid.GridHeight > _grid.FullHeight)
+            {
+                _grid.ScrollY = Math.Max(0, _grid.FullHeight - _grid.GridHeight);
+            }
+            Invalidate();
         }
 
         protected override void OnScroll(ScrollEventArgs se)
         {
             base.OnScroll(se);
-            _grid.ScrollY = -AutoScrollPosition.Y;
-            UpdateAndRepaint();
+
+            PrecalculatePreviewGrid();
+            _grid.ScrollY = MathExtra.Clamp((int)(-AutoScrollPosition.Y / _scaling), 0, _grid.FullHeight - _grid.GridHeight);
+            Invalidate();
         }
 
         protected override void OnMouseClick(MouseEventArgs e)

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -233,9 +233,11 @@ namespace AGS.Editor
 
             int width = ClientSize.Width;
             int height = ClientSize.Height;
+            // When reading BBox be aware that it may be "shifted" to the negative and positive side,
+            // but the drawing origin is always at 0,0.
             Rectangle bbox = _fontMetrics.CharBBox;
-            int cell_w = Math.Max(10, bbox.Width);
-            int cell_h = Math.Max(10, bbox.Height);
+            int cell_w = Math.Max(10, Math.Max(0, bbox.Left) + bbox.Width);
+            int cell_h = Math.Max(10, Math.Max(0, bbox.Top) + bbox.Height);
             // We want cell spacing to include a place for printing character codes;
             // remember that the cue sizes are in unscaled coords, so pre-unscale them here
             int cell_space_x = Math.Max(cell_w / 4, (int)(_codeCue.Width / _scaling) + 1 - cell_w);

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -486,15 +486,23 @@ namespace AGS.Editor
             int width = ClientSize.Width;
             int height = ClientSize.Height;
             int scroll_y = _grid.ScrollY;
+            int firstVisibleRow = (scroll_y) / (_grid.CellHeight + _grid.CellSpaceY);
+            int firstVisibleCell = firstVisibleRow * _grid.CharsPerRow;
+            int lastVisibleRow = firstVisibleRow + (_grid.GridHeight / (_grid.CellHeight + _grid.CellSpaceY));
+            int lastVisibleCell = lastVisibleRow * _grid.CharsPerRow + _grid.CharsPerRow;
+            lastVisibleCell = Math.Min(lastVisibleCell, _charCodes.Length - 1);
 
             g.Clear(Color.Black);
             bool hdcReleased = false;
             try
             {
+                int firstRowDrawPos = _grid.CellSpaceY + firstVisibleRow * (_grid.CellHeight + _grid.CellSpaceY)
+                    - scroll_y;
                 Factory.NativeProxy.DrawFont(g.GetHdc(), _fontNumber, ANSIMode, HideMissingCharacters,
-                    0, 0, width, height,
+                    0, 0, _grid.CellSpaceX, firstRowDrawPos,
                     _grid.CellWidth, _grid.CellHeight, _grid.CellSpaceX, _grid.CellSpaceY,
-                    _scaling, scroll_y);
+                    _grid.CharsPerRow, lastVisibleRow - firstVisibleRow + 1, firstVisibleCell,
+                    _scaling);
                 g.ReleaseHdc();
                 hdcReleased = true;
             }
@@ -522,11 +530,6 @@ namespace AGS.Editor
             // Print char codes
             if (DisplayCodes)
             {
-                int firstVisibleRow = (scroll_y) / (_grid.CellHeight + _grid.CellSpaceY);
-                int firstVisibleCell = firstVisibleRow * _grid.CharsPerRow;
-                int lastVisibleRow = firstVisibleRow + (_grid.GridHeight / (_grid.CellHeight + _grid.CellSpaceY));
-                int lastVisibleCell = lastVisibleRow * _grid.CharsPerRow + _grid.CharsPerRow;
-                lastVisibleCell = Math.Min(lastVisibleCell, _charCodes.Length - 1);
                 int lastCharCode = _fontMetrics.LastCharCode;
                 if (ANSIMode)
                     lastCharCode = Math.Min(lastCharCode, 255);

--- a/Editor/AGS.Editor/Utils/MathExtra.cs
+++ b/Editor/AGS.Editor/Utils/MathExtra.cs
@@ -7,6 +7,9 @@ namespace AGS.Editor
     {
         public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
         {
+            if (min.CompareTo(max) > 0)
+                throw new ArgumentOutOfRangeException("Max is less than min");
+
             if (val.CompareTo(min) < 0) return min;
             else if (val.CompareTo(max) > 0) return max;
             else return val;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -60,9 +60,10 @@ extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
 extern void GetFontValidCharacters(int fontnum, std::vector<int> &char_codes);
 // Draws font char sheet on the provided context
 extern void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
-    int dc_atx, int dc_aty, int dc_width, int dc_height,
-    int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
-    int scroll_y);
+    int dc_atx, int dc_aty, int draw_atx, int draw_aty,
+    int cell_w, int cell_h, int cell_space_x, int cell_space_y,
+    int col_count, int row_count, int first_cell,
+    float scaling);
 extern void DrawTextUsingFontAt(HDC hdc, String^ text, int fontnum,
     int dc_atx, int dc_aty, int dc_width, int dc_height,
     int text_atx, int text_aty, int max_width, float scaling);
@@ -345,16 +346,17 @@ namespace AGS
             return arr;
         }
 
-		void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
-            int dc_atx, int dc_aty, int dc_width, int dc_height,
-            int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
-            int scroll_y)
-		{
-			return DrawFontAt((HDC)hDC, fontNum, ansi_mode, only_valid_chars,
-                              dc_atx, dc_aty, dc_width, dc_height,
-                              cell_w, cell_h, cell_space_x, cell_space_y, scaling,
-                              scroll_y);
-		}
+        void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
+            int dc_atx, int dc_aty, int draw_atx, int draw_aty,
+            int cell_w, int cell_h, int cell_space_x, int cell_space_y,
+            int col_count, int row_count, int first_cell,
+            float scaling)
+        {
+            return DrawFontAt((HDC)hDC, fontNum, ansi_mode, only_valid_chars,
+                dc_atx, dc_aty, draw_atx, draw_aty,
+                cell_w, cell_h, cell_space_x, cell_space_y,
+                col_count, row_count, first_cell, scaling);
+        }
 
         void NativeMethods::DrawTextUsingFont(int hDC, String ^text, int fontNum,
             int dc_atx, int dc_aty, int dc_width, int dc_height,

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -59,7 +59,7 @@ extern bool measure_font_height(const AGSString &filename, int pixel_height, int
 extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
 // Draws font char sheet on the provided context
 extern void DrawFontAt(HDC hdc, int fontnum,
-    int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+    int dc_atx, int dc_aty, int dc_width, int dc_height,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
     int scroll_y);
 extern void DrawTextUsingFontAt(HDC hdc, String^ text, int fontnum,
@@ -335,11 +335,11 @@ namespace AGS
         }
 
 		void NativeMethods::DrawFont(int hDC, int fontNum,
-            int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+            int dc_atx, int dc_aty, int dc_width, int dc_height,
             int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
             int scroll_y)
 		{
-			return DrawFontAt((HDC)hDC, fontNum, dc_atx, dc_aty, dc_width, dc_height, padding,
+			return DrawFontAt((HDC)hDC, fontNum, dc_atx, dc_aty, dc_width, dc_height,
                               cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                               scroll_y);
 		}

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -57,8 +57,9 @@ extern bool reload_font(int curFont);
 extern bool measure_font_height(const AGSString &filename, int pixel_height, int &formal_height);
 // Get the loaded font's metrics (note: expand if necessary)
 extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
+extern void GetFontValidCharacters(int fontnum, std::vector<int> &char_codes);
 // Draws font char sheet on the provided context
-extern void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode,
+extern void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
     int dc_atx, int dc_aty, int dc_width, int dc_height,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
     int scroll_y);
@@ -334,12 +335,23 @@ namespace AGS
                 System::Drawing::Rectangle(bbox.Left, bbox.Top, bbox.GetWidth(), bbox.GetHeight()));
         }
 
-		void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode,
+        cli::array<int> ^NativeMethods::GetFontValidCharacters(int fontNum)
+        {
+            std::vector<int> char_codes;
+            ::GetFontValidCharacters(fontNum, char_codes);
+            cli::array<int> ^arr = gcnew cli::array<int>(char_codes.size());
+            for (size_t i = 0; i < char_codes.size(); ++i)
+                arr[i] = char_codes[i];
+            return arr;
+        }
+
+		void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
             int dc_atx, int dc_aty, int dc_width, int dc_height,
             int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
             int scroll_y)
 		{
-			return DrawFontAt((HDC)hDC, fontNum, ansi_mode, dc_atx, dc_aty, dc_width, dc_height,
+			return DrawFontAt((HDC)hDC, fontNum, ansi_mode, only_valid_chars,
+                              dc_atx, dc_aty, dc_width, dc_height,
                               cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                               scroll_y);
 		}

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -58,7 +58,7 @@ extern bool measure_font_height(const AGSString &filename, int pixel_height, int
 // Get the loaded font's metrics (note: expand if necessary)
 extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
 // Draws font char sheet on the provided context
-extern void DrawFontAt(HDC hdc, int fontnum,
+extern void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode,
     int dc_atx, int dc_aty, int dc_width, int dc_height,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
     int scroll_y);
@@ -334,12 +334,12 @@ namespace AGS
                 System::Drawing::Rectangle(bbox.Left, bbox.Top, bbox.GetWidth(), bbox.GetHeight()));
         }
 
-		void NativeMethods::DrawFont(int hDC, int fontNum,
+		void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode,
             int dc_atx, int dc_aty, int dc_width, int dc_height,
             int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
             int scroll_y)
 		{
-			return DrawFontAt((HDC)hDC, fontNum, dc_atx, dc_aty, dc_width, dc_height,
+			return DrawFontAt((HDC)hDC, fontNum, ansi_mode, dc_atx, dc_aty, dc_width, dc_height,
                               cell_w, cell_h, cell_space_x, cell_space_y, scaling,
                               scroll_y);
 		}

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -55,12 +55,16 @@ extern void save_default_crm_file(Room ^roomToSave);
 extern HAGSError import_sci_font(const AGSString &filename, int fslot);
 extern bool reload_font(int curFont);
 extern bool measure_font_height(const AGSString &filename, int pixel_height, int &formal_height);
-// Draws font char sheet on the provided context and returns the height of drawn object;
-// may be called with hdc = 0 to get required height without drawing anything
-extern int drawFontAt(HDC hdc, int fontnum, int draw_atx, int draw_aty, int width, int height, int scroll_y);
+// Get the loaded font's metrics (note: expand if necessary)
+extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
+// Draws font char sheet on the provided context
+extern void DrawFontAt(HDC hdc, int fontnum,
+    int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+    int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
+    int scroll_y);
 extern void DrawTextUsingFontAt(HDC hdc, String^ text, int fontnum,
     int dc_atx, int dc_aty, int dc_width, int dc_height,
-    int text_atx, int text_aty, int max_width);
+    int text_atx, int text_aty, int max_width, float scaling);
 extern Dictionary<int, Sprite^>^ load_sprite_dimensions();
 extern void drawGUI(HDC hdc, int x, int y, GUI^ gui, int resolutionFactor, float scale, int control_transparency, int selectedControl);
 extern void drawSprite(HDC hdc, int x,int y, int spriteNum, bool flipImage);
@@ -321,16 +325,30 @@ namespace AGS
 			drawSprite((HDC)hDC, x, y, spriteNum, flipImage);
 		}
 
-		int NativeMethods::DrawFont(int hDC, int fontNum, int draw_atx, int draw_aty, int width, int height, int scroll_y)
+        Native::FontMetrics ^NativeMethods::GetFontMetrics(int fontNum)
+        {
+            int last_char;
+            Rect bbox;
+            ::GetFontMetrics(fontNum, last_char, bbox);
+            return gcnew Native::FontMetrics(0, last_char,
+                System::Drawing::Rectangle(bbox.Left, bbox.Top, bbox.GetWidth(), bbox.GetHeight()));
+        }
+
+		void NativeMethods::DrawFont(int hDC, int fontNum,
+            int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+            int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
+            int scroll_y)
 		{
-			return drawFontAt((HDC)hDC, fontNum, draw_atx, draw_aty, width, height, scroll_y);
+			return DrawFontAt((HDC)hDC, fontNum, dc_atx, dc_aty, dc_width, dc_height, padding,
+                              cell_w, cell_h, cell_space_x, cell_space_y, scaling,
+                              scroll_y);
 		}
 
         void NativeMethods::DrawTextUsingFont(int hDC, String ^text, int fontNum,
             int dc_atx, int dc_aty, int dc_width, int dc_height,
-            int text_atx, int text_aty, int max_width)
+            int text_atx, int text_aty, int max_width, float scaling)
         {
-            DrawTextUsingFontAt((HDC)hDC, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width);
+            DrawTextUsingFontAt((HDC)hDC, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width, scaling);
         }
 
 		void NativeMethods::DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -58,6 +58,9 @@ extern bool measure_font_height(const AGSString &filename, int pixel_height, int
 // Draws font char sheet on the provided context and returns the height of drawn object;
 // may be called with hdc = 0 to get required height without drawing anything
 extern int drawFontAt(HDC hdc, int fontnum, int draw_atx, int draw_aty, int width, int height, int scroll_y);
+extern void DrawTextUsingFontAt(HDC hdc, String^ text, int fontnum,
+    int dc_atx, int dc_aty, int dc_width, int dc_height,
+    int text_atx, int text_aty, int max_width);
 extern Dictionary<int, Sprite^>^ load_sprite_dimensions();
 extern void drawGUI(HDC hdc, int x, int y, GUI^ gui, int resolutionFactor, float scale, int control_transparency, int selectedControl);
 extern void drawSprite(HDC hdc, int x,int y, int spriteNum, bool flipImage);
@@ -322,6 +325,13 @@ namespace AGS
 		{
 			return drawFontAt((HDC)hDC, fontNum, draw_atx, draw_aty, width, height, scroll_y);
 		}
+
+        void NativeMethods::DrawTextUsingFont(int hDC, String ^text, int fontNum,
+            int dc_atx, int dc_aty, int dc_width, int dc_height,
+            int text_atx, int text_aty, int max_width)
+        {
+            DrawTextUsingFontAt((HDC)hDC, text, fontNum, dc_atx, dc_aty, dc_width, dc_height, text_atx, text_aty, max_width);
+        }
 
 		void NativeMethods::DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage)
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -54,6 +54,9 @@ namespace AGS
 			// Draws font char sheet on the provided context and returns the height of drawn object;
 			// may be called with hDC = 0 to get required height without drawing anything
 			int  DrawFont(int hDC, int fontNum, int draw_atx, int draw_aty, int width, int height, int scroll_y);
+            void DrawTextUsingFont(int hDC, String ^text, int fontNum,
+                int dc_atx, int dc_aty, int dc_width, int dc_height,
+                int text_atx, int text_aty, int max_width);
 			void DrawBlockOfColour(int hDC, int x, int y, int width, int height, int colourNum);
 			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
 			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -87,8 +87,10 @@ namespace AGS
 			void DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage);
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
             FontMetrics ^GetFontMetrics(int fontNum);
+            cli::array<int> ^GetFontValidCharacters(int fontNum);
             // Draws font char sheet on the provided context
-            void DrawFont(int hDC, int fontNum, bool ansi_mode, int dc_atx, int dc_aty, int dc_width, int dc_height,
+            void DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
+                int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y);
             void DrawTextUsingFont(int hDC, String ^text, int fontNum,

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -34,11 +34,31 @@ namespace AGS
             property int LastCharCode;
             property System::Drawing::Rectangle CharBBox;
 
+            static property FontMetrics ^Empty
+            {
+                FontMetrics ^get()
+                {
+                    if (_empty == nullptr)
+                        _empty = gcnew FontMetrics();
+                    return _empty;
+                }
+            }
+
             FontMetrics(int first_char, int last_char, System::Drawing::Rectangle bbox)
             {
                 FirstCharCode = first_char;
                 LastCharCode = last_char;
                 CharBBox = bbox;
+            }
+
+        private:
+            static FontMetrics ^_empty = nullptr;
+
+            FontMetrics()
+            {
+                FirstCharCode = -1;
+                LastCharCode = -1;
+                CharBBox = System::Drawing::Rectangle::Empty;
             }
         };
 
@@ -68,7 +88,7 @@ namespace AGS
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
             FontMetrics ^GetFontMetrics(int fontNum);
             // Draws font char sheet on the provided context
-            void DrawFont(int hDC, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+            void DrawFont(int hDC, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y);
             void DrawTextUsingFont(int hDC, String ^text, int fontNum,

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -90,9 +90,10 @@ namespace AGS
             cli::array<int> ^GetFontValidCharacters(int fontNum);
             // Draws font char sheet on the provided context
             void DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
-                int dc_atx, int dc_aty, int dc_width, int dc_height,
-                int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
-                int scroll_y);
+                int dc_atx, int dc_aty, int draw_atx, int draw_aty,
+                int cell_w, int cell_h, int cell_space_x, int cell_space_y,
+                int col_count, int row_count, int first_cell,
+                float scaling);
             void DrawTextUsingFont(int hDC, String ^text, int fontNum,
                 int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int text_atx, int text_aty, int max_width, float scaling);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -27,6 +27,21 @@ namespace AGS
 {
 	namespace Native 
 	{
+        public ref class FontMetrics
+        {
+        public:
+            property int FirstCharCode;
+            property int LastCharCode;
+            property System::Drawing::Rectangle CharBBox;
+
+            FontMetrics(int first_char, int last_char, System::Drawing::Rectangle bbox)
+            {
+                FirstCharCode = first_char;
+                LastCharCode = last_char;
+                CharBBox = bbox;
+            }
+        };
+
 		public ref class NativeMethods
 		{
 		private:
@@ -51,12 +66,14 @@ namespace AGS
 			void DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int controlTransparency, int selectedControl);
 			void DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum, bool flipImage);
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
-			// Draws font char sheet on the provided context and returns the height of drawn object;
-			// may be called with hDC = 0 to get required height without drawing anything
-			int  DrawFont(int hDC, int fontNum, int draw_atx, int draw_aty, int width, int height, int scroll_y);
+            FontMetrics ^GetFontMetrics(int fontNum);
+            // Draws font char sheet on the provided context
+            void DrawFont(int hDC, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+                int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
+                int scroll_y);
             void DrawTextUsingFont(int hDC, String ^text, int fontNum,
                 int dc_atx, int dc_aty, int dc_width, int dc_height,
-                int text_atx, int text_aty, int max_width);
+                int text_atx, int text_aty, int max_width, float scaling);
 			void DrawBlockOfColour(int hDC, int x, int y, int width, int height, int colourNum);
 			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
 			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, int transColour, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -88,7 +88,7 @@ namespace AGS
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
             FontMetrics ^GetFontMetrics(int fontNum);
             // Draws font char sheet on the provided context
-            void DrawFont(int hDC, int fontNum, int dc_atx, int dc_aty, int dc_width, int dc_height,
+            void DrawFont(int hDC, int fontNum, bool ansi_mode, int dc_atx, int dc_aty, int dc_width, int dc_height,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
                 int scroll_y);
             void DrawTextUsingFont(int hDC, String ^text, int fontNum,

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -932,6 +932,10 @@ void DrawFontAt(HDC hdc, int fontnum,
     if (dc_width <= 0 || dc_height <= 0)
         return;
 
+    assert(scroll_y >= 0);
+    if (scroll_y < 0)
+        scroll_y = 0;
+
     if (!is_font_loaded(fontnum))
         reload_font(fontnum);
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -938,9 +938,10 @@ void DrawFontAt(HDC hdc, int fontnum,
     antiAliasFonts = thisgame.options[OPT_ANTIALIASFONTS];
 
     const Rect bbox = get_font_glyph_bbox(fontnum);
+    const int font_y_offset = thisgame.fonts[fontnum].YOffset; // hack to avoid YOffset in the preview table
     const ::Size char_size = bbox.GetSize() * thisgame.fonts[fontnum].SizeMultiplier;
     const ::Size cell_size = ::Size(cell_w, cell_h);
-    const ::Point char_off = ::Point(std::max(0, -bbox.Left), std::max(0, -bbox.Top));
+    const ::Point char_off = ::Point(std::max(0, -bbox.Left), std::max(0, -bbox.Top) - font_y_offset);
     const int first_char = 0;
     const int last_char  = get_font_topmost_char_code(fontnum);
     const int char_count = last_char - first_char + 1;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -920,7 +920,7 @@ void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox)
 }
 
 void DrawFontAt(HDC hdc, int fontnum,
-    int dc_atx, int dc_aty, int dc_width, int dc_height, int padding,
+    int dc_atx, int dc_aty, int dc_width, int dc_height,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y, float scaling,
     int scroll_y)
 {
@@ -947,10 +947,11 @@ void DrawFontAt(HDC hdc, int fontnum,
 
     const int grid_width = dc_width / scaling;
     const int grid_height = dc_height / scaling;
-    const int chars_per_row = std::max(1, (grid_width - (padding * 2)) / (cell_size.Width + cell_space_x));
-    const int full_height = (char_count / chars_per_row + 1) * (cell_size.Height + cell_space_y);
+    const int chars_per_row = std::max(1, (grid_width - cell_space_x)) / (cell_size.Width + cell_space_x);
+    const int full_height = (char_count / chars_per_row + 1) * (cell_size.Height + cell_space_y)
+        + cell_space_y;
 
-    const int skip_rows = (scroll_y - padding) / (cell_size.Height + cell_space_y);
+    const int skip_rows = (scroll_y - cell_space_y) / (cell_size.Height + cell_space_y);
     const int first_char_to_draw = skip_rows * chars_per_row;
 
     std::unique_ptr<AGSBitmap> tempblock(BitmapHelper::CreateBitmap(grid_width, grid_height, 8));
@@ -965,8 +966,8 @@ void DrawFontAt(HDC hdc, int fontnum,
             const int char_col = (c % chars_per_row);
             const int char_row = (c / chars_per_row);
             woutprintf(tempblock.get(),
-                       padding + char_col * (cell_size.Width + cell_space_x) + char_off.X,
-                       padding + char_row * (cell_size.Height + cell_space_y) - scroll_y + char_off.Y,
+                       cell_space_x + char_col * (cell_size.Width + cell_space_x) + char_off.X,
+                       cell_space_y + char_row * (cell_size.Height + cell_space_y) - scroll_y + char_off.Y,
                        fontnum, text_color, "%c", c);
         }
     }
@@ -980,8 +981,8 @@ void DrawFontAt(HDC hdc, int fontnum,
             char uchar[Utf8::UtfSz + 1];
             uchar[Utf8::SetChar(c, uchar, sizeof(uchar))] = 0;
             wouttextxy(tempblock.get(),
-                       padding + char_col * (cell_size.Width + cell_space_x) + char_off.X,
-                       padding + char_row * (cell_size.Height + cell_space_y) - scroll_y + char_off.Y,
+                       cell_space_x + char_col * (cell_size.Width + cell_space_x) + char_off.X,
+                       cell_space_y + char_row * (cell_size.Height + cell_space_y) - scroll_y + char_off.Y,
                        fontnum, text_color, uchar);
         }
     }


### PR DESCRIPTION
Resolve #2708

Redesigned Font preview panel, in order to help users see the font when used to draw an actual text, and be able to see all the font's characters when there are more than 256 of them.

1. Font panel is divided (uses splitter) into two parts:
* text preview
* font preview

2. Text preview allows you to type any text and see how it looks like with this font. This allows text wrapping, in order to test line spacing.

3. Font preview displays all the characters available in the font, with a scrollbar if they don't fit into the panel.
4. You can enter either character code or character itself into the input fields, and press "Goto" button to jump to wanted character.
5. You can select a character in the preview and it will be printed in the input fields.
6. Optionally the preview may display character codes right under the characters, there's a checkbox that toggles this mode.

<details>
<summary>Click for Screenshots</summary>


<img width="840" height="868" alt="font-preview-new1" src="https://github.com/user-attachments/assets/0aa2e06a-30f8-4117-8846-c72d8064ca86" />

<img width="841" height="870" alt="font-preview-new2" src="https://github.com/user-attachments/assets/e5efd86c-29e4-4732-8e31-aba171e25e1d" />

</details>

---

TODO:
1. Should refactor coordinate conversion and place into helper methods. Preview pane uses "scaling" factor, which currently depends on the game resolution. This is not entirely good, but regardless, the scaling may be wanted, so I keep it. The calculation code becomes a bit more complicated though.
2. There's a strange glitch where the preview control's bottom is always cut off slightly by the splitter's panel. Could not understand why this happens.
3. Need to figure out if we want to share the text preview and display modes among editors, and/or save them in workspace data between sessions. Idk if that's necessary.