### PR TITLE
Support custom Font character spacing

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -127,7 +127,7 @@ Script module names are written in the game data.
 3.6.2.12:
 Incremented for safety fallback purposes, few very old text alignment mistakes fixed in the engine.
 3.6.3:
-OPT_GUICONTROLMOUSEBUT, game info properties
+OPT_GUICONTROLMOUSEBUT, game info properties, font character spacing
 
 */
 

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -310,6 +310,8 @@ struct FontInfo
     int           YOffset;
     // Custom line spacing between two lines of text (0 = use font height)
     int           LineSpacing;
+    // Horizontal spacing between individual characters, in pixels
+    int           CharacterSpacing;
     // When automatic outlining, style of the outline
     AutoOutlineStyle AutoOutlineStyle;
     // When automatic outlining, thickness of the outline (0 = no auto outline)

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -121,6 +121,8 @@ public:
     virtual void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) = 0;
     // Get a list of supported character codes
     virtual void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) = 0;
+    // Sets additional character spacing, in pixels (can be positive or negative)
+    virtual void SetCharacterSpacing(int fontNumber, int spacing) = 0;
 
 protected:
     IAGSFontRendererInternal() = default;

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -83,6 +83,7 @@ FontInfo::FontInfo()
     , Outline(FONT_OUTLINE_NONE)
     , YOffset(0)
     , LineSpacing(0)
+    , CharacterSpacing(0)
     , AutoOutlineStyle(kSquared)
     , AutoOutlineThickness(0)
 {}
@@ -183,6 +184,12 @@ static void font_post_init(int font_number)
             font.Info.Flags |= FFLG_DEFLINESPACING;
             font.LineSpacingCalc = font.Metrics.CompatHeight + 2 * font.Info.AutoOutlineThickness;
         }
+    }
+
+    // Apply character spacing if supported
+    if (font.RendererInt)
+    {
+        font.RendererInt->SetCharacterSpacing(font_number, font.Info.CharacterSpacing);
     }
 }
 

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -222,6 +222,14 @@ void TTFFontRenderer::GetValidCharCodes(int fontNumber, std::vector<int> &char_c
     free(charcodes);
 }
 
+void TTFFontRenderer::SetCharacterSpacing(int fontNumber, int spacing)
+{
+    if (_fontData.find(fontNumber) != _fontData.end())
+    {
+        alfont_set_char_extra_spacing(_fontData[fontNumber].AlFont, spacing);
+    }
+}
+
 void TTFFontRenderer::FreeMemory(int fontNumber)
 {
   alfont_destroy_font(_fontData[fontNumber].AlFont);

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -48,6 +48,7 @@ public:
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
   void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
   void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) override;
+  void SetCharacterSpacing(int fontNumber, int spacing) override;
 
   TTFFontRenderer(AGS::Common::AssetManager *amgr);
   virtual ~TTFFontRenderer();

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -36,13 +36,20 @@ int WFNFontRenderer::GetTextWidth(const char *text, int fontNumber)
 {
     const WFNFont* font = _fontData[fontNumber].Font;
     const FontRenderParams &params = _fontData[fontNumber].Params;
+    const int char_spacing = _fontData[fontNumber].CharacterSpacing;
     int text_width = 0;
+    int char_count = 0;
 
     for (int code = ugetxc(&text); code; code = ugetxc(&text))
     {
         text_width += font->GetChar(code).Width;
+        char_count++;
     }
-    return text_width * params.SizeMultiplier;
+    text_width *= params.SizeMultiplier;
+    // Add extra character spacing between characters (except the last character)
+    // NOTE: we do NOT scale global scale character spacing with SizeMultiplier
+    text_width += char_spacing * (char_count - 1);
+    return text_width;
 }
 
 int WFNFontRenderer::GetTextHeight(const char *text, int fontNumber)
@@ -69,13 +76,16 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 
   const WFNFont* font = _fontData[fontNumber].Font;
   const FontRenderParams &params = _fontData[fontNumber].Params;
+  const int char_spacing = _fontData[fontNumber].CharacterSpacing * params.SizeMultiplier;
   Bitmap ds(destination, true);
 
   // NOTE: allegro's putpixel ignores clipping (optimization),
   // so we'll have to accomodate for that ourselves
   Rect clip = ds.GetClip();
   for (int code = ugetxc(&text); code; code = ugetxc(&text))
-    x += RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
+  {
+    x += char_spacing + RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
+  }
 
   set_our_eip(oldeip);
 }
@@ -157,6 +167,7 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/, const Str
   }
   _fontData[fontNumber].Font = font;
   _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+  _fontData[fontNumber].CharacterSpacing = 0;
   if (src_filename)
     *src_filename = use_filename;
   if (metrics)
@@ -197,4 +208,12 @@ void WFNFontRenderer::FreeMemory(int fontNumber)
 bool WFNFontRenderer::SupportsExtendedCharacters(int fontNumber)
 {
   return _fontData[fontNumber].Font->GetCharCount() > 128;
+}
+
+void WFNFontRenderer::SetCharacterSpacing(int fontNumber, int spacing)
+{
+    if (_fontData.find(fontNumber) != _fontData.end())
+    {
+        _fontData[fontNumber].CharacterSpacing = spacing;
+    }
 }

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -47,6 +47,7 @@ public:
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
   void GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes) override;
   void GetValidCharCodes(int fontNumber, std::vector<int> &char_codes) override;
+  void SetCharacterSpacing(int fontNumber, int spacing) override;
 
   WFNFontRenderer(AGS::Common::AssetManager *mgr)
       : _amgr(mgr) {}
@@ -57,6 +58,7 @@ private:
   {
     WFNFont         *Font;
     FontRenderParams Params;
+    int              CharacterSpacing;
   };
   std::map<int, FontData> _fontData;
   AGS::Common::AssetManager *_amgr = nullptr;

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -857,9 +857,9 @@ HError GameDataExtReader::ReadBlock(Stream *in, int /*block_id*/, const String &
             finfo.AutoOutlineThickness = in->ReadInt32();
             finfo.AutoOutlineStyle =
                 static_cast<enum FontInfo::AutoOutlineStyle>(in->ReadInt32());
-            // reserved
-            in->ReadInt32();
-            in->ReadInt32();
+            // since kGameVersion_363
+            finfo.CharacterSpacing = in->ReadInt32();
+            in->ReadInt32(); // reserved
             in->ReadInt32();
             in->ReadInt32();
         }

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -114,7 +114,7 @@ namespace AGS.Editor
          * 3.6.2.2        - Button.WrapText, TextPadding.
          * 3.6.2.6        - Settings.GameFPS.
          * 3.6.2.9        - Sprite.TransparentColorIndex (can select transparent palette index).
-         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton.
+         * 3.6.3          - Settings.GUIHandleOnlyLeftMouseButton, Font.CharacterSpacing.
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060300;
         /*

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1836,9 +1836,9 @@ namespace AGS.Editor
             {
                 writer.Write(game.Fonts[i].AutoOutlineThickness);
                 writer.Write((int)game.Fonts[i].AutoOutlineStyle);
-                // reserved ints
-                writer.Write((int)0);
-                writer.Write((int)0);
+                // Since 3.6.3
+                writer.Write(game.Fonts[i].CharacterSpacing);
+                writer.Write((int)0); // reserved
                 writer.Write((int)0);
                 writer.Write((int)0);
             }
@@ -1938,7 +1938,7 @@ namespace AGS.Editor
             {
                 writer.Write(button.TextPaddingHorizontal);
                 writer.Write(button.TextPaddingVertical);
-                writer.Write((int)0);
+                writer.Write((int)0); // reserved
                 writer.Write((int)0);
             }
         }

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2238,6 +2238,7 @@ void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate)
     font_info.SizeMultiplier = font->SizeMultiplier;
     font_info.YOffset = font->VerticalOffset;
     font_info.LineSpacing = font->LineSpacing;
+    font_info.CharacterSpacing = font->CharacterSpacing;
     if (game->Settings->TTFHeightDefinedBy == FontHeightDefinition::PixelHeight)
         font_info.Flags &= ~FFLG_REPORTNOMINALHEIGHT;
     else

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -21,6 +21,7 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
+        private int _characterSpacing;
         private int _autoOutlineThickness = 1;
         private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Squared;
         private FontMetricsFixup _ttfMetricsFixup = FontMetricsFixup.None;
@@ -33,6 +34,7 @@ namespace AGS.Types
             _outlineStyle = FontOutlineStyle.None;
             _fontHeight = 0;
             _lineSpacing = 0;
+            _characterSpacing = 0;
         }
 
         [Description("The ID number of the font")]
@@ -219,6 +221,15 @@ namespace AGS.Types
         {
             get { return _lineSpacing; }
             set { _lineSpacing = value; }
+        }
+
+        [DisplayName("Character Spacing")]
+        [Description("Horizontal spacing between any pair of characters, in pixels, added to the default spacing (kerning)")]
+        [Category("Appearance")]
+        public int CharacterSpacing
+        {
+            get { return _characterSpacing; }
+            set { _characterSpacing = value; }
         }
 
 		[Browsable(false)]


### PR DESCRIPTION
This is a remake of #2767.
@edmundito told me that he's too busy now, so I based on his work with few modifications:
* Added SetCharacterSpacing to the IAGSFontRendererInternal interface, to avoid redundant casts to WFN and TTF renderers.
* Do not scale CharacterSpacing with SizeMultiplier in WFNFontRenderer, for consistency with LineSpacing and VerticalOffset, and to let more precise spacing setting.
* Serialize character spacing property in the existing "v360_fonts" data extension, because it had reserved integers.

Overall the feature is the same:
1. Fonts have CharacterSpacing property.
2. This property defines a global spacing value, in pixels, which is *added* to the default spacing between any pair of characters (kerning).
3. This property is NOT scaled with the font's point size, neither with "size multiplier" (used for bitmap fonts). This lets to have a more precise value.
4. This property may be negative, in which case the spacing is reduced (if it's reduced too much it may actually cause letters to appear in backwards order...)
5. This option appears to be already supported in AlFont library, so no changes were necessary there.
6. This option was recently applied to SDL_TTF library (https://github.com/libsdl-org/SDL_ttf/pull/578), so potentially available there too. (Although the SDL3 version of it; idk if they will backport to SDL2 version, but if not then we might do a custom fork).