### PR TITLE
Script API:  add TextWindowGUI properties for getting border graphics

### DIFF
--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -115,6 +115,19 @@ enum GUIPopupStyle
     kGUIPopupLegacyNormalOff  = 4
 };
 
+// TextWindow Border IDs
+enum GUITextWindowBorder
+{
+    kTW_TopLeft     = 0,
+    kTW_BottomLeft  = 1,
+    kTW_TopRight    = 2,
+    kTW_BottomRight = 3,
+    kTW_Left        = 4,
+    kTW_Right       = 5,
+    kTW_Top         = 6,
+    kTW_Bottom      = 7
+};
+
 // The type of GUIControl
 enum GUIControlType
 {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2164,6 +2164,24 @@ builtin managed struct TextWindowGUI extends GUI {
   import attribute int  TextColor;
   /// Gets/sets the amount of padding, in pixels, surrounding the text in the TextWindow.
   import attribute int  TextPadding;
+#ifdef SCRIPT_API_v363
+  /// Gets the sprite number used for this TextWindow's left border
+  import readonly attribute int LeftGraphic;
+  /// Gets the sprite number used for this TextWindow's top-left corner
+  import readonly attribute int TopLeftGraphic;
+  /// Gets the sprite number used for this TextWindow's top border
+  import readonly attribute int TopGraphic;
+  /// Gets the sprite number used for this TextWindow's top-right corner
+  import readonly attribute int TopRightGraphic;
+  /// Gets the sprite number used for this TextWindow's right border
+  import readonly attribute int RightGraphic;
+  /// Gets the sprite number used for this TextWindow's bottom-right corner
+  import readonly attribute int BottomRightGraphic;
+  /// Gets the sprite number used for this TextWindow's bottom border
+  import readonly attribute int BottomGraphic;
+  /// Gets the sprite number used for this TextWindow's bottom-left corner
+  import readonly attribute int BottomLeftGraphic;
+#endif // SCRIPT_API_v363
 };
 #endif // SCRIPT_API_v350
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -747,7 +747,7 @@ void do_corner(Bitmap *ds, int sprn, int x, int y, int offx, int offy) {
     draw_gui_sprite_v330(ds, sprn, x, y);
 }
 
-int get_but_pic(GUIMain*guo,int indx)
+int get_but_pic(GUIMain*guo, GUITextWindowBorder indx)
 {
     int butid = guo->GetControlID(indx);
     return butid >= 0 ? guibuts[butid].GetNormalImage() : 0;
@@ -777,8 +777,8 @@ void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*
         if (iep->GetBgColor() > 0)
             ds->FillRect(Rect(xx1,yy1,xx2,yy2), draw_color);
 
-        const int leftRightWidth = game.SpriteInfos[get_but_pic(iep,4)].Width;
-        const int topBottomHeight = game.SpriteInfos[get_but_pic(iep,6)].Height;
+        const int leftRightWidth = game.SpriteInfos[get_but_pic(iep, kTW_Left)].Width;
+        const int topBottomHeight = game.SpriteInfos[get_but_pic(iep, kTW_Top)].Height;
         // GUI middle space
         if (iep->GetBgImage()>0)
         {
@@ -808,24 +808,24 @@ void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*
         }
         // Vertical borders
         ds->SetClip(Rect(xx1 - leftRightWidth, yy1, xx2 + 1 + leftRightWidth, yy2));
-        for (int uu=yy1;uu <= yy2;uu+= game.SpriteInfos[get_but_pic(iep,4)].Height)
+        for (int uu=yy1;uu <= yy2;uu+= game.SpriteInfos[get_but_pic(iep, kTW_Left)].Height)
         {
-            do_corner(ds, get_but_pic(iep,4),xx1,uu,-1,0);   // left side
-            do_corner(ds, get_but_pic(iep,5),xx2+1,uu,0,0);  // right side
+            do_corner(ds, get_but_pic(iep, kTW_Left),xx1,uu,-1,0);   // left side
+            do_corner(ds, get_but_pic(iep, kTW_Right),xx2+1,uu,0,0);  // right side
         }
         // Horizontal borders
         ds->SetClip(Rect(xx1, yy1 - topBottomHeight, xx2, yy2 + 1 + topBottomHeight));
-        for (int uu=xx1;uu <= xx2;uu+=game.SpriteInfos[get_but_pic(iep,6)].Width)
+        for (int uu=xx1;uu <= xx2;uu+=game.SpriteInfos[get_but_pic(iep, kTW_Top)].Width)
         {
-            do_corner(ds, get_but_pic(iep,6),uu,yy1,0,-1);  // top side
-            do_corner(ds, get_but_pic(iep,7),uu,yy2+1,0,0); // bottom side
+            do_corner(ds, get_but_pic(iep, kTW_Top),uu,yy1,0,-1);  // top side
+            do_corner(ds, get_but_pic(iep, kTW_Bottom),uu,yy2+1,0,0); // bottom side
         }
         ds->ResetClip();
         // Four corners
-        do_corner(ds, get_but_pic(iep,0),xx1,yy1,-1,-1);  // top left
-        do_corner(ds, get_but_pic(iep,1),xx1,yy2+1,-1,0);  // bottom left
-        do_corner(ds, get_but_pic(iep,2),xx2+1,yy1,0,-1);  //  top right
-        do_corner(ds, get_but_pic(iep,3),xx2+1,yy2+1,0,0);  // bottom right
+        do_corner(ds, get_but_pic(iep, kTW_TopLeft),xx1,yy1,-1,-1);
+        do_corner(ds, get_but_pic(iep, kTW_BottomLeft),xx1,yy2+1,-1,0);
+        do_corner(ds, get_but_pic(iep, kTW_TopRight),xx2+1,yy1,0,-1);
+        do_corner(ds, get_but_pic(iep, kTW_BottomRight),xx2+1,yy2+1,0,0);
     }
 }
 
@@ -842,8 +842,8 @@ int get_textwindow_border_width(int twgui)
         return 0;
     }
 
-    int borwid = game.SpriteInfos[get_but_pic(&guis[twgui], 4)].Width + 
-        game.SpriteInfos[get_but_pic(&guis[twgui], 5)].Width;
+    int borwid = game.SpriteInfos[get_but_pic(&guis[twgui], kTW_Left)].Width +
+        game.SpriteInfos[get_but_pic(&guis[twgui], kTW_Right)].Width;
 
     return borwid;
 }
@@ -860,7 +860,7 @@ int get_textwindow_top_border_height(int twgui)
         return 0;
     }
 
-    return game.SpriteInfos[get_but_pic(&guis[twgui], 6)].Height;
+    return game.SpriteInfos[get_but_pic(&guis[twgui], kTW_Top)].Height;
 }
 
 // Get the padding for a text window
@@ -909,7 +909,7 @@ void draw_text_window(Bitmap **text_window_ds, bool should_free_ds,
     }
     else
     {
-        int tbnum = get_but_pic(&guis[ifnum], 0);
+        int tbnum = get_but_pic(&guis[ifnum], kTW_TopLeft);
 
         wii[0] += get_textwindow_border_width (ifnum);
         xx[0]-=game.SpriteInfos[tbnum].Width;

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -162,7 +162,7 @@ void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align);
 void do_corner(Common::Bitmap *ds, int sprn,int xx1,int yy1,int typx,int typy);
 // Returns the image of a button control on the GUI under given child index
-int get_but_pic(Common::GUIMain*guo,int indx);
+int get_but_pic(Common::GUIMain*guo, AGS::Common::GUITextWindowBorder indx);
 void draw_button_background(Common::Bitmap *ds, int xx1,int yy1,int xx2,int yy2,Common::GUIMain*iep);
 // Calculate the width that the left and right border of the textwindow
 // GUI take up

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include "ac/gui.h"
 #include "ac/common.h"
+#include "ac/display.h"
 #include "ac/draw.h"
 #include "ac/event.h"
 #include "ac/gamesetup.h"
@@ -385,6 +386,54 @@ void GUI_SetTextPadding(ScriptGUI *tehgui, int newpos)
 {
     if (guis[tehgui->id].IsTextWindow())
         guis[tehgui->id].SetPadding(newpos);
+}
+
+int GUI_GetLeftGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_Left) : 0;
+}
+
+int GUI_GetTopLeftGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_TopLeft) : 0;
+}
+
+int GUI_GetTopGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_Top) : 0;
+}
+
+int GUI_GetTopRightGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_TopRight) : 0;
+}
+
+int GUI_GetRightGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_Right) : 0;
+}
+
+int GUI_GetBottomRightGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_BottomRight) : 0;
+}
+
+int GUI_GetBottomGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_Bottom) : 0;
+}
+
+int GUI_GetBottomLeftGraphic(ScriptGUI *tehgui)
+{
+    return guis[tehgui->id].IsTextWindow() ?
+        get_but_pic(&guis[tehgui->id], kTW_BottomLeft) : 0;
 }
 
 ScriptGUI *GetGUIAtLocation(int xx, int yy) {
@@ -1097,6 +1146,46 @@ RuntimeScriptValue Sc_GUI_GetShown(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_BOOL(ScriptGUI, GUI_GetShown);
 }
 
+RuntimeScriptValue Sc_GUI_GetLeftGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetLeftGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetTopLeftGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetTopLeftGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetTopGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetTopGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetTopRightGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetTopRightGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetRightGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetRightGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetBottomRightGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetBottomRightGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetBottomGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetBottomGraphic);
+}
+
+RuntimeScriptValue Sc_GUI_GetBottomLeftGraphic(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetBottomLeftGraphic);
+}
+
 void RegisterGUIAPI()
 {
     ScFnRegister gui_api[] = {
@@ -1127,10 +1216,6 @@ void RegisterGUIAPI()
         { "GUI::get_PopupYPos",           API_FN_PAIR(GUI_GetPopupYPos) },
         { "GUI::set_PopupYPos",           API_FN_PAIR(GUI_SetPopupYPos) },
         { "GUI::get_ScriptName",          API_FN_PAIR(GUI_GetScriptName) },
-        { "TextWindowGUI::get_TextColor", API_FN_PAIR(GUI_GetTextColor) },
-        { "TextWindowGUI::set_TextColor", API_FN_PAIR(GUI_SetTextColor) },
-        { "TextWindowGUI::get_TextPadding", API_FN_PAIR(GUI_GetTextPadding) },
-        { "TextWindowGUI::set_TextPadding", API_FN_PAIR(GUI_SetTextPadding) },
         { "GUI::get_Transparency",        API_FN_PAIR(GUI_GetTransparency) },
         { "GUI::set_Transparency",        API_FN_PAIR(GUI_SetTransparency) },
         { "GUI::get_Visible",             API_FN_PAIR(GUI_GetVisible) },
@@ -1144,6 +1229,18 @@ void RegisterGUIAPI()
         { "GUI::get_ZOrder",              API_FN_PAIR(GUI_GetZOrder) },
         { "GUI::set_ZOrder",              API_FN_PAIR(GUI_SetZOrder) },
         { "GUI::get_Shown",               API_FN_PAIR(GUI_GetShown) },
+        { "TextWindowGUI::get_TextColor", API_FN_PAIR(GUI_GetTextColor) },
+        { "TextWindowGUI::set_TextColor", API_FN_PAIR(GUI_SetTextColor) },
+        { "TextWindowGUI::get_TextPadding", API_FN_PAIR(GUI_GetTextPadding) },
+        { "TextWindowGUI::set_TextPadding", API_FN_PAIR(GUI_SetTextPadding) },
+        { "TextWindowGUI::get_LeftGraphic", API_FN_PAIR(GUI_GetLeftGraphic) },
+        { "TextWindowGUI::get_TopLeftGraphic", API_FN_PAIR(GUI_GetTopLeftGraphic) },
+        { "TextWindowGUI::get_TopGraphic", API_FN_PAIR(GUI_GetTopGraphic) },
+        { "TextWindowGUI::get_TopRightGraphic", API_FN_PAIR(GUI_GetTopRightGraphic) },
+        { "TextWindowGUI::get_RightGraphic", API_FN_PAIR(GUI_GetRightGraphic) },
+        { "TextWindowGUI::get_BottomRightGraphic", API_FN_PAIR(GUI_GetBottomRightGraphic) },
+        { "TextWindowGUI::get_BottomGraphic", API_FN_PAIR(GUI_GetBottomGraphic) },
+        { "TextWindowGUI::get_BottomLeftGraphic", API_FN_PAIR(GUI_GetBottomLeftGraphic) },
     };
 
     ccAddExternalFunctions(gui_api);


### PR DESCRIPTION
Someone reminded me recently, that there's no direct way to get TextWindow's border sprites.
This PR adds following readonly properties:
```
/// Gets the sprite number used for this TextWindow's left border
readonly attribute int TextWindowGUI.LeftGraphic;
/// Gets the sprite number used for this TextWindow's top-left corner
readonly attribute int TextWindowGUI.TopLeftGraphic;
/// Gets the sprite number used for this TextWindow's top border
readonly attribute int TextWindowGUI.TopGraphic;
/// Gets the sprite number used for this TextWindow's top-right corner
readonly attribute int TextWindowGUI.TopRightGraphic;
/// Gets the sprite number used for this TextWindow's right border
readonly attribute int TextWindowGUI.RightGraphic;
/// Gets the sprite number used for this TextWindow's bottom-right corner
readonly attribute int TextWindowGUI.BottomRightGraphic;
/// Gets the sprite number used for this TextWindow's bottom border
readonly attribute int TextWindowGUI.BottomGraphic;
/// Gets the sprite number used for this TextWindow's bottom-left corner
readonly attribute int TextWindowGUI.BottomLeftGraphic;
```