### PR TITLE
Editor: consistent Script Name and Description/Name property labels

### DIFF
--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -12,7 +12,7 @@ namespace AGS.Types
     public class Character : ICustomTypeDescriptor, IToXml, IComparable<Character>
     {
         public const string PROPERTY_NAME_SCRIPTNAME = "ScriptName";
-        public const string PROPERTY_NAME_DESCRIPTION = "RealName";
+        public const string PROPERTY_NAME_DESCRIPTION = "Name";
         public const string PROPERTY_NAME_STARTINGROOM = "StartingRoom";
         public const int NARRATOR_CHARACTER_ID = 999;
 
@@ -84,7 +84,8 @@ namespace AGS.Types
             set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
-        [Description("The full name of the character")]
+        [DisplayName(PROPERTY_NAME_DESCRIPTION)]
+        [Description("The human-readable name or a description of the character")]
         [Category("Design")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string RealName

--- a/Editor/AGS.Types/Dialog.cs
+++ b/Editor/AGS.Types/Dialog.cs
@@ -39,6 +39,7 @@ namespace AGS.Types
             set { _id = value; }
         }
 
+        [DisplayName("ScriptName")]
         [Description("The script name of the dialog")]
         [Category("Design")]
         [BrowsableMultiedit(false)]

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -92,6 +92,7 @@ namespace AGS.Types
             set { _id = value; }
         }
 
+        [DisplayName("ScriptName")]
         [Description("The script name of the GUI")]
         [Category("Design")]
         [BrowsableMultiedit(false)]

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -136,6 +136,7 @@ namespace AGS.Types
             set { _id = value; }
         }
 
+        [DisplayName("ScriptName")]
         [Description("The script name of the control")]
         [Category("Design")]
         [BrowsableMultiedit(false)]

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -107,7 +107,8 @@ namespace AGS.Types
             set { _image = Math.Max(0, value); }
         }
 
-        [Description("Description of the item")]
+        [DisplayName("Name")]
+        [Description("A human readable-name or a description of the item")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string Description
@@ -116,6 +117,7 @@ namespace AGS.Types
             set { _description = value; }
         }
 
+        [DisplayName("ScriptName")]
         [Description("The script name of the item")]
         [Category("Design")]
         [BrowsableMultiedit(false)]

--- a/Editor/AGS.Types/MouseCursor.cs
+++ b/Editor/AGS.Types/MouseCursor.cs
@@ -119,7 +119,8 @@ namespace AGS.Types
             set { _animateDelay = value; }
         }
 
-        [Description("The name of the cursor")]
+        [DisplayName("ScriptName")]
+        [Description("The script name of the cursor")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
         public string Name

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -10,8 +10,8 @@ namespace AGS.Types
     [DefaultProperty("Description")]
     public class RoomHotspot : IChangeNotification
 	{
-		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
-        public const string PROPERTY_NAME_DESCRIPTION = "Description";
+		public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
+        public const string PROPERTY_NAME_DESCRIPTION = "Name";
 
         private static InteractionSchema _interactionSchema;
 
@@ -53,7 +53,8 @@ namespace AGS.Types
             set { _id = value; }
         }
 
-        [Description("Description of the hotspot")]
+        [DisplayName(PROPERTY_NAME_DESCRIPTION)]
+        [Description("A human readable-name or a description of the hotspot")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string Description

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -9,8 +9,8 @@ namespace AGS.Types
     [DefaultProperty("Image")]
 	public class RoomObject : IComparable<RoomObject>, IChangeNotification, ICustomTypeDescriptor
     {
-		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
-        public const string PROPERTY_NAME_DESCRIPTION = "Description";
+		public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
+        public const string PROPERTY_NAME_DESCRIPTION = "Name";
 
         private static InteractionSchema _interactionSchema;
 
@@ -131,7 +131,8 @@ namespace AGS.Types
             set { _y = value; }
         }
 
-        [Description("Description of the object")]
+        [DisplayName(PROPERTY_NAME_DESCRIPTION)]
+        [Description("A human readable-name or a description of the object")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string Description

--- a/Editor/AGS.Types/View.cs
+++ b/Editor/AGS.Types/View.cs
@@ -30,6 +30,7 @@ namespace AGS.Types
             set { _id = value; }
         }
 
+        [DisplayName("ScriptName")]
         [Description("The script name of the view")]
         [Category("Design")]
         [BrowsableMultiedit(false)]


### PR DESCRIPTION
There's a long time issue that the properties that tell "script name" and "human text name" are called differently in the Editor and in the script.

In the old Editor the settings were labelled "Name" and "Script O-Name" (maybe it means "object name", as in OOP).
In the new Editor they got different labels: "Description" for a human name, and "Name" for the script name.
But the script commands stayed the same.

This is an endless source of confusion for beginners, and maybe not only beginners (for example, see recent #2823).

This PR assigns consistent labels to "script name" and "description" kind of properties in all the game entities in the Editor. This also makes them consistent with how they are called in script api. Only *labels* of properties are changed, leaving property identifying names as they are, so there should not be any compatibility issues and the project data format is not changed. The effect is purely in how the users will see these properties are called in the editor panel.