### PR TITLE
Write game version into saves, let read it when scanning/validating a save

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -283,6 +283,16 @@ void StrUtil::ReadStringMap(StringMap &map, Stream *in)
     }
 }
 
+void StrUtil::SkipStringMap(Stream *in)
+{
+    size_t count = in->ReadInt32();
+    for (size_t i = 0; i < count; ++i)
+    {
+        StrUtil::SkipString(in);
+        StrUtil::SkipString(in);
+    }
+}
+
 void StrUtil::WriteStringMap(const StringMap &map, Stream *out)
 {
     out->WriteInt32(map.size());

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -96,6 +96,7 @@ namespace StrUtil
 
     // Serialize and unserialize a string map, both keys and values are read using ReadString
     void            ReadStringMap(StringMap &map, Stream *in);
+    void            SkipStringMap(Stream *in);
     void            WriteStringMap(const StringMap &map, Stream *out);
 
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -3506,6 +3506,8 @@ builtin managed struct RestoredSaveInfo
   import readonly attribute String Description;
   /// Gets the version of the engine which wrote this save.
   import readonly attribute String EngineVersion;
+  /// Gets the version of the game which wrote this save (if provided by developer).
+  import readonly attribute String GameVersion;
   /// Gets the room number this save was made in.
   import readonly attribute int Room;
   /// Gets the number of Audio Types present in this save.

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -1268,6 +1268,14 @@ const char* SaveInfo_GetEngineVersion(ScriptRestoredSaveInfo *info)
     return CreateNewScriptString(info->GetDesc().EngineVersion.LongString.GetCStr());
 }
 
+const char *SaveInfo_GetGameVersion(ScriptRestoredSaveInfo *info)
+{
+    return CreateNewScriptString(
+        (info->GetCounts().GameInfo.count("version") > 0) ?
+        info->GetCounts().GameInfo.at("version").GetCStr()
+        : "");
+}
+
 int SaveInfo_GetAudioClipTypeCount(ScriptRestoredSaveInfo *info)
 {
     return info->GetCounts().AudioClipTypes;
@@ -1418,6 +1426,11 @@ RuntimeScriptValue Sc_SaveInfo_GetEngineVersion(void *self, const RuntimeScriptV
     API_OBJCALL_OBJ(ScriptRestoredSaveInfo, const char, myScriptStringImpl, SaveInfo_GetEngineVersion);
 }
 
+RuntimeScriptValue Sc_SaveInfo_GetGameVersion(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptRestoredSaveInfo, const char, myScriptStringImpl, SaveInfo_GetGameVersion);
+}
+
 RuntimeScriptValue Sc_SaveInfo_GetAudioClipTypeCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptRestoredSaveInfo, SaveInfo_GetAudioClipTypeCount);
@@ -1506,6 +1519,7 @@ void RegisterSaveInfoAPI()
         { "RestoredSaveInfo::get_Slot",                 API_FN_PAIR(SaveInfo_GetSlot) },
         { "RestoredSaveInfo::get_Description",          API_FN_PAIR(SaveInfo_GetDescription) },
         { "RestoredSaveInfo::get_EngineVersion",        API_FN_PAIR(SaveInfo_GetEngineVersion) },
+        { "RestoredSaveInfo::get_GameVersion",          API_FN_PAIR(SaveInfo_GetGameVersion) },
         { "RestoredSaveInfo::get_AudioClipTypeCount",   API_FN_PAIR(SaveInfo_GetAudioClipTypeCount) },
         { "RestoredSaveInfo::get_CharacterCount",       API_FN_PAIR(SaveInfo_GetCharacterCount) },
         { "RestoredSaveInfo::get_DialogCount",          API_FN_PAIR(SaveInfo_GetDialogCount) },

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -258,6 +258,26 @@ inline bool AssertGameObjectContent2(HSaveError &err, const uint32_t new_val, co
 //
 //-----------------------------------------------------------------------------
 
+HSaveError WriteGameInfo(Stream *out)
+{
+    StrUtil::WriteStringMap(game.GameInfo, out);
+    return HSaveError::None();
+}
+
+HSaveError ReadGameInfo(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams & /*pp*/, RestoredData &r_data)
+{
+    // We don't overwrite current game's info, but read this into RestoredData,
+    // in case they want to check it in "validate_restored_save"
+    StrUtil::ReadStringMap(r_data.DataCounts.GameInfo, in);
+    return HSaveError::None();
+}
+
+HSaveError PrescanGameInfo(Stream *in, int32_t cmp_ver, soff_t cmp_size, const PreservedParams & /*pp*/, RestoredData &r_data)
+{
+    StrUtil::ReadStringMap(r_data.DataCounts.GameInfo, in);
+    return HSaveError::None();
+}
+
 void WriteCameraState(const Camera &cam, Stream *out)
 {
     int flags = 0;
@@ -1699,6 +1719,15 @@ ComponentHandler ComponentHandlers[] =
 {
     // NOTE: the new format values should now be defined as AGS version
     // at which a change was introduced, represented as NN,NN,NN,NN.
+    {
+        "Game Info",
+        0,
+        0,
+        kSaveCmp_GameState, // consider this is a part of game state
+        WriteGameInfo,
+        ReadGameInfo,
+        PrescanGameInfo
+    },
     {
         "Game State",
         kGSSvgVersion_363,

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -147,6 +147,7 @@ struct SaveRestoredDataCounts
     std::vector<String> ScriptModuleNames;
     std::vector<uint32_t> ScriptModuleDataSz;
     int Room = -1; // the room this save was made in
+    AGS::Common::StringMap GameInfo; // game info from the game that made this save
 };
 
 // RestoredData keeps certain temporary data to help with


### PR DESCRIPTION
Someone (I think this was @NPatch ?) asked me about this back when I was working on a save upgrade / prescan system, but I postponed this and then forgot, so this piece was not included in 3.6.2.

Earlier we have "game meta information" serialized in game data, and available in script (see #2773).
This PR adds this information into the save. When the save is restored this info does not overwrite the current game's info of course, but is read into RestoredSaveInfo struct, and may be accessed in "validate_restored_save" and used to check the save's compatibility.

Perhaps there may be other uses for this, since this data will be in saves it will be possible to implement more with it in the future.