### PR TITLE
Move label macro resolving from GUI draw functions + fix unintended overhotspot text in old games

### DIFF
--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -316,7 +316,16 @@ struct GuiContext
     SpriteCache *Spriteset = nullptr;
     // Current disabled state
     GuiDisableStyle DisabledState = kGuiDis_Undefined;
-    // Last selected inventory item's pic
+    // Resolved macro values for the label:
+    // A title of the game
+    String GameTitle;
+    // Total game score
+    int TotalScore = 0;
+    // Current game score
+    int Score = 0;
+    // A label from the object under the cursor
+    String Overhotspot;
+    // Last selected inventory item's pic (for the button)
     int InventoryPic = -1;
 };
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -383,6 +383,8 @@ namespace GUI
 
     // Parses the string and returns combination of label macro flags
     GUILabelMacro FindLabelMacros(const String &text);
+    // Resolves macro tokens found in gui text, returns a new string where the macros are replaced by values
+    String ResolveMacroTokens(const String &text);
     // Applies text transformation necessary for rendering, in accordance to the
     // current game settings, such as right-to-left render, and anything else
     String TransformTextForDrawing(const String &text, bool translate, bool apply_direction);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2463,14 +2463,6 @@ void draw_gui_and_overlays()
     // Add GUIs
     set_our_eip(35);
     if (((debug_flags & DBG_NOIFACE)==0) && (displayed_room >= 0)) {
-        if (playerchar->activeinv >= MAX_INV) {
-            quit("!The player.activeinv variable has been corrupted, probably as a result\n"
-                "of an incorrect assignment in the game script.");
-        }
-        if (playerchar->activeinv < 1)
-            GUI::Context.InventoryPic = -1;
-        else
-            GUI::Context.InventoryPic = game.invinfo[playerchar->activeinv].pic;
         set_our_eip(37);
         // Prepare and update GUI textures
         {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -529,60 +529,6 @@ void process_interface_click(int ifce, int btn, int mbut) {
     }
 }
 
-// FIXME: rewrite this awful code, use ready GUILabelMacro (?)
-void replace_macro_tokens(const char *text, String &fixed_text) {
-    const char*curptr=&text[0];
-    char tmpm[3];
-    const char*endat = curptr + strlen(text);
-    fixed_text.Empty();
-    char tempo[STD_BUFFER_SIZE];
-
-    while (1) {
-        if (curptr[0]==0) break;
-        if (curptr>=endat) break;
-        if (curptr[0]=='@') {
-            const char *curptrWasAt = curptr;
-            char macroname[21]; int idd=0; curptr++;
-            for (idd=0;idd<20;idd++) {
-                if (curptr[0]=='@') {
-                    macroname[idd]=0;
-                    curptr++;
-                    break;
-                }
-                // unterminated macro (eg. "@SCORETEXT"), so abort
-                if (curptr[0] == 0)
-                    break;
-                macroname[idd]=curptr[0];
-                curptr++;
-            }
-            macroname[idd]=0; 
-            tempo[0]=0;
-            if (ags_stricmp(macroname,"score")==0)
-                snprintf(tempo, sizeof(tempo), "%d", GUI::Context.Score);
-            else if (ags_stricmp(macroname,"totalscore")==0)
-                snprintf(tempo, sizeof(tempo), "%d", GUI::Context.TotalScore);
-            else if (ags_stricmp(macroname,"scoretext")==0)
-                snprintf(tempo, sizeof(tempo), "%d of %d", GUI::Context.Score, GUI::Context.TotalScore);
-            else if (ags_stricmp(macroname,"gamename")==0)
-                snprintf(tempo, sizeof(tempo), "%s", GUI::Context.GameTitle.GetCStr());
-            else if (ags_stricmp(macroname,"overhotspot")==0) {
-                snprintf(tempo, sizeof(tempo), "%s", GUI::Context.Overhotspot.GetCStr());
-            }
-            else { // not a macro, there's just a @ in the message
-                curptr = curptrWasAt + 1;
-                snprintf(tempo, sizeof(tempo), "%s", "@");
-            }
-
-            fixed_text.Append(tempo);
-        }
-        else {
-            tmpm[0]=curptr[0]; tmpm[1]=0;
-            fixed_text.Append(tmpm);
-            curptr++;
-        }
-    }
-}
-
 bool sort_gui_less(const int g1, const int g2)
 {
     return (guis[g1].GetZOrder() < guis[g2].GetZOrder()) ||

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -558,19 +558,15 @@ void replace_macro_tokens(const char *text, String &fixed_text) {
             macroname[idd]=0; 
             tempo[0]=0;
             if (ags_stricmp(macroname,"score")==0)
-                snprintf(tempo, sizeof(tempo), "%d",play.score);
+                snprintf(tempo, sizeof(tempo), "%d", GUI::Context.Score);
             else if (ags_stricmp(macroname,"totalscore")==0)
-                snprintf(tempo, sizeof(tempo), "%d",MAXSCORE);
+                snprintf(tempo, sizeof(tempo), "%d", GUI::Context.TotalScore);
             else if (ags_stricmp(macroname,"scoretext")==0)
-                snprintf(tempo, sizeof(tempo), "%d of %d",play.score,MAXSCORE);
+                snprintf(tempo, sizeof(tempo), "%d of %d", GUI::Context.Score, GUI::Context.TotalScore);
             else if (ags_stricmp(macroname,"gamename")==0)
-                snprintf(tempo, sizeof(tempo), "%s", play.game_name.GetCStr());
+                snprintf(tempo, sizeof(tempo), "%s", GUI::Context.GameTitle.GetCStr());
             else if (ags_stricmp(macroname,"overhotspot")==0) {
-                // While game is in Wait mode, or in room transition: no overhotspot text
-                if (!IsInterfaceEnabled() || in_room_transition)
-                    tempo[0] = 0;
-                else
-                    GetLocationNameInBuf(game_to_data_coord(mousex), game_to_data_coord(mousey), tempo);
+                snprintf(tempo, sizeof(tempo), "%s", GUI::Context.Overhotspot.GetCStr());
             }
             else { // not a macro, there's just a @ in the message
                 curptr = curptrWasAt + 1;

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -30,7 +30,6 @@
 using namespace AGS::Common;
 
 extern int eip_guiobj;
-extern void replace_macro_tokens(const char*, String&);
 
 extern SpriteCache spriteset;
 extern GameSetupStruct game;
@@ -148,7 +147,7 @@ void GUIObject::ClearChanged()
 int GUILabel::PrepareTextToDraw()
 {
     const bool is_translated = (_flags & kGUICtrl_Translated) != 0;
-    replace_macro_tokens(is_translated ? get_translation(_text.GetCStr()) : _text.GetCStr(), _textToDraw);
+    _textToDraw = GUI::ResolveMacroTokens(is_translated ? get_translation(_text.GetCStr()) : _text);
     return GUI::SplitLinesForDrawing(_textToDraw, is_translated, Lines, _font, _width);
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -870,6 +870,37 @@ static void update_cursor_view()
     }
 }
 
+// Assign GUI context parameters, read from the game state.
+// This will be required for GUI labels render.
+static void update_gui_context()
+{
+    if (play.fast_forward)
+        return;
+    if (displayed_room < 0)
+        return;
+
+    // It's easier to update these every game tick, this is simple data and copy is fast,
+    // OTOH it may be inconvenient to have this in every place where this data changes.
+    GUI::Context.GameTitle = play.game_name;
+    GUI::Context.TotalScore = play.totalscore;
+    GUI::Context.Score = play.score;
+
+    if (playerchar->activeinv < 1 || playerchar->activeinv >= MAX_INV)
+        GUI::Context.InventoryPic = -1;
+    else
+        GUI::Context.InventoryPic = game.invinfo[playerchar->activeinv].pic;
+
+    // Update a location name for the GUI labels. We do this every game
+    // tick, because this does not depend only on cursor position, but also
+    // on game object positions, and game state changes, and we cannot track all of that here.
+    // While game is in Wait mode, or in room transition: set empty overhotspot text.
+    if (!IsInterfaceEnabled() || in_room_transition)
+        GUI::Context.Overhotspot = "";
+    else
+        GUI::Context.Overhotspot = GetLocationName(game_to_data_coord(mousex), game_to_data_coord(mousey));
+}
+
+// Detect mouse move over hotspot, and run respective event if necessary
 static void update_cursor_over_location(int mwasatx, int mwasaty)
 {
     if (play.fast_forward)
@@ -877,7 +908,6 @@ static void update_cursor_over_location(int mwasatx, int mwasaty)
     if (displayed_room < 0)
         return;
 
-    // Check Mouse Moves Over Hotspot event
     auto view = play.GetRoomViewportAt(mousex, mousey);
     auto cam = view ? view->GetCamera() : nullptr;
     if (!cam)
@@ -895,7 +925,8 @@ static void update_cursor_over_location(int mwasatx, int mwasaty)
         (offsetxWas != offsetx) || (offsetyWas != offsety))) 
     {
         // mouse moves over hotspot
-        if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT) {
+        if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT)
+        {
             int onhs = getloctype_index;
 
             setevent(AGSEvent_Interaction(kIntEventType_Hotspot, onhs, kHotspotEvent_MouseOver));
@@ -1060,6 +1091,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     // historically room object and character scaling was updated
     // right before the drawing
     update_objects_scale();
+    update_gui_context();
     update_cursor_over_location(mwasatx, mwasaty);
     update_cursor_view();
 
@@ -1102,10 +1134,13 @@ void UpdateGameAudioOnly()
     WaitForNextFrame();
 }
 
-static void UpdateMouseOverLocation()
+// Update the "saved cursor until it leaves location" state
+static void UpdateSavedCursorOverLocation()
 {
     // Call GetLocationName - it will internally force a GUI refresh
     // if the result it returns has changed from last time
+    // CHECKME: this is also likely called in the main game update function,
+    // so it may be not necessary here.
     GetLocationName(game_to_data_coord(mousex), game_to_data_coord(mousey));
 
     if ((play.get_loc_name_save_cursor >= 0) &&
@@ -1194,7 +1229,8 @@ static void GameTick()
         quit("!A blocking function was called before the first room has been loaded");
 
     UpdateGameOnce(true);
-    UpdateMouseOverLocation();
+    // TODO: figure out if it's safe to move this function inside UpdateGameOnce!
+    UpdateSavedCursorOverLocation();
 }
 
 // This function is called from lot of various functions

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -872,7 +872,7 @@ static void update_cursor_view()
 
 // Assign GUI context parameters, read from the game state.
 // This will be required for GUI labels render.
-static void update_gui_context()
+static void update_gui_context(int mwasatx, int mwasaty)
 {
     if (play.fast_forward)
         return;
@@ -893,9 +893,13 @@ static void update_gui_context()
     // Update a location name for the GUI labels. We do this every game
     // tick, because this does not depend only on cursor position, but also
     // on game object positions, and game state changes, and we cannot track all of that here.
+    //
     // While game is in Wait mode, or in room transition: set empty overhotspot text.
     if (!IsInterfaceEnabled() || in_room_transition)
         GUI::Context.Overhotspot = "";
+    // Games prior to 3.6.0 had a slightly different order of updates, so use old cursor pos for them
+    else if (loaded_game_file_version < kGameVersion_360_21)
+        GUI::Context.Overhotspot = GetLocationName(game_to_data_coord(mwasatx), game_to_data_coord(mwasaty));
     else
         GUI::Context.Overhotspot = GetLocationName(game_to_data_coord(mousex), game_to_data_coord(mousey));
 }
@@ -1091,7 +1095,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     // historically room object and character scaling was updated
     // right before the drawing
     update_objects_scale();
-    update_gui_context();
+    update_gui_context(mwasatx, mwasaty);
     update_cursor_over_location(mwasatx, mwasaty);
     update_cursor_view();
 


### PR DESCRIPTION
Addresses #2821 (not fixes fully yet)
Fix #2817

This change caches values required by the labels with macros in them, so to prevent these labels from accessing other game data and updating game state right in the middle of their drawing function. The idea is that the timing of macro resolution should be strict and deterministic (and relative order compared with other parts of game update).

Additionally, fixes a potential issue in pre-3.6.0 games, which may appear after #1957, where we changed an order of cursor-related updates. Because of that change some older games may have overhotpost labels displaying text unintended (see #2817 for more details on this issue).

