### PR TITLE
3.6.2: fix ambiguous ScriptDateTime constructors

### DIFF
--- a/Engine/ac/datetime.cpp
+++ b/Engine/ac/datetime.cpp
@@ -35,7 +35,7 @@ ScriptDateTime* DateTime_CreateFromDate(int year, int month, int day, int hour, 
     }
     else
     {
-        sdt = new ScriptDateTime(year, month, day, hour, minute, second);
+        sdt = ScriptDateTime::FromFullDate(year, month, day, hour, minute, second);
     }
     ccRegisterManagedObject(sdt, sdt);
     return sdt;
@@ -50,7 +50,7 @@ ScriptDateTime* DateTime_CreateFromRawTime(int raw_time) {
     }
     else
     {
-        sdt = new ScriptDateTime(raw_time);
+        sdt = ScriptDateTime::FromRawTime(raw_time);
     }
     ccRegisterManagedObject(sdt, sdt);
     return sdt;

--- a/Engine/ac/dynobj/scriptdatetime.cpp
+++ b/Engine/ac/dynobj/scriptdatetime.cpp
@@ -31,22 +31,26 @@ const char *ScriptDateTime::GetType()
     return "DateTime";
 }
 
-ScriptDateTime::ScriptDateTime(const time_t &time)
-{
-    SetTime(SystemClock::from_time_t(time));
-}
-
 ScriptDateTime::ScriptDateTime(const ClockTimePoint &time)
 {
     SetTime(time);
 }
 
-ScriptDateTime::ScriptDateTime(int raw_time)
+/* static */ ScriptDateTime *ScriptDateTime::FromStdTime(const time_t &time)
 {
-    SetTime(ClockTimePoint(std::chrono::seconds(raw_time)));
+    ScriptDateTime *sdt = new ScriptDateTime();
+    sdt->SetTime(SystemClock::from_time_t(time));
+    return sdt;
 }
 
-ScriptDateTime::ScriptDateTime(int year, int month, int day, int hour, int minute, int second)
+/* static */ ScriptDateTime *ScriptDateTime::FromRawTime(int raw_time)
+{
+    ScriptDateTime *sdt = new ScriptDateTime();
+    sdt->SetTime(ClockTimePoint(std::chrono::seconds(raw_time)));
+    return sdt;
+}
+
+/* static */ ScriptDateTime *ScriptDateTime::FromFullDate(int year, int month, int day, int hour, int minute, int second)
 {
     // NOTE: we do not init our calendar fields here directly, and instead
     // go through SetTime, in case the combination of input values does not
@@ -60,7 +64,9 @@ ScriptDateTime::ScriptDateTime(int year, int month, int day, int hour, int minut
                    /* .tm_year = */ year - 1900,
                 };
     tm.tm_isdst = -1; // use DST value from local time zone
-    SetTime(std::chrono::system_clock::from_time_t(std::mktime(&tm)));
+    ScriptDateTime *sdt = new ScriptDateTime();
+    sdt->SetTime(std::chrono::system_clock::from_time_t(std::mktime(&tm)));
+    return sdt;
 }
 
 void ScriptDateTime::SetTime(const ClockTimePoint &time)

--- a/Engine/ac/dynobj/scriptdatetime.h
+++ b/Engine/ac/dynobj/scriptdatetime.h
@@ -29,14 +29,15 @@ public:
 
     // Constructs DateTime initialized with zero time
     ScriptDateTime() = default;
-    // Constructs DateTime initialized using C time_t
-    ScriptDateTime(const time_t &time);
     // Constructs DateTime initialized using chrono::time_point
     ScriptDateTime(const ClockTimePoint &time);
+
+    // Constructs DateTime initialized using C time_t
+    static ScriptDateTime *FromStdTime(const time_t &time);
     // Constructs DateTime initialized with raw time (unix time)
-    ScriptDateTime(int raw_time);
+    static ScriptDateTime *FromRawTime(int raw_time);
     // Constructs DateTime initialized with all the date/time components
-    ScriptDateTime(int year, int month, int day, int hour, int minute, int second);
+    static ScriptDateTime *FromFullDate(int year, int month, int day, int hour, int minute, int second);
 
     int Dispose(void *address, bool force) override;
     const char *GetType() override;

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -71,7 +71,7 @@ ScriptDateTime* File_GetFileTime(const char *fnmm) {
     ft = File::GetFileTime(rp.FullPath);
   }
 
-  ScriptDateTime *sdt = new ScriptDateTime(ft);
+  ScriptDateTime *sdt = ScriptDateTime::FromStdTime(ft);
   ccRegisterManagedObject(sdt, sdt);
   return sdt;
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -423,7 +423,7 @@ const char* Game_GetSaveSlotDescription(int slnum) {
 ScriptDateTime* Game_GetSaveSlotTime(int slnum)
 {
     time_t ft = File::GetFileTime(get_save_game_path(slnum));
-    ScriptDateTime *sdt = new ScriptDateTime(ft);
+    ScriptDateTime *sdt = ScriptDateTime::FromStdTime(ft);
     ccRegisterManagedObject(sdt, sdt);
     return sdt;
 }


### PR DESCRIPTION
Fix #2844

Because time_t is usually an integer value, it may be confused with "raw_time" parameter. And some compilers apparently have it as 32-bit, which makes two constructor declarations ambiguous.
Replaced some constructors with static factory methods, having distinct names.