### PR TITLE
Dialog options as screen overlay

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2340,6 +2340,8 @@ builtin managed struct Dialog {
   import static attribute int OptionsReadColor; // $AUTOCOMPLETESTATICONLY$
   /// Gets/sets the horizontal alignment of each dialog option's text
   import static attribute HorizontalAlignment OptionsTextAlignment; // $AUTOCOMPLETESTATICONLY$
+  /// Gets/sets the z-order of dialog options, relative to GUI and on-screen Overlays.
+  import static attribute int OptionsZOrder; // $AUTOCOMPLETESTATICONLY$
 #endif // SCRIPT_API_v363
 
   int reserved[2];   // $AUTOCOMPLETEIGNORE$

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -218,6 +218,16 @@ void Dialog_SetOptionsTextAlignment(int align)
     play.dialog_options_textalign = (HorAlignment)align;
 }
 
+int Dialog_GetOptionsZOrder()
+{
+    return play.dialog_options_zorder;
+}
+
+void Dialog_SetOptionsZOrder(int zorder)
+{
+    play.dialog_options_zorder = zorder;
+}
+
 int Dialog_GetOptionsGap()
 {
     return game.options[OPT_DIALOGGAP];
@@ -1173,6 +1183,7 @@ void DialogOptions::Draw()
     // if we created a new bitmap then assign one to overlay.
     options_over->x = position.Left;
     options_over->y = position.Top;
+    options_over->zorder = play.dialog_options_zorder;
     if (new_options_bmp)
     {
         options_over->SetImage(std::move(new_options_bmp), options_have_alpha);
@@ -2086,6 +2097,16 @@ RuntimeScriptValue Sc_Dialog_SetOptionsTextAlignment(const RuntimeScriptValue *p
     API_SCALL_VOID_PINT(Dialog_SetOptionsTextAlignment);
 }
 
+RuntimeScriptValue Sc_Dialog_GetOptionsZOrder(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Dialog_GetOptionsZOrder);
+}
+
+RuntimeScriptValue Sc_Dialog_SetOptionsZOrder(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Dialog_SetOptionsZOrder);
+}
+
 RuntimeScriptValue Sc_Dialog_GetOptionsGap(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_INT(Dialog_GetOptionsGap);
@@ -2201,6 +2222,8 @@ void RegisterDialogAPI()
         { "Dialog::set_OptionsReadColor",  API_FN_PAIR(Dialog_SetOptionsReadColor) },
         { "Dialog::get_OptionsTextAlignment", API_FN_PAIR(Dialog_GetOptionsTextAlignment) },
         { "Dialog::set_OptionsTextAlignment", API_FN_PAIR(Dialog_SetOptionsTextAlignment) },
+        { "Dialog::get_OptionsZOrder",    API_FN_PAIR(Dialog_GetOptionsZOrder) },
+        { "Dialog::set_OptionsZOrder",    API_FN_PAIR(Dialog_SetOptionsZOrder) },
         { "Dialog::get_ScriptName",       API_FN_PAIR(Dialog_GetScriptName) },
         { "Dialog::get_ShowTextParser",   API_FN_PAIR(Dialog_GetShowTextParser) },
         { "Dialog::DisplayOptions^1",     API_FN_PAIR(Dialog_DisplayOptions) },

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1074,8 +1074,8 @@ void DialogOptions::Draw()
         xspos = (ui_view.GetWidth() - areawid) - get_fixed_pixel_size(10);
 
       // needs to draw the right text window, not the default
-      Bitmap *text_window_ds = nullptr;
-      draw_text_window(&text_window_ds, false, &txoffs,&tyoffs,&xspos,&yspos,&areawid,nullptr,needheight, game.options[OPT_DIALOGIFACE], DisplayVars());
+      std::unique_ptr<Bitmap> text_window_ds =
+        draw_text_window(&txoffs,&tyoffs,&xspos,&yspos,&areawid,nullptr,needheight, game.options[OPT_DIALOGIFACE], DisplayVars());
       options_surface_has_alpha = guis[game.options[OPT_DIALOGIFACE]].HasAlphaChannel();
       // since draw_text_window incrases the width, restore the inner placement
       areawid = savedwid;
@@ -1084,7 +1084,7 @@ void DialogOptions::Draw()
       // because it has its own padding property
       position = RectWH(xspos, yspos, text_window_ds->GetWidth(), text_window_ds->GetHeight());
       inner_position = Point(txoffs, tyoffs);
-      optionsBitmap.reset(text_window_ds);
+      optionsBitmap = std::move(text_window_ds);
 
       // NOTE: presumably, txoffs and tyoffs are already offset by padding,
       // although it's not entirely reliable, because these calculations are done inside draw_text_window.

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -127,7 +127,7 @@ DisplayTextPosition get_textpos_from_scriptcoords(int x, int y, bool for_speech)
 // but this should not be done here at all.
 // FIXME: xx is allowed to be passed as OVR_AUTOPLACE, which has special meaning,
 // but that's a confusing use of this argument.
-Common::Bitmap *create_textual_image(const char *text, const DisplayTextLooks &look, color_t text_color,
+std::unique_ptr<Common::Bitmap> create_textual_image(const char *text, const DisplayTextLooks &look, color_t text_color,
     int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont,
     bool &alphaChannel, const TopBarSettings *topbar);
 // Creates a textual overlay using the given parameters;
@@ -175,15 +175,13 @@ int get_textwindow_border_width (int twgui);
 // get the hegiht of the text window's top border
 int get_textwindow_top_border_height (int twgui);
 // draw_text_window: draws the normal or custom text window
-// create a new bitmap the size of the window before calling, and
-//   point text_window_ds to it
-// returns text start x & y pos in parameters
-// Warning!: draw_text_window() and draw_text_window_and_bar() can create new text_window_ds
-void draw_text_window(Common::Bitmap **text_window_ds, bool should_free_ds, int*xins,int*yins,int*xx,int*yy,int*wii,
-    color_t *set_text_color,int ovrheight, int ifnum, const DisplayVars &disp);
-void draw_text_window_and_bar(Common::Bitmap **text_window_ds, bool should_free_ds,
-                              const TopBarSettings *topbar, const DisplayVars &disp,
-                              int*xins,int*yins,int*xx,int*yy,int*wii,color_t *set_text_color,int ovrheight=0, int ifnum=-1);
+// creates and returns a new bitmap
+// assings text start x & y pos in parameters
+std::unique_ptr<Common::Bitmap> draw_text_window(int *xins, int *yins, int *xx, int *yy, int *wii,
+    color_t *set_text_color, int ovrheight, int ifnum, const DisplayVars &disp);
+std::unique_ptr<Common::Bitmap> draw_text_window_and_bar(const TopBarSettings *topbar,
+    const DisplayVars &disp, int *xins,int *yins, int *xx, int *yy, int *wii, color_t *set_text_color,
+    int ifnum =- 1);
 int get_textwindow_padding(int ifnum);
 
 // The efficient length of the last source text prepared for display

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -661,6 +661,18 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
         dialog_options_textalign = kHAlignLeft;
         dialog_options_font = -1;
     }
+
+    if (svg_ver >= kGSSvgVersion_363_02)
+    {
+        dialog_options_zorder = in->ReadInt32();
+        in->ReadInt32(); // reserved up to 4 ints
+        in->ReadInt32();
+        in->ReadInt32();
+    }
+    else
+    {
+        dialog_options_zorder = INT32_MAX;
+    }
 }
 
 void GamePlayState::WriteForSavegame(Stream *out) const
@@ -851,6 +863,11 @@ void GamePlayState::WriteForSavegame(Stream *out) const
     out->WriteInt32(dialog_options_gui_y);
     out->WriteInt32(dialog_options_textalign);
     out->WriteInt32(dialog_options_font);
+    // kGSSvgVersion_363_02
+    out->WriteInt32(dialog_options_zorder);
+    out->WriteInt32(0); // reserved up to 4 ints
+    out->WriteInt32(0);
+    out->WriteInt32(0);
 }
 
 void GamePlayState::FreeProperties()

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -62,7 +62,8 @@ enum GameStateSvgVersion
     kGSSvgVersion_350_9     = 2,
     kGSSvgVersion_350_10    = 3,
     kGSSvgVersion_361_14    = 4,
-    kGSSvgVersion_363       = 3060300
+    kGSSvgVersion_363       = 3060300,
+    kGSSvgVersion_363_02    = 3060302
 };
 
 // SavedLocationType defines the type of location which
@@ -313,6 +314,7 @@ struct GamePlayState
     HorAlignment dialog_options_textalign = kHAlignLeft;
     // Font of dialog options texts, if negative then use "normal font"
     int   dialog_options_font = 0;
+    int   dialog_options_zorder = INT32_MAX;
 
     // Dynamic custom property values for characters and items
     std::vector<AGS::Common::StringIMap> charProps;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -101,13 +101,13 @@ void Overlay_SetText(ScreenOverlay &over, int x, int y, int width, int fontid, i
     // Recreate overlay image
     int dummy_x = x, dummy_y = y, adj_x = x, adj_y = y;
     bool has_alpha = false;
-    Bitmap *image = create_textual_image(draw_text,
+    std::unique_ptr<Bitmap> image = create_textual_image(draw_text,
         DisplayTextLooks(kDisplayTextStyle_TextWindow, (DisplayTextPosition)text_pos, allow_shrink),
         text_color, dummy_x, dummy_y, adj_x, adj_y,
         width, fontid, has_alpha, nullptr);
 
     // Update overlay properties
-    over.SetImage(std::unique_ptr<Bitmap>(image), has_alpha, adj_x - dummy_x, adj_y - dummy_y);
+    over.SetImage(std::move(image), has_alpha, adj_x - dummy_x, adj_y - dummy_y);
 }
 
 int Overlay_GetX(ScriptOverlay *scover)
@@ -448,8 +448,8 @@ ScreenOverlay *get_overlay(int type)
         screenover[type].type >= 0) ? &screenover[type] : nullptr;
 }
 
-size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum, Bitmap *piccy,
-    int pic_offx, int pic_offy, bool has_alpha)
+size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum,
+    std::unique_ptr<Bitmap> piccy, int pic_offx, int pic_offy, bool has_alpha)
 {
     if (type == OVER_CUSTOM)
     {
@@ -472,7 +472,7 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
     over.type = type;
     if (piccy)
     {
-        over.SetImage(std::unique_ptr<Bitmap>(piccy), has_alpha, pic_offx, pic_offy);
+        over.SetImage(std::move(piccy), has_alpha, pic_offx, pic_offy);
     }
     else
     {
@@ -518,12 +518,17 @@ size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum)
 
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, bool has_alpha)
 {
-    return add_screen_overlay_impl(roomlayer, x, y, type, -1, piccy, 0, 0, has_alpha);
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::unique_ptr<Bitmap>(piccy), 0, 0, has_alpha);
 }
 
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha)
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha)
 {
-    return add_screen_overlay_impl(roomlayer, x, y, type, -1, piccy, pic_offx, pic_offy, has_alpha);
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::unique_ptr<Bitmap>(piccy), pic_offx, pic_offy, has_alpha);
+}
+
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Bitmap> piccy, int pic_offx, int pic_offy, bool has_alpha)
+{
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::move(piccy), pic_offx, pic_offy, has_alpha);
 }
 
 Point get_overlay_position(const ScreenOverlay &over)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -236,9 +236,9 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
     // We clone only dynamic sprites, because it makes no sense to clone normal ones
     if (clone && ((game.SpriteInfos[slot].Flags & SPF_DYNAMICALLOC) != 0))
     {
-        Bitmap *screeno = BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height, game.GetColorDepth());
+        std::unique_ptr<Bitmap> screeno(BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height, game.GetColorDepth()));
         screeno->Blit(spriteset[slot], 0, 0, transparent ? kBitmap_Transparency : kBitmap_Copy);
-        overid = add_screen_overlay(room_layer, x, y, OVER_CUSTOM, screeno,
+        overid = add_screen_overlay(room_layer, x, y, OVER_CUSTOM, std::move(screeno),
             (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
     }
     else
@@ -516,14 +516,9 @@ size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum)
     return add_screen_overlay_impl(roomlayer, x, y, type, sprnum, nullptr, 0, 0, false);
 }
 
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, bool has_alpha)
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Bitmap> piccy, bool has_alpha)
 {
-    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::unique_ptr<Bitmap>(piccy), 0, 0, has_alpha);
-}
-
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha)
-{
-    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::unique_ptr<Bitmap>(piccy), pic_offx, pic_offy, has_alpha);
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, std::move(piccy), 0, 0, has_alpha);
 }
 
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Bitmap> piccy, int pic_offx, int pic_offy, bool has_alpha)

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -46,6 +46,7 @@ Point get_overlay_position(const ScreenOverlay &over);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool has_alpha);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Common::Bitmap> piccy, int pic_offx, int pic_offy, bool has_alpha);
 void remove_screen_overlay(int type);
 void remove_all_overlays();
 // Creates and registers a managed script object for existing overlay object;

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -44,8 +44,7 @@ ScreenOverlay *get_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)
 Point get_overlay_position(const ScreenOverlay &over);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool has_alpha);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Common::Bitmap> piccy, bool has_alpha);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, std::unique_ptr<Common::Bitmap> piccy, int pic_offx, int pic_offy, bool has_alpha);
 void remove_screen_overlay(int type);
 void remove_all_overlays();

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -13,6 +13,7 @@
 //=============================================================================
 #include "ac/screenoverlay.h"
 #include "ac/dynamicsprite.h"
+#include "ac/game.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/spritecache.h"
 #include "gfx/bitmap.h"
@@ -75,6 +76,11 @@ void ScreenOverlay::SetImage(std::unique_ptr<Common::Bitmap> pic, bool has_alpha
         _sprnum = add_dynamic_sprite(std::move(pic), has_alpha, SPF_OBJECTOWNED);
     }
     MarkChanged();
+}
+
+void ScreenOverlay::MarkImageChanged()
+{
+    game_sprite_updated(_sprnum);
 }
 
 void ScreenOverlay::SetSpriteNum(int sprnum, int offx, int offy)

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -89,10 +89,11 @@ struct ScreenOverlay
         on ? _flags |= (kOver_RoomLayer | kOver_PositionAtRoomXY) :
              _flags &= ~(kOver_RoomLayer | kOver_PositionAtRoomXY);
     }
-    // Gets actual overlay's image, whether owned by overlay or by a sprite reference
+    // Gets actual overlay's image
     Common::Bitmap *GetImage() const;
     // Get this overlay's sprite id
     int  GetSpriteNum() const { return _sprnum; }
+    // Get this overlay's graphical dimensions
     Size GetGraphicSize() const;
     // Assigns an exclusive image to this overlay; the image will be stored as a dynamic sprite
     // in a sprite cache, but owned by this overlay and therefore disposed at its disposal
@@ -105,6 +106,8 @@ struct ScreenOverlay
     void MarkChanged() { _hasChanged = true; }
     // Clears changed flag
     void ClearChanged() { _hasChanged = false; }
+    // Marks that the overlay's image has changed and the texture has to be updated
+    void MarkImageChanged();
 
     void ReadFromSavegame(Common::Stream *in, bool &has_bitmap, int32_t cmp_ver);
     void WriteToSavegame(Common::Stream *out) const;

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1746,7 +1746,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Game State",
-        kGSSvgVersion_363,
+        kGSSvgVersion_363_02,
         kGSSvgVersion_Initial,
         kSaveCmp_GameState,
         WriteGameState,


### PR DESCRIPTION
Resolve #2859

Reimplement Dialog Options drawing to create a screen overlay instead of a special texture. This makes them a part of the rest of the graphic objects. Add Dialog.OptionsZOrder script property, which lets to change dialog options sorting position among other overlays and GUIs. This allows to have custom effects on top of the dialog options, which is specifically useful for custom drawn cursors.