### PR TITLE
New compiler: Allow constructor calls to initialize ancesters of structs

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -390,6 +390,9 @@ private:
     // Track a forward-declared struct and one of its references to it.
     std::map<Symbol, size_t> _structRefs;
 
+    // The function that is currently being compiled (qualified when it's a struct function)
+    Symbol _currentlyCompiledFunction = kKW_NoSymbol;
+
     size_t _lastEmittedSectionId;
     size_t _lastEmittedLineno;
 


### PR DESCRIPTION
Fixes #2810

Normally, it is not allowed to call a constructor as a function. But when within the constructor of a struct, you may call the constructors of ancesters of that struct  (to initialize the ancester fields).

Implement this latter exception. Add some googletests.

Typical code:
```
managed struct vehicle
{
    writeprotected int max_speed;
    import void vehicle(int max_speed);
};

managed struct car extends vehicle
{
};

managed struct volvo extends car
{
    import void volvo();
};

// A call to this function is generated automatically for every 'new volvo()'
void volvo::volvo()
{
    // Assure that the fields of 'vehicle' are initialized; this must be done manually
    this.vehicle(9);
    this.volvo(); // ← not allowed, compiler will balk
}

void game_start()
{
    volvo v = new volvo();
    v.volvo(); // ← not allowed, compiler will balk
    v.vehicle(77); // ← not allowed, compiler will balk
}
```