### PR TITLE
New compiler: Report the correct line number when encountering an unknown symbol

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -6842,6 +6842,7 @@ void AGS::Parser::ParseAssignmentOrExpression()
         !_sym.IsPredefined(next_sym) &&
         _sym.kNoSrcLocation == _sym.GetDeclared(next_sym))
     {
+        SkipNextSymbol(_src, next_sym);
         UserError("Identifier '%s' is undeclared (did you mis-spell it?)", _sym.GetName(next_sym).c_str());
     }
     if (expression.Length() == 0u)

--- a/Compiler/test2/cc_parser_test_2.cpp
+++ b/Compiler/test2/cc_parser_test_2.cpp
@@ -1208,10 +1208,16 @@ TEST_F(Compile2, NullAsStringArgument) {
 TEST_F(Compile2, Unexpected_Undefined) {
 
     // Should complain about "undeclared" function instead of "unexpected" symbol
+    // Undefined symbol should be reported for line #9, not earlier
 
     std::string inpl = R"%&/(
         void game_start()
         {
+            int i;
+
+
+
+
             func(null);
         }
         )%&/";
@@ -1221,4 +1227,5 @@ TEST_F(Compile2, Unexpected_Undefined) {
 
     ASSERT_STRNE("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
     EXPECT_NE(std::string::npos, err_msg.find("ndeclared"));
+    ASSERT_EQ(9, mh.GetError().Lineno);
 }


### PR DESCRIPTION
Fixes #2902

Fix bug: When reporting an undefined symbol, the compiler didn't report the line that the symbol itself was on, but the line of the _preceding_ symbol.

Typical code:
`func` is unknown, this should be reported for the line 8, not 3
```
void game_start() // line 1
{
    int i; // line 3




    func(null); // line 8
}
```