### PR TITLE
New Compiler: Accept UTF-8 within `'…'`

### DIFF
--- a/Compiler/script2/cs_scanner.h
+++ b/Compiler/script2/cs_scanner.h
@@ -98,6 +98,7 @@ private:
     // We need that, so we collect in _eofReached the fact that end-of-stream has ever been reached.
     bool _eofReached = false;
     bool _failed = false;
+    bool _useUtf8;
     std::size_t _lineno;
     std::string _section;
     SrcList &_tokenList;
@@ -130,6 +131,9 @@ private:
 
     // Translate a '\\' combination into a character, backslash is already read in
     void EscapedChar2Char(int first_char_after_backslash, std::string &symstring, int &converted);
+
+    // Read a sequence of bytes in UTF-8 format, translate to the respective codepoint
+    void ReadInCharLit_utf8(int first_char, std::string &symstring, int &converted);
 
     // Read oct combination \777; backslash is already read in
     int OctDigits2Char(int first_digit_char, std::string &symstring);
@@ -192,10 +196,13 @@ protected:
     inline static void ReplaceToken(std::string &where, std::string const &token, std::string const &replacement) { where.replace(where.find(token), token.length(), replacement); }
 
 public:
-    Scanner(std::string const &input, SrcList &token_list, ccCompiledScript &string_collector, SymbolTable &symt, MessageHandler &messageHandler);
+    Scanner(std::string const &input, bool use_utf8, SrcList &token_list, ccCompiledScript &string_collector, SymbolTable &symt, MessageHandler &messageHandler);
 
     // Scan the input into token_list; symbols into symt; strings into _string_collector
     void Scan();
+
+    // Whether UTF-8 encoding is used
+    inline bool UseUtf8() const { return _useUtf8; }
 
     // Returns whether we've encountered EOF.
     inline bool EOFReached() const { return _eofReached; };

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -19,6 +19,7 @@
 
 #include "script2/cc_symboltable.h"
 #include "script2/cc_internallist.h"
+#include "script2/cs_scanner.h"
 #include "script2/cs_parser.h"
 
 #include "cc_parser_test_lib.h"
@@ -300,9 +301,12 @@ TEST_F(Compile0, EnumNegative) {
         };\
         ";
 
-    // Call cc_scan() and cc_parse() by hand so that we can see the symbol table
-    ASSERT_LE(0, cc_scan(inpl, targ, scrip, sym, mh));
-    int compile_result = cc_parse(targ, options, scrip, sym, mh);
+    // Call scanner and parser by hand so that we can see the symbol table
+    AGS::Scanner scanner = { inpl, false, targ, scrip, sym, mh };
+    scanner.Scan();
+    ASSERT_FALSE(mh.HasError());
+    AGS::Parser parser = { targ, options, scrip, sym, mh };
+    parser.Parse();
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
@@ -351,12 +355,14 @@ TEST_F(Compile0, DefaultParametersLargeInts) {
         ";
 
 
-    ASSERT_LE(0, cc_scan(inpl, targ, scrip, sym, mh));
-    int compile_result = cc_parse(targ, options, scrip, sym, mh);
+    AGS::Scanner scanner = { inpl, false, targ, scrip, sym, mh };
+    scanner.Scan();
+    ASSERT_FALSE(mh.HasError());
+    AGS::Parser parser = { targ, options, scrip, sym, mh };
+    parser.Parse();
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
-
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     AGS::Symbol const funcidx = sym.Find("importedfunc");
@@ -405,12 +411,14 @@ TEST_F(Compile0, ImportFunctionReturningDynamicArray) {
         };                                  \n\
         ";
 
-    ASSERT_LE(0, cc_scan(inpl, targ, scrip, sym, mh));
-    int compile_result = cc_parse(targ, options, scrip, sym, mh);
+    AGS::Scanner scanner = { inpl, false, targ, scrip, sym, mh };
+    scanner.Scan();
+    ASSERT_FALSE(mh.HasError());
+    AGS::Parser parser = { targ, options, scrip, sym, mh };
+    parser.Parse();
     std::string const &err_msg = mh.GetError().Message;
     size_t err_line = mh.GetError().Lineno;
     EXPECT_EQ(0u, mh.WarningsCount());
-
     ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     int funcidx;
@@ -847,8 +855,13 @@ TEST_F(Compile0, LocalGlobalSeq2) {
     AGS::SymbolTable sym;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    ASSERT_LE(0, cc_scan(inpl, targ, scrip, sym, mh));
-    ASSERT_EQ(0, cc_parse(targ, options, scrip, sym, mh));
+    AGS::Scanner scanner = { inpl, false, targ, scrip, sym, mh };
+    scanner.Scan();
+    ASSERT_FALSE(mh.HasError());
+    AGS::Parser parser = { targ, options, scrip, sym, mh };
+    parser.Parse();
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     ASSERT_LE(1u, mh.GetMessages().size());
     EXPECT_EQ(7u, mh.GetMessages()[0].Lineno);
@@ -1850,8 +1863,13 @@ TEST_F(Compile0, Import2GlobalAllocation) {
     AGS::SymbolTable sym;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    ASSERT_LE(0, cc_scan(inpl, targ, scrip, sym, mh));
-    ASSERT_EQ(0, cc_parse(targ, options, scrip, sym, mh));
+    AGS::Scanner scanner = { inpl, false, targ, scrip, sym, mh };
+    scanner.Scan();
+    ASSERT_FALSE(mh.HasError());
+    AGS::Parser parser = { targ, options, scrip, sym, mh };
+    parser.Parse();
+    std::string const &err_msg = mh.GetError().Message;
+    ASSERT_STREQ("Ok", mh.HasError() ? err_msg.c_str() : "Ok");
 
     AGS::Symbol const idx = sym.Find("J");
     ASSERT_LE(0, idx);

--- a/Compiler/test2/cc_parser_test_lib.h
+++ b/Compiler/test2/cc_parser_test_lib.h
@@ -22,21 +22,5 @@
 extern char kAgsHeaderString[];
 extern char kAgsHeaderBool[];
 
-// Only use this function for googletests. Scan and tokenize the input.
-extern int cc_scan(
-    std::string const &inpl,        // preprocessed text to be tokenized
-    AGS::SrcList &src,              // store for the tokenized text
-    AGS::ccCompiledScript &scrip,   // repository for the strings in the text
-    AGS::SymbolTable &symt,         // symbol table
-    AGS::MessageHandler &mh);       // warnings and the error
-
-// Only use this function for googletests. Parse the input
-extern int cc_parse(
-    AGS::SrcList &src,              // tokenized text
-    AGS::FlagSet options,           // as defined in cc_options 
-    AGS::ccCompiledScript &scrip,   // result of the compilation
-    AGS::SymbolTable &symt,         // symbol table
-    AGS::MessageHandler &mh);       // warnings and the error 
-
 
 #endif

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -42,7 +42,7 @@ TEST_F(Scan, ShortInputBackslash1)
     // Should read in an identifier and an escaped backslash.
 
     std::string Input1 = "Test\\";
-    AGS::Scanner scanner1(Input1, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner1(Input1, false, token_list, string_collector, sym, mh);
 
     // Test
     EXPECT_EQ(0, scanner1.GetNextSymstringT(symstring, sct, value));
@@ -59,7 +59,7 @@ TEST_F(Scan, ShortInputBackslash2)
 
     std::string Input = "int i = '\\";
 
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     for (size_t loop = 0; loop < 3; loop++)
     {
         ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -75,7 +75,7 @@ TEST_F(Scan, ShortInputBackslash3)
     // Should detect unclosed string.
 
     std::string Input = "String s = \"a\\";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     for (size_t loop = 0; loop < 3; loop++)
     {
         EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -90,7 +90,7 @@ TEST_F(Scan, ShortInputSimple1)
     // Should detect unclosed quote mark.
 
     std::string Input = "int i = ' ";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     for (size_t loop = 0; loop < 3; loop++)
     {
         EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -105,7 +105,7 @@ TEST_F(Scan, ShortInputSimple2)
 {
     // Should detect unclosed quote mark (the second one)
     std::string Input = "String s = \"a";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     for (size_t loop = 0; loop < 3; loop++)
     {
         EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -120,7 +120,7 @@ TEST_F(Scan, ShortInputString1) {
     // String literal isn't ended
 
     char const *Input = "\"Supercalifragilisticexpialidocious";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
     std::string errmsg = mh.GetError().Message;
@@ -132,7 +132,7 @@ TEST_F(Scan, ShortInputString2) {
     // String literal isn't ended
 
     char const *Input = "\"Donaudampfschiffahrtskapitaen\\";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
     std::string errmsg = mh.GetError().Message;
@@ -144,7 +144,7 @@ TEST_F(Scan, ShortInputString3) {
     // String literal isn't ended
 
     char const *Input = "\"Aldiborontiphoscophornio!\nWhere left you...";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
     std::string errmsg = mh.GetError().Message;
@@ -156,7 +156,7 @@ TEST_F(Scan, TwoByteSymbols1)
     // Should recognize the two-byte symbols ++ and <=
 
     std::string Input = "i++<=j";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_EQ(0, symstring.compare("i"));
@@ -173,7 +173,7 @@ TEST_F(Scan, TwoByteSymbols2)
     // Mustn't use '..'; it's either '.' or '...'
 
     std::string Input = "i .. ";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_EQ(0, symstring.compare("i"));
@@ -185,7 +185,7 @@ TEST_F(Scan, IdentifiersElementary)
     // Should scan common forms of identifier.
 
     std::string Input = "\nIdentifier\r\nIden2tifier\r\r iden_ti_9f9_ier3";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     int lno = scanner.GetLineno();
@@ -211,7 +211,7 @@ TEST_F(Scan, IdentifiersNumbers)
     // Should scan common forms of numbers and identifiers
 
     std::string Input = "Ident 4ify5er; _4 6.5 6996";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
 
     int lno = scanner.GetLineno();
@@ -252,7 +252,7 @@ TEST_F(Scan, Strings)
         "\"ABC\"\n'G' \
          \"\nH\" flurp";
 
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     size_t lno;
     std::string errorstring;
 
@@ -288,7 +288,7 @@ TEST_F(Scan, StringCollect)
 
     std::string Input = "String s = \"Zwiebelkuchen\"; s = \"Holz\\7schuh\";";
 
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
 
@@ -315,7 +315,7 @@ TEST_F(Scan, LiteralInt1)
 {
     char const *inp = "15 3 05 ";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
 
@@ -338,7 +338,7 @@ TEST_F(Scan, LiteralInt2)
     // Accept LONG_MIN written in decimal (will yield 2 symbols)
     char const *inp = "-2147483648";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     EXPECT_EQ(2u, token_list.Length());
@@ -349,7 +349,7 @@ TEST_F(Scan, LiteralInt3)
     // Accept large hexadecimal, treat as negative number (will yield 1 symbol)
     char const *inp = "0XFF000000";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     int32_t const res = 0XFF000000L;
@@ -362,7 +362,7 @@ TEST_F(Scan, LiteralInt4)
     // Accept LONG_MIN written as hexadecimal (will yield 1 symbol)
     char const *inp = "0x80000000";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     AGS::Symbol token = token_list[0];
@@ -374,7 +374,7 @@ TEST_F(Scan, LiteralInt5)
     // Leading zeroes in hex literal
     char const *inp = "0x000000001234";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     AGS::Symbol token = token_list[0];
@@ -386,7 +386,7 @@ TEST_F(Scan, LiteralInt6a)
     // Huge hexadecimal, too many significant hex digits
     char const *inp = "0x000123456789";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
 }
@@ -398,7 +398,7 @@ TEST_F(Scan, LiteralInt6b)
                       "1234567890123456789012345678901234567890123456789012345678901234567890"
                       "1234567890123456789012345678901234567890123456789012345678901234567890";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
 }
@@ -409,7 +409,7 @@ TEST_F(Scan, LiteralInt7)
     // interpret such a number in decimal (!) notation
     char const *inp = "0123";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     AGS::Symbol token = token_list[0];
@@ -421,7 +421,7 @@ TEST_F(Scan, LiteralIntLimits)
     // Should correctly parse INT32_MAX and INT32_MIN
     char const *inp1 = "-2147483648 2147483647";
 
-    AGS::Scanner scanner(inp1, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp1, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
     AGS::Symbol const lit_min = token_list[1u]; // 0u is '-'
@@ -443,7 +443,7 @@ TEST_F(Scan, LiteralIntOverflow)
     // Should detect int32 overflow
     char const *inp1 = "-2147483649";
     
-    AGS::Scanner scanner1(inp1, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner1(inp1, false, token_list, string_collector, sym, mh);
     scanner1.Scan();
     ASSERT_TRUE(mh.HasError());
 
@@ -458,7 +458,7 @@ TEST_F(Scan, LiteralIntHex)
 {
     char const *inp = "0x7FFFFFFF 0xFFFFFFFF";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
 
@@ -476,7 +476,7 @@ TEST_F(Scan, LiteralFloat)
     //           0u 1u  2u  3u  4u   5u    6u   7u    8u   9u    10u
     char const *inp = "3. 3.0 0.0 0.3 33E5 3e-15 3.E5 3.E-5 .3E5 .3E-5 3.14E+2";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp, false, token_list, string_collector, sym, mh);
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
 
@@ -545,7 +545,7 @@ TEST_F(Scan, CharLit1)
 
     std::string Input = "foo \'";
     
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("foo", symstring.c_str());
 
@@ -560,7 +560,7 @@ TEST_F(Scan, CharLit2)
     // Should detect unclosed char literal.
 
     std::string Input = "foo '\\";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
     
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("foo", symstring.c_str());
@@ -575,7 +575,7 @@ TEST_F(Scan, CharLit3)
     // Should detect over long char literal.
 
     std::string Input = "foo \'A$";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("foo", symstring.c_str());
@@ -590,7 +590,7 @@ TEST_F(Scan, CharLit4)
     // Should complain about escape sequence \A
 
     std::string Input = "foo '\\A'";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("foo", symstring.c_str());
@@ -605,11 +605,46 @@ TEST_F(Scan, CharLit5)
     // Should convert backslash combination to 10
 
     std::string Input = "'\\n'";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_EQ(10, value);
     EXPECT_STREQ("'\\n'", symstring.c_str());
+}
+
+TEST_F(Scan, CharLit6)
+{
+    // Should accept UTF-8 sequence
+
+    std::string Input = "'\xc3\xa7'"; // cedille
+    AGS::Scanner scanner = { Input, true, token_list, string_collector, sym, mh };
+
+    ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
+    EXPECT_EQ(231, value);
+    EXPECT_STREQ("'\xc3\xa7'", symstring.c_str());
+}
+
+TEST_F(Scan, CharLit7)
+{
+    // Should accept UTF-8 sequence
+
+    std::string Input = "'\xf0\x9f\x91\xb9'"; // devil mask
+    AGS::Scanner scanner = { Input, true, token_list, string_collector, sym, mh };
+
+    ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
+    EXPECT_EQ(128121, value);
+    EXPECT_STREQ("'\xf0\x9f\x91\xb9'", symstring.c_str());
+}
+
+TEST_F(Scan, CharLit8)
+{
+    // Should NOT accept illegal UTF-8
+
+    std::string Input = "'\xe0\x9f\x91'"; // 2nd byte is illegal
+    AGS::Scanner scanner = { Input, true, token_list, string_collector, sym, mh };
+
+    ASSERT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
+    EXPECT_NE(std::string::npos, mh.GetError().Message.find("9F'"));
 }
 
 TEST_F(Scan, BackslashBracketInChar) {
@@ -617,7 +652,7 @@ TEST_F(Scan, BackslashBracketInChar) {
     // Character literal '\[' is forbidden ('[' is okay)
 
     char const *Input = "int i = '\\[';";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     scanner.Scan();
     EXPECT_TRUE(mh.HasError());
@@ -631,7 +666,7 @@ TEST_F(Scan, BackslashOctal1) {
 
     char const *Input = "String s = \"Boom\\19 Box\";";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("String", symstring.c_str());
@@ -651,7 +686,7 @@ TEST_F(Scan, BackslashOctal2) {
 
     char const *Input = "String s = \"Boom\\7/Box\\444/Borg\";";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     for (size_t symbol_idx = 4; symbol_idx --> 1 ;) // note! smiley ";)" needed
         EXPECT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -668,7 +703,7 @@ TEST_F(Scan, BackslashOctal3) {
 
     char const *Input = "\"b\\102b\" '\\234'";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -684,7 +719,7 @@ TEST_F(Scan, BackslashHex1) {
 
     char const *Input = "\"Le\\xicon\"";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     scanner.Scan();
     EXPECT_TRUE(mh.HasError());
@@ -701,7 +736,7 @@ TEST_F(Scan, BackslashHex2) {
 
     char const *Input = "\"He\\xA/meter \\xC@fe Nicolas C\\xAGE \\xFACE \"";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -717,7 +752,7 @@ TEST_F(Scan, BackslashOctHex) {
     char const *Input =
         "\" \\x19 \\x2a \\x3A \\xb4 \\xcd \\xeB \\xC5 \\xDf \\xEF \""
         "\" \\31 \\52 \\72 \\264 \\315 \\353 \\305 \\337 \\357 \"";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -733,7 +768,7 @@ TEST_F(Scan, BackslashCSym) {
     // Test different symbol characters after '\'
 
     char const *Input = "\" Is \\'Java\\' \\equal to \\\"Ja\\va\\\" \\? \"";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -746,7 +781,7 @@ TEST_F(Scan, BackslashBackslash) {
     // Backslash Backslash in strings or char literals converts to backslash.
 
     char const *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -764,7 +799,7 @@ TEST_F(Scan, String1)
     // Should scan advanced escape sequences within string.
 
     std::string Input = "\"Oh, \\the \\brow\\n \\fo\\x5e jumps [ove\\r] the \\100\\azy dog.\"";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
@@ -783,7 +818,7 @@ TEST_F(Scan, UnknownKeywordAfterReadonly) {
                       readonly int2 b; \
                     };";
 
-    AGS::Scanner scanner = { inpl, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { inpl, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     EXPECT_FALSE(mh.HasError());
 }
@@ -798,7 +833,7 @@ TEST_F(Scan, SectionChange)
         String A = \"__NEWSCRIPTSTART_Foo\"; \n\
      ";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_FALSE(mh.HasError());
     token_list.SetCursor(0u);
@@ -839,7 +874,7 @@ TEST_F(Scan, MatchBraceParen1)
         ];                  \r\n\
         ";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     EXPECT_TRUE(mh.HasError());
 
@@ -854,7 +889,7 @@ TEST_F(Scan, MatchBraceParen2)
     // "This closing ')' does not match the '[' on this line"
 
     std::string Input = "f(a[bb.ccc * (d + e - ( f - g)))";
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     EXPECT_TRUE(mh.HasError());
     EXPECT_EQ(1u, scanner.GetLineno());
@@ -872,7 +907,7 @@ TEST_F(Scan, MatchBraceParen3)
             float A;        \r\n\
         };";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
     EXPECT_EQ(5u, scanner.GetLineno());
@@ -886,7 +921,7 @@ TEST_F(Scan, MatchBraceParen4)
 
     std::string Input = "struct B );";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
     EXPECT_EQ(1u, scanner.GetLineno());
@@ -909,7 +944,7 @@ TEST_F(Scan, MatchBraceParen5)
                 S.          \n\
         ";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
     EXPECT_EQ(6u, scanner.GetLineno());
@@ -932,7 +967,7 @@ TEST_F(Scan, MatchBraceParen6)
             }               \n\
         ";
 
-    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    AGS::Scanner scanner = { Input, false, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
     EXPECT_EQ(2u, scanner.GetLineno());
@@ -945,7 +980,7 @@ TEST_F(Scan, ConsecutiveStringLiterals1)
     // Consecutive string literals should be concatenated
 
     std::string Input = "\"Supercalifragilistic\"\n   \n   \n  \"expialidocious\"; ";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"Supercalifragilisticexpialidocious\"", symstring.c_str());
@@ -968,7 +1003,7 @@ TEST_F(Scan, ConsecutiveStringLiterals2)
         \"__NEWSCRIPTSTART_File2\" \
         ";
 
-    AGS::Scanner scanner(input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_EQ(Scanner::kSct_SectionChange, sct);
@@ -986,7 +1021,7 @@ TEST_F(Scan, ConsecutiveStringLiterals3)
     // Handling string literals with escaped characters
 
     std::string Input = "\"Escape\\nSequence\" \"Another\\tOne\"; ";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"Escape\\nSequenceAnother\\tOne\"", symstring.c_str());
@@ -1001,7 +1036,7 @@ TEST_F(Scan, ConsecutiveStringLiterals4)
     // and there's an unclosed empty string literal in the end.
 
     std::string Input = "\"Supercalifragilistic  \"expialidocious\"; ";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"Supercalifragilistic  \"", symstring.c_str());
@@ -1018,7 +1053,7 @@ TEST_F(Scan, ConsecutiveStringLiterals5)
     // Consecutive string literals where the trailing one was not closed
 
     std::string Input = "\"Supercalifragilistic\"\n   \n   \n  \"expialidocious";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_TRUE(scanner.EOFReached());
@@ -1031,7 +1066,7 @@ TEST_F(Scan, EmptyStringLiteral)
     // Handling empty string literal
 
     std::string Input = "\"\"";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"\"", symstring.c_str());
@@ -1048,7 +1083,7 @@ TEST_F(Scan, SmallStringLiteral)
     // A small string literal
 
     std::string Input = "\"small\";";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"small\"", symstring.c_str());
@@ -1065,7 +1100,7 @@ TEST_F(Scan, SmallConsecutiveStringLiterals)
     // A small string literal
 
     std::string Input = "\"sm\" \"al\"  \"l\";";
-    AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(Input, false, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));
     EXPECT_STREQ("\"small\"", symstring.c_str());


### PR DESCRIPTION
Fixes #2909 

Allow UTF-8 byte sequences within single quotes. This is equivalent to the codepoint of the respective byte sequence.

Typical code:
```
String utfText = "Test";
utfText = utfText.AppendChar('👹'); // → utfText.AppendChar(128121)
```

I'm taking this as an opportunity to refactor the code a bit by inlining and then killing `cc_parse()` and `cc_scan()`. (Both functions had been reserved for internal use in googletests.)