### PR TITLE
Tool: spritepak

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -395,7 +395,7 @@ void SpriteCache::InitNullSprite(sprkey_t index)
     _spriteData[index] = SpriteData();
 }
 
-int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index)
+HError SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index)
 {
     // Gather a list of sprites;
     // the list contains pairs, where first element tells whether the sprites

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -337,9 +337,9 @@ Bitmap *SpriteCache::LoadSprite(sprkey_t index, bool lock)
         return nullptr;
     assert((_spriteData[index].Flags & SPRCACHEFLAG_ISASSET) != 0);
 
-    Bitmap *image{};
-    HError err = _file.LoadSprite(index, image);
-    if (!image)
+    PixelBuffer pxbuf;
+    HError err = _file.LoadSprite(index, pxbuf);
+    if (!pxbuf)
     {
         Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Warn,
             "LoadSprite: failed to load sprite %d:\n%s\n - remapping to placeholder.", index,
@@ -349,6 +349,7 @@ Bitmap *SpriteCache::LoadSprite(sprkey_t index, bool lock)
     }
 
     // Let the external user convert this sprite's image for their needs
+    Bitmap *image = new Bitmap(std::move(pxbuf));
     image = _callbacks.InitSprite(index, image, _sprInfos[index].Flags);
     if (!image)
     {
@@ -401,7 +402,7 @@ int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompr
     // exists at all (either have a ready image, or found in a input file).
     // SaveSpriteFile will either use a ready image or load missing images
     // before saving to the destination.
-    std::vector<std::pair<bool, Bitmap*>> sprites;
+    std::vector<std::pair<bool, BitmapData>> sprites;
     for (size_t i = 0; i < _spriteData.size(); ++i)
     {
         auto &image = ResourceCache::Get(i);
@@ -409,7 +410,7 @@ int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompr
             _callbacks.PrewriteSprite(image.get());
         sprites.push_back(std::make_pair(
             (image || _spriteData[i].IsAssetSprite()),
-            image.get()));
+            image->GetBitmapData()));
     }
     return SaveSpriteFile(filename, sprites, &_file, store_flags, compress, index);
 }

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -92,7 +92,7 @@ public:
     HError      InitFile(std::unique_ptr<Stream> &&sprite_file,
                          std::unique_ptr<Stream> &&index_file);
     // Saves current cache contents to the file
-    int         SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index);
+    HError      SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index);
     // Closes an active sprite file stream
     void        DetachFile();
 

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 #include "core/types.h"
+#include "gfx/bitmapdata.h"
 #include "util/error.h"
 #include "util/geometry.h"
 #include "util/stream.h"
@@ -34,8 +35,6 @@ namespace AGS
 {
 namespace Common
 {
-
-class Bitmap;
 
 // TODO: research old version differences
 enum SpriteFileVersion
@@ -149,7 +148,7 @@ public:
                                     sprkey_t topmost, std::vector<Size> &metrics);
 
     // Loads an image data and creates a ready bitmap
-    HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
+    HError      LoadSprite(sprkey_t index, PixelBuffer &sprite);
     // Loads a raw sprite element data into the buffer, stores header info separately
     HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
 
@@ -195,7 +194,7 @@ public:
     // optionally hint how many sprites will be written.
     void Begin(int store_flags, SpriteCompression compress, sprkey_t last_slot = -1);
     // Writes a bitmap into file, compressing if necessary
-    void WriteBitmap(const Bitmap *image);
+    void WriteBitmap(const BitmapData &image);
     // Writes an empty slot marker
     void WriteEmptySlot();
     // Writes a raw sprite data without any additional processing
@@ -222,11 +221,11 @@ private:
 
 // Saves all sprites to file; fills in index data for external use.
 // TODO: refactor to be able to save main file and index file separately (separate function for gather data?)
-// Accepts available sprites as pairs of bool and Bitmap pointer, where boolean value
-// tells if sprite exists and Bitmap pointer may be null;
+// Accepts available sprites as pairs of bool and BitmapData buffers, where boolean value
+// tells if sprite exists, and BitmapData may be invalid;
 // If a sprite's bitmap is missing, it will try reading one from the input file stream.
 int SaveSpriteFile(const String &save_to_file,
-    const std::vector<std::pair<bool, Bitmap*>> &sprites,
+    const std::vector<std::pair<bool, BitmapData>> &sprites,
     SpriteFile *read_from_file, // optional file to read missing sprites from
     int store_flags, SpriteCompression compress, SpriteFileIndex &index);
 // Saves sprite index table in a separate file

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -61,6 +61,7 @@ enum SpriteIndexFileVersion
 // Instructions to how the sprites are allowed to be stored
 enum SpriteStorage
 {
+    kSprStore_None            = 0x00,
     // When possible convert the sprite into another format for less disk space
     // e.g. save 16/32-bit images as 8-bit colormaps with palette
     kSprStore_OptimizeForSize = 0x01
@@ -131,8 +132,17 @@ public:
     SpriteFile();
     // Loads sprite reference information and inits sprite stream
     HError      OpenFile(std::unique_ptr<Stream> &&sprite_file,
+                         std::unique_ptr<Stream> &&index_file);
+    // Loads sprite reference information and inits sprite stream;
+    // fills in found sprites's basic metrics.
+    HError      OpenFile(std::unique_ptr<Stream> &&sprite_file,
                          std::unique_ptr<Stream> &&index_file,
                          std::vector<Size> &metrics);
+    // Loads sprite reference information and inits sprite stream;
+    // fills in found sprites's extended metrics.
+    HError      OpenFile(std::unique_ptr<Stream> &&sprite_file,
+                         std::unique_ptr<Stream> &&index_file,
+                         std::vector<SpriteDatHeader> &metrics);
     // Closes stream; no reading will be possible unless opened again
     void        Close();
 
@@ -141,20 +151,31 @@ public:
     SpriteCompression GetSpriteCompression() const;
     // Tells the highest known sprite index
     sprkey_t    GetTopmostSprite() const;
+    // Tells the total valid sprite count (remember that sprite
+    // indexes may be not sequential)
+    size_t      GetSpriteCount() const;
 
-    // Loads sprite index file
-    bool        LoadSpriteIndexFile(std::unique_ptr<Stream> &&index_file,
-                                    int expectedFileID, soff_t spr_initial_offs,
-                                    sprkey_t topmost, std::vector<Size> &metrics);
-
+    // Tells if the sprite of this index exists in the file
+    bool        DoesSpriteExist(sprkey_t index);
     // Loads an image data and creates a ready bitmap
     HError      LoadSprite(sprkey_t index, PixelBuffer &sprite);
     // Loads a raw sprite element data into the buffer, stores header info separately
     HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
+    // Loads all sprites's available metrics
+    HError      LoadSpriteMetrics(std::vector<SpriteDatHeader> &metrics);
 
 private:
+    HError      OpenFileImpl(std::unique_ptr<Stream> &&sprite_file,
+                         std::unique_ptr<Stream> &&index_file,
+                         std::vector<Size> *metrics, std::vector<SpriteDatHeader> *metrics2);
+    // Loads sprite index file
+    bool        LoadSpriteIndexFile(std::unique_ptr<Stream> &&index_file,
+                        int expectedFileID, sprkey_t topmost, std::vector<Size> *metrics);
+    // Reload sprite metrics, optionally uses ready index, optionally
+    HError      LoadSpriteMetricsImpl(std::vector<SpriteDatHeader> *metrics);
     // Rebuilds sprite index from the main sprite file
-    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost, std::vector<Size> &metrics);
+    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost,
+                        std::vector<Size> *metrics, std::vector<SpriteDatHeader> *metrics2);
     // Seek stream to sprite
     void        SeekToSprite(sprkey_t index);
 
@@ -168,6 +189,7 @@ private:
 
     // Array of sprite references
     std::vector<SpriteRef> _spriteData;
+    size_t _validCount = 0u;
     std::unique_ptr<Stream> _stream; // the sprite stream
     SpriteFileVersion _version = kSprfVersion_Current;
     int _storeFlags = 0; // storage flags, specify how sprites may be stored
@@ -220,16 +242,16 @@ private:
 
 
 // Saves all sprites to file; fills in index data for external use.
-// TODO: refactor to be able to save main file and index file separately (separate function for gather data?)
 // Accepts available sprites as pairs of bool and BitmapData buffers, where boolean value
 // tells if sprite exists, and BitmapData may be invalid;
 // If a sprite's bitmap is missing, it will try reading one from the input file stream.
-int SaveSpriteFile(const String &save_to_file,
+HError SaveSpriteFile(const String &save_to_file,
     const std::vector<std::pair<bool, BitmapData>> &sprites,
     SpriteFile *read_from_file, // optional file to read missing sprites from
     int store_flags, SpriteCompression compress, SpriteFileIndex &index);
 // Saves sprite index table in a separate file
-int SaveSpriteIndex(const String &filename, const SpriteFileIndex &index);
+// FIXME: return HError!
+HError SaveSpriteIndex(const String &filename, const SpriteFileIndex &index);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -325,19 +325,19 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 
     // Primary background (LZW or RLE compressed depending on format)
     if (data_ver >= kRoomVersion_pre114_5)
-        room->BgFrames[0].Graphic =
-            load_lzw(in, room->BackgroundBPP, &room->Palette);
+        room->BgFrames[0].Graphic = std::make_shared<Bitmap>(
+            load_lzw(in, room->BackgroundBPP, &room->Palette));
     else
-        room->BgFrames[0].Graphic = load_rle_bitmap8(in);
+        room->BgFrames[0].Graphic = std::make_shared<Bitmap>(load_rle_bitmap8(in));
 
     // Area masks
     if (data_ver >= kRoomVersion_255b)
-        room->RegionMask = load_rle_bitmap8(in);
+        room->RegionMask = std::make_shared<Bitmap>(load_rle_bitmap8(in));
     else if (data_ver >= kRoomVersion_114)
         skip_rle_bitmap8(in); // an old version - clear the 'shadow' area into a blank regions bmp (???)
-    room->WalkAreaMask = load_rle_bitmap8(in);
-    room->WalkBehindMask = load_rle_bitmap8(in);
-    room->HotspotMask = load_rle_bitmap8(in);
+    room->WalkAreaMask = std::make_shared<Bitmap>(load_rle_bitmap8(in));
+    room->WalkBehindMask = std::make_shared<Bitmap>(load_rle_bitmap8(in));
+    room->HotspotMask = std::make_shared<Bitmap>(load_rle_bitmap8(in));
     return HError::None();
 }
 
@@ -414,8 +414,8 @@ HError ReadAnimBgBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 
     for (size_t i = 1; i < room->BgFrameCount; ++i)
     {
-        room->BgFrames[i].Graphic =
-            load_lzw(in, room->BackgroundBPP, &room->BgFrames[i].Palette);
+        room->BgFrames[i].Graphic = std::make_shared<Bitmap>(
+            load_lzw(in, room->BackgroundBPP, &room->BgFrames[i].Palette));
     }
     return HError::None();
 }
@@ -830,11 +830,11 @@ void WriteMainBlock(const RoomStruct *room, Stream *out)
     for (uint32_t i = 0; i < (uint32_t)MAX_ROOM_REGIONS; ++i)
         out->WriteInt32(room->Regions[i].Tint);
 
-    save_lzw(out, room->BgFrames[0].Graphic.get(), &room->Palette);
-    save_rle_bitmap8(out, room->RegionMask.get());
-    save_rle_bitmap8(out, room->WalkAreaMask.get());
-    save_rle_bitmap8(out, room->WalkBehindMask.get());
-    save_rle_bitmap8(out, room->HotspotMask.get());
+    save_lzw(out, room->BgFrames[0].Graphic->GetBitmapData(), &room->Palette);
+    save_rle_bitmap8(out, room->RegionMask->GetBitmapData());
+    save_rle_bitmap8(out, room->WalkAreaMask->GetBitmapData());
+    save_rle_bitmap8(out, room->WalkBehindMask->GetBitmapData());
+    save_rle_bitmap8(out, room->HotspotMask->GetBitmapData());
 }
 
 void WriteCompSc3Block(const RoomStruct *room, Stream *out)
@@ -864,7 +864,7 @@ void WriteAnimBgBlock(const RoomStruct *room, Stream *out)
     for (size_t i = 0; i < room->BgFrameCount; ++i)
         out->WriteInt8(room->BgFrames[i].IsPaletteShared ? 1 : 0);
     for (size_t i = 1; i < room->BgFrameCount; ++i)
-        save_lzw(out, room->BgFrames[i].Graphic.get(), &room->BgFrames[i].Palette);
+        save_lzw(out, room->BgFrames[i].Graphic->GetBitmapData(), &room->BgFrames[i].Palette);
 }
 
 void WritePropertiesBlock(const RoomStruct *room, Stream *out)

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -119,10 +119,15 @@ public:
     operator bool() const { return _cbuf != nullptr; }
 
     inline PixelFormat GetFormat() const { return _format; }
+    // Gets color depth in bits per pixel
     inline int GetColorDepth() const { return _bitsPerPixel; }
+    inline int GetBytesPerPixel() const { return (_bitsPerPixel + 7) / 8; }
     inline int GetWidth() const { return _width; }
     inline int GetHeight() const { return _height; }
+    // Gets the total size of the pixel data buffer, in bytes
     inline size_t GetDataSize() const { return _dataSize; }
+    // Gets the length of a single bitmap line, in bytes;
+    // this line may have extra padding beyond the bitmap's width
     inline size_t GetStride() const { return _stride; }
     inline const uint8_t *GetData() const { return _cbuf; }
     inline uint8_t *GetData() { return _buf; }

--- a/Common/gfx/image_file.cpp
+++ b/Common/gfx/image_file.cpp
@@ -685,11 +685,9 @@ bool SavePCX(const BitmapData &bmp, const RGB *pal, Stream *out)
     char runchar;
     char ch;
 
-    PALETTE tmppal;
     /* we really need a palette */
     if (!pal) {
-        get_palette(tmppal);
-        pal = tmppal;
+        return false;
     }
 
     color_depth = bmp.GetColorDepth();

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -11,38 +11,49 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#ifndef __AC_COMPRESS_H
-#define __AC_COMPRESS_H
+//
+// Various compression utilities for pixel data.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__COMPRESS_H
+#define __AGS_CN_UTIL__COMPRESS_H
 
-#include "core/types.h"
 #include <memory>
 #include <vector>
+#include "core/types.h"
+#include "gfx/bitmapdata.h"
+#include "util/stream.h"
 
 struct RGB;
 
-namespace AGS { namespace Common { class Stream; class Bitmap; } }
-using namespace AGS; // FIXME later
+namespace AGS
+{
+namespace Common
+{
 
 // RLE compression
-bool rle_compress(const uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *out);
-bool rle_decompress(uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *in);
+bool rle_compress(const uint8_t *data, size_t data_sz, int image_bpp, Stream *out);
+bool rle_decompress(uint8_t *data, size_t data_sz, int image_bpp, Stream *in);
 // Packs a 8-bit bitmap using RLE compression, and writes into stream along with the palette
-void save_rle_bitmap8(Common::Stream *out, const Common::Bitmap *bmp, const RGB (*pal)[256] = nullptr);
+void save_rle_bitmap8(Stream *out, const BitmapData &bmdata, const RGB (*pal)[256] = nullptr);
 // Reads a 8-bit bitmap with palette from the stream and unpacks from RLE
-std::unique_ptr<Common::Bitmap> load_rle_bitmap8(Common::Stream *in, RGB (*pal)[256] = nullptr);
+PixelBuffer load_rle_bitmap8(Stream *in, RGB (*pal)[256] = nullptr);
 // Skips the 8-bit RLE bitmap
-void skip_rle_bitmap8(Common::Stream *in);
+void skip_rle_bitmap8(Stream *in);
 
 // LZW compression
-bool lzw_compress(const uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *out);
-bool lzw_decompress(uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *in, size_t in_sz);
+bool lzw_compress(const uint8_t *data, size_t data_sz, int image_bpp, Stream *out);
+bool lzw_decompress(uint8_t *data, size_t data_sz, int image_bpp, Stream *in, size_t in_sz);
 // Saves bitmap with an optional palette compressed by LZW
-void save_lzw(Common::Stream *out, const Common::Bitmap *bmpp, const RGB (*pal)[256] = nullptr);
+void save_lzw(Stream *out, const BitmapData &bmdata, const RGB (*pal)[256] = nullptr);
 // Loads bitmap decompressing
-std::unique_ptr<Common::Bitmap> load_lzw(Common::Stream *in, int dst_bpp, RGB (*pal)[256] = nullptr);
+PixelBuffer load_lzw(Stream *in, int dst_bpp, RGB (*pal)[256] = nullptr);
 
 // Deflate compression
-bool deflate_compress(const uint8_t* data, size_t data_sz, int image_bpp, Common::Stream* out);
-bool inflate_decompress(uint8_t* data, size_t data_sz, int image_bpp, Common::Stream* in, size_t in_sz);
+bool deflate_compress(const uint8_t* data, size_t data_sz, int image_bpp, Stream* out);
+bool inflate_decompress(uint8_t* data, size_t data_sz, int image_bpp, Stream* in, size_t in_sz);
 
-#endif // __AC_COMPRESS_H
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__COMPRESS_H

--- a/Common/util/directory.h
+++ b/Common/util/directory.h
@@ -160,7 +160,6 @@ private:
 //
 // FindFile searches the directory for files or subdirs,
 // using defined sort of directory iteration (flat or recursive), and a match pattern.
-// TODO: accept regex in ctor.
 // TODO: move to its own header? with or w/o DirIterator?
 //
 class FindFile
@@ -173,18 +172,28 @@ public:
     // Open FindFile with the given search parameters
     static FindFile Open(const String &path, const String &wildcard,
         bool do_files, bool do_dirs, size_t max_level = SIZE_MAX);
+    static FindFile Open(const String &path, const std::regex &regex,
+        bool do_files, bool do_dirs, size_t max_level = SIZE_MAX);
     // Search for files, strictly in the given dir
     static FindFile OpenFiles(const String &path, const String &wildcard = "*")
         { return Open(path, wildcard, true, false, 0); }
+    static FindFile OpenFiles(const String &path, const std::regex &regex)
+        { return Open(path, regex, true, false, 0); }
     // Search for directories, strictly in the given dir
     static FindFile OpenDirs(const String &path, const String &wildcard = "*")
         { return Open(path, wildcard, false, true, 0); }
+    static FindFile OpenDirs(const String &path, const std::regex &regex)
+        { return Open(path, regex, false, true, 0); }
     // Search for files, recursively, in the given dir, and all nested subdirs
     static FindFile OpenFilesRecursive(const String &path, const String &wildcard = "*")
         { return Open(path, wildcard, true, false, SIZE_MAX); }
+    static FindFile OpenFilesRecursive(const String &path, const std::regex &regex)
+        { return Open(path, regex, true, false, SIZE_MAX); }
     // Search for directories, recursively, in the given dir, and all nested subdirs
     static FindFile OpenDirsRecursive(const String &path, const String &wildcard = "*")
         { return Open(path, wildcard, false, true, SIZE_MAX); }
+    static FindFile OpenDirsRecursive(const String &path, const std::regex &regex)
+        { return Open(path, regex, false, true, SIZE_MAX); }
 
     bool AtEnd() const { return _di.AtEnd(); }
     void Close() { _di = DirectoryRecursiveIterator(); }
@@ -196,6 +205,9 @@ public:
     FindFile &operator =(FindFile &&ff) = default;
 
 private:
+    static FindFile OpenImpl(const String &path, std::regex &&regex,
+        bool do_files, bool do_dirs, size_t max_level);
+
     FindFile(DirectoryRecursiveIterator &&di, std::regex &&regex, bool files, bool dirs)
         : _di(std::move(di)), _regex(std::move(regex))
         , _doFiles(files), _doDirs(dirs) {}

--- a/Common/util/stream.cpp
+++ b/Common/util/stream.cpp
@@ -55,6 +55,19 @@ size_t Stream::ReadAndConvertArrayOfInt64(int64_t *buffer, size_t count)
     return count;
 }
 
+size_t Stream::ReadAndConvertArrayOfUInt24(uint8_t *buffer, size_t count)
+{
+    // NOTE: count is number of 3-byte elements
+    count = ReadArray(buffer, sizeof(uint8_t) * 3, count);
+    for (size_t i = 0; i < count; ++i, buffer += 3)
+    {
+        uint8_t temp = buffer[0];
+        buffer[0] = buffer[3];
+        buffer[3] = temp;
+    }
+    return count;
+}
+
 size_t Stream::ReadAndConvertArrayOfFloat32(float *buffer, size_t count)
 {
     count = ReadArray(buffer, sizeof(float), count);
@@ -103,6 +116,24 @@ size_t Stream::WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t count)
         int64_t val = *buffer;
         val = BBOp::SwapBytesInt64(val);
         if (Write(&val, sizeof(int64_t)) < sizeof(int64_t))
+        {
+            break;
+        }
+    }
+    return elem;
+}
+
+size_t Stream::WriteAndConvertArrayOfUInt24(const uint8_t *buffer, size_t count)
+{
+    size_t elem;
+    uint8_t elem_buf[3];
+    // NOTE: count is number of 3-byte elements
+    for (elem = 0; elem < count && !EOS(); ++elem, buffer += 3)
+    {
+        elem_buf[0] = buffer[2];
+        elem_buf[1] = buffer[1];
+        elem_buf[2] = buffer[0];
+        if (Write(elem_buf, sizeof(elem_buf)) < sizeof(elem_buf))
         {
             break;
         }

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -285,6 +285,14 @@ public:
         Read(&val, sizeof(int64_t));
         return BBOp::Int64FromLE(val);
     }
+    // Reads a 3-byte unsigned integer value into uint32 (most significant byte is always zero)
+    uint32_t ReadUInt24()
+    {
+        uint32_t val = 0;
+        Read(&val, 3);
+        // TODO: consider changing BBOp operations to work with uints, with helpers accepting ints
+        return static_cast<uint32_t>(BBOp::Int32FromLE(static_cast<int32_t>(val))); // NOTE: we still swap as 32-bit
+    }
     float ReadFloat32()
     {
         float val = 0.f;
@@ -339,6 +347,13 @@ public:
         val = BBOp::Int64FromLE(val);
         return Write(&val, sizeof(int64_t));
     }
+    // Writes a uint32 value into 3 bytes (most significant byte is discarded!)
+    size_t WriteUInt24(uint32_t val)
+    {
+        // TODO: consider changing BBOp operations to work with uints, with helpers accepting ints
+        val = static_cast<uint32_t>(BBOp::Int32FromLE(static_cast<int32_t>(val))); // NOTE: we still swap as 32-bit
+        return Write(&val, 3);
+    }
     size_t WriteFloat32(float val)
     {
         val = BBOp::Float32FromLE(val);
@@ -386,6 +401,14 @@ public:
         return ReadArray(buffer, sizeof(int64_t), count);
     #endif
     }
+    size_t ReadArrayOfUInt24(uint8_t *buffer, size_t count)
+    {
+#if defined (BITBYTE_BIG_ENDIAN)
+        return ReadAndConvertArrayOfInt24(buffer, count);
+#else
+        return ReadArray(buffer, sizeof(uint8_t) * 3, count);
+#endif
+    }
     size_t ReadArrayOfFloat32(float *buffer, size_t count)
     {
     #if defined (BITBYTE_BIG_ENDIAN)
@@ -427,6 +450,14 @@ public:
         return WriteArray(buffer, sizeof(int64_t), count);
     #endif
     }
+    size_t WriteArrayOfUInt24(const uint8_t *buffer, size_t count)
+    {
+#if defined (BITBYTE_BIG_ENDIAN)
+        return WriteAndConvertArrayOfUInt24(buffer, count);
+#else
+        return WriteArray(buffer, sizeof(uint8_t) * 3, count);
+#endif
+    }
     size_t WriteArrayOfFloat32(const float *buffer, size_t count)
     {
     #if defined (BITBYTE_BIG_ENDIAN)
@@ -450,10 +481,12 @@ private:
     size_t  ReadAndConvertArrayOfInt16(int16_t *buffer, size_t count);
     size_t  ReadAndConvertArrayOfInt32(int32_t *buffer, size_t count);
     size_t  ReadAndConvertArrayOfInt64(int64_t *buffer, size_t count);
+    size_t  ReadAndConvertArrayOfUInt24(uint8_t *buffer, size_t count);
     size_t  ReadAndConvertArrayOfFloat32(float *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt16(const int16_t *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt32(const int32_t *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t count);
+    size_t  WriteAndConvertArrayOfUInt24(const uint8_t *buffer, size_t count);
     size_t  WriteAndConvertArrayOfFloat32(const float *buffer, size_t count);
 };
 

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <unordered_map>
 
+#include <array>
 #include <vector>
 #include "util/string.h"
 

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -33,13 +33,23 @@ String StrUtil::IntToString(int d)
     return String::FromFormat("%d", d);
 }
 
-int StrUtil::StringToInt(const String &s, int def_val)
+inline int StringToIntImpl(const String &s, int radix, int def_val)
 {
     if (s.IsEmpty())
         return def_val;
     char *stop_ptr;
-    int val = strtol(s.GetCStr(), &stop_ptr, 0);
+    int val = strtol(s.GetCStr(), &stop_ptr, radix);
     return (stop_ptr == s.GetCStr() + s.GetLength()) ? val : def_val;
+}
+
+int StrUtil::StringToInt(const String &s, int def_val)
+{
+    return StringToIntImpl(s, 0, def_val);
+}
+
+int StrUtil::StringToIntHex(const String &s, int def_val)
+{
+    return StringToIntImpl(s, 16, def_val);
 }
 
 StrUtil::ConversionError StrUtil::StringToInt(const String &s, int &val, int def_val)

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -41,6 +41,7 @@ namespace StrUtil
     // Tries to convert whole string into integer value;
     // returns def_val on failure
     int             StringToInt(const String &s, int def_val = 0);
+    int             StringToIntHex(const String &s, int def_val = 0);
     int64_t         StringToInt64(const String &s, int64_t def_val = 0);
     uint64_t        StringToUInt64(const String &s, uint64_t def_val = 0);
     // Tries to convert whole string into integer value;

--- a/Editor/AGS.Native/SpriteFileReader_NET.cpp
+++ b/Editor/AGS.Native/SpriteFileReader_NET.cpp
@@ -56,22 +56,23 @@ SpriteFileReader::!SpriteFileReader()
 
 System::Drawing::Bitmap ^SpriteFileReader::LoadSprite(int spriteIndex, bool useAlphaChannel)
 {
-    AGSBitmap *sprite;
-    if (!_nativeReader->LoadSprite(spriteIndex, sprite))
+    std::unique_ptr<AGSBitmap> sprite;
+    AGS::Common::PixelBuffer pxbuf;
+    if (!_nativeReader->LoadSprite(spriteIndex, pxbuf))
         return nullptr;
 
-    System::Drawing::Bitmap ^bmp = ConvertBlockToBitmap(sprite, useAlphaChannel);
-    delete sprite;
+    sprite.reset(new AGSBitmap(std::move(pxbuf)));
+    System::Drawing::Bitmap ^bmp = ConvertBlockToBitmap(sprite.get(), useAlphaChannel);
     return bmp;
 }
 
 NativeBitmap ^SpriteFileReader::LoadSpriteAsNativeBitmap(int spriteIndex)
 {
-    AGSBitmap *sprite;
-    if (!_nativeReader->LoadSprite(spriteIndex, sprite))
+    AGS::Common::PixelBuffer pxbuf;
+    if (!_nativeReader->LoadSprite(spriteIndex, pxbuf))
         return nullptr;
 
-    return gcnew NativeBitmap(sprite);
+    return gcnew NativeBitmap(new AGSBitmap(std::move(pxbuf)));
 }
 
 SpriteFile::RawSpriteData ^SpriteFileReader::LoadSpriteAsRawData(int spriteIndex)

--- a/Editor/AGS.Native/SpriteFileWriter_NET.cpp
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.cpp
@@ -54,7 +54,7 @@ void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image)
     RGB imgPalBuf[256];
     int importedColourDepth;
     std::unique_ptr<AGSBitmap> native_bmp(CreateBlockFromBitmap(image, imgPalBuf, nullptr, true, true /* FIXME */, true, true, &importedColourDepth));
-    _nativeWriter->WriteBitmap(native_bmp.get());
+    _nativeWriter->WriteBitmap(native_bmp->GetBitmapData());
 }
 
 void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::SpriteImportTransparency transparency,
@@ -62,12 +62,12 @@ void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::S
 {
     std::unique_ptr<AGSBitmap> native_bmp(CreateNativeBitmap(image, (int)transparency, transColour,
         remapColours, useRoomBackgroundColours, alphaChannel, nullptr));
-    _nativeWriter->WriteBitmap(native_bmp.get());
+    _nativeWriter->WriteBitmap(native_bmp->GetBitmapData());
 }
 
 void SpriteFileWriter::WriteNativeBitmap(NativeBitmap ^bitmap)
 {
-    _nativeWriter->WriteBitmap(bitmap->GetNativePtr());
+    _nativeWriter->WriteBitmap(bitmap->GetNativePtr()->GetBitmapData());
 }
 
 void SpriteFileWriter::WriteRawData(RawSpriteData^ data)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1192,20 +1192,8 @@ void new_font () {
 
 void setup_color_conversions()
 {
-    // RGB shifts for Allegro's pixel data
-    _rgb_a_shift_32 = 24;
-    _rgb_r_shift_32 = 16;
-    _rgb_g_shift_32 = 8;
-    _rgb_b_shift_32 = 0;
-    _rgb_r_shift_24 = 16;
-    _rgb_g_shift_24 = 8;
-    _rgb_b_shift_24 = 0;
-    _rgb_r_shift_16 = 11;
-    _rgb_g_shift_16 = 5;
-    _rgb_b_shift_16 = 0;
-    _rgb_r_shift_15 = 10;
-    _rgb_g_shift_15 = 5;
-    _rgb_b_shift_15 = 0;
+    // Init Allegro RGB shifts; necessary for doing color conversions
+    set_rgb_shifts(10, 5, 0, 11, 5, 0, 16, 8, 0, 16, 8, 0, 24);
 }
 
 bool initialize_native()
@@ -2026,11 +2014,13 @@ void SaveTempSpritefile(int store_flags, AGS::Common::SpriteCompression compress
     AGSString n_temp_spritefile = TextHelper::ConvertUTF8(temp_spritefile);
     AGSString n_temp_indexfile = TextHelper::ConvertUTF8(temp_indexfile);
     AGS::Common::SpriteFileIndex index;
-    if (spriteset.SaveToFile(n_temp_spritefile, store_flags, compressSprites, index) != 0)
-        throw gcnew AGSEditorException(String::Format("Unable to save the sprites. An error occurred whilst writing the sprite file.{0}Temp path: {1}",
-            Environment::NewLine, temp_spritefile));
+    HAGSError err = spriteset.SaveToFile(n_temp_spritefile, store_flags, compressSprites, index);
+    if (!err)
+        throw gcnew AGSEditorException(String::Format("Unable to save the sprites. An error occurred whilst writing the sprite file:{0}{1}{2}Temp path: {1}",
+            Environment::NewLine, gcnew String(err->FullMessage().GetCStr()), Environment::NewLine, temp_spritefile));
     saved_spritefile = n_temp_spritefile;
-    if (AGS::Common::SaveSpriteIndex(n_temp_indexfile, index) == 0)
+    err = AGS::Common::SaveSpriteIndex(n_temp_indexfile, index);
+    if (err)
         saved_indexfile = n_temp_indexfile;
 }
 

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -798,6 +798,7 @@
     <ClInclude Include="..\..\Common\util\deflatestream.h" />
     <ClInclude Include="..\..\libsrc\allegro\include\allegro.h" />
     <ClInclude Include="..\..\libsrc\allegro\include\allegro\base.h" />
+    <ClInclude Include="..\..\libsrc\allegro\include\allegro\colblend.h" />
     <ClInclude Include="..\..\libsrc\allegro\include\allegro\color.h" />
     <ClInclude Include="..\..\libsrc\allegro\include\allegro\debug.h" />
     <ClInclude Include="..\..\libsrc\allegro\include\allegro\draw.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -910,5 +910,8 @@
     <ClInclude Include="..\..\Common\libsrc\freetype-2.1.3\include\freetype\freetype.h">
       <Filter>Library Sources\freetype</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\libsrc\allegro\include\allegro\colblend.h">
+      <Filter>Library Sources\allegro</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Tools.App/spritepak.vcxproj
+++ b/Solutions/Tools.App/spritepak.vcxproj
@@ -1,0 +1,195 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\ac\spritefile.cpp" />
+    <ClCompile Include="..\..\Common\gfx\bitmapdata.cpp" />
+    <ClCompile Include="..\..\Common\gfx\image_file.cpp" />
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\cmdlineopts.cpp" />
+    <ClCompile Include="..\..\Common\util\compress.cpp" />
+    <ClCompile Include="..\..\Common\util\directory.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\lzw.cpp" />
+    <ClCompile Include="..\..\Common\util\memorystream.cpp" />
+    <ClCompile Include="..\..\Common\util\path.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\libsrc\allegro\src\color.c" />
+    <ClCompile Include="..\..\libsrc\miniz\miniz.c" />
+    <ClCompile Include="..\..\Tools\spritepak\main.cpp" />
+    <ClCompile Include="..\..\Tools\spritepak\commands.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Common\ac\spritefile.h" />
+    <ClInclude Include="..\..\Common\gfx\bitmapdata.h" />
+    <ClInclude Include="..\..\Common\gfx\image_file.h" />
+    <ClInclude Include="..\..\Common\util\bufferedstream.h" />
+    <ClInclude Include="..\..\Common\util\cmdlineopts.h" />
+    <ClInclude Include="..\..\Common\util\compress.h" />
+    <ClInclude Include="..\..\Common\util\directory.h" />
+    <ClInclude Include="..\..\Common\util\file.h" />
+    <ClInclude Include="..\..\Common\util\filestream.h" />
+    <ClInclude Include="..\..\Common\util\lzw.h" />
+    <ClInclude Include="..\..\Common\util\memorystream.h" />
+    <ClInclude Include="..\..\Common\util\path.h" />
+    <ClInclude Include="..\..\Common\util\stdio_compat.h" />
+    <ClInclude Include="..\..\Common\util\stream.h" />
+    <ClInclude Include="..\..\Common\util\string.h" />
+    <ClInclude Include="..\..\Common\util\string_compat.h" />
+    <ClInclude Include="..\..\Common\util\string_utils.h" />
+    <ClInclude Include="..\..\libsrc\miniz\miniz.h" />
+    <ClInclude Include="..\..\Tools\spritepak\commands.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1D3E1B95-BD32-4A33-84FE-C995D9015657}</ProjectGuid>
+    <RootNamespace>MakeRoomHeader</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>spritepak</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Tools.App/spritepak.vcxproj.filters
+++ b/Solutions/Tools.App/spritepak.vcxproj.filters
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spritepak">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="miniz">
+      <UniqueIdentifier>{3c265ae8-b584-444e-af07-9c70a00f4543}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="allegro">
+      <UniqueIdentifier>{9f02011e-fa1a-41f3-97bd-8d6b72d66542}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Tools\spritepak\main.cpp">
+      <Filter>spritepak</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\spritepak\commands.cpp">
+      <Filter>spritepak</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\ac\spritefile.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\gfx\image_file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\cmdlineopts.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\compress.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\directory.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\memorystream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\path.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\miniz\miniz.c">
+      <Filter>miniz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\lzw.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\gfx\bitmapdata.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\allegro\src\color.c">
+      <Filter>allegro</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Tools\spritepak\commands.h">
+      <Filter>spritepak</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\ac\spritefile.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\gfx\image_file.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\bufferedstream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\cmdlineopts.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\compress.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\directory.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\file.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\stream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\string.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\string_utils.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\memorystream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\filestream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\stdio_compat.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\path.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\string_compat.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libsrc\miniz\miniz.h">
+      <Filter>miniz</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\lzw.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\gfx\bitmapdata.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -15,6 +15,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "crmpak", "Tools.App\crmpak.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agfexport", "Tools.App\agfexport.vcxproj", "{776E38BA-D6A4-431E-8053-299310D85301}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spritepak", "Tools.App\spritepak.vcxproj", "{1D3E1B95-BD32-4A33-84FE-C995D9015657}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -71,6 +73,14 @@ Global
 		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x64.Build.0 = Release|x64
 		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x86.ActiveCfg = Release|Win32
 		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x86.Build.0 = Release|Win32
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Debug|x64.ActiveCfg = Debug|x64
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Debug|x64.Build.0 = Debug|x64
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Debug|x86.ActiveCfg = Debug|Win32
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Debug|x86.Build.0 = Debug|Win32
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Release|x64.ActiveCfg = Release|x64
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Release|x64.Build.0 = Release|x64
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Release|x86.ActiveCfg = Release|Win32
+		{1D3E1B95-BD32-4A33-84FE-C995D9015657}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(libtools PUBLIC .)
 # we could link to AGS::Common, but this provides much faster LTO times with Release builds
 target_include_directories(libtools PUBLIC ../Common)
 set(TOOLS_COMMON_SOURCES
+        ../Common/ac/spritefile.cpp
         ../Common/ac/wordsdictionary.cpp
         ../Common/core/asset.cpp
         ../Common/debug/debugmanager.cpp
@@ -19,12 +20,16 @@ set(TOOLS_COMMON_SOURCES
         ../Common/game/data_helpers.h
         ../Common/game/room_file_base.cpp
         ../Common/game/tra_file.cpp
+        ../Common/gfx/bitmapdata.cpp
+        ../Common/gfx/image_file.cpp
         ../Common/util/bufferedstream.cpp
         ../Common/util/cmdlineopts.cpp
+        ../Common/util/compress.cpp
         ../Common/util/data_ext.cpp
         ../Common/util/directory.cpp
         ../Common/util/file.cpp
         ../Common/util/filestream.cpp
+        ../Common/util/lzw.cpp
         ../Common/util/memorystream.cpp
         ../Common/util/multifilelib.cpp
         ../Common/util/path.cpp
@@ -34,6 +39,10 @@ set(TOOLS_COMMON_SOURCES
         ../Common/util/string_compat.c
         ../Common/util/string_utils.cpp
         ../Common/util/textstreamreader.cpp)
+        
+target_include_directories(libtools PUBLIC ../libsrc/allegro/include)
+set(TOOLS_MINIMAL_ALLEGRO_SOURCES
+        ../libsrc/allegro/src/color.c)
 
 target_sources(libtools
         PRIVATE
@@ -55,8 +64,10 @@ target_sources(libtools
         data/tra_utils.cpp
         data/tra_utils.h
         ${TOOLS_COMMON_SOURCES}
+        ${TOOLS_MINIMAL_ALLEGRO_SOURCES}
         )
-
+        
+target_link_libraries(libtools PUBLIC MiniZ::MiniZ)
 target_link_libraries(libtools PUBLIC TinyXML2::TinyXML2)
 if (WIN32)
     target_link_libraries(libtools PUBLIC shlwapi)
@@ -105,6 +116,17 @@ set_target_properties(crmpak PROPERTIES
         )
 target_link_libraries(crmpak PUBLIC libtools)
 
+#----- spritepak -------------------------------------------------
+add_executable(spritepak spritepak/main.cpp
+        spritepak/commands.h
+        spritepak/commands.cpp
+        )
+set_target_properties(spritepak PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(spritepak PUBLIC libtools)
+
 #----- trac ---------------------------------------------------
 add_executable(trac trac/main.cpp)
 set_target_properties(trac PROPERTIES
@@ -119,6 +141,7 @@ list(APPEND TOOLS_TARGETS
         agspak
         crm2ash
         crmpak
+        spritepak
         trac
         )
 

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -39,10 +39,33 @@ set(TOOLS_COMMON_SOURCES
         ../Common/util/string_compat.c
         ../Common/util/string_utils.cpp
         ../Common/util/textstreamreader.cpp)
-        
+
+
+#-----------------------------------------------------------------------------#
+# Minimal Allegro config
+#-----------------------------------------------------------------------------#
+
+include(TestBigEndian)
+
+test_big_endian(ALLEGRO_BIG_ENDIAN)
+if(NOT ALLEGRO_BIG_ENDIAN)
+   set(ALLEGRO_LITTLE_ENDIAN 1)
+endif(NOT ALLEGRO_BIG_ENDIAN)
+
+if(CMAKE_COMPILER_IS_GNUCC)
+    set(ALLEGRO_GCC 1)
+endif(CMAKE_COMPILER_IS_GNUCC)
+
+if(MSVC)
+    set(ALLEGRO_MSVC 1)
+endif()
+
+#-----------------------------------------------------------------------------#
+
 target_include_directories(libtools PUBLIC ../libsrc/allegro/include)
 set(TOOLS_MINIMAL_ALLEGRO_SOURCES
         ../libsrc/allegro/src/color.c)
+target_compile_definitions(libtools PRIVATE ALLEGRO_STATICLINK)
 
 target_sources(libtools
         PRIVATE

--- a/Tools/spritepak/Makefile
+++ b/Tools/spritepak/Makefile
@@ -1,4 +1,4 @@
-INCDIR = ../../Common ../../libsrc/miniz
+INCDIR = ../../Common ../../libsrc/miniz ../../libsrc/allegro/include
 LIBDIR =
 
 CFLAGS := -O2 -g \
@@ -8,6 +8,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/Tools/spritepak/Makefile
+++ b/Tools/spritepak/Makefile
@@ -1,0 +1,101 @@
+INCDIR = ../../Common ../../libsrc/miniz
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/ac/spritefile.cpp \
+	../../Common/gfx/bitmapdata.cpp \
+	../../Common/gfx/image_file.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/cmdlineopts.cpp \
+	../../Common/util/compress.cpp \
+	../../Common/util/directory.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/lzw.cpp \
+	../../Common/util/memorystream.cpp \
+	../../Common/util/path.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp
+
+MINIMAL_ALLEGRO_OBJS = \
+	../../libsrc/allegro/src/color.c
+
+MINIZ_OBJS = \
+	../../libsrc/miniz/miniz.c
+
+OBJS := main.cpp \
+	commands.cpp \
+	$(COMMON_OBJS) \
+	$(MINIZ_OBJS)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags spritepak
+
+spritepak: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags spritepak
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f spritepak $(OBJS) $(DEPFILES)
+
+install: spritepak
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin spritepak
+
+uninstall:
+	rm -f $(PREFIX)/bin/spritepak

--- a/Tools/spritepak/commands.cpp
+++ b/Tools/spritepak/commands.cpp
@@ -1,0 +1,461 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "commands.h"
+#include <allegro.h>
+#include "ac/spritefile.h"
+#include "gfx/image_file.h"
+#include "util/directory.h"
+#include "util/file.h"
+#include "util/path.h"
+#include "util/string_utils.h"
+
+using namespace AGS::Common;
+
+namespace SpritePak
+{
+
+static const String DefaultPattern = "spr%06d";
+static const String DefaultRegexPattern = "spr\\d{6}";
+static const String DefaultExtension = "bmp"; // TODO: replace with PNG when engine code has support
+static const CstrArr<kNumSprCompressTypes> CompressionNames = {{"none", "rle", "lzw", "deflate"}};
+
+void Init()
+{
+    // Init Allegro RGB shifts; necessary for doing color conversions
+    set_rgb_shifts(10, 5, 0, 11, 5, 0, 16, 8, 0, 16, 8, 0, 24);
+}
+
+String GetCompressionName(SpriteCompression compress)
+{
+    return String::Wrapper(StrUtil::SelectCStr<kNumSprCompressTypes>(
+        CompressionNames, compress, "unknown"));
+}
+
+SpriteCompression CompressionFromName(const String &compress_name)
+{
+    return StrUtil::ParseEnum<SpriteCompression, kNumSprCompressTypes>(
+        compress_name, CompressionNames, kSprCompress_None);
+}
+
+static void ResolveImageFilePattern(const String &pattern, String &res_pattern, String &regex_pattern)
+{
+    if (pattern.IsNullOrSpace())
+    {
+        res_pattern = String::FromFormat("%s.%s", DefaultPattern.GetCStr(), DefaultExtension.GetCStr());
+        regex_pattern = String::FromFormat("%s.%s", DefaultRegexPattern.GetCStr(), DefaultExtension.GetCStr());
+    }
+
+    res_pattern = "";
+    regex_pattern = "";
+    const auto parts = pattern.Split('%');
+    // Each second part is assumed a placeholder between two '%'
+    for (size_t i = 0; i < parts.size(); ++i)
+    {
+        if (i % 2 == 0)
+        {
+            res_pattern.Append(parts[i]);
+            regex_pattern.Append(parts[i]);
+        }
+        else if (i < parts.size() - 1)
+        {
+            // Resolve placeholder
+            if (parts[i] == "N" || parts[i] == "n")
+            {
+                res_pattern.Append("%06d");
+                regex_pattern.Append("\\d{6}");
+            }
+            else
+            {
+                res_pattern.Append("_");
+                regex_pattern.Append("_");
+            }
+        }
+    }
+
+    if (Path::GetFileExtension(res_pattern).IsEmpty())
+    {
+        res_pattern = String::FromFormat("%s.%s", res_pattern.GetCStr(), DefaultExtension.GetCStr());
+        regex_pattern = String::FromFormat("%s.%s", regex_pattern.GetCStr(), DefaultExtension.GetCStr());
+    }
+}
+
+static String ResolveImageFilePattern(const String &pattern)
+{
+    String res_pattern, regex_pattern;
+    ResolveImageFilePattern(pattern, res_pattern, regex_pattern);
+    return res_pattern;
+}
+
+static HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex)
+{
+    for (FindFile ff = FindFile::Open(asset_dir, regex, true, false, 0);
+         !ff.AtEnd(); ff.Next())
+    {
+        String filename = ff.Current();
+        files.push_back(filename);
+    }
+    return HError::None();
+}
+
+static HError OpenSpriteFile(SpriteFile &reader, const String &sprite_file, const String &index_file,
+    std::vector<SpriteDatHeader> *metrics = nullptr)
+{
+    std::unique_ptr<Stream> file_in = File::OpenFileRead(sprite_file);
+    if (!file_in)
+        return new Error(String::FromFormat("Failed to open spritefile for reading: %s", sprite_file.GetCStr()));
+    std::unique_ptr<Stream> index_in;
+    if (!index_file.IsEmpty())
+    {
+        index_in = File::OpenFileRead(index_file);
+        if (!index_in)
+        {
+            printf("Error: failed to open index for reading: %s\n", index_file.GetCStr());
+        }
+    }
+
+    printf("Parsing the sprite file...\n");
+    HError err;
+    if (metrics)
+        err = reader.OpenFile(std::move(file_in), std::move(index_in), *metrics);
+    else
+        err = reader.OpenFile(std::move(file_in), std::move(index_in));
+    if (!err)
+        return new Error("Failed to initialize sprite file", err);
+    return 0;
+}
+
+static void SaveIndexFile(const String &index_file, const SpriteFileIndex &index)
+{
+    if (!index_file.IsEmpty())
+    {
+        printf("Writing the new index file...\n");
+        HError err = SaveSpriteIndex(index_file, index);
+        if (err)
+        {
+            printf("Index file written successfully.\n");
+        }
+        else
+        {
+            printf("Error: failed to write index file (%s):\n", index_file.GetCStr());
+            printf("%s\n", err->FullMessage().GetCStr());
+        }
+    }
+}
+
+static void PrintQuickInfo(const SpriteFile &reader)
+{
+    printf("Sprite file info:\n\tcompression: %s\n\tstorage flags: 0x%08x\n\ttotal sprites: %zu\n\thighest sprite: %d\n",
+           GetCompressionName(reader.GetSpriteCompression()).GetCStr(),
+           reader.GetStoreFlags(),
+           reader.GetSpriteCount(),
+           reader.GetTopmostSprite());
+}
+
+int Command_Create(const String &src_dir, const String &dst_pak, const CommandOptions &opts, bool verbose)
+{
+    printf("Input directory: %s\n", src_dir.GetCStr());
+    printf("Output spritefile: %s\n", dst_pak.GetCStr());
+    if (!opts.IndexFile.IsEmpty())
+        printf("Output index file: %s\n", opts.IndexFile.GetCStr());
+
+    if (!File::IsDirectory(src_dir))
+    {
+        printf("Error: not a valid input directory.\n");
+        return -1;
+    }
+
+    String image_pattern, regex_pattern;
+    ResolveImageFilePattern(opts.ImageFilePattern, image_pattern, regex_pattern);
+    printf("Image file pattern: %s\n", image_pattern.GetCStr());
+    printf("Sprite file compression: %s\n", GetCompressionName(opts.Compress).GetCStr());
+    printf("Sprite file storage flags: 0x%08x\n", opts.StorageFlags);
+
+    //-----------------------------------------------------------------------//
+    // Gather image file list
+    //-----------------------------------------------------------------------//
+    std::vector<String> files;
+    printf("Scanning the directory...\n");
+    HError err = MakeListOfFiles(files, src_dir, std::regex(regex_pattern.GetCStr(), std::regex_constants::icase));
+    if (!err)
+    {
+        printf("Error: failed to gather list of image files:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    if (files.size() == 0)
+    {
+        printf("Warning: no pattern-matching files found in the provided directory.\n");
+    }
+    else
+    {
+        printf("Found: %zu matching input files.\n", files.size());
+    }
+
+    sprkey_t top_index = -1;
+    std::vector<std::pair<sprkey_t, String>> sorted_files;
+    for (const auto &imf : files)
+    {
+        sprkey_t slot;
+        if ((sscanf(imf.GetCStr(), image_pattern.GetCStr(), &slot) == 1)
+            && (slot >= 0) && (slot < INT32_MAX))
+        {
+            sorted_files.push_back(std::make_pair(slot, imf));
+            top_index = std::max(top_index, slot);
+        }
+    }
+    std::sort(sorted_files.begin(), sorted_files.end(),
+        [](const auto &f1, const auto &f2) { return f1.first < f2.first; });
+
+    //-----------------------------------------------------------------------//
+    // Write sprite file
+    //-----------------------------------------------------------------------//
+    auto out = File::OpenFileWrite(dst_pak);
+    if (!out)
+    {
+        printf("Error: failed to open sprite file for writing: %s\n", dst_pak.GetCStr());
+        return -1;
+    }
+    printf("Writing the new sprite file...\n");
+    size_t import_count = 0u;
+    SpriteFileWriter writer(std::move(out));
+    // TODO: move this process to a separate code module;
+    // there's a lot more to this, as the process of sprite file generation may
+    // need to include extra image processing, such as transparent color selection,
+    // tile cropping, etc, which options we may need to read from some kind of a
+    // "sprite definition" file (or Game.agf).
+    writer.Begin(opts.StorageFlags, opts.Compress, top_index);
+    for (const auto &imf : sorted_files)
+    {
+        auto im_in = File::OpenFileRead(Path::ConcatPaths(src_dir, imf.second));
+        if (!im_in)
+        {
+            writer.WriteEmptySlot();
+            printf("Error: failed to open image file for input: %s\n", imf.second.GetCStr());
+            continue;
+        }
+
+        PixelBuffer pxbuf = ImageFile::LoadImage(im_in.get(), Path::GetFileExtension(imf.second));
+        if (!pxbuf)
+        {
+            writer.WriteEmptySlot();
+            printf("Error: failed to load an image from file: %s\n", imf.second.GetCStr());
+            continue;
+        }
+
+        writer.WriteBitmap(pxbuf);
+        import_count++;
+        if (verbose)
+            printf("+ [%06d] - '%s'\n", imf.first, imf.second.GetCStr());
+    }
+    writer.Finalize();
+    printf("Sprite file written successfully.\n");
+    printf("Imported %zu sprites.\n", import_count);
+
+    SaveIndexFile(opts.IndexFile, writer.GetIndex());
+    printf("Done.\n");
+    return 0;
+}
+
+int Command_Export(const String &src_pak, const String &dst_dir, const CommandOptions &opts, bool verbose)
+{
+    printf("Input spritefile: %s\n", src_pak.GetCStr());
+    if (!opts.IndexFile.IsEmpty())
+        printf("Input index file: %s\n", opts.IndexFile.GetCStr());
+    printf("Output directory: %s\n", dst_dir.GetCStr());
+
+    if (!File::IsDirectory(dst_dir))
+    {
+        printf("Error: not a valid output directory.\n");
+        return -1;
+    }
+
+    String image_pattern = ResolveImageFilePattern(opts.ImageFilePattern);
+    printf("Image file pattern: %s\n", image_pattern.GetCStr());
+
+    //-----------------------------------------------------------------------//
+    // Read the sprite file
+    //-----------------------------------------------------------------------//
+    SpriteFile reader;
+    HError err = OpenSpriteFile(reader, src_pak, opts.IndexFile);
+    if (!err)
+    {
+        printf("Error: failed to open and/or parse the sprite file:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    if (reader.GetSpriteCount() == 0)
+    {
+        printf("Spritefile has no sprites.\nDone.\n");
+        return 0;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Extract sprites
+    //-----------------------------------------------------------------------//
+    printf("Exporting sprites...\n");
+    const sprkey_t top_sprite = reader.GetTopmostSprite();
+    const String file_ext = Path::GetFileExtension(image_pattern);
+    size_t export_count = 0;
+    for (sprkey_t i = 0; i <= top_sprite; ++i)
+    {
+        if (reader.DoesSpriteExist(i))
+        {
+            PixelBuffer pxbuf;
+            HError err = reader.LoadSprite(i, pxbuf);
+            if (!err)
+            {
+                printf("Error: failed to unpack sprite %d\n", i);
+                continue;
+            }
+            String image_file = Path::ConcatPaths(dst_dir, String::FromFormat(image_pattern.GetCStr(), i));
+            auto out = File::OpenFileWrite(image_file);
+            if (!out)
+            {
+                printf("Error: failed to open image file for writing: %s\n", image_file.GetCStr());
+                continue;
+            }
+            if (!ImageFile::SaveImage(pxbuf, nullptr, out.get(), file_ext))
+            {
+                printf("Error: failed to save image file: %s\n", image_file.GetCStr());
+                continue;
+            }
+            export_count++;
+            if (verbose)
+                printf("- [%06d] - '%s'\n", i, image_file.GetCStr());
+        }
+    }
+    printf("Exported %zu sprites.\n", export_count);
+    printf("Done.\n");
+    return 0;
+}
+
+int Command_Info(const String &src_pak, const CommandOptions &opts)
+{
+    printf("Input spritefile: %s\n", src_pak.GetCStr());
+    if (!opts.IndexFile.IsEmpty())
+        printf("Input index file: %s\n", opts.IndexFile.GetCStr());
+
+    //-----------------------------------------------------------------------//
+    // Read and print the sprite file info
+    //-----------------------------------------------------------------------//
+    SpriteFile reader;
+    HError err = OpenSpriteFile(reader, src_pak, opts.IndexFile);
+    if (!err)
+    {
+        printf("Error: failed to open and/or parse the sprite file:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    PrintQuickInfo(reader);
+    printf("Done.\n");
+    return 0;
+}
+
+int Command_List(const String &src_pak, const CommandOptions &opts)
+{
+    printf("Input spritefile: %s\n", src_pak.GetCStr());
+    if (!opts.IndexFile.IsEmpty())
+        printf("Input index file: %s\n", opts.IndexFile.GetCStr());
+
+    //-----------------------------------------------------------------------//
+    // Read and print the sprite file TOC
+    //-----------------------------------------------------------------------//
+    SpriteFile reader;
+    std::vector<SpriteDatHeader> metrics;
+    HError err = OpenSpriteFile(reader, src_pak, opts.IndexFile, &metrics);
+    if (!err)
+    {
+        printf("Error: failed to open and/or parse the sprite file:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    PrintQuickInfo(reader);
+    if (reader.GetSpriteCount() == 0)
+    {
+        printf("Sprite file has no sprites.\nDone.\n");
+        return 0;
+    }
+
+    printf("Sprite file TOC:\n");
+    const sprkey_t top_sprite = reader.GetTopmostSprite();
+    for (sprkey_t i = 0; i <= top_sprite; ++i)
+    {
+        const auto &hdr = metrics[i];
+        if (hdr.BPP == 0)
+            continue;
+
+        printf("* [%06d]: %dx%d %d-bit\n", i, hdr.Width, hdr.Height, hdr.BPP * 8);
+    }
+    printf("Done.\n");
+    return 0;
+}
+
+int Command_Rewrite(const String &src_pak, const String &dst_pak, const CommandOptions &opts, bool verbose)
+{
+    printf("Input spritefile: %s\n", src_pak.GetCStr());
+    if (!opts.IndexFile.IsEmpty())
+        printf("Input index file: %s\n", opts.IndexFile.GetCStr());
+    printf("Output spritefile: %s\n", dst_pak.GetCStr());
+    printf("Output file compression: %s\n", GetCompressionName(opts.Compress).GetCStr());
+    printf("Output file storage flags: 0x%08x\n", opts.StorageFlags);
+
+    //-----------------------------------------------------------------------//
+    // Read the sprite file
+    //-----------------------------------------------------------------------//
+    SpriteFile reader;
+    HError err = OpenSpriteFile(reader, src_pak, opts.IndexFile);
+    if (!err)
+    {
+        printf("Error: failed to open and/or parse the sprite file:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write the destination sprite file
+    //-----------------------------------------------------------------------//
+    // TODO: the SaveSpriteFile variant that does not require sprite array at all,
+    // and only works with SpriteFile reader directly!
+    std::vector<std::pair<bool, BitmapData>> dummy_sprites;
+    const sprkey_t top_sprite = reader.GetTopmostSprite();
+    dummy_sprites.resize(top_sprite + 1);
+    for (sprkey_t i = 0; i <= top_sprite; ++i)
+    {
+        dummy_sprites[i].first = reader.DoesSpriteExist(i);
+    }
+
+    SpriteFileIndex index;
+    printf("Writing the new sprite file...\n");
+    err = SaveSpriteFile(dst_pak, dummy_sprites, &reader, opts.StorageFlags, opts.Compress, index);
+    if (err)
+    {
+        printf("Sprite file written successfully.\n");
+    }
+    else
+    {
+        printf("Error: failed to write sprite file (%s):\n", dst_pak.GetCStr());
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    SaveIndexFile(opts.OutIndexFile, index);
+    printf("Done.\n");
+    return 0;
+}
+
+} // namespace SpritePak

--- a/Tools/spritepak/commands.cpp
+++ b/Tools/spritepak/commands.cpp
@@ -204,7 +204,8 @@ int Command_Create(const String &src_dir, const String &dst_pak, const CommandOp
     }
 
     sprkey_t top_index = -1;
-    std::vector<std::pair<sprkey_t, String>> sorted_files;
+    typedef std::pair<sprkey_t, String> SlotImageFilePair;
+    std::vector<SlotImageFilePair> sorted_files;
     for (const auto &imf : files)
     {
         sprkey_t slot;
@@ -216,7 +217,7 @@ int Command_Create(const String &src_dir, const String &dst_pak, const CommandOp
         }
     }
     std::sort(sorted_files.begin(), sorted_files.end(),
-        [](const auto &f1, const auto &f2) { return f1.first < f2.first; });
+        [](const SlotImageFilePair &f1, const SlotImageFilePair &f2) { return f1.first < f2.first; });
 
     //-----------------------------------------------------------------------//
     // Write sprite file

--- a/Tools/spritepak/commands.h
+++ b/Tools/spritepak/commands.h
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_TOOL_SPRITEPAK__COMMANDS_H
+#define __AGS_TOOL_SPRITEPAK__COMMANDS_H
+
+#include "ac/spritefile.h"
+#include "util/string.h"
+
+namespace SpritePak
+{
+    using String = AGS::Common::String;
+    using SpriteStorage = AGS::Common::SpriteStorage;
+    using SpriteCompression = AGS::Common::SpriteCompression;
+
+    struct CommandOptions
+    {
+        String IndexFile;
+        String OutIndexFile;
+        String ImageFilePattern;
+        SpriteStorage StorageFlags = AGS::Common::kSprStore_OptimizeForSize;
+        SpriteCompression Compress = AGS::Common::kSprCompress_Deflate;
+    };
+
+    String GetCompressionName(SpriteCompression compress);
+    SpriteCompression CompressionFromName(const String &compress_name);
+
+    void Init();
+    int Command_Create(const String &src_dir, const String &dst_pak, const CommandOptions &opts, bool verbose);
+    int Command_Export(const String &src_pak, const String &dst_dir, const CommandOptions &opts, bool verbose);
+    int Command_Info(const String &src_pak, const CommandOptions &opts);
+    int Command_List(const String &src_pak, const CommandOptions &opts);
+    int Command_Rewrite(const String &src_pak, const String &dst_pak, const CommandOptions &opts, bool verbose);
+}
+
+#endif // __AGS_TOOL_SPRITEPAK__COMMANDS_H

--- a/Tools/spritepak/commands.h
+++ b/Tools/spritepak/commands.h
@@ -40,7 +40,7 @@ namespace SpritePak
     int Command_Export(const String &src_pak, const String &dst_dir, const CommandOptions &opts, bool verbose);
     int Command_Info(const String &src_pak, const CommandOptions &opts);
     int Command_List(const String &src_pak, const CommandOptions &opts);
-    int Command_Rewrite(const String &src_pak, const String &dst_pak, const CommandOptions &opts, bool verbose);
+    int Command_Copy(const String &src_pak, const String &dst_pak, const CommandOptions &opts, bool verbose);
 }
 
 #endif // __AGS_TOOL_SPRITEPAK__COMMANDS_H

--- a/Tools/spritepak/main.cpp
+++ b/Tools/spritepak/main.cpp
@@ -35,47 +35,49 @@ const char *HELP_STRING = "Usage:\n"
 "      Options may adjust the operation further.\n"
 "\n"
 "Commands:\n"
-"  -c, --create           create a spritefile, gathering the files from the\n"
-"                         input directory.\n"
-"  -e, --export           export (extract) files from the existing spritefile\n"
-"                         into the output directory.\n"
-"  -l, --list             print spritefile's table of contents.\n"
-"  -q, --info             print quick info about spritefile.\n"
-"  -w, --rewrite          rewrites spritefile contents into another spritefile,\n"
-"                         optionally using different storage options.\n"
+"  -c, --create     create a spritefile, gathering the files from the input\n"
+"                   directory.\n"
+"  -e, --export     export (extract) files from the existing spritefile into\n"
+"                   the output directory.\n"
+"  -l, --list       print spritefile's table of contents.\n"
+"  -q, --info       print quick info about spritefile.\n"
+"  -y, --copy       copies spritefile contents over into another spritefile,\n"
+"                   letting to use different storage options.\n"
 "\n"
 "Command options:\n"
 "  -n, --index <indexfile>\n"
-"                         specifies the index file to read or write, depending\n"
-"                         respectively on the current command.\n"
+"                   specifies the index file to read or write, depending\n"
+"                   respectively on the current command.\n"
 "  --out-index <indexfile>\n"
-"                         when rewriting a spritefile, specifies new index file.\n"
-"  -p, --pattern <file pattern>\n"
-"                         when creating the new spritefile, or exporting one,\n"
-"                         use the given pattern for individual image files,\n"
-"                         either with or without file extension. The pattern\n"
-"                         may contain following placeholders:\n"
-"                           * %N% - sprite number\n"
-"                         If no pattern is provided, the program will use\n"
-"                         \"spr%N%\" pattern by default. If neither pattern\n"
-"                         nor extension is provided, then \".bmp\" will be used.\n"
+"                   when rewriting a spritefile, specifies new index file.\n"
+"  -p, --pattern <name pattern>\n"
+"                   when creating the new spritefile, or extracting one, use the\n"
+"                   given pattern when searching for or creating image files.\n"
+"                   The pattern may be given with or without file extension.\n"
+"                   The pattern may contain following placeholders:\n"
+"                     * %xN% - sprite number, where 'x' may be any single digit\n"
+"                              integer specifying number of padding zeroes,\n"
+"                              e.g. \"%6N%."
+"                   If no pattern is provided, the program will use \"spr%6N%\"\n"
+"                   pattern by default. If no extension is specified in the\n"
+"                   pattern, then \".bmp\" will be used as an extension.\n"
 // TODO: replace default with PNG after PNG read/write support is added to the engine
 "  -s, --storage-flags <flags>\n"
-"                         when creating the new spritefile, use additional\n"
-"                         storage options, defined using a hexadecimal bitset:\n"
-"                           * 0x01 - optimize storage size when possible;\n"
-"                             e.g. write 16/32-bit images as 8-bit images with\n"
-"                             palette (only when this achieves less space).\n"
-"                         default is \"0x01\"\n"
-"  -z, --compress <type>  when creating the new spritefile, use compression:\n"
-"                           * none\n"
-"                           * rle\n"
-"                           * lzw\n"
-"                           * deflate\n"
-"                         default is \"deflate\"\n"
+"                   when creating the new spritefile, use additional storage\n"
+"                   options, defined using a hexadecimal bitset:\n"
+"                     * 0x01 - optimize storage size when possible;\n"
+"                   e.g. write 16/32-bit images as 8-bit images with palette\n"
+"                   (only when this achieves less space). default is \"0x01\"\n"
+"  -z, --compress <type>\n"
+"                   when creating the new spritefile, use compression:\n"
+"                     * none\n"
+"                     * rle\n"
+"                     * lzw\n"
+"                     * deflate\n"
+"                   default is \"deflate\"\n"
 "\n"
 "Other options:\n"
-"  -v, --verbose          print operation details"
+"  -v, --verbose    print operation details"
 ;
 
 
@@ -105,9 +107,9 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
             command = 'q'; // info
             break;
         }
-        if (opt == "-w" || opt == "--rewrite")
+        if (opt == "-y" || opt == "--copy")
         {
-            command = 'w'; // rewrite
+            command = 'y'; // copy
             break;
         }
     }
@@ -175,11 +177,11 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
             break; // not enough args
         return SpritePak::Command_Info(sprite_file, opts);
     }
-    case 'w': // rewrite
+    case 'y': // copy
     {
         if (cmdargs.PosArgs.size() < 2)
             break; // not enough args
-        return SpritePak::Command_Rewrite(sprite_file, work_file_or_dir, opts, verbose);
+        return SpritePak::Command_Copy(sprite_file, work_file_or_dir, opts, verbose);
     }
     default:
         printf("Error: no valid command is specified\n");

--- a/Tools/spritepak/main.cpp
+++ b/Tools/spritepak/main.cpp
@@ -1,0 +1,208 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+// 
+// AGS sprite file pack/unpack utility.
+// 
+//=============================================================================
+#include "commands.h"
+#include "util/cmdlineopts.h"
+#include "util/string.h"
+#include "util/string_utils.h"
+
+using namespace AGS::Common;
+
+
+const char *BIN_STRING = "spritepak v0.1.0 - AGS spritefile tool\n"
+"Copyright (c) 2026 AGS Team and contributors\n";
+
+const char *HELP_STRING = "Usage:\n"
+//------------------------------------------------------------------------------|
+"  spritepak <COMMAND> <SPRITEFILE> [<WORK-DIR> | <DEST-SPRITEFILE>] [OPTIONS]\n"
+"      executes an operation regarding the chosen sprite file, a working\n"
+"      directory OR another destination spritefile. Depending on a command\n"
+"      either the spritefile or the directory is an input or an output.\n"
+"      Options may adjust the operation further.\n"
+"\n"
+"Commands:\n"
+"  -c, --create           create a spritefile, gathering the files from the\n"
+"                         input directory.\n"
+"  -e, --export           export (extract) files from the existing spritefile\n"
+"                         into the output directory.\n"
+"  -l, --list             print spritefile's table of contents.\n"
+"  -q, --info             print quick info about spritefile.\n"
+"  -w, --rewrite          rewrites spritefile contents into another spritefile,\n"
+"                         optionally using different storage options.\n"
+"\n"
+"Command options:\n"
+"  -n, --index <indexfile>\n"
+"                         specifies the index file to read or write, depending\n"
+"                         respectively on the current command.\n"
+"  --out-index <indexfile>\n"
+"                         when rewriting a spritefile, specifies new index file.\n"
+"  -p, --pattern <file pattern>\n"
+"                         when creating the new spritefile, or exporting one,\n"
+"                         use the given pattern for individual image files,\n"
+"                         either with or without file extension. The pattern\n"
+"                         may contain following placeholders:\n"
+"                           * %N% - sprite number\n"
+"                         If no pattern is provided, the program will use\n"
+"                         \"spr%N%\" pattern by default. If neither pattern\n"
+"                         nor extension is provided, then \".bmp\" will be used.\n"
+// TODO: replace default with PNG after PNG read/write support is added to the engine
+"  -s, --storage-flags <flags>\n"
+"                         when creating the new spritefile, use additional\n"
+"                         storage options, defined using a hexadecimal bitset:\n"
+"                           * 0x01 - optimize storage size when possible;\n"
+"                             e.g. write 16/32-bit images as 8-bit images with\n"
+"                             palette (only when this achieves less space).\n"
+"                         default is \"0x01\"\n"
+"  -z, --compress <type>  when creating the new spritefile, use compression:\n"
+"                           * none\n"
+"                           * rle\n"
+"                           * lzw\n"
+"                           * deflate\n"
+"                         default is \"deflate\"\n"
+"\n"
+"Other options:\n"
+"  -v, --verbose          print operation details"
+;
+
+
+int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
+{
+    // Parse the command
+    char command = 0;
+    for (const auto &opt : cmdargs.Opt)
+    {
+        if (opt == "-c" || opt == "--create")
+        {
+            command = 'c'; // create
+            break;
+        }
+        if (opt == "-e" || opt == "--export")
+        {
+            command = 'e'; // export
+            break;
+        }
+        if (opt == "-l" || opt == "--list")
+        {
+            command = 'l'; // list
+            break;
+        }
+        if (opt == "-q" || opt == "--info")
+        {
+            command = 'q'; // info
+            break;
+        }
+        if (opt == "-w" || opt == "--rewrite")
+        {
+            command = 'w'; // rewrite
+            break;
+        }
+    }
+
+    // Fixed pos options
+    const String sprite_file = cmdargs.PosArgs.size() > 0 ? cmdargs.PosArgs[0] : String();
+    const String work_file_or_dir = cmdargs.PosArgs.size() > 1 ? cmdargs.PosArgs[1] : String();
+
+    // TODO: easier way to:
+    //  - get either short or long named option;
+    //  - get option's value without the search loop in the code
+    SpritePak::CommandOptions opts;
+    for (const auto &opt_with_value : cmdargs.OptWithValue)
+    {
+        if (opt_with_value.first == "-n" || opt_with_value.first == "--index")
+        {
+            opts.IndexFile = opt_with_value.second;
+        }
+        if (opt_with_value.first == "--out-index")
+        {
+            opts.OutIndexFile = opt_with_value.second;
+        }
+        else if (opt_with_value.first == "-p" || opt_with_value.first == "--pattern")
+        {
+            opts.ImageFilePattern = opt_with_value.second;
+        }
+        else if (opt_with_value.first == "-s" || opt_with_value.first == "--storage-flags")
+        {
+            opts.StorageFlags = static_cast<SpritePak::SpriteStorage>(StrUtil::StringToIntHex(opt_with_value.second));
+        }
+        else if (opt_with_value.first == "-z" || opt_with_value.first == "--compress")
+        {
+            opts.Compress = SpritePak::CompressionFromName(opt_with_value.second);
+        }
+    }
+    const bool verbose = cmdargs.Opt.count("-v") || cmdargs.Opt.count("--verbose");
+
+    // Init
+    SpritePak::Init();
+
+    // Run supported commands
+    switch (command)
+    {
+    case 'c': // create
+    {
+        if (cmdargs.PosArgs.size() < 2)
+            break; // not enough args
+        return SpritePak::Command_Create(work_file_or_dir, sprite_file, opts, verbose);
+    }
+    case 'e': // export
+    {
+        if (cmdargs.PosArgs.size() < 2)
+            break; // not enough args
+        return SpritePak::Command_Export(sprite_file, work_file_or_dir, opts, verbose);
+    }
+    case 'l': // list
+    {
+        if (cmdargs.PosArgs.size() < 1)
+            break; // not enough args
+        return SpritePak::Command_List(sprite_file, opts);
+    }
+    case 'q': // info
+    {
+        if (cmdargs.PosArgs.size() < 1)
+            break; // not enough args
+        return SpritePak::Command_Info(sprite_file, opts);
+    }
+    case 'w': // rewrite
+    {
+        if (cmdargs.PosArgs.size() < 2)
+            break; // not enough args
+        return SpritePak::Command_Rewrite(sprite_file, work_file_or_dir, opts, verbose);
+    }
+    default:
+        printf("Error: no valid command is specified\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    printf("Error: not enough arguments\n");
+    printf("%s\n", HELP_STRING);
+    return -1;
+}
+
+int main(int argc, char *argv[])
+{
+    printf("%s\n", BIN_STRING);
+
+    CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv,
+        { "-n", "-p", "-s", "-z", "--compress", "--index", "--out-index", "--pattern", "--storage-flags",});
+    if (cmdargs.HelpRequested)
+    {
+        printf("%s\n", HELP_STRING);
+        return 0; // display help and bail out
+    }
+
+    return DoCommand(cmdargs);
+}

--- a/libsrc/allegro/cmake/FileList.cmake
+++ b/libsrc/allegro/cmake/FileList.cmake
@@ -56,6 +56,7 @@ set(ALLEGRO_SRC_WIN_FILES
 set(ALLEGRO_INCLUDE_ALLEGRO_FILES
         include/allegro/base.h
         include/allegro/color.h
+        include/allegro/colblend.h
         include/allegro/debug.h
         include/allegro/draw.h
         include/allegro/file.h

--- a/libsrc/allegro/include/allegro.h
+++ b/libsrc/allegro/include/allegro.h
@@ -32,6 +32,7 @@
 #include "allegro/palette.h"
 #include "allegro/gfx.h"
 #include "allegro/color.h"
+#include "allegro/colblend.h"
 #include "allegro/draw.h"
 
 #include "allegro/fli.h"

--- a/libsrc/allegro/include/allegro/colblend.h
+++ b/libsrc/allegro/include/allegro/colblend.h
@@ -1,0 +1,54 @@
+/*         ______   ___    ___
+ *        /\  _  \ /\_ \  /\_ \
+ *        \ \ \L\ \\//\ \ \//\ \      __     __   _ __   ___
+ *         \ \  __ \ \ \ \  \ \ \   /'__`\ /'_ `\/\`'__\/ __`\
+ *          \ \ \/\ \ \_\ \_ \_\ \_/\  __//\ \L\ \ \ \//\ \L\ \
+ *           \ \_\ \_\/\____\/\____\ \____\ \____ \ \_\\ \____/
+ *            \/_/\/_/\/____/\/____/\/____/\/___L\ \/_/ \/___/
+ *                                           /\____/
+ *                                           \_/__/
+ *
+ *      Color blending routines.
+ *
+ *      By Shawn Hargreaves.
+ *
+ *      See readme.txt for copyright information.
+ */
+
+#ifndef ALLEGRO_COLORBLEND_H
+#define ALLEGRO_COLORBLEND_H
+
+#include "base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef AL_METHOD(uint32_t, BLENDER_FUNC, (uint32_t x, uint32_t y, uint32_t n));
+
+AL_FUNC(void, set_blender_mode, (BLENDER_FUNC b15, BLENDER_FUNC b16, BLENDER_FUNC b24, int r, int g, int b, int a));
+AL_FUNC(void, set_blender_mode_ex, (BLENDER_FUNC b15, BLENDER_FUNC b16, BLENDER_FUNC b24, BLENDER_FUNC b32, BLENDER_FUNC b15x, BLENDER_FUNC b16x, BLENDER_FUNC b24x, int r, int g, int b, int a));
+
+AL_FUNC(void, set_alpha_blender, (void));
+AL_FUNC(void, set_write_alpha_blender, (void));
+AL_FUNC(void, set_trans_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_add_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_burn_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_color_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_difference_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_dissolve_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_dodge_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_hue_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_invert_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_luminance_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_multiply_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_saturation_blender, (int r, int g, int b, int a));
+AL_FUNC(void, set_screen_blender, (int r, int g, int b, int a));
+
+AL_FUNC(void, create_blender_table, (COLOR_MAP *table, AL_CONST PALETTE pal, AL_METHOD(void, callback, (int pos))));
+
+#ifdef __cplusplus
+   }
+#endif
+
+#endif /* ifndef ALLEGRO_COLORBLEND_H */

--- a/libsrc/allegro/include/allegro/color.h
+++ b/libsrc/allegro/include/allegro/color.h
@@ -90,28 +90,6 @@ AL_FUNC(void, create_rgb_table, (RGB_MAP *table, AL_CONST PALETTE pal, AL_METHOD
 AL_FUNC(void, create_light_table, (COLOR_MAP *table, AL_CONST PALETTE pal, int r, int g, int b, AL_METHOD(void, callback, (int pos))));
 AL_FUNC(void, create_trans_table, (COLOR_MAP *table, AL_CONST PALETTE pal, int r, int g, int b, AL_METHOD(void, callback, (int pos))));
 AL_FUNC(void, create_color_table, (COLOR_MAP *table, AL_CONST PALETTE pal, AL_METHOD(void, blend, (AL_CONST PALETTE pal, int x, int y, RGB *rgb)), AL_METHOD(void, callback, (int pos))));
-AL_FUNC(void, create_blender_table, (COLOR_MAP *table, AL_CONST PALETTE pal, AL_METHOD(void, callback, (int pos))));
-
-typedef AL_METHOD(uint32_t, BLENDER_FUNC, (uint32_t x, uint32_t y, uint32_t n));
-
-AL_FUNC(void, set_blender_mode, (BLENDER_FUNC b15, BLENDER_FUNC b16, BLENDER_FUNC b24, int r, int g, int b, int a));
-AL_FUNC(void, set_blender_mode_ex, (BLENDER_FUNC b15, BLENDER_FUNC b16, BLENDER_FUNC b24, BLENDER_FUNC b32, BLENDER_FUNC b15x, BLENDER_FUNC b16x, BLENDER_FUNC b24x, int r, int g, int b, int a));
-
-AL_FUNC(void, set_alpha_blender, (void));
-AL_FUNC(void, set_write_alpha_blender, (void));
-AL_FUNC(void, set_trans_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_add_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_burn_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_color_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_difference_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_dissolve_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_dodge_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_hue_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_invert_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_luminance_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_multiply_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_saturation_blender, (int r, int g, int b, int a));
-AL_FUNC(void, set_screen_blender, (int r, int g, int b, int a));
 
 AL_FUNC(void, hsv_to_rgb, (float h, float s, float v, int *r, int *g, int *b));
 AL_FUNC(void, rgb_to_hsv, (int r, int g, int b, float *h, float *s, float *v));

--- a/libsrc/allegro/include/allegro/color.h
+++ b/libsrc/allegro/include/allegro/color.h
@@ -70,6 +70,9 @@ AL_ARRAY(int, _rgb_scale_6);
 
 AL_VAR(int *, palette_color);
 
+AL_FUNC(void, set_rgb_shifts, (int r15, int g15, int b15, int r16, int g16, int b16,
+                               int r24, int g24, int b24, int r32, int g32, int b32, int a32));
+
 AL_FUNC(void, set_color, (int idx, AL_CONST RGB *p));
 AL_FUNC(void, set_palette, (AL_CONST PALETTE p));
 AL_FUNC(void, set_palette_range, (AL_CONST PALETTE p, int from, int to, int retracesync));

--- a/libsrc/allegro/src/allegro.c
+++ b/libsrc/allegro/src/allegro.c
@@ -70,7 +70,6 @@ unsigned int _drawing_y_mask = 0;
 
 /* default palette structures */
 PALETTE black_palette;
-PALETTE _current_palette; 
 
 int _current_palette_changed = 0xFFFFFFFF;
 

--- a/libsrc/allegro/src/colblend.c
+++ b/libsrc/allegro/src/colblend.c
@@ -444,3 +444,48 @@ void set_alpha_blender(void)
    set_blender_mode_ex(_blender_black, _blender_black, _blender_black,
 		       f32, f15, f16, f24, 0, 0, 0, 0);
 }
+
+
+
+/* create_blender_table:
+ *  Fills the specified color mapping table with lookup data for doing a 
+ *  paletted equivalent of whatever truecolor blender mode is currently 
+ *  selected.
+ */
+void create_blender_table(COLOR_MAP *table, AL_CONST PALETTE pal, void (*callback)(int pos))
+{
+   int x, y, c;
+   int r, g, b;
+   int r1, g1, b1;
+   int r2, g2, b2;
+
+   ASSERT(_blender_func24);
+
+   for (x=0; x<PAL_SIZE; x++) {
+      for (y=0; y<PAL_SIZE; y++) {
+	 r1 = (pal[x].r << 2) | ((pal[x].r & 0x30) >> 4);
+	 g1 = (pal[x].g << 2) | ((pal[x].g & 0x30) >> 4);
+	 b1 = (pal[x].b << 2) | ((pal[x].b & 0x30) >> 4);
+
+	 r2 = (pal[y].r << 2) | ((pal[y].r & 0x30) >> 4);
+	 g2 = (pal[y].g << 2) | ((pal[y].g & 0x30) >> 4);
+	 b2 = (pal[y].b << 2) | ((pal[y].b & 0x30) >> 4);
+
+	 c = _blender_func24(makecol24(r1, g1, b1), makecol24(r2, g2, b2), _blender_alpha);
+
+	 r = getr24(c);
+	 g = getg24(c);
+	 b = getb24(c);
+
+	 if (rgb_map)
+	    table->data[x][y] = rgb_map->data[r>>3][g>>3][b>>3];
+	 else
+	    table->data[x][y] = bestfit_color(pal, r>>2, g>>2, b>>2);
+      }
+
+      if (callback)
+	 (*callback)(x);
+   }
+}
+
+

--- a/libsrc/allegro/src/color.c
+++ b/libsrc/allegro/src/color.c
@@ -82,6 +82,24 @@ RGB_MAP *rgb_map = NULL;               /* RGB -> palette entry conversion */
 COLOR_MAP *color_map = NULL;           /* translucency/lighting table */
 
 
+void set_rgb_shifts(int r15, int g15, int b15, int r16, int g16, int b16,
+                    int r24, int g24, int b24, int r32, int g32, int b32, int a32)
+{
+   _rgb_r_shift_15 = r15;
+   _rgb_g_shift_15 = g15;
+   _rgb_b_shift_15 = b15;
+   _rgb_r_shift_16 = r16;
+   _rgb_g_shift_16 = g16;
+   _rgb_b_shift_16 = b16;
+   _rgb_r_shift_24 = r24;
+   _rgb_g_shift_24 = g24;
+   _rgb_b_shift_24 = b24;
+   _rgb_a_shift_32 = a32;
+   _rgb_r_shift_32 = r32;
+   _rgb_g_shift_32 = g32;
+   _rgb_b_shift_32 = b32;
+}
+
 /* makecol_depth:
  *  Converts R, G, and B values (ranging 0-255) to whatever pixel format
  *  is required by the specified color depth.

--- a/libsrc/allegro/src/graphics.c
+++ b/libsrc/allegro/src/graphics.c
@@ -33,12 +33,6 @@ extern void blit_end(void);   /* for LOCK_FUNCTION; defined in blit.c */
 
 int _sub_bitmap_id_count = 1;          /* hash value for sub-bitmaps */
 
-RGB_MAP *rgb_map = NULL;               /* RGB -> palette entry conversion */
-
-COLOR_MAP *color_map = NULL;           /* translucency/lighting table */
-
-int _color_depth = 8;                  /* how many bits per pixel? */
-
 int _color_conv = COLORCONV_TOTAL;     /* which formats to auto convert? */
 
 static int color_conv_set = FALSE;     /* has the user set conversion mode? */
@@ -66,44 +60,6 @@ int _blender_col_24 = 0;
 int _blender_col_32 = 0;
 
 int _blender_alpha = 0;                /* for truecolor translucent drawing */
-
-int _rgb_r_shift_15 = DEFAULT_RGB_R_SHIFT_15;     /* truecolor pixel format */
-int _rgb_g_shift_15 = DEFAULT_RGB_G_SHIFT_15;
-int _rgb_b_shift_15 = DEFAULT_RGB_B_SHIFT_15;
-int _rgb_r_shift_16 = DEFAULT_RGB_R_SHIFT_16;
-int _rgb_g_shift_16 = DEFAULT_RGB_G_SHIFT_16;
-int _rgb_b_shift_16 = DEFAULT_RGB_B_SHIFT_16;
-int _rgb_r_shift_24 = DEFAULT_RGB_R_SHIFT_24;
-int _rgb_g_shift_24 = DEFAULT_RGB_G_SHIFT_24;
-int _rgb_b_shift_24 = DEFAULT_RGB_B_SHIFT_24;
-int _rgb_r_shift_32 = DEFAULT_RGB_R_SHIFT_32;
-int _rgb_g_shift_32 = DEFAULT_RGB_G_SHIFT_32;
-int _rgb_b_shift_32 = DEFAULT_RGB_B_SHIFT_32;
-int _rgb_a_shift_32 = DEFAULT_RGB_A_SHIFT_32;
-
-
-/* lookup table for scaling 5 bit colors up to 8 bits */
-int _rgb_scale_5[32] =
-{
-   0,   8,   16,  24,  33,  41,  49,  57,
-   66,  74,  82,  90,  99,  107, 115, 123,
-   132, 140, 148, 156, 165, 173, 181, 189,
-   198, 206, 214, 222, 231, 239, 247, 255
-};
-
-
-/* lookup table for scaling 6 bit colors up to 8 bits */
-int _rgb_scale_6[64] =
-{
-   0,   4,   8,   12,  16,  20,  24,  28,
-   32,  36,  40,  44,  48,  52,  56,  60,
-   65,  69,  73,  77,  81,  85,  89,  93,
-   97,  101, 105, 109, 113, 117, 121, 125,
-   130, 134, 138, 142, 146, 150, 154, 158,
-   162, 166, 170, 174, 178, 182, 186, 190,
-   195, 199, 203, 207, 211, 215, 219, 223,
-   227, 231, 235, 239, 243, 247, 251, 255
-};
 
 
 /* lock_bitmap:


### PR DESCRIPTION
Implements a spritepak standalone tool, meant for unpacking and (re)packing sprite file.
The tool is used from a command line, and has following parameters:

```
spritepak <COMMAND> <SPRITEFILE> [<WORK-DIR> | <DEST-SPRITEFILE>] [OPTIONS]
```

Commands are:
```
  -c, --create           create a spritefile, gathering the files from the
                         input directory.
  -e, --export           export (extract) files from the existing spritefile
                         into the output directory.
  -l, --list             print spritefile's table of contents.
  -q, --info             print quick info about spritefile.
  -w, --rewrite          rewrites spritefile contents into another spritefile,
                         optionally using different storage options.
```

Command options:
```
  -n, --index <indexfile>
                         specifies the index file to read or write, depending
                         respectively on the current command.
  --out-index <indexfile>
                         when rewriting a spritefile, specifies new index file.
  -p, --pattern <file pattern>
                         when creating the new spritefile, or exporting one,
                         use the given pattern for individual image files,
                         either with or without file extension. The pattern
                         may contain following placeholders:
                           * %N% - sprite number
                         If no pattern is provided, the program will use
                         "spr%N%" pattern by default. If neither pattern
                         nor extension is provided, then ".bmp" will be used.
  -s, --storage-flags <flags>
                         when creating the new spritefile, use additional
                         storage options, defined using a hexadecimal bitset:
                           * 0x01 - optimize storage size when possible;
                             e.g. write 16/32-bit images as 8-bit images with
                             palette (only when this achieves less space).
  -z, --compress <type>  when creating the new spritefile, use compression:
                           * none
                           * rle
                           * lzw
                           * deflate
  -v, --verbose          print operation details
```

Although formally working, this tool's functionality has limited uses, because
1. It currently does not support packing sprite file by reading import instructions (e.g. from Game.agf), only packs numbered image files as-is. Therefore it cannot substitute the process integrated into the Editor. NOTE: i'm not yet sure if the full import feature should eventually be the part of this tool, or a separate one, meant strictly for that purpose.
2. ~There's no support for exporting image formats with alpha channel, because we don't have available C++ code in the engine. While the BMP format should theoretically support alpha channel, there's some restriction in this regard in the LoadBMP/SaveBMP functions, which afaik originally come from Allegro 4 library. Maybe that restriction can be lifted by adjusting the code~. **Partially fixed by supporting 32-bit ARGB BMP files** But the best option is adding PNG load/save support (and this was requested by users for the engine before).

In its current state this tool is best used for diagnostic and test purposes:
- checking the contents of the existing game's sprite file
- recreating the existing spritefile with different compression parameters (this works well, because there's no intermediate serialization of image files, only processing of plain pixel data in memory).