### PR TITLE
Use lexographical comparison for script strings and sortable objects

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -30,10 +30,10 @@
 #include "game/main_game_file.h" // TODO: constants to separate header or split out reading functions
 
 
-using AGS::Common::UInteraction;
-using AGS::Common::UInteractionEvents;
-using AGS::Common::InteractionVariable;
-using AGS::Common::HGameFileError;
+using Common::UInteraction;
+using Common::UInteractionEvents;
+using Common::InteractionVariable;
+using Common::HGameFileError;
 
 
 // TODO: split GameSetupStruct into struct used to hold loaded game data, and actual runtime object
@@ -56,9 +56,9 @@ struct GameSetupStruct : public GameSetupStructBase
     GameDataVersion   filever = kGameVersion_Undefined;
     Common::String    compiled_with; // version of AGS this data was created by
     char              lipSyncFrameLetters[MAXLIPSYNCFRAMES][50] = {{ 0 }};
-    AGS::Common::PropertySchema propSchema;
-    std::vector<AGS::Common::StringIMap> charProps;
-    AGS::Common::StringIMap invProps[MAX_INV];
+    Common::PropertySchema propSchema;
+    std::vector<Common::StringIMap> charProps;
+    Common::StringIMap invProps[MAX_INV];
     // NOTE: although the view names are stored in game data, they are never
     // used, nor registered as script exports; numeric IDs are used to
     // reference views instead.
@@ -86,7 +86,9 @@ struct GameSetupStruct : public GameSetupStructBase
     int               numCompatGameChannels = 0;
 
     // A dictionary of semi-arbitrary game info properties: title, developer's name, etc
-    AGS::Common::StringMap GameInfo;
+    Common::StringMap GameInfo;
+    // Game text language definition, in the form of locale name ('en', 'en_US' etc)
+    Common::String GameTextLanguage;
     
     // TODO: I converted original array of sprite infos to vector here, because
     // statistically in most games sprites go in long continious sequences with minimal

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -535,6 +535,11 @@ void UpgradeGame(GameSetupStruct &game, GameDataVersion data_ver)
     {
         game.options[OPT_GAMEFPS] = 40; // default to 40 fps in the older games
     }
+
+    if (game.GameInfo.count("text_lang") > 0)
+    {
+        game.GameTextLanguage = game.GameInfo["text_lang"];
+    }
 }
 
 void UpgradeDialogs(GameSetupStruct &game, LoadedGameEntities &ents, GameDataVersion data_ver)

--- a/Common/util/directory.h
+++ b/Common/util/directory.h
@@ -18,9 +18,11 @@
 #ifndef __AGS_CN_UTIL__DIRECTORY_H
 #define __AGS_CN_UTIL__DIRECTORY_H
 
+#include <locale>
 #include <memory>
 #include <regex>
 #include <stack>
+#include <stdexcept>
 #include <vector>
 #include "platform/platform.h"
 #include "util/string.h"
@@ -240,6 +242,35 @@ struct FileEntryEqByNameCI
     }
 };
 
+struct FileEntryEqByNameLexographicalCI
+{
+    FileEntryEqByNameLexographicalCI()
+        : _loc(std::locale())
+    {
+    }
+
+    FileEntryEqByNameLexographicalCI(const char *locale_name)
+    {
+        try
+        {
+            _loc = std::locale(locale_name);
+        }
+        catch (const std::runtime_error&)
+        {
+            _loc = std::locale();
+        }
+    }
+
+    bool operator()(const FileEntry &fe1, const FileEntry &fe2) const
+    {
+        return std::use_facet<std::collate<char>>(_loc).
+            compare(fe1.Name.GetCStr(), fe1.Name.GetCStr() + fe1.Name.GetLength(), fe2.Name.GetCStr(), fe2.Name.GetCStr() + fe2.Name.GetLength()) == 0;
+    }
+
+private:
+    std::locale _loc;
+};
+
 struct FileEntryCmpByName
 {
     bool operator()(const FileEntry &fe1, const FileEntry &fe2) const
@@ -254,6 +285,35 @@ struct FileEntryCmpByNameCI
     {
         return fe1.Name.CompareNoCase(fe2.Name) < 0;
     }
+};
+
+struct FileEntryCmpByNameLexographicalCI
+{
+    FileEntryCmpByNameLexographicalCI()
+        : _loc(std::locale())
+    {
+    }
+
+    FileEntryCmpByNameLexographicalCI(const char *locale_name)
+    {
+        try
+        {
+            _loc = std::locale(locale_name);
+        }
+        catch (const std::runtime_error&)
+        {
+            _loc = std::locale();
+        }
+    }
+
+    bool operator()(const FileEntry &fe1, const FileEntry &fe2) const
+    {
+        return std::use_facet<std::collate<char>>(_loc).
+            compare(fe1.Name.GetCStr(), fe1.Name.GetCStr() + fe1.Name.GetLength(), fe2.Name.GetCStr(), fe2.Name.GetCStr() + fe2.Name.GetLength()) < 0;
+    }
+
+private:
+    std::locale _loc;
 };
 
 struct FileEntryCmpByTime

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -17,6 +17,7 @@
 #include <cctype>
 #include <functional>
 #include <locale>
+#include <stdexcept>
 #include <unordered_map>
 
 #include <array>

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -16,6 +16,7 @@
 
 #include <cctype>
 #include <functional>
+#include <locale>
 #include <unordered_map>
 
 #include <array>
@@ -104,13 +105,69 @@ private:
     String _lookFor;
 };
 
-// Case-insensitive String less
+// Case-insensitive String less predicate
 struct StrLessNoCase
 {
     bool operator()(const String &s1, const String &s2) const
     {
         return s1.CompareNoCase(s2) < 0;
     }
+};
+
+// Unicode String less predicate, comparing strings lexographically.
+// With this predicate, characters are compared by their meaning; for example,
+// 'À' follows 'A' and 'Č' follows 'C', as opposed to common char code-based
+// comparison, where 'À' is positioned after 'Z'.
+struct LexographicalStrLess
+{
+public:
+    LexographicalStrLess()
+        : _loc(std::locale(""))
+    {
+    }
+
+    LexographicalStrLess(const char *locale_name)
+        : _loc(std::locale(locale_name))
+    {
+    }
+
+    bool operator()(const String &s1, const String &s2) const
+    {
+        return std::use_facet<std::collate<char>>(_loc).
+            compare(s1.GetCStr(), s1.GetCStr() + s1.GetLength(), s2.GetCStr(), s2.GetCStr() + s2.GetLength()) < 0;
+    }
+
+private:
+    const std::locale _loc;
+};
+
+// Unicode String less predicate, comparing strings lexographically, and
+// case-insensitively.
+// With this predicate, characters are compared by their meaning; for example,
+// 'À' follows 'A' and 'Č' follows 'C', as opposed to common char code-based
+// comparison, where 'À' is positioned after 'Z'.
+struct LexographicalStrLessNoCase
+{
+    LexographicalStrLessNoCase()
+        : _loc(std::locale(""))
+    {
+    }
+
+    LexographicalStrLessNoCase(const char *locale_name)
+        : _loc(std::locale(locale_name))
+    {
+    }
+
+    bool operator()(const String &s1, const String &s2) const
+    {
+        String s1lower = s1.LowerUTF8();
+        String s2lower = s2.LowerUTF8();
+        return std::use_facet<std::collate<char>>(_loc).
+            compare(s1lower.GetCStr(), s1lower.GetCStr() + s1lower.GetLength(), s2lower.GetCStr(), s2lower.GetCStr() + s2lower.GetLength()) < 0;
+    }
+
+private:
+    const std::locale _loc;
 };
 
 // Compute case-insensitive hash for a String object

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -122,13 +122,20 @@ struct LexographicalStrLess
 {
 public:
     LexographicalStrLess()
-        : _loc(std::locale(""))
+        : _loc(std::locale())
     {
     }
 
     LexographicalStrLess(const char *locale_name)
-        : _loc(std::locale(locale_name))
     {
+        try
+        {
+            _loc = std::locale(locale_name);
+        }
+        catch (const std::runtime_error&)
+        {
+            _loc = std::locale();
+        }
     }
 
     bool operator()(const String &s1, const String &s2) const
@@ -138,7 +145,7 @@ public:
     }
 
 private:
-    const std::locale _loc;
+    std::locale _loc;
 };
 
 // Unicode String less predicate, comparing strings lexographically, and
@@ -149,13 +156,20 @@ private:
 struct LexographicalStrLessNoCase
 {
     LexographicalStrLessNoCase()
-        : _loc(std::locale(""))
+        : _loc(std::locale())
     {
     }
 
     LexographicalStrLessNoCase(const char *locale_name)
-        : _loc(std::locale(locale_name))
     {
+        try
+        {
+            _loc = std::locale(locale_name);
+        }
+        catch (const std::runtime_error&)
+        {
+            _loc = std::locale();
+        }
     }
 
     bool operator()(const String &s1, const String &s2) const
@@ -167,7 +181,7 @@ struct LexographicalStrLessNoCase
     }
 
 private:
-    const std::locale _loc;
+    std::locale _loc;
 };
 
 // Compute case-insensitive hash for a String object

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -28,6 +28,22 @@ namespace AGS
 namespace Common
 {
 
+int StrUtil::LexographicalCompare(const String &s1, const String &s2, const char *locale_name)
+{
+    const auto loc = std::locale(locale_name);
+    const auto &fac_c = std::use_facet<std::collate<char>>(loc);
+    return fac_c.compare(s1.GetCStr(), s1.GetCStr() + s1.GetLength(), s2.GetCStr(), s2.GetCStr() + s2.GetLength());
+}
+
+int StrUtil::LexographicalCompareNoCase(const String &s1, const String &s2, const char *locale_name)
+{
+    String s1lower = s1.LowerUTF8();
+    String s2lower = s2.LowerUTF8();
+    const auto loc = std::locale(locale_name);
+    const auto &fac_c = std::use_facet<std::collate<char>>(loc);
+    return fac_c.compare(s1lower.GetCStr(), s1lower.GetCStr() + s1lower.GetLength(), s2lower.GetCStr(), s2lower.GetCStr() + s2lower.GetLength());
+}
+
 String StrUtil::IntToString(int d)
 {
     return String::FromFormat("%d", d);

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -30,18 +30,32 @@ namespace Common
 
 int StrUtil::LexographicalCompare(const String &s1, const String &s2, const char *locale_name)
 {
-    const auto loc = std::locale(locale_name);
-    const auto &fac_c = std::use_facet<std::collate<char>>(loc);
-    return fac_c.compare(s1.GetCStr(), s1.GetCStr() + s1.GetLength(), s2.GetCStr(), s2.GetCStr() + s2.GetLength());
+    try
+    {
+        const auto loc = std::locale(locale_name);
+        const auto &fac_c = std::use_facet<std::collate<char>>(loc);
+        return fac_c.compare(s1.GetCStr(), s1.GetCStr() + s1.GetLength(), s2.GetCStr(), s2.GetCStr() + s2.GetLength());
+    }
+    catch (const std::runtime_error&)
+    {
+        return s1.Compare(s2);
+    }
 }
 
 int StrUtil::LexographicalCompareNoCase(const String &s1, const String &s2, const char *locale_name)
 {
-    String s1lower = s1.LowerUTF8();
-    String s2lower = s2.LowerUTF8();
-    const auto loc = std::locale(locale_name);
-    const auto &fac_c = std::use_facet<std::collate<char>>(loc);
-    return fac_c.compare(s1lower.GetCStr(), s1lower.GetCStr() + s1lower.GetLength(), s2lower.GetCStr(), s2lower.GetCStr() + s2lower.GetLength());
+    try
+    {
+        const auto loc = std::locale(locale_name);
+        const auto &fac_c = std::use_facet<std::collate<char>>(loc);
+        String s1lower = s1.LowerUTF8();
+        String s2lower = s2.LowerUTF8();
+        return fac_c.compare(s1lower.GetCStr(), s1lower.GetCStr() + s1lower.GetLength(), s2lower.GetCStr(), s2lower.GetCStr() + s2lower.GetLength());
+    }
+    catch (const std::runtime_error&)
+    {
+        return Utf8::StrCmpNoCase(s1.GetCStr(), s2.GetCStr());
+    }
 }
 
 String StrUtil::IntToString(int d)
@@ -407,6 +421,43 @@ size_t StrUtil::ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t 
     }
     *out_mbstr = 0;
     return len;
+}
+
+static bool TryUTF8LocaleName(const String &locale_name)
+{
+    try
+    {
+        auto locale = std::locale(locale_name.GetCStr());
+        if (locale_name.CompareNoCase(locale.name().c_str()) == 0)
+            return true;
+    }
+    catch (const std::runtime_error&)
+    {
+    }
+    return false;
+}
+
+String StrUtil::FindCompatibleUTF8LocaleName(const String &lang_name)
+{
+    if (lang_name.IsEmpty())
+        return "";
+
+    String locale_name = lang_name;
+    locale_name.Replace('-', '_');
+    // Try several suffix variants which are commonly supported by the C++ runtime libs
+    String try_locale = String::FromFormat("%s.utf8", locale_name.GetCStr());
+    if (TryUTF8LocaleName(try_locale))
+        return try_locale;
+    try_locale = String::FromFormat("%s.utf-8", locale_name.GetCStr());
+    if (TryUTF8LocaleName(try_locale))
+        return try_locale;
+    try_locale = String::FromFormat("%s.UTF8", locale_name.GetCStr());
+    if (TryUTF8LocaleName(try_locale))
+        return try_locale;
+    try_locale = String::FromFormat("%s.UTF-8", locale_name.GetCStr());
+    if (TryUTF8LocaleName(try_locale))
+        return try_locale;
+    return "";
 }
 
 } // namespace Common

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -42,10 +42,14 @@ namespace StrUtil
     // follows 'C', as opposed to common char code-based comparison, where 'À'
     // is positioned after 'Z'.
     int             LexographicalCompare(const String &s1, const String &s2, const char *locale_name = "");
+    inline int      LexographicalCompare(const char *cstr1, const char *cstr2, const char *locale_name = "")
+                        { return LexographicalCompare(String::Wrapper(cstr1), String::Wrapper(cstr2), locale_name); }
     // Compares two strings lexographically and case-insensitively.
     // For example, 'À' follows 'A' and 'Č' follows 'C', as opposed to common
     // char code-based comparison, where 'À' is positioned after 'Z'.
     int             LexographicalCompareNoCase(const String &s1, const String &s2, const char *locale_name = "");
+    inline int      LexographicalCompareNoCase(const char* cstr1, const char* cstr2, const char* locale_name = "")
+                        { return LexographicalCompareNoCase(String::Wrapper(cstr1), String::Wrapper(cstr2), locale_name); }
 
     // Convert integer to string, by printing its value
     String          IntToString(int val);
@@ -183,6 +187,11 @@ namespace StrUtil
     // Convert wide-string to utf-8 string;
     // writes into out_mbstr buffer limited by out_sz *bytes*; returns *bytes* written.
     size_t ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t out_sz);
+
+    // Tries to find a UTF8 locale name for the given language name,
+    // suitable for the current runtime backend. Returns the locale name found,
+    // or empty string if none was found.
+    String FindCompatibleUTF8LocaleName(const String &lang_name);
 }
 } // namespace Common
 } // namespace AGS

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -37,6 +37,16 @@ namespace StrUtil
         kOutOfRange // the resulting value is out of range
     };
 
+    // Compares two strings lexographically, by the meaning of their characters
+    // rather than their code values. For example, 'À' follows 'A' and 'Č'
+    // follows 'C', as opposed to common char code-based comparison, where 'À'
+    // is positioned after 'Z'.
+    int             LexographicalCompare(const String &s1, const String &s2, const char *locale_name = "");
+    // Compares two strings lexographically and case-insensitively.
+    // For example, 'À' follows 'A' and 'Č' follows 'C', as opposed to common
+    // char code-based comparison, where 'À' is positioned after 'Z'.
+    int             LexographicalCompareNoCase(const String &s1, const String &s2, const char *locale_name = "");
+
     // Convert integer to string, by printing its value
     String          IntToString(int val);
     // Tries to convert whole string into integer value;

--- a/Common/util/utf8.h
+++ b/Common/util/utf8.h
@@ -1044,6 +1044,24 @@ inline size_t CStrToLower(const char *src, char *dst, size_t dst_sz)
     }
 }
 
+inline int StrCmpNoCase(const char* cstr1, const char* cstr2)
+{
+    for (;;)
+    {
+        Rune c1, c2;
+        cstr1 += GetChar(cstr1, UtfSz, &c1);
+        cstr2 += GetChar(cstr2, UtfSz, &c2);
+        c1 = ToLower(c1);
+        c2 = ToLower(c2);
+
+        if (c1 != c2)
+            return c1 - c2;
+
+        if (!c1)
+            return 0;
+    }
+}
+
 } // namespace Utf8
 
 #endif // __AGS_CN_UTIL__UTF8_H

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -120,9 +120,10 @@ namespace AGS.Editor
          * 3.6.3.5        - Renamed ShadowColor -> BorderShadeColor.
          * 3.6.3.6        - Character.BlockingRectangle, RoomObject.BlockingRectangle.
          *                  expose Character.Transparency, Baseline, RoomObject.Transparency.
-         * 3.6.3.8        - New Translation settings, TextOutlineColor in GUI controls.
+         * 3.6.3.8        - Font Overrides in Translation, TextOutlineColor in GUI controls.
+         * 3.6.3.10       - GameTextLanguage.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060308;
+        public const int    LATEST_XML_VERSION_INDEX = 3060310;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -154,9 +154,11 @@ namespace AGS.Editor.Components
 
         private void WriteExtStrOptions(BinaryWriter bw, Translation translation, CompileMessages errors)
         {
-            bw.Write((int)1); // size of key/value table
+            bw.Write((int)2); // size of key/value table
             DataFileWriter.FilePutString("encoding", bw);
             DataFileWriter.FilePutString(translation.EncodingHint, bw);
+            DataFileWriter.FilePutString("language", bw);
+            DataFileWriter.FilePutString(translation.TextLanguage, bw);
         }
         
         private void WriteExtFontOverrides(BinaryWriter bw, Translation translation, CompileMessages errors)

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -2028,6 +2028,8 @@ namespace AGS.Editor
             gameinfo.Add("genre", ents.Game.Settings.Genre);
             gameinfo.Add("release_date", ents.Game.Settings.ReleaseDate.ToString("dd.MM.yyyy"));
             gameinfo.Add("version", ents.Game.Settings.Version);
+            // following is not quite meta-data, but it was easier to add here, than to make a separate extension
+            gameinfo.Add("text_lang", ents.Game.Settings.GameTextLanguage.Replace('-', '_'));
 
             writer.Write(gameinfo.Count);
             foreach (var item in gameinfo)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -228,6 +228,7 @@
     <Compile Include="PropertyGridExtras\FontFileUIEditor.cs" />
     <Compile Include="PropertyGridExtras\FontSizeTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\FontSizeUIEditor.cs" />
+    <Compile Include="PropertyGridExtras\TextLanguageTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\GUIIndexTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\InteractionEventPropertyDescriptor.cs" />

--- a/Editor/AGS.Types/PropertyGridExtras/TextLanguageTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/TextLanguageTypeConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+
+namespace AGS.Types
+{
+    public class TextLanguageTypeConverter : BaseListSelectTypeConverter<string, string>
+    {
+        private static Dictionary<string, string> _possibleValues = new Dictionary<string, string>();
+
+        static TextLanguageTypeConverter()
+        {
+            _possibleValues.Add("", "(undefined language)");
+            var cultures =
+                CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+            foreach (var ci in cultures)
+                _possibleValues.Add(ci.Name, $"{ci.Name} | {{{ci.DisplayName}}}");
+        }
+
+        protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _possibleValues;
+        }
+    }
+}

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -48,6 +48,7 @@ namespace AGS.Types
         private Size _resolution = new Size(320, 200);
         private GameColorDepth _colorDepth = GameColorDepth.TrueColor;
         private string _gameTextEncoding = Encoding.UTF8.WebName;
+        private string _gameTextLanguage = "en-US";
         private int _gameFPS = 60;
         private bool _allowRelativeAssetResolution = false;
         private bool _debugMode = true;
@@ -300,6 +301,17 @@ namespace AGS.Types
         {
             get { return _gameTextEncoding; }
             set { _gameTextEncoding = value; }
+        }
+
+        [DisplayName("Text language")]
+        [Description("Defines base game language. Assign as 'undefined language' if you do not want to specify one.\nThis setting is used whenever engine needs to identify the game text as being of a particular language or using particular alphabet.")]
+        [DefaultValue("en-US")]
+        [Category("(Basic properties)")]
+        [TypeConverter(typeof(TextLanguageTypeConverter))]
+        public string GameTextLanguage
+        {
+            get { return _gameTextLanguage; }
+            set { _gameTextLanguage = value; }
         }
 
         [DisplayName("Game Speed (FPS)")]

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -16,6 +16,7 @@ namespace AGS.Types
         private const string SPEECH_FONT_TAG = "SpeechFont";
         private const string TEXT_DIRECTION_TAG = "TextDirection";
         private const string ENCODING_TAG = "Encoding";
+        private const string LANGUAGE_TAG = "Language";
         private const string FONT_OVERRIDE_TAG = "Font";
         private const string TAG_DEFAULT = "DEFAULT";
         private const string TAG_DIRECTION_LEFT = "LEFT";
@@ -29,6 +30,7 @@ namespace AGS.Types
         private bool? _rightToLeftText;
         private string _encodingHint;
         private Encoding _encoding;
+        private string _language;
         private Dictionary<int, Font> _fontOverrides = new Dictionary<int, Font>();
         private Dictionary<string, string> _translatedLines;
 
@@ -40,6 +42,7 @@ namespace AGS.Types
             _speechFont = null;
             _rightToLeftText = null;
             EncodingHint = "UTF-8";
+            _language = "en_US";
         }
 
         public string Name
@@ -97,6 +100,12 @@ namespace AGS.Types
         public Encoding Encoding
         {
             get { return _encoding; }
+        }
+
+        public string TextLanguage
+        {
+            get { return _language; }
+            set { _language = value; }
         }
 
         /// <summary>
@@ -166,6 +175,8 @@ namespace AGS.Types
                 sw.WriteLine("//#TextDirection=" + ((_rightToLeftText == true) ? TAG_DIRECTION_RIGHT : ((_rightToLeftText == null) ? TAG_DEFAULT : TAG_DIRECTION_LEFT)));
                 sw.WriteLine("// Text encoding hint - ASCII or UTF-8");
                 sw.WriteLine("//#Encoding=" + (_encodingHint ?? "ASCII"));
+                sw.WriteLine("// Text language, use standard locale strings, like 'en', 'en_US', etc");
+                sw.WriteLine($"//#Language={( _language != null ? _language.Replace('-', '_') : string.Empty )}");
                 if (_fontOverrides.Count != 0)
                 {
                     WriteFontOverrides(sw);
@@ -288,6 +299,10 @@ namespace AGS.Types
             else if (key == ENCODING_TAG)
             {
                 EncodingHint = value;
+            }
+            else if (key == LANGUAGE_TAG)
+            {
+                TextLanguage = value;
             }
             else if (key.StartsWith(FONT_OVERRIDE_TAG))
             {

--- a/Engine/ac/dynobj/scriptdict.h
+++ b/Engine/ac/dynobj/scriptdict.h
@@ -67,12 +67,16 @@ private:
 };
 
 template <typename TDict, bool is_sorted, bool is_casesensitive>
-class ScriptDictImpl final : public ScriptDictBase
+class ScriptDictImpl : public ScriptDictBase
 {
 public:
     typedef typename TDict::const_iterator ConstIterator;
 
     ScriptDictImpl() = default;
+    ScriptDictImpl(const TDict &dic)
+        : _dic(dic) { }
+    ScriptDictImpl(TDict &&dic)
+        : _dic(std::move(dic)) { }
 
     bool IsCaseSensitive() const override { return is_casesensitive; }
     bool IsSorted() const override { return is_sorted; }
@@ -172,9 +176,34 @@ private:
     TDict _dic;
 };
 
-typedef ScriptDictImpl< std::map<String, String>, true, true > ScriptDict;
-typedef ScriptDictImpl< std::map<String, String, StrLessNoCase>, true, false > ScriptDictCI;
-typedef ScriptDictImpl< std::unordered_map<String, String>, false, true > ScriptHashDict;
-typedef ScriptDictImpl< std::unordered_map<String, String, HashStrNoCase, StrEqNoCase>, false, false > ScriptHashDictCI;
+template <typename TKey, typename TValue, typename TLess,
+    bool is_sorted, bool is_casesensitive>
+class ScriptDictMap final : public ScriptDictImpl<std::map<TKey, TValue, TLess>,
+    is_sorted, is_casesensitive>
+{
+public:
+    ScriptDictMap() = default;
+    ScriptDictMap(const TLess &less)
+        : ScriptDictImpl<std::map<TKey, TValue, TLess>, is_sorted, is_casesensitive>
+                (std::move(std::map<TKey, TValue, TLess>(less)))
+    {
+    }
+};
+
+template <typename TKey, typename TValue, typename TKeyHash, typename TKeyEqual,
+    bool is_sorted, bool is_casesensitive>
+class ScriptDictHashMap final : public ScriptDictImpl<std::unordered_map<TKey, TValue, TKeyHash, TKeyEqual>,
+    is_sorted, is_casesensitive>
+{
+public:
+    ScriptDictHashMap() = default;
+};
+
+typedef ScriptDictMap< String, String, std::less<String>, true, true > ScriptDict;
+typedef ScriptDictMap< String, String, StrLessNoCase, true, false > ScriptDictCI;
+typedef ScriptDictMap< String, String, LexographicalStrLess, true, true > ScriptDictUnicode;
+typedef ScriptDictMap< String, String, LexographicalStrLessNoCase, true, false > ScriptDictUnicodeCI;
+typedef ScriptDictHashMap< String, String, std::hash<String>, std::equal_to<String>, false, true > ScriptHashDict;
+typedef ScriptDictHashMap< String, String, HashStrNoCase, StrEqNoCase, false, false > ScriptHashDictCI;
 
 #endif // __AC_SCRIPTDICT_H

--- a/Engine/ac/dynobj/scriptset.h
+++ b/Engine/ac/dynobj/scriptset.h
@@ -64,12 +64,16 @@ private:
 };
 
 template <typename TSet, bool is_sorted, bool is_casesensitive>
-class ScriptSetImpl final : public ScriptSetBase
+class ScriptSetImpl : public ScriptSetBase
 {
 public:
     typedef typename TSet::const_iterator ConstIterator;
 
     ScriptSetImpl() = default;
+    ScriptSetImpl(const TSet &set)
+        : _set(set) { }
+    ScriptSetImpl(TSet &&set)
+        : _set(std::move(set)) { }
 
     bool IsCaseSensitive() const override { return is_casesensitive; }
     bool IsSorted() const override { return is_sorted; }
@@ -142,9 +146,30 @@ private:
     TSet _set;
 };
 
-typedef ScriptSetImpl< std::set<String>, true, true > ScriptSet;
-typedef ScriptSetImpl< std::set<String, StrLessNoCase>, true, false > ScriptSetCI;
-typedef ScriptSetImpl< std::unordered_set<String>, false, true > ScriptHashSet;
-typedef ScriptSetImpl< std::unordered_set<String, HashStrNoCase, StrEqNoCase>, false, false > ScriptHashSetCI;
+template <typename TKey, typename TLess, bool is_sorted, bool is_casesensitive>
+class ScriptSetSet final : public ScriptSetImpl<std::set<TKey, TLess>, is_sorted, is_casesensitive>
+{
+public:
+    ScriptSetSet() = default;
+    ScriptSetSet(const TLess &less)
+        : ScriptSetImpl<std::set<TKey, TLess>, is_sorted, is_casesensitive>
+        (std::move(std::set<TKey, TLess>(less)))
+    {
+    }
+};
+
+template <typename TKey, typename THash, typename TEqual, bool is_sorted, bool is_casesensitive>
+class ScriptSetHashSet final : public ScriptSetImpl<std::unordered_set<TKey, THash, TEqual>, is_sorted, is_casesensitive>
+{
+public:
+    ScriptSetHashSet() = default;
+};
+
+typedef ScriptSetSet< String, std::less<String>, true, true > ScriptSet;
+typedef ScriptSetSet< String, StrLessNoCase, true, false > ScriptSetCI;
+typedef ScriptSetSet< String, LexographicalStrLess, true, true > ScriptSetUnicode;
+typedef ScriptSetSet< String, LexographicalStrLessNoCase, true, false > ScriptSetUnicodeCI;
+typedef ScriptSetHashSet< String, std::hash<String>, std::equal_to<String>, false, true > ScriptHashSet;
+typedef ScriptSetHashSet< String, HashStrNoCase, StrEqNoCase, false, false > ScriptHashSetCI;
 
 #endif // __AC_SCRIPTSET_H

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -16,6 +16,7 @@
 #include "ac/file.h"
 #include "ac/common.h"
 #include "ac/game.h"
+#include "ac/gamestate.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/global_file.h"
@@ -41,6 +42,7 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
+extern GamePlayState play;
 extern AGSPlatformDriver *platform;
 
 // object-based File routines
@@ -138,6 +140,9 @@ void FillDirList(std::vector<String> &files, const String &pattern, ScriptFileSo
         return;
 
     std::vector<FileEntry> fileents;
+    const FileEntryCmpByNameLexographicalCI fileent_name_less(play.GetTextLocaleName().GetCStr());
+    const FileEntryEqByNameLexographicalCI fileent_name_eq(play.GetTextLocaleName().GetCStr());
+
     if (rp.AssetMgr)
     {
         // AssetManager returns asset entries with possibly parent paths,
@@ -160,13 +165,13 @@ void FillDirList(std::vector<String> &files, const String &pattern, ScriptFileSo
             {
                 std::vector<FileEntry> fileents_alt;
                 FillDirList(fileents_alt, alt_rp.Loc, Path::GetFilename(alt_rp.FullPath));
-                std::sort(fileents.begin(), fileents.end(), FileEntryCmpByNameCI());
+                std::sort(fileents.begin(), fileents.end(), fileent_name_less);
                 // TODO: following algorithm pushes element if not matching any existing;
                 // pick this out as a common algorithm somewhere?
                 size_t src_size = fileents.size();
                 for (const auto &alt_fe : fileents_alt)
                 {
-                    if (std::binary_search(fileents.begin(), fileents.begin() + src_size, alt_fe, FileEntryEqByNameCI()))
+                    if (std::binary_search(fileents.begin(), fileents.begin() + src_size, alt_fe, fileent_name_eq))
                         continue;
                     fileents.push_back(alt_fe);
                 }
@@ -179,9 +184,9 @@ void FillDirList(std::vector<String> &files, const String &pattern, ScriptFileSo
     {
     case kScFileSort_Name:
         if (ascending)
-            std::sort(fileents.begin(), fileents.end(), FileEntryCmpByNameCI());
+            std::sort(fileents.begin(), fileents.end(), fileent_name_less);
         else
-            std::sort(fileents.rbegin(), fileents.rend(), FileEntryCmpByNameCI());
+            std::sort(fileents.rbegin(), fileents.rend(), fileent_name_less);
         break;
     case kScFileSort_Time:
         if (ascending)

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -42,10 +42,17 @@ GamePlayState::GamePlayState()
 {
 }
 
-void GamePlayState::SetTextLocaleName(const String &language)
+void GamePlayState::SetGameTextLanguage(const String &language)
 {
-    _localeNameUTF8 = (get_uformat() == U_ASCII || language.IsEmpty()) ? ""
-        : String::FromFormat("%s.utf8", _localeNameUTF8.GetCStr());
+    _gameTextLanguage = language;
+    if (get_uformat() == U_UTF8)
+    {
+        _localeNameUTF8 = StrUtil::FindCompatibleUTF8LocaleName(language.GetCStr());
+    }
+    else
+    {
+        _localeNameUTF8 = "";
+    }
 }
 
 bool GamePlayState::IsAutoRoomViewport() const

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -42,6 +42,12 @@ GamePlayState::GamePlayState()
 {
 }
 
+void GamePlayState::SetTextLocaleName(const String &language)
+{
+    _localeNameUTF8 = (get_uformat() == U_ASCII || language.IsEmpty()) ? ""
+        : String::FromFormat("%s.utf8", _localeNameUTF8.GetCStr());
+}
+
 bool GamePlayState::IsAutoRoomViewport() const
 {
     return _isAutoRoomViewport;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -356,9 +356,13 @@ struct GamePlayState
 
     GamePlayState();
 
-    // Game texts locale; used for lexographical string comparison
+    // Current set game text language; this may be set either by the base game,
+    // or by the loaded translation.
+    const Common::String &GetTextLanguage() const { return _gameTextLanguage; }
+    // Current game texts locale; used for lexographical string comparison.
     const Common::String &GetTextLocaleName() const { return _localeNameUTF8; }
-    void SetTextLocaleName(const Common::String &language);
+
+    void SetGameTextLanguage(const Common::String &language);
 
     //
     // Viewport and camera control.
@@ -509,6 +513,7 @@ private:
     VpPoint ScreenToRoomImpl(int scrx, int scry, int view_index, bool clip_viewport, bool convert_cam_to_data);
     void UpdateRoomCamera(int index);
 
+    Common::String _gameTextLanguage;
     // Name of the current used locale for UTF8 text mode
     Common::String _localeNameUTF8;
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -216,7 +216,8 @@ struct GamePlayState
     int   player_on_region = 0;    // player's current region
     int   screen_is_faded_out = 0; // the screen is currently black
     int   check_interaction_only = 0;
-    int   bg_frame,bg_anim_delay = 0;  // for animating backgrounds
+    int   bg_frame = 0; // for animating backgrounds
+    int   bg_anim_delay = 0;
     int   music_vol_was = 0;  // before the volume drop
     short wait_counter = 0;
     char  wait_skipped_by = 0; // tells how last blocking wait was skipped [not serialized]
@@ -294,17 +295,17 @@ struct GamePlayState
     QueuedAudioItem new_music_queue[MAX_QUEUED_MUSIC]{};
     char  takeover_from[50]{};
     // Currently played external file; this is only for reference
-    AGS::Common::String playmp3file_name;
+    Common::String playmp3file_name;
     char  globalstrings[MAXGLOBALSTRINGS][MAX_MAXSTRLEN]{};
     char  lastParserEntry[MAX_MAXSTRLEN]{};
-    AGS::Common::String game_name;
+    Common::String game_name;
     int   ground_level_areas_disabled = 0;
     int   next_screen_transition = 0;
     int   gamma_adjustment = 0;
     short temporarily_turned_off_character = 0;  // Hide Player Charactr ticked
     short inv_backwards_compatibility = 0; // tells to use legacy inv_* variables
     std::vector<int> gui_draw_order; // used only for hit detection now
-    std::unordered_set<AGS::Common::String> do_once_tokens;
+    std::unordered_set<Common::String> do_once_tokens;
     int   text_min_display_time_ms = 0;
     int   ignore_user_input_after_text_timeout_ms = 0;
     std::vector<int> default_audio_type_volumes;
@@ -319,8 +320,8 @@ struct GamePlayState
     int   dialog_options_zorder = INT32_MAX;
 
     // Dynamic custom property values for characters and items
-    std::vector<AGS::Common::StringIMap> charProps;
-    AGS::Common::StringIMap invProps[MAX_INV];
+    std::vector<Common::StringIMap> charProps;
+    Common::StringIMap invProps[MAX_INV];
 
     // Dynamic speech state
     //
@@ -354,6 +355,10 @@ struct GamePlayState
 
 
     GamePlayState();
+
+    // Game texts locale; used for lexographical string comparison
+    const Common::String &GetTextLocaleName() const { return _localeNameUTF8; }
+    void SetTextLocaleName(const Common::String &language);
 
     //
     // Viewport and camera control.
@@ -503,6 +508,9 @@ struct GamePlayState
 private:
     VpPoint ScreenToRoomImpl(int scrx, int scry, int view_index, bool clip_viewport, bool convert_cam_to_data);
     void UpdateRoomCamera(int index);
+
+    // Name of the current used locale for UTF8 text mode
+    Common::String _localeNameUTF8;
 
     // Defines if the room viewport should be adjusted to the room size automatically.
     bool _isAutoRoomViewport = true;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -310,9 +310,9 @@ static void SortSaveList(std::vector<SaveListItem> &saves, ScriptSaveGameSortSty
         break;
     case kScSaveGameSort_Description:
         if (ascending)
-            std::sort(saves.begin(), saves.end(), SaveItemCmpByDesc());
+            std::sort(saves.begin(), saves.end(), SaveItemCmpByDesc(play.GetTextLocaleName().GetCStr()));
         else
-            std::sort(saves.rbegin(), saves.rend(), SaveItemCmpByDesc());
+            std::sort(saves.rbegin(), saves.rend(), SaveItemCmpByDesc(play.GetTextLocaleName().GetCStr()));
         break;
     default: break;
     }

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -18,6 +18,8 @@
 #ifndef __AGS_EE_AC__GLOBALGAME_H
 #define __AGS_EE_AC__GLOBALGAME_H
 
+#include <locale>
+#include <stdexcept>
 #include <time.h>
 #include "ac/runtime_defines.h"
 #include "util/string.h"
@@ -54,10 +56,31 @@ struct SaveItemCmpByTime
 
 struct SaveItemCmpByDesc
 {
+    SaveItemCmpByDesc()
+        : _loc(std::locale())
+    {
+    }
+
+    SaveItemCmpByDesc(const char *locale_name)
+    {
+        try
+        {
+            _loc = std::locale(locale_name);
+        }
+        catch (const std::runtime_error&)
+        {
+            _loc = std::locale();
+        }
+    }
+
     bool operator()(const SaveListItem &item1, const SaveListItem &item2) const
     {
-        return item1.Description.Compare(item2.Description) < 0;
+        return std::use_facet<std::collate<char>>(_loc).
+            compare(item1.Description.GetCStr(), item1.Description.GetCStr() + item1.Description.GetLength(), item2.Description.GetCStr(), item2.Description.GetCStr() + item2.Description.GetLength()) == 0;
     }
+
+private:
+    std::locale _loc;
 };
 
 

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -15,6 +15,7 @@
 // Containers script API.
 //
 //=============================================================================
+#include <allegro.h> // get_uformat
 #include "ac/common.h" // quit
 #include "ac/string.h"
 #include "ac/dynobj/cc_dynamicarray.h"
@@ -38,10 +39,20 @@ ScriptDictBase *Dict_CreateImpl(bool sorted, bool case_sensitive)
     ScriptDictBase *dic;
     if (sorted)
     {
-        if (case_sensitive)
-            dic = new ScriptDict();
+        if (get_uformat() == U_UTF8)
+        {
+            if (case_sensitive)
+                dic = new ScriptDictUnicode(LexographicalStrLess());
+            else
+                dic = new ScriptDictUnicodeCI(LexographicalStrLessNoCase());
+        }
         else
-            dic = new ScriptDictCI();
+        {
+            if (case_sensitive)
+                dic = new ScriptDict();
+            else
+                dic = new ScriptDictCI();
+        }
     }
     else
     {
@@ -199,10 +210,20 @@ ScriptSetBase *Set_CreateImpl(bool sorted, bool case_sensitive)
     ScriptSetBase *set;
     if (sorted)
     {
-        if (case_sensitive)
-            set = new ScriptSet();
+        if (get_uformat() == U_UTF8)
+        {
+            if (case_sensitive)
+                set = new ScriptSetUnicode(LexographicalStrLess());
+            else
+                set = new ScriptSetUnicodeCI(LexographicalStrLessNoCase());
+        }
         else
-            set = new ScriptSetCI();
+        {
+            if (case_sensitive)
+                set = new ScriptSet();
+            else
+                set = new ScriptSetCI();
+        }
     }
     else
     {

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -17,6 +17,7 @@
 //=============================================================================
 #include <allegro.h> // get_uformat
 #include "ac/common.h" // quit
+#include "ac/gamestate.h"
 #include "ac/string.h"
 #include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/cc_scriptobject.h"
@@ -42,9 +43,9 @@ ScriptDictBase *Dict_CreateImpl(bool sorted, bool case_sensitive)
         if (get_uformat() == U_UTF8)
         {
             if (case_sensitive)
-                dic = new ScriptDictUnicode(LexographicalStrLess());
+                dic = new ScriptDictUnicode(LexographicalStrLess(play.GetTextLocaleName().GetCStr()));
             else
-                dic = new ScriptDictUnicodeCI(LexographicalStrLessNoCase());
+                dic = new ScriptDictUnicodeCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()));
         }
         else
         {
@@ -213,9 +214,9 @@ ScriptSetBase *Set_CreateImpl(bool sorted, bool case_sensitive)
         if (get_uformat() == U_UTF8)
         {
             if (case_sensitive)
-                set = new ScriptSetUnicode(LexographicalStrLess());
+                set = new ScriptSetUnicode(LexographicalStrLess(play.GetTextLocaleName().GetCStr()));
             else
-                set = new ScriptSetUnicodeCI(LexographicalStrLessNoCase());
+                set = new ScriptSetUnicodeCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()));
         }
         else
         {

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -137,11 +137,11 @@ int String_CompareTo(const char *thisString, const char *otherString, bool caseS
     {
         if (caseSensitive)
         {
-            return StrUtil::LexographicalCompare(thisString, otherString);
+            return StrUtil::LexographicalCompare(thisString, otherString, play.GetTextLocaleName().GetCStr());
         }
         else
         {
-            return StrUtil::LexographicalCompareNoCase(thisString, otherString);
+            return StrUtil::LexographicalCompareNoCase(thisString, otherString, play.GetTextLocaleName().GetCStr());
         }
     }
     else

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -131,13 +131,29 @@ const char* String_Substring(const char *thisString, int index, int length) {
     return CreateNewScriptString(std::move(buf));
 }
 
-int String_CompareTo(const char *thisString, const char *otherString, bool caseSensitive) {
-
-    if (caseSensitive) {
-        return strcmp(thisString, otherString);
+int String_CompareTo(const char *thisString, const char *otherString, bool caseSensitive)
+{
+    if (get_uformat() == U_UTF8)
+    {
+        if (caseSensitive)
+        {
+            return StrUtil::LexographicalCompare(thisString, otherString);
+        }
+        else
+        {
+            return StrUtil::LexographicalCompareNoCase(thisString, otherString);
+        }
     }
-    else {
-        return ustricmp(thisString, otherString);
+    else
+    {
+        if (caseSensitive)
+        {
+            return strcmp(thisString, otherString);
+        }
+        else
+        {
+            return ags_stricmp(thisString, otherString);
+        }
     }
 }
 

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -92,6 +92,7 @@ void close_translation ()
         set_uformat(U_UTF8);
     else
         set_uformat(U_ASCII);
+    play.SetTextLocaleName(game.GameTextLanguage);
 }
 
 bool init_translation(const String &lang, const String &fallback_lang)
@@ -164,8 +165,10 @@ bool init_translation(const String &lang, const String &fallback_lang)
         set_uformat(U_UTF8);
     else
         set_uformat(U_ASCII);
+    String language = trans.StrOptions["language"];
+
     String encoding_msg = !encoding.IsEmpty() ? encoding : "presume ASCII";
-    Debug::Printf("Translation's encoding: %s", encoding_msg.GetCStr());
+    Debug::Printf("Translation's encoding: %s, language: %s", encoding_msg.GetCStr(), language.GetCStr());
 
     // Mixed encoding support: 
     // original text unfortunately may contain extended ASCII chars (> 127);
@@ -197,6 +200,8 @@ bool init_translation(const String &lang, const String &fallback_lang)
             Debug::Printf(kDbgMsg_Warn, "WARNING: UTF-8 translation in the ASCII/ANSI game, but no encoding hint for TRA keys conversion");
         }
     }
+
+    play.SetTextLocaleName(language);
 
     Debug::Printf(kDbgMsg_Info, "Translation initialized: %s (format: %s)", trans_name.GetCStr(), encoding_msg.GetCStr());
     return true;

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -92,7 +92,7 @@ void close_translation ()
         set_uformat(U_UTF8);
     else
         set_uformat(U_ASCII);
-    play.SetTextLocaleName(game.GameTextLanguage);
+    play.SetGameTextLanguage(game.GameTextLanguage);
 }
 
 bool init_translation(const String &lang, const String &fallback_lang)
@@ -201,7 +201,7 @@ bool init_translation(const String &lang, const String &fallback_lang)
         }
     }
 
-    play.SetTextLocaleName(language);
+    play.SetGameTextLanguage(language);
 
     Debug::Printf(kDbgMsg_Info, "Translation initialized: %s (format: %s)", trans_name.GetCStr(), encoding_msg.GetCStr());
     return true;

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -510,7 +510,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     play.fade_effect = game.options[OPT_FADETYPE];
     play.std_gui_textheight = get_font_height_outlined(0) + 1;
     play.enable_antialiasing = usetup.AntialiasSprites;
-    play.SetTextLocaleName(game.GameTextLanguage);
+    play.SetGameTextLanguage(game.GameTextLanguage);
 
     //
     // 5. Initialize runtime state of certain game objects

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -510,6 +510,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     play.fade_effect = game.options[OPT_FADETYPE];
     play.std_gui_textheight = get_font_height_outlined(0) + 1;
     play.enable_antialiasing = usetup.AntialiasSprites;
+    play.SetTextLocaleName(game.GameTextLanguage);
 
     //
     // 5. Initialize runtime state of certain game objects

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -637,6 +637,9 @@ void engine_init_game_settings()
         set_uformat(U_UTF8);
     else
         set_uformat(U_ASCII);
+    Debug::Printf("Game text encoding: %s, text language: %s",
+        get_uformat() == U_UTF8 ? "UTF-8" : "ASCII",
+        game.GameTextLanguage.IsEmpty() ? "not set" : game.GameTextLanguage.GetCStr());
 
     int ee;
 

--- a/Tools/data/tra_utils.cpp
+++ b/Tools/data/tra_utils.cpp
@@ -32,6 +32,7 @@ const String SPEECH_FONT_TAG("SpeechFont");
 const String TEXT_DIRECTION_TAG("TextDirection");
 const String ENCODING_TAG("Encoding");
 const String GAMEENCODING_TAG("GameEncoding");
+const String LANGUAGE_TAG("Language");
 const String FONT_OVERRIDE_TAG("Font");
 const char *TAG_DEFAULT = "DEFAULT";
 const char *TAG_DIRECTION_LEFT = "LEFT";
@@ -200,6 +201,10 @@ static void ReadSpecialTags(Translation &tra, const String &line)
     else if (key == GAMEENCODING_TAG)
     {
         tra.StrOptions["gameencoding"] = value;
+    }
+    else if (key == LANGUAGE_TAG)
+    {
+        tra.StrOptions["language"] = value;
     }
     else if (key.StartsWith(FONT_OVERRIDE_TAG))
     {


### PR DESCRIPTION
Following a user request, this implements a lexographical comparison for script strings.

By default, when comparing strings for sorting purposes (so not for equality, but to get which string gets earlier order), the character codes are used, but this is not always suitable for characters in unicode range, because there may be alphabets which use part of the standard latin range (A-Z) and then few more letters with much higher codes (easiest example is letters with accents such as ''À"). For the game made in non-English language or a translation it may be desired to have a sorting based on the language's alphabet instead.

For example, if we have following strings:
* Atext
* Btext
* Ztext
* Àtext
* Čtext

the above would be the character-code-reliant order, but the alphabetically correct order would be:
* Atext
* Àtext
* Btext
* Čtext
* Ztext


What this PR does:
1. Added "GameTextLanguage" property in General Settings (actually, backported one from AGS 4.0, where it was used for generating PO translation source files). It's supposed to be initialized with a language name used for locales, such as "en", "en_US" and so forth.
2. Support "#Language" option in TRS as well, with values set by the same principles.
3. At runtime, the engine will set a locale name for game texts by combining the language setting and ".utf8" postfix, so e.g. "en_US.utf8".
4. This locale will be used to do string collation for game strings. Currently this is implemented in:
* String.CompareTo function
* Dictionary object (when it's created with "sorted" style)
* Set object  (when it's created with "sorted" style)
5. This locale changes when game uses a translation, using translation's own setting.
6. For backwards compatibility, or when the setting is not present, the "default locale" will be used instead.