### PR TITLE
Script API: implement few sorting functions for Strings, ints and floats

### DIFF
--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -308,6 +308,15 @@ void GUIListBox::RemoveItem(int index)
     MarkChanged();
 }
 
+void GUIListBox::SortItems(bool nocase, bool ascending)
+{
+    auto str_less = StrUtil::GetStrLessAutoFor(get_uformat() == U_UTF8, nocase, GUI::Context.TextLocaleName.GetCStr());
+    if (ascending)
+        std::sort(_items.begin(), _items.end(), str_less);
+    else
+        std::sort(_items.rbegin(), _items.rend(), str_less);
+}
+
 void GUIListBox::UpdateVisualState()
 {
     MarkPositionChanged(true);

--- a/Common/gui/guilistbox.h
+++ b/Common/gui/guilistbox.h
@@ -71,6 +71,7 @@ public:
     void Draw(Bitmap *ds, int x = 0, int y = 0) override;
     int InsertItem(int index, const String &text);
     void RemoveItem(int index);
+    void SortItems(bool nocase, bool ascending);
     void UpdateVisualState() override;
 
     // Events

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -320,8 +320,11 @@ struct GuiOptions
 class SpriteCache;
 
 // Global GUI context, affects controls behavior (drawing, updating)
+// TODO: normally this should be strictly in runtime engine code, not Common lib.
 struct GuiContext
 {
+    // Name of locale to use for the text collation (where applicable)
+    String TextLocaleName;
     // Sprite cache, for GUI drawing in software mode
     SpriteCache *Spriteset = nullptr;
     // Current disabled state.

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -14,14 +14,14 @@
 #ifndef __AGS_CN_UTIL__STRINGTYPES_H
 #define __AGS_CN_UTIL__STRINGTYPES_H
 
+#include <array>
 #include <cctype>
 #include <functional>
 #include <locale>
+#include <memory>
 #include <stdexcept>
-#include <unordered_map>
-
-#include <array>
 #include <vector>
+#include <unordered_map>
 #include "util/string.h"
 
 namespace FNV
@@ -189,6 +189,69 @@ struct LexographicalStrLessNoCase
 
 private:
     std::locale _loc;
+};
+
+// Internal implementation for StrLessAuto predicate
+struct StrLessAutoImpl
+{
+    virtual ~StrLessAutoImpl(){}
+    virtual bool operator()(const String &s1, const String &s2) const = 0;
+};
+
+// The 'less' predicate, which acts according to its configuration
+struct StrLessAuto
+{
+    StrLessAuto(std::unique_ptr<StrLessAutoImpl> &&less_impl)
+        : _lessImpl(std::move(less_impl)) { }
+
+    bool operator()(const String &s1, const String &s2) const
+    {
+        return _lessImpl->operator()(s1, s2);
+    }
+
+private:
+    // It's shared ptr, because STL requires a copy constructor for predicates
+    std::shared_ptr<StrLessAutoImpl> _lessImpl;
+};
+
+struct StrLessAutoDirect : public StrLessAutoImpl
+{
+    bool operator()(const String &s1, const String &s2) const override
+    {
+        return s1 < s2;
+    }
+};
+
+struct StrLessAutoNoCase : public StrLessAutoImpl
+{
+    bool operator()(const String &s1, const String &s2) const override
+    {
+        return s1.CompareNoCase(s2) < 0;
+    }
+};
+
+struct StrLessAutoLexographical : public StrLessAutoImpl, LexographicalStrLess
+{
+    StrLessAutoLexographical() = default;
+    StrLessAutoLexographical(const char *locale_name)
+        : LexographicalStrLess(locale_name) {}
+
+    bool operator()(const String &s1, const String &s2) const override
+    {
+        return LexographicalStrLess::operator()(s1, s2);
+    }
+};
+
+struct StrLessAutoLexographicalNoCase : public StrLessAutoImpl, LexographicalStrLessNoCase
+{
+    StrLessAutoLexographicalNoCase() = default;
+    StrLessAutoLexographicalNoCase(const char *locale_name)
+        : LexographicalStrLessNoCase(locale_name) {}
+
+    bool operator()(const String &s1, const String &s2) const override
+    {
+        return LexographicalStrLessNoCase::operator()(s1, s2);
+    }
 };
 
 // Compute case-insensitive hash for a String object

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -58,6 +58,24 @@ int StrUtil::LexographicalCompareNoCase(const String &s1, const String &s2, cons
     }
 }
 
+std::unique_ptr<StrLessAutoImpl> StrUtil::GetStrLessAutoImplFor(bool unicode, bool nocase, const char *locale_name)
+{
+    if (unicode)
+    {
+        if (nocase)
+            return std::unique_ptr<StrLessAutoImpl>(new StrLessAutoLexographicalNoCase(locale_name));
+        else
+            return std::unique_ptr<StrLessAutoImpl>(new StrLessAutoLexographical(locale_name));
+    }
+    else
+    {
+        if (nocase)
+            return std::unique_ptr<StrLessAutoImpl>(new StrLessAutoNoCase());
+        else
+            return std::unique_ptr<StrLessAutoImpl>(new StrLessAutoDirect());
+    }
+}
+
 String StrUtil::IntToString(int d)
 {
     return String::FromFormat("%d", d);

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -51,6 +51,13 @@ namespace StrUtil
     inline int      LexographicalCompareNoCase(const char* cstr1, const char* cstr2, const char* locale_name = "")
                         { return LexographicalCompareNoCase(String::Wrapper(cstr1), String::Wrapper(cstr2), locale_name); }
 
+    // Constructs a automatic string 'less' predicate purposed for the certain case described by parameters
+    std::unique_ptr<StrLessAutoImpl> GetStrLessAutoImplFor(bool unicode, bool nocase, const char *locale_name = "");
+    inline StrLessAuto GetStrLessAutoFor(bool unicode, bool nocase, const char *locale_name = "")
+    {
+        return StrLessAuto(GetStrLessAutoImplFor(unicode, nocase, locale_name));
+    }
+
     // Convert integer to string, by printing its value
     String          IntToString(int val);
     // Tries to convert whole string into integer value;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2178,6 +2178,8 @@ builtin managed struct ListBox extends GUIControl {
   /// Gets/sets whether the border around the list box is shown.
   import attribute bool ShowBorder;
 #endif // SCRIPT_COMPAT_v363
+  /// Sorts the ListBox in alphabetic order
+  import void SortItems(StringCompareStyle, SortDirection);
   /// Gets/sets whether the clickable scroll arrows are shown.
   import attribute bool ShowScrollArrows;
   /// Gets/sets color of the list item's selection
@@ -3715,8 +3717,7 @@ enum SaveComponentSelection
 };
 
 #ifdef SCRIPT_API_v362
-builtin managed struct RestoredSaveInfo
-{
+builtin managed struct RestoredSaveInfo {
   /// Gets/sets whether this game's save should be cancelled.
   import attribute bool Cancel;
   /// Gets/sets whether this game's save should be reloaded again without particular components.
@@ -3770,6 +3771,13 @@ builtin managed struct RestoredSaveInfo
 };
 #endif
 
+#ifdef SCRIPT_API_v363
+builtin struct Utils {
+  import static void SortStrings(String stringArr[], StringCompareStyle, SortDirection);
+  import static void SortInts(int intArr[], SortDirection);
+  import static void SortFloats(float floatArr[], SortDirection);
+};
+#endif // SCRIPT_API_v363
 
 
 import readonly Character *player;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -277,6 +277,7 @@ target_sources(engine
     ac/timer.h
     ac/translation.cpp
     ac/translation.h
+    ac/utils_script.cpp
     ac/viewframe.cpp
     ac/viewframe.h
     ac/viewport_script.cpp

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -106,17 +106,17 @@ DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char
 {
     // NOTE: we need element size of "handle" for array of managed pointers
     DynObjectRef arr = globalDynamicArray.Create(items.size(), sizeof(int32_t), true);
-    if (!arr.Obj)
+    if (!arr.Obj())
         return arr;
     // Create script strings and put handles into array
-    int32_t *slots = static_cast<int32_t*>(arr.Obj);
+    int32_t *slots = static_cast<int32_t*>(arr.Obj());
     for (auto s : items)
     {
         DynObjectRef str = ScriptString::Create(s);
         // We must add reference count, because the string is going to be saved
         // within another object (array), not returned to script directly
-        ccAddObjectReference(str.Handle);
-        *(slots++) = str.Handle;
+        ccAddObjectReference(str.Handle());
+        *(slots++) = str.Handle();
     }
     return arr;
 }
@@ -125,19 +125,99 @@ DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<String> &i
 {
     // NOTE: we need element size of "handle" for array of managed pointers
     DynObjectRef arr = globalDynamicArray.Create(items.size(), sizeof(int32_t), true);
-    if (!arr.Obj)
+    if (!arr.Obj())
         return arr;
     // Create script strings and put handles into array
-    int32_t *slots = static_cast<int32_t*>(arr.Obj);
+    int32_t *slots = static_cast<int32_t*>(arr.Obj());
     for (auto s : items)
     {
         DynObjectRef str = ScriptString::Create(s.GetCStr());
         // We must add reference count, because the string is going to be saved
         // within another object (array), not returned to script directly
-        ccAddObjectReference(str.Handle);
-        *(slots++) = str.Handle;
+        ccAddObjectReference(str.Handle());
+        *(slots++) = str.Handle();
     }
     return arr;
+}
+
+bool DynamicArrayHelpers::ResolveIntArray(const void *arrobj, std::vector<int> &ints)
+{
+    assert(arrobj);
+    if (!arrobj)
+        return false;
+
+    ints.clear();
+    const auto &header = CCDynamicArray::GetHeader(arrobj);
+    const int *data = static_cast<const int*>(arrobj);
+    ints.reserve(header.GetElemCount());
+    for (uint32_t i = 0; i < header.GetElemCount(); ++i)
+    {
+        ints.push_back(data[i]);
+    }
+    return true;
+}
+
+bool DynamicArrayHelpers::ResolveFloatArray(const void *arrobj, std::vector<float> &floats)
+{
+    assert(arrobj);
+    if (!arrobj)
+        return false;
+
+    floats.clear();
+    const auto &header = CCDynamicArray::GetHeader(arrobj);
+    const float *data = static_cast<const float*>(arrobj);
+    floats.reserve(header.GetElemCount());
+    for (uint32_t i = 0; i < header.GetElemCount(); ++i)
+    {
+        floats.push_back(data[i]);
+    }
+    return true;
+}
+
+bool DynamicArrayHelpers::ResolvePointerArray(const void* arrobj, std::vector<void*> &objects)
+{
+    assert(arrobj);
+    if (!arrobj)
+        return false;
+
+    objects.clear();
+    const auto &header = CCDynamicArray::GetHeader(arrobj);
+    assert(header.IsPointerArray());
+    if (!header.IsPointerArray())
+        return false;
+
+    const uint32_t *handles = static_cast<const uint32_t*>(arrobj);
+    objects.reserve(header.GetElemCount());
+    for (uint32_t i = 0; i < header.GetElemCount(); ++i)
+    {
+        objects.push_back(ccGetObjectAddressFromHandle(handles[i]));
+    }
+    return true;
+}
+
+
+bool DynamicArrayHelpers::ResolvePointerArray(const void* arrobj, std::vector<DynObjectRef> &objects)
+{
+    assert(arrobj);
+    if (!arrobj)
+        return false;
+
+    objects.clear();
+    const auto &header = CCDynamicArray::GetHeader(arrobj);
+    assert(header.IsPointerArray());
+    if (!header.IsPointerArray())
+        return false;
+
+    const uint32_t *handles = static_cast<const uint32_t*>(arrobj);
+    objects.reserve(header.GetElemCount());
+    for (uint32_t i = 0; i < header.GetElemCount(); ++i)
+    {
+        void *obj;
+        IScriptObject *mgr;
+        ccGetObjectAddressAndManagerFromHandle(handles[i], obj, mgr);
+        objects.push_back(DynObjectRef(handles[i], obj, mgr));
+    }
+    return true;
 }
 
 

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -34,7 +34,7 @@ public:
         // TODO: refactor and store "elem size" instead
         uint32_t TotalSize = 0u; // total size in bytes
 
-        inline bool IsManagedType() const { return (ElemCount & ARRAY_MANAGED_TYPE_FLAG) != 0; }
+        inline bool IsPointerArray() const { return (ElemCount & ARRAY_MANAGED_TYPE_FLAG) != 0; }
         inline uint32_t GetElemCount() const { return ElemCount & ~ARRAY_MANAGED_TYPE_FLAG; }
     };
 
@@ -76,6 +76,15 @@ namespace DynamicArrayHelpers
     // Create array of managed strings
     DynObjectRef CreateStringArray(const std::vector<const char*> &);
     DynObjectRef CreateStringArray(const std::vector<AGS::Common::String> &);
+    // Resolves a dynamic array of integers
+    bool ResolveIntArray(const void *arrobj, std::vector<int> &ints);
+    // Resolves a dynamic array of floats
+    bool ResolveFloatArray(const void *arrobj, std::vector<float> &floats);
+    // Resolves a dynamic array of managed pointers (handles) to a list of object addresses
+    bool ResolvePointerArray(const void* arrobj, std::vector<void*> &objects);
+    // Resolves a dynamic array of managed pointers (handles) to a list of DynObjectRef structs,
+    // which define object address, manager and handle
+    bool ResolvePointerArray(const void* arrobj, std::vector<DynObjectRef> &objects);
 };
 
 #endif

--- a/Engine/ac/dynobj/cc_scriptobject.h
+++ b/Engine/ac/dynobj/cc_scriptobject.h
@@ -31,14 +31,21 @@ struct IScriptObject;
 // A convenience struct for grouping handle and dynamic object
 struct DynObjectRef
 {
-    const int Handle = 0;
-    void * const Obj = nullptr;
-    IScriptObject * const Mgr = nullptr;
-
+public:
     DynObjectRef() = default;
     DynObjectRef(int handle, void *obj, IScriptObject *mgr)
-        : Handle(handle), Obj(obj), Mgr(mgr) {}
-    inline operator bool() const { return Handle > 0; }
+        : _handle(handle), _obj(obj), _mgr(mgr) {}
+
+    inline int Handle() const { return _handle; }
+    inline void *Obj() const { return _obj; }
+    inline IScriptObject *Mgr() const { return _mgr; }
+
+    inline operator bool() const { return _handle > 0; }
+
+private:
+    int _handle = 0;
+    void *_obj = nullptr;
+    IScriptObject *_mgr = nullptr;
 };
 
 

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -77,7 +77,7 @@ ScriptUserObject globalDynamicStruct;
 ScriptUserObject *ScriptStructHelpers::CreatePoint(int x, int y)
 {
     DynObjectRef ref = ScriptUserObject::Create(sizeof(int32_t) * 2);
-    ref.Mgr->WriteInt32(ref.Obj, 0, x);
-    ref.Mgr->WriteInt32(ref.Obj, sizeof(int32_t), y);
-    return static_cast<ScriptUserObject*>(ref.Obj);
+    ref.Mgr()->WriteInt32(ref.Obj(), 0, x);
+    ref.Mgr()->WriteInt32(ref.Obj(), sizeof(int32_t), y);
+    return static_cast<ScriptUserObject*>(ref.Obj());
 }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -205,14 +205,14 @@ void FillDirList(std::vector<String> &files, const String &pattern, ScriptFileSo
 
 void *File_GetFiles(const char *filemask, int file_sort, int sort_dir)
 {
-    file_sort = ValidateFileSort("ListBox.FillDirList", file_sort);
-    sort_dir = ValidateSortDirection("ListBox.FillDirList", sort_dir);
+    file_sort = ValidateFileSort("File.GetFiles", file_sort);
+    sort_dir = ValidateSortDirection("File.GetFiles", sort_dir);
 
     std::vector<String> files;
     FillDirList(files, filemask, (ScriptFileSortStyle)file_sort, (ScriptSortDirection)sort_dir);
 
     DynObjectRef arr = DynamicArrayHelpers::CreateStringArray(files);
-    return arr.Obj;
+    return arr.Obj();
 }
 
 void *sc_OpenFile(const char *fnmm, int mode) {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -747,6 +747,16 @@ ScriptSortDirection ValidateSortDirection(const char *apiname, int sort_dir)
     return static_cast<ScriptSortDirection>(sort_dir);
 }
 
+ScriptStringComparison ValidateStringComparison(const char* apiname, int case_sensitive)
+{
+    if (case_sensitive < kScCaseInsensitive || case_sensitive > kScCaseSensitive)
+    {
+        debug_script_warn("%s: invalid case sensitivity (%d)", apiname, case_sensitive);
+        return kScCaseInsensitive;
+    }
+    return static_cast<ScriptStringComparison>(case_sensitive);
+}
+
 bool ValidateSaveSlotRange(const char *api_name, int &min_slot, int &max_slot)
 {
     int do_max_slot = std::min(max_slot, TOP_SAVESLOT);
@@ -1120,7 +1130,7 @@ void Game_PrecacheView(int view, int first_loop, int last_loop)
 void *Game_GetSaveSlots(int min_slot, int max_slot, int save_sort, int sort_dir)
 {
     if (!ValidateSaveSlotRange("Game.GetSaveSlots", min_slot, max_slot))
-        return CCDynamicArray::Create(0, sizeof(int32_t), false).Obj;
+        return CCDynamicArray::Create(0, sizeof(int32_t), false).Obj();
     save_sort = ValidateSaveGameSort("Game.GetSaveSlots", save_sort);
     sort_dir = ValidateSortDirection("Game.GetSaveSlots", sort_dir);
 
@@ -1128,10 +1138,10 @@ void *Game_GetSaveSlots(int min_slot, int max_slot, int save_sort, int sort_dir)
     FillSaveList(saves, min_slot, max_slot, false /* no desc */, (ScriptSaveGameSortStyle)save_sort, (ScriptSortDirection)sort_dir);
 
     DynObjectRef arr = CCDynamicArray::Create(saves.size(), sizeof(int32_t), false);
-    int32_t *arr_ptr = static_cast<int32_t*>(arr.Obj);
+    int32_t *arr_ptr = static_cast<int32_t*>(arr.Obj());
     for (const auto &save : saves)
         *(arr_ptr++) = save.Slot;
-    return arr.Obj;
+    return arr.Obj();
 }
 
 extern void prescan_saves(int *dest_arr, size_t dest_count, int min_slot, int max_slot, int file_sort, int sort_dir);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -91,6 +91,7 @@ const char* Game_GetGlobalStrings(int index);
 ScriptFileSortStyle ValidateFileSort(const char *apiname, int file_sort);
 ScriptSaveGameSortStyle ValidateSaveGameSort(const char *apiname, int save_sort);
 ScriptSortDirection ValidateSortDirection(const char *apiname, int sort_dir);
+ScriptStringComparison ValidateStringComparison(const char *apiname, int case_sensitive);
 // Save slot range validation; fixups min and max slots, returns if the resulting range is non-empty
 bool ValidateSaveSlotRange(const char *api_name, int &min_slot, int &max_slot);
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -53,6 +53,7 @@ void GamePlayState::SetGameTextLanguage(const String &language)
     {
         _localeNameUTF8 = "";
     }
+    GUI::Context.TextLocaleName = _localeNameUTF8;
 }
 
 bool GamePlayState::IsAutoRoomViewport() const

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -190,6 +190,16 @@ void ListBox_SetItemText(GUIListBox *listbox, int index, const char *newtext) {
   }
 }
 
+void ListBox_SortItems(GUIListBox *listbox, int case_sensitive, int sort_dir)
+{
+    case_sensitive = ValidateStringComparison("ListBox.SortItems", case_sensitive);
+    sort_dir = ValidateSortDirection("ListBox.SortItems", sort_dir);
+    if (sort_dir != kScSortNone)
+    {
+        listbox->SortItems((case_sensitive == kScCaseInsensitive), (sort_dir != kScSortDescending));
+    }
+}
+
 void ListBox_RemoveItem(GUIListBox *listbox, int index) {
   
   if ((index < 0) || (static_cast<uint32_t>(index) >= listbox->GetItemCount()))
@@ -437,6 +447,11 @@ RuntimeScriptValue Sc_ListBox_SetItemText(void *self, const RuntimeScriptValue *
     API_OBJCALL_VOID_PINT_POBJ(GUIListBox, ListBox_SetItemText, const char);
 }
 
+RuntimeScriptValue Sc_ListBox_SortItems(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT2(GUIListBox, ListBox_SortItems);
+}
+
 // int (GUIListBox *listbox)
 RuntimeScriptValue Sc_ListBox_GetFont(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -614,6 +629,7 @@ void RegisterListBoxAPI()
         { "ListBox::ScrollDown^0",        API_FN_PAIR(ListBox_ScrollDown) },
         { "ListBox::ScrollUp^0",          API_FN_PAIR(ListBox_ScrollUp) },
         { "ListBox::SetItemText^2",       API_FN_PAIR(ListBox_SetItemText) },
+        { "ListBox::SortItems^2",         API_FN_PAIR(ListBox_SortItems) },
         { "ListBox::get_Font",            API_FN_PAIR(ListBox_GetFont) },
         { "ListBox::set_Font",            API_FN_PAIR(ListBox_SetFont) },
         { "ListBox::get_ShowBorder",      API_FN_PAIR(ListBox_GetShowBorder) },

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -170,6 +170,12 @@ enum ScriptSortDirection
     kScSortDescending = 2,
 };
 
+enum ScriptStringComparison
+{
+    kScCaseInsensitive = 0,
+    kScCaseSensitive   = 1
+};
+
 // Script API FileSortStyle
 enum ScriptFileSortStyle
 {

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -132,7 +132,7 @@ void *Dict_GetKeysAsArray(ScriptDictBase *dic)
     if (items.size() == 0)
         return nullptr;
     DynObjectRef arr = DynamicArrayHelpers::CreateStringArray(items);
-    return arr.Obj;
+    return arr.Obj();
 }
 
 void *Dict_GetValuesAsArray(ScriptDictBase *dic)
@@ -142,7 +142,7 @@ void *Dict_GetValuesAsArray(ScriptDictBase *dic)
     if (items.size() == 0)
         return nullptr;
     DynObjectRef arr = DynamicArrayHelpers::CreateStringArray(items);
-    return arr.Obj;
+    return arr.Obj();
 }
 
 RuntimeScriptValue Sc_Dict_Create(const RuntimeScriptValue *params, int32_t param_count)
@@ -297,7 +297,7 @@ void *Set_GetItemsAsArray(ScriptSetBase *set)
     if (items.size() == 0)
         return nullptr;
     DynObjectRef arr = DynamicArrayHelpers::CreateStringArray(items);
-    return arr.Obj;
+    return arr.Obj();
 }
 
 RuntimeScriptValue Sc_Set_Create(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -46,7 +46,7 @@ int ValidateFontNumber(const char *apiname, int font_num)
 
 const char *CreateNewScriptString(const char *text)
 {
-    return static_cast<const char*>(ScriptString::Create(text).Obj);
+    return static_cast<const char*>(ScriptString::Create(text).Obj());
 }
 
 

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -37,7 +37,7 @@ const char *CreateNewScriptString(const char *text);
 inline const char *CreateNewScriptString(const AGS::Common::String &text)
     { return CreateNewScriptString(text.GetCStr()); }
 inline const char *CreateNewScriptString(ScriptString::Buffer &&buf)
-    { return static_cast<const char*>(ScriptString::Create(std::move(buf)).Obj); }
+    { return static_cast<const char*>(ScriptString::Create(std::move(buf)).Obj()); }
 
 int String_IsNullOrEmpty(const char *thisString);
 const char* String_Copy(const char *srcString);

--- a/Engine/ac/utils_script.cpp
+++ b/Engine/ac/utils_script.cpp
@@ -1,0 +1,124 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "ac/game.h"
+#include "ac/gamestate.h"
+#include "ac/string.h"
+#include "ac/dynobj/cc_dynamicarray.h"
+#include "ac/dynobj/dynobj_manager.h"
+#include "debug/debug_log.h"
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+#include "util/string_utils.h"
+
+using namespace AGS::Common;
+
+struct DynStrCmpAuto
+{
+    DynStrCmpAuto(std::unique_ptr<StrLessAutoImpl> &&less_impl)
+        : _lessImpl(std::move(less_impl)) { }
+
+    bool operator()(const DynObjectRef &s1, const DynObjectRef &s2) const
+    {
+        return _lessImpl->operator()(
+            String::Wrapper(static_cast<const char*>(s1.Obj())),
+            String::Wrapper(static_cast<const char*>(s2.Obj())));
+    }
+
+private:
+    // It's shared ptr, because STL requires a copy constructor for predicates
+    std::shared_ptr<StrLessAutoImpl> _lessImpl;
+};
+
+void Utils_SortStrings(void* arrobj, int string_compare, int sort_dir)
+{
+    const auto scsort_dir = ValidateSortDirection("Utils.SortStrings", sort_dir);
+    if (scsort_dir == kScSortNone)
+        return;
+
+    std::vector<DynObjectRef> string_objs;
+    if (!DynamicArrayHelpers::ResolvePointerArray(arrobj, string_objs))
+    {
+        debug_script_warn("Utils.SortStrings: internal error: provided array is not a pointer array?");
+        return;
+    }
+
+    const auto scstring_compare = ValidateStringComparison("Utils.SortStrings", string_compare);
+    DynStrCmpAuto dynstr_less(StrUtil::GetStrLessAutoImplFor(get_uformat() == U_UTF8, string_compare == kScCaseInsensitive, play.GetTextLocaleName().GetCStr()));
+    if (scsort_dir == kScSortAscending)
+        std::sort(string_objs.begin(), string_objs.end(), dynstr_less);
+    else
+        std::sort(string_objs.rbegin(), string_objs.rend(), dynstr_less);
+
+    int *handle_begin = static_cast<int*>(arrobj);
+    int *handle_end = handle_begin + CCDynamicArray::GetHeader(arrobj).GetElemCount();
+    int *handle = handle_begin;
+    for (auto scstr = string_objs.cbegin(); scstr != string_objs.cend() && handle != handle_end; ++scstr, ++handle)
+    {
+        *handle = scstr->Handle();
+    }
+}
+
+void Utils_SortInts(void* arrobj, int sort_dir)
+{
+    auto scsort_dir = ValidateSortDirection("Utils.SortInts", sort_dir);
+    if (scsort_dir == kScSortNone)
+        return;
+    
+    int *int_begin = static_cast<int*>(arrobj);
+    int *int_end = int_begin + CCDynamicArray::GetHeader(arrobj).GetElemCount();
+    if (scsort_dir == kScSortAscending)
+        std::sort(int_begin, int_end);
+    else
+        std::sort(int_begin, int_end, std::greater<int>());
+}
+
+void Utils_SortFloats(void* arrobj, int sort_dir)
+{
+    auto scsort_dir = ValidateSortDirection("Utils.SortFloats", sort_dir);
+    if (scsort_dir == kScSortNone)
+        return;
+
+    float *float_begin = static_cast<float*>(arrobj);
+    float *float_end = float_begin + CCDynamicArray::GetHeader(arrobj).GetElemCount();
+    if (scsort_dir == kScSortAscending)
+        std::sort(float_begin, float_end);
+    else
+        std::sort(float_begin, float_end, std::greater<float>());
+}
+
+RuntimeScriptValue Sc_Utils_SortStrings(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_POBJ_PINT2(Utils_SortStrings, void);
+}
+
+RuntimeScriptValue Sc_Utils_SortInts(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_POBJ_PINT(Utils_SortInts, void);
+}
+
+RuntimeScriptValue Sc_Utils_SortFloats(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_POBJ_PINT(Utils_SortFloats, void);
+}
+
+void RegisterUtilsAPI()
+{
+    ScFnRegister utils_api[] = {
+        { "Utils::SortStrings^3",       API_FN_PAIR(Utils_SortStrings) },
+        { "Utils::SortInts^2",          API_FN_PAIR(Utils_SortInts) },
+        { "Utils::SortFloats^2",        API_FN_PAIR(Utils_SortFloats) },
+    };
+
+    ccAddExternalFunctions(utils_api);
+}

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -863,7 +863,7 @@ void *IAGSEngine::CreateDynamicArray(size_t elem_count, size_t elem_size, bool i
 
     auto obj_ref = CCDynamicArray::Create(static_cast<uint32_t>(elem_count), static_cast<uint32_t>(elem_size), is_managed_type);
     // Should be standard dynamic object, because not managed by plugin
-    return obj_ref.Obj;
+    return obj_ref.Obj();
 }
 
 size_t IAGSEngine::GetDynamicArrayLength(const void *arr)

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1469,7 +1469,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                 return kInstErr_Generic;
             }
             DynObjectRef ref = CCDynamicArray::Create(static_cast<uint32_t>(arg_elnum), arg_elsize, arg_managed);
-            reg1.SetScriptObject(ref.Obj, &globalDynamicArray);
+            reg1.SetScriptObject(ref.Obj(), &globalDynamicArray);
             break;
         }
         case SCMD_NEWUSEROBJECT:
@@ -1482,7 +1482,7 @@ ccInstError ccInstance::Run(int32_t curpc)
                 return kInstErr_Generic;
             }
             DynObjectRef ref = ScriptUserObject::Create(arg_size);
-            reg1.SetScriptObject(ref.Obj, ref.Mgr);
+            reg1.SetScriptObject(ref.Obj(), ref.Mgr());
             break;
         }
         case SCMD_FADD:
@@ -1586,7 +1586,7 @@ ccInstError ccInstance::Run(int32_t curpc)
             auto &reg1 = _registers[codeOp.Arg1i()];
             const char *ptr = reinterpret_cast<const char*>(reg1.GetDirectPtr());
             DynObjectRef ref = ScriptString::Create(ptr);
-            reg1.SetScriptObject(ref.Obj, &myScriptStringImpl);
+            reg1.SetScriptObject(ref.Obj(), &myScriptStringImpl);
             break;
         }
         case SCMD_STRINGSEQUAL:

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -52,6 +52,7 @@ extern void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat
 extern void RegisterStringAPI();
 extern void RegisterSystemAPI();
 extern void RegisterTextBoxAPI();
+extern void RegisterUtilsAPI();
 extern void RegisterViewFrameAPI();
 extern void RegisterViewportAPI();
 extern void RegisterSaveInfoAPI();
@@ -94,6 +95,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterStringAPI();
     RegisterSystemAPI();
     RegisterTextBoxAPI();
+    RegisterUtilsAPI();
     RegisterViewFrameAPI();
     RegisterViewportAPI();
     RegisterSaveInfoAPI();

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -576,6 +576,7 @@
     <ClCompile Include="..\..\Engine\ac\textbox.cpp" />
     <ClCompile Include="..\..\Engine\ac\timer.cpp" />
     <ClCompile Include="..\..\Engine\ac\translation.cpp" />
+    <ClCompile Include="..\..\Engine\ac\utils_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\viewframe.cpp" />
     <ClCompile Include="..\..\Engine\ac\viewport_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\walkablearea.cpp" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -819,6 +819,9 @@
     <ClCompile Include="..\..\Engine\gfx\gfxfilter_aa_sdl_renderer.cpp">
       <Filter>Source Files\gfx</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\utils_script.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">


### PR DESCRIPTION
Sorting was never present in AGS script api, leaving users to implement their own sort, but not everyone can script a optimal implementation, and it will be slower in ags script anyway. So here's minimal sort support for 3 most used types that might require sorting (ints, floats and Strings).
Internally this uses std::sort, which is equivalent or similar to qsort afaik.

This adds:
* ListBox.SortItems(StringCompareStyle, SortDirection)
* Utils.SortStrings(String stringArr[], StringCompareStyle, SortDirection)
* Utils.SortInts(int intArr[], SortDirection)
* Utils.SortFloats(float floatArr[], SortDirection)

ListBox.SortItems does a one-time sort operation of its items, it does not keep items sorted if more are added (meaning, there's no "sorting" mode in ListBox).
The three SortX functions sort dynamic arrays of respective types in-place.