### PR TITLE
Add Android to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
     - name: Set up Tappy
       run: pip install tap.py
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: mymindstorm/setup-emsdk@v14
+    - uses: mymindstorm/setup-emsdk@v16
       if: ${{ matrix.platform.name == 'Emscripten' }}
       with:
         version: 3.1.74
@@ -76,7 +76,7 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.platform.artifact }}
         path: |
@@ -135,12 +135,12 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
   
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -157,7 +157,7 @@ jobs:
         run: sdkmanager --install "ndk;25.2.9519653" "build-tools;34.0.0"
   
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
@@ -177,12 +177,12 @@ jobs:
       - name: Create project archive
         run: cd Android && ./and-build.sh archive_project
   
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: android-apks
           path: AGS-*.apk
   
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: android-project
           path: AGS-*-android-proj-*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,3 +131,58 @@ jobs:
       working-directory: ${{github.workspace}}/build/${{matrix.platform.bindir}}
       run: |
         tappy agstest_software.tap
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+  
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+  
+      - name: Set up Android SDK
+        run: |
+          cd Android && ./and-download-sdk-tools.sh linux
+          echo "${ANDROID_HOME}/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+          echo "${ANDROID_HOME}/platform-tools" >> "$GITHUB_PATH"
+          echo "ANDROID_HOME=${ANDROID_HOME}" >> "$GITHUB_ENV"
+          echo "ANDROID_SDK_ROOT=${ANDROID_HOME}" >> "$GITHUB_ENV"
+  
+      - name: Install Android NDK r25
+        run: sdkmanager --install "ndk;25.2.9519653" "build-tools;34.0.0"
+  
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+  
+      - name: Prepare Android build
+        run: cd Android && ./and-build.sh prepare
+  
+      - name: Build debug APK
+        run: cd Android && ./and-build.sh build_debug
+  
+      - name: Build release APK
+        run: cd Android && ./and-build.sh build_release
+  
+      - name: Rename APKs
+        run: cd Android && ./and-build.sh archive_apks
+  
+      - name: Create project archive
+        run: cd Android && ./and-build.sh archive_project
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-apks
+          path: AGS-*.apk
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-project
+          path: AGS-*-android-proj-*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+
+      - name: Install bsdtar
+        run: |
+          sudo apt-get install -y libarchive-tools
   
       - name: Set up Android SDK
         run: |

--- a/Android/and-build.sh
+++ b/Android/and-build.sh
@@ -5,6 +5,13 @@ set -e
 # if statement, part of a && or || list, or if the command's return status
 # is being inverted using !.
 
+# FIX-ME: turns out tar doesn't actually creates zip file, it is creating
+# a fake zip that is actually a tar file. I need to remake the zip as a
+# function like in and-download-sdk-tools.sh, but figure a different
+# strategy from strip-components, which doesn't exist in the zip tool.
+# For now, just install libarchive-tools on the ubuntu in the ci.
+# This works on Windows because its tar is actually bsdtar.
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 TAR_CMD="bsdtar"
 command -v bsdtar >/dev/null 2>&1 || { TAR_CMD="tar" ; }

--- a/Android/and-download-sdk-tools.sh
+++ b/Android/and-download-sdk-tools.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+set -e
+#   This is a command line helper to download the sdkmanager and command line
+# tools. This will always get the latest stuff. Later you can use the sdkmanager
+# to get the specific version of the ndk and build tools you need, but I think
+# it should work fine with the latest version of command line tools. If it turns
+# out I am wrong we will figure this later.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+CMDLINE_DIR_BASE="${ANDROID_HOME}/cmdline-tools"
+CMDLINE_DIR="${CMDLINE_DIR_BASE}/latest"
+
+PLATFORM=""
+CMD_TOOLS_URL=""
+
+
+function usage
+{
+   echo "Android SDK and Command Line Tools setup script."
+   echo
+   echo "Syntax: and-download-sdk-tools.sh [platform] [version]"
+   echo "platform:"
+   echo "  linux"
+   echo "  macos"
+   echo "  windows"
+   echo
+   echo "version:"
+   echo "  7.0 | 8.0 | 9.0 | 10.0 | 11.0 | 12.0 | 13.0 | 16.0 | 20.0"
+   echo "  default is 11.0"
+   echo
+   echo "Example:"
+   echo "  ./and-download-sdk-tools linux"
+   echo
+}
+
+function extract_zip
+{
+  ZIP_FILE="$1"
+  TARGET_DIR="$2"
+
+  mkdir -p "$TARGET_DIR"
+
+  if command -v bsdtar >/dev/null 2>&1; then
+    bsdtar -xf "$ZIP_FILE" -C "$TARGET_DIR"
+  elif command -v unzip >/dev/null 2>&1; then
+    unzip -q "$ZIP_FILE" -d "$TARGET_DIR"
+  else
+    echo "Error: neither bsdtar nor unzip is available"
+    exit 1
+  fi
+}
+
+function download_cmdline_tools
+{
+  set -e
+  echo "Downloading Android command line tools..."
+
+  TMP_DIR="${SCRIPT_DIR}/tmp_cmd_tools_dir"
+  TMP_ZIP="${SCRIPT_DIR}/tmp_cmd_tools.zip"
+
+  curl -L "$CMD_TOOLS_URL" -o "$TMP_ZIP"
+
+  mkdir -p "${CMDLINE_DIR_BASE}"
+  mkdir -p "${TMP_DIR}"
+
+  echo "Extracting..."
+  extract_zip "$TMP_ZIP" "${TMP_DIR}"
+
+  rm -rf "${CMDLINE_DIR}"
+  mkdir -p "${CMDLINE_DIR_BASE}"
+
+  mv "$TMP_DIR/cmdline-tools" "$CMDLINE_DIR"
+
+  rm -rf "${TMP_DIR}"
+  rm -f "${TMP_ZIP}"
+
+  echo "Download and extraction complete."
+}
+
+function setup_environment
+{
+  set -e
+  echo "Setting up environment..."
+
+  mkdir -p "${ANDROID_HOME}"
+  touch "${ANDROID_HOME}/repositories.cfg"
+
+  export ANDROID_HOME
+  export ANDROID_SDK_ROOT="${ANDROID_HOME}"
+  export PATH="${CMDLINE_DIR}/bin:${ANDROID_HOME}/platform-tools:$PATH"
+
+  echo "Environment ready."
+}
+
+function test_sdkmanager
+{
+  set -e
+  echo "Testing sdkmanager..."
+  "$CMDLINE_DIR/bin/sdkmanager" --version || true
+}
+
+function resolve_version_long {
+  case "$1" in
+    20.0) echo "14742923" ;;
+    16.0) echo "12266719" ;;
+    13.0) echo "11479570" ;;
+    12.0) echo "11076708" ;;
+    11.0) echo "10406996" ;;
+    10.0) echo "9862592" ;;
+    9.0)  echo "9477386" ;;
+    8.0)  echo "9123335" ;;
+    7.0)  echo "8512546" ;;
+    *)    echo "$1" ;;  # already a long version
+  esac
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit
+fi
+
+case "$1" in
+  macos)
+     PLATFORM=mac
+     ;;
+  windows)
+     PLATFORM=win
+     ;;
+  linux)
+     PLATFORM=linux
+     ;;
+  -h|--help)
+     usage
+     exit 0
+     ;;
+  *)
+     usage
+     exit 1
+     ;;
+esac
+
+INPUT_VERSION="${2:-11.0}"
+CMDLINE_VERSION="$(resolve_version_long "$INPUT_VERSION")"
+
+if [[ -z "${PLATFORM}" ]]; then
+    usage
+    exit
+fi
+
+CMD_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-${PLATFORM}-${CMDLINE_VERSION}_latest.zip"
+
+download_cmdline_tools
+setup_environment
+test_sdkmanager


### PR DESCRIPTION
I made a script to download the Android stuff that was needed in the CI, I tried to make it in a way that one could use in their local machine - I tested it on my Mac and it appears to run alright in the Linux in GitHub. I followed [the setup-android actions script](https://github.com/android-actions/setup-android/blob/main/src/main.ts), I wasn't sure how maintained that action would be and I wanted something I could test more easily.



<details><summary>The GitHub Actions I tried to follow closely to out Cirrus build of it.</summary>

https://github.com/adventuregamestudio/ags/blob/ad5f1abdaa11c91dacf9f12ba715f2c4dabe9e88/.cirrus.yml#L256-L288


</details>

It looks like it is building, but it seems it takes around 14 minutes to finish.

This looked like it was the easy part of https://github.com/adventuregamestudio/ags/issues/2960, I will now work on the rest of it.