### PR TITLE
Add Engine MSVC build and MSVC tests to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,9 @@ jobs:
       run: |
         tappy agstest_software.tap
 
+
   build-android:
+    name: Android
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -190,3 +192,191 @@ jobs:
         with:
           name: android-project
           path: AGS-*-android-proj-*.zip
+
+
+  windows-msvc-tests:
+    name: Windows MSVC Tests
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      AGS_LIBOGG_LIB:        C:\Lib\Xiph\x86
+      AGS_LIBTHEORA_LIB:     C:\Lib\Xiph\x86
+      AGS_LIBVORBIS_LIB:     C:\Lib\Xiph\x86
+      AGS_SDL_INCLUDE:       C:\Lib\SDL2\include
+      AGS_SDL_LIB:           C:\Lib\SDL2\lib\x86
+      AGS_SDL_SOUND_INCLUDE: C:\Lib\SDL_sound\src
+      AGS_SDL_SOUND_LIB:     C:\Lib\SDL_sound\lib\x86
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: microsoft/setup-msbuild@v3
+
+      - name: Cache Windows build dependencies
+        id: cache-win-deps
+        uses: actions/cache@v5
+        with:
+          path: C:\Lib
+          key: win-deps-${{ hashFiles('Windows/setup_ags_build_deps.bat') }}
+
+      - name: Install Windows build dependencies
+        if: steps.cache-win-deps.outputs.cache-hit != 'true'
+        shell: cmd
+        run: Windows\setup_ags_build_deps.bat
+
+      - name: Build Compiler test runner (x86)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Compiler.Lib.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+
+      - name: Run Compiler tests (x86)
+        run: Solutions\.test\Release\Compiler.Lib.Test.exe
+
+      - name: Build AGS test runners (x86)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Tests.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+
+      - name: Run Common tests (x86)
+        run: Solutions\.test\Release\Common.Lib.Test.exe
+
+      - name: Run Engine tests (x86)
+        run: Solutions\.test\Release\Engine.App.Test.exe
+
+      - name: Run Tools tests (x86)
+        run: Solutions\.test\Release\Tools.Test.exe
+
+      - name: Clean up
+        shell: cmd
+        run: cd Solutions && rd /s /q .test
+
+      - name: Build Compiler test runner (x64)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Compiler.Lib.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+
+      - name: Run Compiler tests (x64)
+        run: Solutions\.test\Release\Compiler.Lib.Test.exe
+
+      - name: Build AGS test runners (x64)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Tests.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+
+      - name: Run Common tests (x64)
+        run: Solutions\.test\Release\Common.Lib.Test.exe
+
+      - name: Run Engine tests (x64)
+        run: Solutions\.test\Release\Engine.App.Test.exe
+
+      - name: Run Tools tests (x64)
+        run: Solutions\.test\Release\Tools.Test.exe
+
+
+  windows-msvc-engine:
+    name: Windows MSVC Engine
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      AGS_LIBOGG_LIB:        C:\Lib\Xiph\x86
+      AGS_LIBTHEORA_LIB:     C:\Lib\Xiph\x86
+      AGS_LIBVORBIS_LIB:     C:\Lib\Xiph\x86
+      AGS_SDL_INCLUDE:       C:\Lib\SDL2\include
+      AGS_SDL_LIB:           C:\Lib\SDL2\lib\x86
+      AGS_SDL_SOUND_INCLUDE: C:\Lib\SDL_sound\src
+      AGS_SDL_SOUND_LIB:     C:\Lib\SDL_sound\lib\x86
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: microsoft/setup-msbuild@v3
+
+      - name: Cache Windows build dependencies
+        id: cache-win-deps
+        uses: actions/cache@v5
+        with:
+          path: C:\Lib
+          key: win-deps-${{ hashFiles('Windows/setup_ags_build_deps.bat') }}
+
+      - name: Install Windows build dependencies
+        if: steps.cache-win-deps.outputs.cache-hit != 'true'
+        shell: cmd
+        run: Windows\setup_ags_build_deps.bat
+
+      - name: Build Engine (x86 Debug)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Engine.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=Win32 /maxcpucount /nologo
+
+      - name: Build Tools (x86 Debug)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Tools.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=x86 /maxcpucount /nologo
+
+      - name: Build Engine (x86 Release)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Engine.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo
+
+      - name: Build Tools (x86 Release)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Tools.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x86 /maxcpucount /nologo
+
+      - name: Upload x86 Engine PDBs
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-engine-pdb-x86
+          include-hidden-files: true
+          path: Solutions/.build/*/acwin.pdb
+
+      - name: Delete x86 PDB / intermediate files
+        shell: cmd
+        run: |
+          cd Solutions\.build
+          del /s /q *.pdb *.map *.ilk *.iobj *.ipdb
+
+      - name: Upload x86 binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-engine-binaries-x86
+          include-hidden-files: true
+          path: Solutions/.build/*/*
+
+      - name: Delete Win32 build output
+        shell: cmd
+        run: cd Solutions && rd /s /q .build
+
+      - name: Build Engine (x64 Release)
+        shell: cmd
+        run: |
+          cd Solutions
+          msbuild Engine.sln /m /p:MultiProcessorCompilation=true /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=x64 /maxcpucount /nologo
+
+      - name: Upload x64 Engine PDBs
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-engine-pdb-x64
+          include-hidden-files: true
+          path: Solutions/.build/*/acwin.pdb
+
+      - name: Delete x64 PDB / intermediate files
+        shell: cmd
+        run: |
+          cd Solutions\.build
+          del /s /q *.pdb *.map *.ilk *.iobj *.ipdb
+
+      - name: Upload x64 binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-engine-binaries-x64
+          include-hidden-files: true
+          path: Solutions/.build/*/*

--- a/Windows/setup_ags_build_deps.bat
+++ b/Windows/setup_ags_build_deps.bat
@@ -1,0 +1,149 @@
+@echo off
+
+REM Script to quickly setup dev environment in Windows
+REM This script will retrieve Xiph and SDL2 binaries but it will have to build
+REM SDL_sound because no binary release for it exists.
+REM It also uses CMake, VS, curl, nuget. I think those exists in a regular CI.
+REM Windows comes with bsdtar by default, so this script assumes it exists.
+
+set XIPH_VERSION=2022.12.23
+set SDL2_VERSION_TAG=release-2.30.11
+set SDL2_VERSION_NUMBER=2.30.11
+set SDLSOUND_COMMIT=474dbf755a1b67ebe7a55467b4f65e033f268aff
+
+set INSTALL_ROOT=C:\Lib
+
+REM --- First check -----------------------------------------------------------
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget not found in PATH
+    echo Get nuget from https://www.nuget.org/downloads
+    echo And put in a directory in your PATH
+    exit /b 1
+)
+
+where cmake >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: cmake not found in PATH
+    echo Install cmake from https://cmake.org/download/
+    echo And make sure it is in your PATH
+    exit /b 1
+)
+
+goto :main
+
+REM --- Helpers ---------------------------------------------------------------
+:recreate_dir
+REM %1 = directory
+if exist "%~1" (
+    echo Removing "%~1"
+    rmdir /s /q "%~1"
+)
+echo Creating "%~1"
+mkdir "%~1"
+exit /b
+
+:download
+REM %1 = URL, %2 = output file
+curl.exe -L --fail --silent --show-error -o "%~2" "%~1"
+if errorlevel 1 (
+    echo Download failed: %~1
+    exit /b 1
+)
+exit /b
+
+
+:main
+
+REM --- irrKlang begin --------------------------------------------------------
+REM Note: irrKlang is only required for the AGS Editor.
+REM There are also no newer releases of it, so no need to worry about versions.
+echo Downloading irrKlang...
+set IRRKLANG_ZIP=%TEMP%\irrKlang.zip
+call :download https://github.com/ericoporto/irrKlang-for-ags/releases/download/1.6.0/irrKlang.zip "%IRRKLANG_ZIP%" || exit /b 1
+
+call :recreate_dir "%INSTALL_ROOT%\irrKlang"
+tar -xf "%IRRKLANG_ZIP%" -C "%INSTALL_ROOT%\irrKlang"
+del "%IRRKLANG_ZIP%"
+
+echo Downloaded and extracted irrKlang.
+echo Done.
+REM --- irrKlang end ----------------------------------------------------------
+
+REM --- Xiph begin ------------------------------------------------------------
+echo Downloading Xiph libs...
+set XIPH_TMP=%TEMP%\nuget-xiph
+call :recreate_dir "%XIPH_TMP%"
+
+nuget install ericoporto.xiph-for-ags -Version %XIPH_VERSION% -OutputDirectory "%XIPH_TMP%" -NonInteractive
+
+set XIPH_SRC=%XIPH_TMP%\ericoporto.xiph-for-ags.%XIPH_VERSION%\native\lib
+
+for %%A in (x86 x64) do (
+    call :recreate_dir "%INSTALL_ROOT%\Xiph\%%A"
+    copy "%XIPH_SRC%\%%A\*.lib" "%INSTALL_ROOT%\Xiph\%%A\" >nul
+    echo Copied Xiph %%A
+)
+
+rmdir /s /q "%XIPH_TMP%"
+echo Downloaded and extracted Xiph from NuGET.
+echo Done.
+REM --- Xiph end --------------------------------------------------------------
+
+REM --- SDL2 begin ------------------------------------------------------------
+echo Downloading SDL2...
+set SDL2_ZIP=%TEMP%\SDL2.zip
+call :download https://github.com/libsdl-org/SDL/releases/download/%SDL2_VERSION_TAG%/SDL2-devel-%SDL2_VERSION_NUMBER%-VC.zip "%SDL2_ZIP%" || exit /b 1
+
+call :recreate_dir "%INSTALL_ROOT%\SDL2"
+tar -xf "%SDL2_ZIP%" -C "%INSTALL_ROOT%\SDL2" --strip-components=1
+del "%SDL2_ZIP%"
+
+echo Downloaded and extracted SDL2 VC build.
+echo Done.
+REM --- SDL2 end --------------------------------------------------------------
+
+REM --- SDL_sound begin -------------------------------------------------------
+echo Downloading SDL_sound...
+set SDLSOUND_TAR=%TEMP%\SDL_sound.tar.gz
+call :download https://github.com/icculus/SDL_sound/archive/%SDLSOUND_COMMIT%.tar.gz "%SDLSOUND_TAR%" || exit /b 1
+
+set SDLSOUND_SRC=%INSTALL_ROOT%\SDL_sound
+call :recreate_dir "%SDLSOUND_SRC%"
+tar -xf "%SDLSOUND_TAR%" -C "%SDLSOUND_SRC%" --strip-components=1
+del "%SDLSOUND_TAR%"
+
+echo Downloaded and extracted SDL_sound.
+
+echo Building SDL_sound...
+for %%A in (x86 x64) do (
+
+    echo Building SDL_sound %%A...
+
+    if "%%A"=="x86" (
+        cmake -S "%SDLSOUND_SRC%" -B "%SDLSOUND_SRC%\build_%%A" ^
+            -G "Visual Studio 17 2022" -T v142 -A Win32 ^
+            -DCMAKE_PREFIX_PATH="%INSTALL_ROOT%\SDL2" ^
+            -DSDLSOUND_DECODER_MIDI=1
+    ) else (
+        cmake -S "%SDLSOUND_SRC%" -B "%SDLSOUND_SRC%\build_%%A" ^
+            -G "Visual Studio 17 2022" -T v142 -A x64 ^
+            -DCMAKE_PREFIX_PATH="%INSTALL_ROOT%\SDL2" ^
+            -DSDLSOUND_DECODER_MIDI=1
+    )
+
+    cmake --build "%SDLSOUND_SRC%\build_%%A" --config Release --parallel 2
+
+    call :recreate_dir "%SDLSOUND_SRC%\lib\%%A"
+    copy "%SDLSOUND_SRC%\build_%%A\Release\SDL2_sound-static.lib" "%SDLSOUND_SRC%\lib\%%A\" >nul
+)
+
+echo Built SDL_sound.
+echo Done.
+REM --- SDL_sound end -------------------------------------------------------
+
+echo All dependencies installed to %INSTALL_ROOT%
+echo irrKlang:  %INSTALL_ROOT%\irrKlang
+echo Xiph:      %INSTALL_ROOT%\Xiph
+echo SDL2:      %INSTALL_ROOT%\SDL2
+echo SDL_sound: %INSTALL_ROOT%\SDL_sound


### PR DESCRIPTION
I am porting the `build_windows_task` and `ags_windows_tests_task` from Cirrus CI to GitHub Actions. I am not really worried yet to properly packaging things to retrieve them properly later in the pipeline or on getting things super fast (though I am still trying to cache things when possible).

For now, I just want to port each pipeline separately (in a few PRs to test things quickly) as fast as I can on my time, and to then proceed to link things, fix issues that arise, and getting a release build working.

Later, I will try to improve a few things. I will also update the python script that sets the proper versions of the dependencies that used to be in the dockerfiles.

For reference:

<details>
<summary>**`build_windows_task`**</summary>

https://github.com/adventuregamestudio/ags/blob/4c8858452f228042a187be049da97d1065235458/.cirrus.yml#L6-L54

</details>

<details>
<summary>**`ags_windows_tests_task`**</summary>

https://github.com/adventuregamestudio/ags/blob/4c8858452f228042a187be049da97d1065235458/.cirrus.yml#L482-L515

</details>