### PR TITLE
Editor: support renaming custom properties

### DIFF
--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms;
 using System.Xml;
 using AGS.Types;
 using AGS.Editor.TextProcessing;
-using System.Linq;
 
 namespace AGS.Editor.Components
 {

--- a/Editor/AGS.Editor/Components/CustomPropertiesComponent.cs
+++ b/Editor/AGS.Editor/Components/CustomPropertiesComponent.cs
@@ -56,9 +56,35 @@ namespace AGS.Editor.Components
 
         private void ShowSchemaEditor()
         {
-            CustomPropertySchemaEditor schemaEditor = new CustomPropertySchemaEditor(_agsEditor.CurrentGame.PropertySchema);
-            schemaEditor.ShowDialog();
+            List<CustomPropertyDefChange> schemaChanges = null;
+            var schemaCopy = new CustomPropertySchema(_agsEditor.CurrentGame.PropertySchema);
+            CustomPropertySchemaEditor schemaEditor = new CustomPropertySchemaEditor(schemaCopy);
+            if (schemaEditor.ShowDialog() == DialogResult.OK)
+            {
+                schemaChanges = schemaEditor.SchemaChanges;
+            }
             schemaEditor.Dispose();
+
+            if (schemaChanges != null)
+            {
+                // Filter out name changes - these are the only changes we want to react to.
+                var wantedChanges = schemaChanges.Where(
+                    sc => (sc.Type == CustomPropertyDefChangeType.Edit && sc.OriginalName != sc.NewName)).ToArray();
+                if (wantedChanges.Length == 0)
+                {
+                    _agsEditor.CurrentGame.PropertySchema.CopyFrom(schemaCopy);
+                    return;
+                }
+
+                if (GUIController.Instance.ShowQuestion($"You have renamed some of the custom properties. Editor will have to apply modifications to each object in game which has these properties, including objects in Rooms. This process may take some time, because each Room will have to be loaded and resaved.{Environment.NewLine}{Environment.NewLine}"
+                                                     + "If you cancel this operation now, the Custom Properties Schema will be reverted to its previous state in order to prevent mismatches.",
+                                                     MessageBoxIcon.Question) == DialogResult.Yes)
+                {
+                    _agsEditor.CurrentGame.PropertySchema.CopyFrom(schemaCopy);
+                    _agsEditor.Tasks.HandleCustomPropertySchemaChanges(schemaChanges);
+                    Factory.GUIController.RefreshPropertyGrid();
+                }
+            }
         }
 
         private void ExportSchema()

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1943,5 +1943,83 @@ namespace AGS.Editor.Components
                     $"Region{reg.ID}", reg.ID, room.Number, reg.Interactions, room.Script.AutoCompleteData, true, false, errors);
             }
         }
+
+        private struct ModifyRoomParameters
+        {
+            internal Action<Room, CompileMessages> ModifyAction { get; set; }
+            internal CompileMessages Errors { get; set; }
+
+            internal ModifyRoomParameters(Action<Room, CompileMessages> action, CompileMessages errors)
+            {
+                ModifyAction = action;
+                Errors = errors;
+            }
+        }
+
+        public bool ModifyAllRooms(Action<Room, CompileMessages> modifyAction)
+        {
+            CompileMessages errors = new CompileMessages();
+            if (_loadedRoom != null)
+            {
+                if (!SaveRoomIfModifiedAndShowErrors(_loadedRoom, _roomSettings?.Control as RoomSettingsEditor))
+                    return false; // no changes were made
+
+                UnloadCurrentRoomAndGreyOutTree();
+            }
+
+            try
+            {
+                BusyDialog.Show("Please wait while the necessary operations are performed...", new BusyDialog.ProcessingHandler(ModifyRoomsOnThread),
+                    new ModifyRoomParameters(modifyAction, errors));
+            }
+            catch (AGSEditorException ex)
+            {
+                errors.Add(new CompileError(ex.Message, ex));
+            }
+
+            if (errors.Count > 0)
+            {
+                if (errors.HasErrors)
+                    _guiController.ShowMessage("There have been errors while trying to perform necessary operations over rooms. Refer to the output panel for more details.", MessageBoxIcon.Warning);
+                _guiController.ShowOutputPanel(errors);
+            }
+
+            // Assume that some changes were made
+            return true;
+        }
+
+        private object ModifyRoomsOnThread(IWorkProgress progress, object parameter)
+        {
+            ModifyRoomParameters modifyRoom = (ModifyRoomParameters)parameter;
+            progress.Total = _agsEditor.CurrentGame.Rooms.Count;
+            progress.Current = 0;
+            foreach (UnloadedRoom unloadedRoom in _agsEditor.CurrentGame.RootRoomFolder.AllItemsFlat)
+            {
+                Room room;
+                if ((_loadedRoom == null) || (_loadedRoom.Number != unloadedRoom.Number))
+                {
+                    _guiController.Invoke(new Action(() => { UnloadCurrentRoomAndGreyOutTree(); }));
+                    room = LoadRoomAsTemporary(unloadedRoom, modifyRoom.Errors);
+                }
+                else
+                {
+                    room = _loadedRoom;
+                }
+
+                if (room != null)
+                {
+                    CompileMessages roomErrors = new CompileMessages();
+                    modifyRoom.ModifyAction.Invoke(room, roomErrors);
+                    if (!roomErrors.HasErrors && room.Modified)
+                    {
+                        SaveRoomDirectly(room, roomErrors);
+                        room.Modified = false;
+                    }
+                }
+
+                progress.Current++;
+            }
+            return null;
+        }
     }
 }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1,16 +1,17 @@
+using AGS.CScript.Compiler;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
-using AGS.Types;
 using WeifenLuo.WinFormsUI.Docking;
-using System.Threading;
-using System.Reflection;
 
 namespace AGS.Editor.Components
 {
@@ -137,7 +138,7 @@ namespace AGS.Editor.Components
             }
 			else if (controlID.StartsWith(TREE_PREFIX_ROOM_SETTINGS))
 			{
-				LoadRoom(controlID);
+                LoadRoomAndShowEditor(controlID);
 			}
 			else if (controlID.StartsWith(TREE_PREFIX_ROOM_SCRIPT))
 			{
@@ -173,7 +174,7 @@ namespace AGS.Editor.Components
             }
             else if (controlID.StartsWith(TREE_PREFIX_ROOM_NODE))
             {
-                LoadRoom(controlID);
+                LoadRoomAndShowEditor(controlID);
             }
         }
 
@@ -220,7 +221,7 @@ namespace AGS.Editor.Components
             SelectRoomByNumber(roomNumber);
         }
 
-        private void TryLoadScriptAndCreateMissing(UnloadedRoom room)
+        private void TryLoadScriptAndCreateMissing(UnloadedRoom room, CompileMessages errors = null, bool silent = false)
         {
             try
             {
@@ -228,8 +229,12 @@ namespace AGS.Editor.Components
             }
             catch (FileNotFoundException)
             {
-                _guiController.ShowMessage("The script file '" + room.ScriptFileName + "' is missing. An empty script has been created instead.", MessageBoxIcon.Warning);
                 room.Script.SaveToDisk(true);
+                string errorMsg = $"The script file '{room.ScriptFileName}' is missing. An empty script has been created instead.";
+                if (errors != null)
+                    errors.Add(new CompileWarning(errorMsg));
+                if (!silent)
+                    _guiController.ShowMessage(errorMsg, MessageBoxIcon.Warning);
             }
         }
 
@@ -395,14 +400,16 @@ namespace AGS.Editor.Components
 			}
 		}
 
-        private void UnloadRoom(IRoom roomToDelete)
+        private void UnloadRoom(IRoom room)
         {
-            if ((_loadedRoom != null) && (roomToDelete.Number == _loadedRoom.Number))
+            if ((_loadedRoom != null) && (room.Number == _loadedRoom.Number))
             {
                 UnloadCurrentRoom();
             }
-            
-            RoomListTypeConverter.SetRoomList(_agsEditor.CurrentGame.Rooms);            
+            else
+            {
+                _nativeProxy.UnloadRoom(_loadedRoom);
+            }
         }
 
         private void ImportExistingRoomFile(string fileName)
@@ -745,6 +752,24 @@ namespace AGS.Editor.Components
             return null;
         }
 
+        /// <summary>
+        /// Save the given room into its file.
+        /// Do not recompile room scripts.
+        /// Do only minimal required pre-save checks and corrections.
+        /// </summary>
+        private void SaveRoomDirectly(Room room, CompileMessages errors)
+        {
+            PerformPreSaveChecks(room);
+
+            if (!_agsEditor.AttemptToGetWriteAccess(room.FileName))
+            {
+                errors.Add(new CompileError("Unable to open file " + room.FileName + " for writing"));
+                return;
+            }
+
+            _nativeProxy.SaveRoom(room);
+        }
+
         private IScriptEditor GetScriptEditor(string fileName, bool showEditor)
         {
             int roomNumberToEdit = GetRoomNumberForFileName(fileName, false);
@@ -855,7 +880,7 @@ namespace AGS.Editor.Components
             return true;
         }
 
-        private void LoadRoom(string controlID)
+        private void LoadRoomAndShowEditor(string controlID)
         {
             LoadRoomAndShowEditor(Convert.ToInt32(controlID.Substring(3)));
         }
@@ -892,8 +917,6 @@ namespace AGS.Editor.Components
 
         private void UnloadCurrentRoomAndGreyOutTree()
         {
-            ProjectTree treeController = _guiController.ProjectTree;
-
             if (_loadedRoom != null)
             {
                 if (_roomScriptEditors.ContainsKey(_loadedRoom.Number))
@@ -901,6 +924,7 @@ namespace AGS.Editor.Components
                     ((ScriptEditor)_roomScriptEditors[_loadedRoom.Number].Control).Room = null;
                 }
 
+                ProjectTree treeController = _guiController.ProjectTree;
                 treeController.ChangeNodeIcon(this, TREE_PREFIX_ROOM_NODE + _loadedRoom.Number, ROOM_ICON_UNLOADED);
                 treeController.ChangeNodeIcon(this, TREE_PREFIX_ROOM_SETTINGS + _loadedRoom.Number, ROOM_ICON_UNLOADED);
             }
@@ -921,34 +945,25 @@ namespace AGS.Editor.Components
 			if (_loadedRoom != null)
 			{
 				_loadedRoom.RoomModifiedChanged -= _modifiedChangedHandler;
+                _nativeProxy.UnloadRoom(_loadedRoom);
 			}
 			_loadedRoom = null;
 		}
 
-        private Room LoadNewRoomIntoMemory(UnloadedRoom newRoom, CompileMessages errors)
+        private Room LoadNewRoomForEditing(UnloadedRoom newRoom, CompileMessages errors)
         {
-            if ((newRoom.Script == null) || (!newRoom.Script.Modified))
-            {
-                TryLoadScriptAndCreateMissing(newRoom);
-            }
-            else if (_roomScriptEditors.ContainsKey(newRoom.Number))
-            {
-                ((ScriptEditor)_roomScriptEditors[newRoom.Number].Control).UpdateScriptObjectWithLatestTextInWindow();
-            }
-            _loadedRoom = _nativeProxy.LoadRoom(newRoom);
-            // TODO: group these in some UpdateRoomToNewVersion method
-            _loadedRoom.Modified = ImportExport.CreateInteractionScripts(_loadedRoom, errors);
-            _loadedRoom.Modified |= HookUpInteractionVariables(_loadedRoom);
-            _loadedRoom.Modified |= HandleObsoleteSettings(_loadedRoom, errors);
-            _loadedRoom.Modified |= AddPlayMusicCommandToPlayerEntersRoomScript(_loadedRoom, errors);
-            _loadedRoom.Modified |= AdjustRoomResolution(_loadedRoom);
+            // CHECKME: why do we load script BEFORE loading room data here?
+            LoadRoomScript(newRoom, errors, silentIfMissing: false);
+
+            // Load the room into the editing state;
+            // currently AGS Editor supports only a single room in edit state.
+            _loadedRoom = _nativeProxy.LoadRoomForEditing(newRoom);
+            CheckRoomForValidity(_loadedRoom, errors);
+            UpdateRoomToCurrentVersion(_loadedRoom, errors);
+            // Sync the loaded room with the up-to-date game data
             _loadedRoom.Modified |= SyncCustomProperties(_loadedRoom);
-            // NOTE: currently the only way to know if the room was not affected by
-            // game's settings is to test whether it has game's ID.
-            if (_loadedRoom.GameID != _agsEditor.CurrentGame.Settings.UniqueID)
-            {
-                _loadedRoom.Modified |= ApplyDefaultMaskResolution(_loadedRoom);
-            }
+
+            // Force reload room script into the respective editor panel, if necessary
 			if (_loadedRoom.Script.Modified)
 			{
 				if (_roomScriptEditors.ContainsKey(_loadedRoom.Number))
@@ -957,6 +972,51 @@ namespace AGS.Editor.Components
 				}
 			}
             return _loadedRoom;
+        }
+
+        private Room LoadRoomAsTemporary(UnloadedRoom newRoom, CompileMessages errors)
+        {
+            Room room = _nativeProxy.LoadRoom(newRoom);
+            LoadRoomScript(room, errors, silentIfMissing: true);
+
+            CheckRoomForValidity(room, errors);
+            UpdateRoomToCurrentVersion(room, errors);
+            // NOTE: currently the only way to know if the room was not affected by
+            // game's settings is to test whether it has game's ID.
+            if (room.GameID != _agsEditor.CurrentGame.Settings.UniqueID)
+            {
+                room.Modified |= ApplyDefaultMaskResolution(room);
+            }
+            return room;
+        }
+
+        private void LoadRoomScript(UnloadedRoom room, CompileMessages errors, bool silentIfMissing)
+        {
+            if ((room.Script == null) || (!room.Script.Modified))
+            {
+                TryLoadScriptAndCreateMissing(room, errors, silentIfMissing);
+            }
+            else if (_roomScriptEditors.ContainsKey(room.Number))
+            {
+                ((ScriptEditor)_roomScriptEditors[room.Number].Control).UpdateScriptObjectWithLatestTextInWindow();
+            }
+        }
+
+        private void UpdateRoomToCurrentVersion(Room room, CompileMessages errors)
+        {
+            room.Modified = ImportExport.CreateInteractionScripts(room, errors);
+            room.Modified |= HookUpInteractionVariables(room);
+            room.Modified |= HandleObsoleteSettings(room, errors);
+            room.Modified |= AddPlayMusicCommandToPlayerEntersRoomScript(room, errors);
+            room.Modified |= AdjustRoomResolution(room);
+        }
+
+        private void CheckRoomForValidity(Room room, CompileMessages errors)
+        {
+            if (room.ColorDepth > 8 && _agsEditor.CurrentGame.Settings.ColorDepth == GameColorDepth.Palette)
+            {
+                errors.Add(new CompileWarning("This room is hi-color, but your game is currently 256-colour. You will not be able to use this room in this game. Also, the room background will not look right in the editor."));
+            }
         }
 
         private bool HandleObsoleteSettings(Room room, CompileMessages errors)
@@ -1128,7 +1188,7 @@ namespace AGS.Editor.Components
 				{
 					CompileMessages errors = new CompileMessages();
 
-					LoadNewRoomIntoMemory(newRoom, errors);
+					LoadNewRoomForEditing(newRoom, errors);
 
 					_loadedRoom.RoomModifiedChanged += _modifiedChangedHandler;
 
@@ -1576,7 +1636,7 @@ namespace AGS.Editor.Components
 				if ((_loadedRoom == null) || (_loadedRoom.Number != unloadedRoom.Number))
 				{
 					UnloadCurrentRoomAndGreyOutTree();
-					room = LoadNewRoomIntoMemory(unloadedRoom, errors);
+					room = LoadRoomAsTemporary(unloadedRoom, errors);
 				}
 				else
 				{
@@ -1589,19 +1649,26 @@ namespace AGS.Editor.Components
 				CompileMessages roomErrors = new CompileMessages();
 				SaveRoomButDoNotShowAnyErrors(room, roomErrors, $"Rebuilding room {room.Number} {rebuildReason}...");
 
-				if (roomErrors.HasErrors)
+                if (roomErrors.HasErrors)
 				{
 					errors.Add(new CompileError($"Failed to save room {room.FileName}; details below"));
 					errors.AddRange(roomErrors);
 					success = false;
-					break;
 				}
                 else if (roomErrors.Count > 0)
                 {
                     errors.Add(new CompileWarning($"Room {room.FileName} was saved, but there were warnings; details below"));
                     errors.AddRange(roomErrors);
                 }
-			}
+
+                if (_loadedRoom == null)
+                {
+                    UnloadRoom(room);
+                }
+
+                if (!success)
+                    break;
+            }
 
             return success;
         }
@@ -1669,10 +1736,11 @@ namespace AGS.Editor.Components
 				}
 			}
 
+            UnloadCurrentRoomAndGreyOutTree();
+
             foreach (UnloadedRoom unloadedRoom in _agsEditor.CurrentGame.RootRoomFolder.AllItemsFlat)
             {
-                UnloadCurrentRoom();
-                Room room = LoadNewRoomIntoMemory(unloadedRoom, errors);
+                Room room = LoadRoomAsTemporary(unloadedRoom, errors);
 
                 room.Script.Text = processor.ProcessText(room.Script.Text, GameTextType.Script);
                 if (processor.MakesChanges)
@@ -1715,6 +1783,8 @@ namespace AGS.Editor.Components
                         errors.Add(roomErrors[0]);
                     }
                 }
+
+                UnloadRoom(room);
             }
         }
 

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.Designer.cs
@@ -37,17 +37,18 @@ namespace AGS.Editor
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.btnCancel = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOK.Location = new System.Drawing.Point(12, 274);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(109, 29);
             this.btnOK.TabIndex = 1;
-            this.btnOK.Text = "Close";
+            this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
             // 
@@ -112,13 +113,26 @@ namespace AGS.Editor
             this.columnHeader6.Text = "Translated";
             this.columnHeader6.Width = 80;
             // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(127, 274);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(109, 29);
+            this.btnCancel.TabIndex = 3;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
             // CustomPropertySchemaEditor
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.CancelButton = this.btnOK;
+            this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(562, 310);
+            this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.schemaList);
@@ -149,5 +163,6 @@ namespace AGS.Editor
         private System.Windows.Forms.ColumnHeader columnHeader4;
         private System.Windows.Forms.ColumnHeader columnHeader5;
         private System.Windows.Forms.ColumnHeader columnHeader6;
+        private System.Windows.Forms.Button btnCancel;
     }
 }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.cs
@@ -17,11 +17,13 @@ namespace AGS.Editor
         private const string MENU_ITEM_DELETE = "DeleteSchemaItem";
 
         private CustomPropertySchema _schema;
+        private CustomPropertySchema _srcSchema;
 
         public CustomPropertySchemaEditor(CustomPropertySchema schema)
         {
             InitializeComponent();
-            _schema = schema;
+            _srcSchema = schema;
+            _schema = new CustomPropertySchema(schema);
         }
 
         private void RepopulateListView()
@@ -69,19 +71,6 @@ namespace AGS.Editor
             }
         }
 
-        private bool IsThereACustomPropertyWithThisName(string nameToCheckLowerCase)
-        {
-            foreach (CustomPropertySchemaItem item in _schema.PropertyDefinitions)
-            {
-                if (item.Name.ToLowerInvariant() == nameToCheckLowerCase)
-                {
-                    MessageBox.Show("You already have a property with this name.", "Property already exists", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return true;
-                }
-            }
-            return false;
-        }
-
         private void EditOrAddItem(CustomPropertySchemaItem schemaItem)
         {
             bool isNewItem = false;
@@ -91,15 +80,12 @@ namespace AGS.Editor
                 schemaItem.Type = CustomPropertyType.Boolean;
                 isNewItem = true;
             }
-            CustomPropertySchemaItemEditor itemEditor = new CustomPropertySchemaItemEditor(schemaItem, isNewItem);
+            CustomPropertySchemaItemEditor itemEditor = new CustomPropertySchemaItemEditor(schemaItem, isNewItem, _schema);
             if (itemEditor.ShowDialog() == DialogResult.OK)
             {
                 if (isNewItem)
                 {
-                    if (!IsThereACustomPropertyWithThisName(schemaItem.Name.ToLowerInvariant()))
-                    {
-                        _schema.PropertyDefinitions.Add(schemaItem);
-                    }
+                    _schema.PropertyDefinitions.Add(schemaItem);
                 }
                 RepopulateListView();
             }
@@ -145,6 +131,12 @@ namespace AGS.Editor
         }
 
         private void btnOK_Click(object sender, EventArgs e)
+        {
+            _srcSchema.CopyFrom(_schema);
+            this.Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
         {
             this.Close();
         }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaEditor.cs
@@ -10,6 +10,28 @@ using System.Windows.Forms;
 
 namespace AGS.Editor
 {
+    public enum CustomPropertyDefChangeType
+    {
+        None,
+        Add,
+        Edit,
+        Remove
+    }
+
+    public struct CustomPropertyDefChange
+    {
+        public CustomPropertyDefChangeType Type;
+        public string OriginalName;
+        public string NewName;
+
+        public CustomPropertyDefChange(CustomPropertyDefChangeType type, string originalName, string newName)
+        {
+            Type = type;
+            OriginalName = originalName;
+            NewName = newName;
+        }
+    }
+
     public partial class CustomPropertySchemaEditor : Form
     {
         private const string MENU_ITEM_ADD = "AddSchemaItem";
@@ -18,12 +40,18 @@ namespace AGS.Editor
 
         private CustomPropertySchema _schema;
         private CustomPropertySchema _srcSchema;
+        private List<CustomPropertyDefChange> _schemaChanges = new List<CustomPropertyDefChange>();
 
         public CustomPropertySchemaEditor(CustomPropertySchema schema)
         {
             InitializeComponent();
             _srcSchema = schema;
             _schema = new CustomPropertySchema(schema);
+        }
+
+        public List<CustomPropertyDefChange> SchemaChanges
+        {
+            get { return _schemaChanges; }
         }
 
         private void RepopulateListView()
@@ -74,18 +102,29 @@ namespace AGS.Editor
         private void EditOrAddItem(CustomPropertySchemaItem schemaItem)
         {
             bool isNewItem = false;
+            string oldName = null;
             if (schemaItem == null) 
             {
                 schemaItem = new CustomPropertySchemaItem();
                 schemaItem.Type = CustomPropertyType.Boolean;
                 isNewItem = true;
             }
+            else
+            {
+                oldName = schemaItem.Name;
+            }
+
             CustomPropertySchemaItemEditor itemEditor = new CustomPropertySchemaItemEditor(schemaItem, isNewItem, _schema);
             if (itemEditor.ShowDialog() == DialogResult.OK)
             {
                 if (isNewItem)
                 {
                     _schema.PropertyDefinitions.Add(schemaItem);
+                    _schemaChanges.Add(new CustomPropertyDefChange(CustomPropertyDefChangeType.Add, null, schemaItem.Name));
+                }
+                else
+                {
+                    _schemaChanges.Add(new CustomPropertyDefChange(CustomPropertyDefChangeType.Edit, oldName, schemaItem.Name));
                 }
                 RepopulateListView();
             }
@@ -106,9 +145,10 @@ namespace AGS.Editor
             }
             else if (menuItem.Name == MENU_ITEM_DELETE)
             {
-                if (MessageBox.Show("Are you sure you want to delete this entry from the schema? It will be removed from all items in the game that currently have this property set.", "Confirm delete", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                if (MessageBox.Show("Are you sure you want to delete this entry from the schema? It will be removed from all objects in the game that currently have this property set.", "Confirm delete", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     _schema.PropertyDefinitions.Remove(schemaItem);
+                    _schemaChanges.Add(new CustomPropertyDefChange(CustomPropertyDefChangeType.Remove, schemaItem.Name, null));
                     RepopulateListView();
                 }
             }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.Designer.cs
@@ -46,6 +46,7 @@ namespace AGS.Editor
             this.chkObjects = new System.Windows.Forms.CheckBox();
             this.chkCharacters = new System.Windows.Forms.CheckBox();
             this.chkTranslated = new System.Windows.Forms.CheckBox();
+            this.btnRename = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -87,9 +88,11 @@ namespace AGS.Editor
             // 
             // txtName
             // 
+            this.txtName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtName.Location = new System.Drawing.Point(96, 18);
             this.txtName.Name = "txtName";
-            this.txtName.Size = new System.Drawing.Size(194, 21);
+            this.txtName.Size = new System.Drawing.Size(280, 21);
             this.txtName.TabIndex = 4;
             // 
             // txtDescription
@@ -139,7 +142,7 @@ namespace AGS.Editor
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(129, 239);
+            this.btnCancel.Location = new System.Drawing.Point(113, 239);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(92, 26);
             this.btnCancel.TabIndex = 9;
@@ -233,6 +236,18 @@ namespace AGS.Editor
             this.chkTranslated.Text = "Add Text property values to the game\'s translation file";
             this.chkTranslated.UseVisualStyleBackColor = true;
             // 
+            // btnRename
+            // 
+            this.btnRename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRename.Location = new System.Drawing.Point(382, 18);
+            this.btnRename.Name = "btnRename";
+            this.btnRename.Size = new System.Drawing.Size(92, 22);
+            this.btnRename.TabIndex = 13;
+            this.btnRename.Text = "Rename";
+            this.btnRename.UseVisualStyleBackColor = true;
+            this.btnRename.Click += new System.EventHandler(this.btnRename_Click);
+            // 
             // CustomPropertySchemaItemEditor
             // 
             this.AcceptButton = this.btnOK;
@@ -240,6 +255,7 @@ namespace AGS.Editor
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(488, 277);
+            this.Controls.Add(this.btnRename);
             this.Controls.Add(this.chkTranslated);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.btnCancel);
@@ -290,5 +306,6 @@ namespace AGS.Editor
         private System.Windows.Forms.CheckBox chkCharacters;
         private System.Windows.Forms.CheckBox chkRooms;
         private System.Windows.Forms.CheckBox chkTranslated;
+        private System.Windows.Forms.Button btnRename;
     }
 }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
@@ -11,11 +11,13 @@ namespace AGS.Editor
 {
     public partial class CustomPropertySchemaItemEditor : Form
     {
+        private CustomPropertySchema _schema;
         private CustomPropertySchemaItem _itemToEdit;
         private CustomPropertySchemaItem _copyOfItem;
 
-        public CustomPropertySchemaItemEditor(CustomPropertySchemaItem item, bool isNewItem)
+        public CustomPropertySchemaItemEditor(CustomPropertySchemaItem item, bool isNewItem, CustomPropertySchema schema)
         {
+            _schema = schema;
             _itemToEdit = item;
             _copyOfItem = (CustomPropertySchemaItem)item.Clone();
             InitializeComponent();
@@ -43,6 +45,14 @@ namespace AGS.Editor
             if (_copyOfItem.Name == string.Empty)
             {
                 MessageBox.Show("You must enter a name for the new property.", "Name missing", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                txtName.Focus();
+                return;
+            }
+            // Test if there is no item of this name, except for the item which we current edit
+            if (_schema.PropertyDefinitions.Find(pd => pd != _itemToEdit && pd.Name.ToLowerInvariant() == _copyOfItem.Name) != null)
+            {
+                MessageBox.Show("You already have a property with this name.", "Property already exists", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                txtName.Focus();
                 return;
             }
             if (propertyType == CustomPropertyType.Boolean)
@@ -52,6 +62,7 @@ namespace AGS.Editor
                     (_copyOfItem.DefaultValue != "0"))
                 {
                     MessageBox.Show("The default value for a Boolean item must be 0 or 1.", "Validation error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    txtDefaultValue.Focus();
                     return;
                 }
             }
@@ -61,19 +72,13 @@ namespace AGS.Editor
                 if (!Int32.TryParse(_copyOfItem.DefaultValue, out result))
                 {
                     MessageBox.Show("The default value for a Number item must be a valid integer.", "Validation error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    txtDefaultValue.Focus();
                     return;
                 }
             }
-            _itemToEdit.Name = _copyOfItem.Name;
-            _itemToEdit.Description = _copyOfItem.Description;
-            _itemToEdit.DefaultValue = _copyOfItem.DefaultValue;
-            _itemToEdit.Type = propertyType;
-            _itemToEdit.AppliesToCharacters = _copyOfItem.AppliesToCharacters;
-            _itemToEdit.AppliesToHotspots = _copyOfItem.AppliesToHotspots;
-            _itemToEdit.AppliesToInvItems = _copyOfItem.AppliesToInvItems;
-            _itemToEdit.AppliesToObjects = _copyOfItem.AppliesToObjects;
-            _itemToEdit.AppliesToRooms = _copyOfItem.AppliesToRooms;
-            _itemToEdit.Translated = _copyOfItem.Translated;
+            _copyOfItem.Type = propertyType;
+
+            _itemToEdit.CopyFrom(_copyOfItem);
             this.DialogResult = DialogResult.OK;
             this.Close();
         }

--- a/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
+++ b/Editor/AGS.Editor/GUI/CustomPropertySchemaItemEditor.cs
@@ -33,10 +33,8 @@ namespace AGS.Editor
             chkTranslated.DataBindings.Add("Checked", _copyOfItem, "Translated", true, DataSourceUpdateMode.OnPropertyChanged);
             cmbType.SelectedIndex = ((int)_copyOfItem.Type) - 1;
 
-            if (!isNewItem)
-            {
-                txtName.Enabled = false;
-            }
+            txtName.Enabled = isNewItem;
+            btnRename.Enabled = !isNewItem;
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -49,7 +47,7 @@ namespace AGS.Editor
                 return;
             }
             // Test if there is no item of this name, except for the item which we current edit
-            if (_schema.PropertyDefinitions.Find(pd => pd != _itemToEdit && pd.Name.ToLowerInvariant() == _copyOfItem.Name) != null)
+            if (_schema.PropertyDefinitions.Find(pd => pd != _itemToEdit && pd.Name.ToLowerInvariant() == _copyOfItem.Name.ToLowerInvariant()) != null)
             {
                 MessageBox.Show("You already have a property with this name.", "Property already exists", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtName.Focus();
@@ -98,6 +96,16 @@ namespace AGS.Editor
         private void cmbType_SelectedIndexChanged(object sender, EventArgs e)
         {
             chkTranslated.Enabled = ((CustomPropertyType)(cmbType.SelectedIndex + 1)) == CustomPropertyType.Text;
+        }
+
+        private void btnRename_Click(object sender, EventArgs e)
+        {
+            if (MessageBox.Show("Are you sure you want to rename this property? Editor will automatically replace it in all objects in the game that currently have this property set (including rooms)."
+                + $"{Environment.NewLine}But you will have to fix all of its uses in script by hand!", "Confirm rename", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                txtName.Enabled = true;
+                btnRename.Enabled = false;
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -321,9 +321,19 @@ namespace AGS.Editor
             }
         }
 
+        public Room LoadRoomForEditing(UnloadedRoom roomToLoad, Encoding defEncoding = null)
+        {
+            return _native.LoadRoomForEditing(roomToLoad, defEncoding);
+        }
+
         public Room LoadRoom(UnloadedRoom roomToLoad, Encoding defEncoding = null)
         {
-            return _native.LoadRoomFile(roomToLoad, defEncoding);
+            return _native.LoadRoom(roomToLoad, defEncoding);
+        }
+
+        public void UnloadRoom(Room room)
+        {
+
         }
 
         public void SaveRoom(Room roomToSave)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -1390,5 +1390,62 @@ namespace AGS.Editor
                 return null;
             return scripts.Name;
         }
+
+        private void ApplyCustomPropertySchemaChanges(List<CustomProperties> allProps, List<CustomPropertyDefChange> schemaChanges)
+        {
+            if (allProps.Count == 0 || schemaChanges.Count == 0)
+                return;
+
+            foreach (var props in allProps)
+            {
+                if (props.PropertyValues.Count == 0)
+                    continue;
+
+                foreach (var change in schemaChanges)
+                {
+                    if (change.Type == CustomPropertyDefChangeType.Remove)
+                    {
+                        props.PropertyValues.Remove(change.OriginalName);
+                    }
+                    else if (change.Type == CustomPropertyDefChangeType.Edit &&
+                        change.NewName.ToLowerInvariant() != change.OriginalName.ToLowerInvariant())
+                    {
+                        if (props.PropertyValues.ContainsKey(change.OriginalName))
+                        {
+                            var oldProp = props.PropertyValues[change.OriginalName];
+                            props.PropertyValues.Remove(change.OriginalName);
+                            oldProp.Name = change.NewName;
+                            props.PropertyValues.Add(change.NewName, oldProp);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ApplyCustomPropertySchemaChangesInRoom(Room room, List<CustomPropertyDefChange> schemaChanges)
+        {
+            List<CustomProperties> allProps = new List<CustomProperties>();
+            allProps.Add(room.Properties);
+            foreach(var o in room.Objects)
+                allProps.Add(o.Properties);
+            foreach (var h in room.Hotspots)
+                allProps.Add(h.Properties);
+            ApplyCustomPropertySchemaChanges(allProps, schemaChanges);
+            room.Modified = true;
+        }
+
+        public void HandleCustomPropertySchemaChanges(List<CustomPropertyDefChange> schemaChanges)
+        {
+            List<CustomProperties> allProps = new List<CustomProperties>();
+            var game = AGSEditor.Instance.CurrentGame;
+            foreach (var c in game.Characters)
+                allProps.Add(c.Properties);
+            foreach (var i in game.InventoryItems)
+                allProps.Add(i.Properties);
+            ApplyCustomPropertySchemaChanges(allProps, schemaChanges);
+
+            ComponentController.Instance.FindComponent<RoomsComponent>()?
+                .ModifyAllRooms((r, m) => { ApplyCustomPropertySchemaChangesInRoom(r, schemaChanges); });
+        }
     }
 }

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -1301,6 +1301,7 @@ namespace AGS.Editor
             {
                 var loadedRoom = Factory.NativeProxy.LoadRoom((UnloadedRoom)room, oldEnc);
                 Factory.NativeProxy.SaveRoom(loadedRoom);
+                Factory.NativeProxy.UnloadRoom(loadedRoom);
             }
             // Save game with a new encoding
             if (Factory.GUIController.InvokeRequired)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -49,7 +49,9 @@ extern bool initialize_native();
 extern void shutdown_native();
 extern AGS::Types::Game^ import_compiled_game_dta(const AGSString &filename);
 extern void free_old_game_data();
-extern AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+extern AGS::Types::Room^ load_room_for_editing(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+extern AGS::Types::Room^ load_room(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+extern void unload_room(AGS::Types::Room^ room);
 extern void save_crm_file(Room ^roomToSave);
 extern void save_default_crm_file(Room ^roomToSave);
 extern HAGSError import_sci_font(const AGSString &filename, int fslot);
@@ -589,10 +591,20 @@ namespace AGS
 			return load_sprite_dimensions();
 		}
 
-		AGS::Types::Room^ NativeMethods::LoadRoomFile(UnloadedRoom^ roomToLoad, System::Text::Encoding ^defEncoding)
+		AGS::Types::Room^ NativeMethods::LoadRoomForEditing(UnloadedRoom^ roomToLoad, System::Text::Encoding ^defEncoding)
 		{
-			return load_crm_file(roomToLoad, defEncoding);
+			return load_room_for_editing(roomToLoad, defEncoding);
 		}
+
+        AGS::Types::Room^ NativeMethods::LoadRoom(UnloadedRoom^ roomToLoad, System::Text::Encoding ^defEncoding)
+        {
+            return load_room(roomToLoad, defEncoding);
+        }
+
+        void NativeMethods::UnloadRoom(Room^ room)
+        {
+            unload_room(room);
+        }
 
 		void NativeMethods::SaveRoomFile(AGS::Types::Room ^roomToSave)
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -125,7 +125,9 @@ namespace AGS
 			Dictionary<int,Sprite^>^ LoadAllSpriteDimensions();
 			void LoadNewSpriteFile();
             void ReplaceSpriteFile(String ^srcFileName);
-			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+			Room^ LoadRoomForEditing(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+            Room^ LoadRoom(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
+            void UnloadRoom(Room ^room);
 			void SaveRoomFile(Room ^roomToSave);
             void SaveDefaultRoomFile(Room ^roomToSave);
 			void DrawRoomBackground(int hDC, Room ^room, int x, int y, int backgroundNumber, float scaleFactor, RoomAreaMaskType maskType, int selectedArea, int maskTransparency);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1790,12 +1790,6 @@ AGSString load_room_file(RoomStruct &rs, const AGSString &filename) {
   }
 
   set_palette_range(palette, 0, 255, 0);
-  
-  if ((rs.BgFrames[0].Graphic->GetColorDepth() > 8) &&
-      (thisgame.color_depth == 1))
-  {
-      MessageBox(NULL, "WARNING: This room is hi-color, but your game is currently 256-colour. You will not be able to use this room in this game. Also, the room background will not look right in the editor.", "Colour depth warning", MB_OK);
-  }
 
   RoomTools->roomModified = false;
 
@@ -4154,7 +4148,10 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
     room->Interactions->ScriptModule = roomScriptName;
 }
 
-AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding)
+// Loads room file for editing in the editor.
+// This initializes the singleton of type RoomStruct in the native code,
+// and the editing tools.
+AGS::Types::Room^ load_room_for_editing(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding)
 {
     AGSString roomFileName = TextHelper::ConvertUTF8(roomToLoad->FileName);
 
@@ -4169,12 +4166,49 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding
     Room ^room = gcnew Room(roomToLoad->Number);
     convert_room_from_native(thisroom, room, defEncoding);
     room->_roomStructPtr = (IntPtr)&thisroom;
-
     room->Description = roomToLoad->Description;
     room->Script = roomToLoad->Script;
 
     clear_undo_buffer();
     return room;
+}
+
+// Load room file into the temporary object and converts to the managed Room object.
+// This does not affect the editor's state.
+AGS::Types::Room^ load_room(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding)
+{
+    AGSString roomFileName = TextHelper::ConvertUTF8(roomToLoad->FileName);
+
+    std::unique_ptr<RoomStruct> rs(new RoomStruct());
+    AGSString errorMsg = load_room_file(*rs, roomFileName);
+    if (!errorMsg.IsEmpty())
+    {
+        throw gcnew AGSEditorException(TextHelper::ConvertUTF8(errorMsg));
+    }
+
+    Room ^room = gcnew Room(roomToLoad->Number);
+    convert_room_from_native(*rs, room, defEncoding);
+    room->_roomStructPtr = (IntPtr)rs.release();
+    room->Description = roomToLoad->Description;
+    room->Script = roomToLoad->Script;
+    return room;
+}
+
+void unload_room(Room^ room)
+{
+    RoomStruct *theRoom = (RoomStruct*)(void*)room->_roomStructPtr;
+    if (theRoom)
+    {
+        if (theRoom == &thisroom)
+        {
+            thisroom.Free();
+        }
+        else
+        {
+            delete theRoom;
+        }
+    }
+    room->_roomStructPtr = IntPtr();
 }
 
 void convert_room_interactions_to_native(Room ^room, RoomStruct &rs);

--- a/Editor/AGS.Types/CustomPropertySchema.cs
+++ b/Editor/AGS.Types/CustomPropertySchema.cs
@@ -21,9 +21,21 @@ namespace AGS.Types
         {
         }
 
+        public CustomPropertySchema(CustomPropertySchema copyFrom)
+        {
+            CopyFrom(copyFrom);
+        }
+
         public List<CustomPropertySchemaItem> PropertyDefinitions
         {
             get { return _propertyDefinitions; }
+        }
+
+        public void CopyFrom(CustomPropertySchema copyFrom)
+        {
+            _propertyDefinitions.Clear();
+            foreach (var item in copyFrom.PropertyDefinitions)
+                _propertyDefinitions.Add((CustomPropertySchemaItem)item.Clone());
         }
 
         public void FromXml(XmlNode node)

--- a/Editor/AGS.Types/CustomPropertySchemaItem.cs
+++ b/Editor/AGS.Types/CustomPropertySchemaItem.cs
@@ -140,6 +140,7 @@ namespace AGS.Types
             this.AppliesToInvItems = schemaItem.AppliesToInvItems;
             this.AppliesToObjects = schemaItem.AppliesToObjects;
             this.AppliesToRooms = schemaItem.AppliesToRooms;
+            this.Translated = schemaItem.Translated;
         }
 
         public object Clone()


### PR DESCRIPTION
Renaming custom properties was not available by default, because if these properties have been used within the game objects, then renaming a property would require to fix all game objects which have that property value set, *including room objects*.
Here I tried to implement this process, but at the same time have the rename operation protected behind a "lock", in order to warn user about this complication.

What is done in this PR:
1. Added Cancel to the Custom Property Schema window. This lets to cancel all changes done to custom properties. It's achieved by editing a copy of schema within this dialog, and applying the modified copy to the game's schema only when user closes the window with OK. (**This change may be applied regardless of the rest**)
2. Added a mechanism for loading rooms as temporary objects, not touching the "edited room" singleton, and performing some action over all rooms in a order: load room as a temporary object -> perform action -> save room -> unload temporary room object.
3. Added a Rename button to the Custom Property Schema Item dialog, besides the Name field. The Name field is disabled for the existing properties, and Rename button "unlocks" it, but with a warning to user. Schema window remembers types of changes done to schema: items added, edited, or removed. When user confirms the changes by pressing OK, the Editor will check if there are any *renames*, and if there are, then tells user that it has to process all game and rooms now. User has a last chance to cancel the operation and restore previous version of the schema. If user confirms, then Editor applies the property renaming to all game objects as necessary.

<img width="663" height="401" alt="custompropertyrename" src="https://github.com/user-attachments/assets/8351ec26-b69f-42a2-9e73-c84d0c37cd7f" />

