### PR TITLE
CI: adds build of Linux bundle and full installer and zip archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
-    name: Runtime ${{ matrix.platform.name }} Build and Tests
+  build-test:
+    name: Test ${{ matrix.platform.name }} Build
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 20
     defaults:
@@ -682,6 +682,7 @@ jobs:
     needs:
       - build-emscripten-bundle
       - build-android-bundle
+      - build-linux-bundle
       - windows-deps
       - windows-msvc-editor
       - windows-msvc-engine
@@ -731,6 +732,20 @@ jobs:
           mkdir Windows\Installer\Source\Templates
           curl -fLSs https://github.com/%TEMPLATES_REPOSITORY%/tarball/${{env.BASE_BRANCH}} | tar -f - -xvzC Windows\Installer\Source\Templates --strip-components 2
 
+      - name: Download Linux bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: ags-bundle-linux
+          path: _linux_tmp
+
+      - name: Extract Linux bundle
+        shell: cmd
+        run: |
+          mkdir Windows\Installer\Source\Linux
+          call Script\setvar.cmd ACI_VERSION_STR
+          tar -f _linux_tmp\ags_%ACI_VERSION_STR%_linux.tar.gz -xvC Windows\Installer\Source\Linux --strip-components 1
+          rd /s /q _linux_tmp
+
       - name: Download Emscripten bundle
         uses: actions/download-artifact@v8
         with:
@@ -759,17 +774,36 @@ jobs:
           tar -f _android_tmp\AGS-%ACI_VERSION_STR%-android-proj-release.zip -xvzC Windows\Installer\Source\Android
           rd /s /q _android_tmp
 
+      #   NOTE: Inno Setup 6.7.1 comes preinstalled in Windows runners.
+      #   It looks like it is also in PATH already, but our script expects its
+      # path through a parameter.
+      #   I will run it without anything because it should print the version
+      # and information that we can use to monitor what is pre-installed and
+      # if it changes.
+      - name: Run Inno Setup
+        shell: pwsh
+        run: |
+          ISCC.exe
+          Windows\Installer\build.ps1 -IsccPath 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: ags-installer
+          path: Windows\Installer\Output\*.exe
+
       - name: Build release archive
         shell: cmd
         run: |
           move Windows\Installer\Source\Docs\* Windows\Installer\Source\Editor\
           move Windows\Installer\Source\Engine\* Windows\Installer\Source\Editor\
           move Windows\Installer\Source\Licenses Windows\Installer\Source\Editor\
+          move Windows\Installer\Source\Linux     Windows\Installer\Source\Editor\
           move Windows\Installer\Source\Web       Windows\Installer\Source\Editor\
           move Windows\Installer\Source\Android   Windows\Installer\Source\Editor\
           move Windows\Installer\Source\Templates Windows\Installer\Source\Editor\
           move Windows\Installer\Source\URLs Windows\Installer\Source\Editor\
-          tar -f AGS-Package.zip -acv --strip-components 4 Windows\Installer\Source\Editor
+          for %%f in (Windows\Installer\Output\*.exe) do tar -f %%~nf.zip -acv --strip-components 4 Windows\Installer\Source\Editor
 
       - name: Upload archive
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: GitHub Actions Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   BASE_BRANCH: master
   MANUAL_ASSET: ags-help.chm
@@ -582,6 +586,94 @@ jobs:
           name: pdb-archive
           include-hidden-files: true
           path: AGS-*-pdb.zip
+
+  linux-binaries-builds:
+    name: Linux (${{ matrix.platform.arch }}, ${{ matrix.platform.rpath && 'Tar.gz' || 'Deb PKG' }})
+    runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 90
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { arch: amd64, rpath: true,  os: ubuntu-latest }
+        - { arch: i386,  rpath: true,  os: ubuntu-latest }
+        - { arch: amd64, rpath: false, os: ubuntu-latest }
+        - { arch: i386,  rpath: false, os: ubuntu-latest }
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run build inside container
+        run: |
+          TAG_NAME=${{ env.BASE_BRANCH }}-${{ matrix.platform.arch }}
+          IMAGE="ghcr.io/${{ github.repository_owner }}/ags-linux-builder-image:$TAG_NAME"          
+          if [ "${{matrix.platform.rpath}}" = "true" ]; then
+            PREFIX=lib
+          else
+            PREFIX=
+          fi
+
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            -e RPATH_PREFIX=$PREFIX \
+            "$IMAGE" \
+            bash debian/build.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-deb-${{ matrix.platform.arch }}${{ matrix.platform.rpath && '-rpath' || '' }}
+          path: ${{ matrix.platform.rpath && 'data_*.tar.gz' || 'ags_*.deb' }}
+
+  build-linux-bundle:
+    name: Linux Bundle
+    needs: linux-binaries-builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install bsdtar
+        run: sudo apt-get update -y && sudo apt-get install -y libarchive-tools
+
+      - name: Download amd64 data archive
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-deb-amd64-rpath
+          path: /tmp/linux-amd64
+
+      - name: Download i386 data archive
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-deb-i386-rpath
+          path: /tmp/linux-i386
+
+      - name: Assemble Linux bundle
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          mkdir -p $tmp/data
+          bsdtar -f /tmp/linux-amd64/data_amd64.tar.gz -xvzC $tmp/data
+          bsdtar -f /tmp/linux-i386/data_i386.tar.gz   -xvzC $tmp/data
+          cp -v debian/copyright $tmp/data/licenses/ags-copyright
+          cp -v debian/ags+libraries/startgame $tmp/
+          awk 'BEGIN { RS="" } !/make_ags/ { if (NR>1) print RS; print }' debian/ags+libraries/README > $tmp/README
+          version=$(awk -F'[ "]+' '$1=="#define" && $2=="ACI_VERSION_STR" { print $3; exit }' Common/ac/def_version.h)
+          bsdtar -f ags_${version}_linux.tar.gz -cvzC $tmp data startgame README
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ags-bundle-linux
+          path: ags_*_linux.tar.gz
 
   windows-packaging:
     name: Windows Packaging

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+# This build script is meant to be run by the docker image in the CI.
+# This is why there are some environment variable here that exist by magic.
+# The code from here was pulled from the Cirrus CI yaml file.
+#
+# FIX-ME: make this a more proper script at some point that take command line
+# parameters and adjust the GitHub Actions line that uses it.
+
+
+echo "------------ begin debian/build.sh -----------------"
+echo "Running build script in:"
+uname -a
+echo "Building for architecture:"
+dpkg --print-architecture
+echo "----------------------------------------------------"
+
+ARCH=$(dpkg --print-architecture)
+VERSION=$(awk -F'[ "]+' '$1=="#define" && $2=="ACI_VERSION_STR" { print $3; exit }' Common/ac/def_version.h)
+sed -i -s "s/ags \(.*\)(.*)/ags \($VERSION\)\1/" debian/changelog
+if [ -n "$RPATH_PREFIX" ]; then
+  case $ARCH in
+    amd64)
+      bit=64
+      ;;
+    i386)
+      bit=32
+      ;;
+    *)
+      echo "Unknown architecture"
+      exit 1
+      ;;
+  esac
+  DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" DEB_LDFLAGS_MAINT_APPEND=-Wl,--disable-new-dtags fakeroot debian/rules binary
+  sed -E "/^BI(NDMOUNT|T)=/d" debian/ags+libraries/hooks/B00_copy_libs.sh | BIT=$bit BINDMOUNT=$(pwd) sh
+  ar -p ../ags_${VERSION}_$ARCH.deb data.tar.xz | unxz | tar -f - -xvC data --transform "s/.*ags/ags$bit/" ./usr/bin/ags
+  cd data && \
+  (cd lib$bit && find . \
+    \( \
+    -name "libogg.so.*" -o \
+    -name "libtheora.so.*" -o \
+    -name "libvorbisfile.so.*" -o \
+    -name "libvorbis.so.*" \
+    \) \
+    -exec cp -L -v "/opt/lib/{}" "{}" \;) && \
+  tar -cvzf ../data_$ARCH.tar.gz *
+else
+  fakeroot debian/rules binary
+  mv ../ags_${VERSION}_$ARCH.deb .
+fi
+
+echo "------------ end of debian/build.sh ----------------"


### PR DESCRIPTION
This is part of the solution for #2960 , note there is still work later on to add a proper release tasks that picks the artifacts and put them in the Release as an asset attached, given a tag created.

I am creating this as a PR to get a little feedback, and information if the Editor archive and installer is properly working.

A few things that will change:

- Cirrus got a great way to schedule the Dockerfile builds, and queue their usages. Only the Linux build really required a Dockerfile and for now they are building in a separate workflow, so I can't queue. I can move this to be in the same workflow later if this turns out to be a problem - this means if in a commit you change the Linux Dockerfile, the build of the Linux image will run before this new image is built, so it will run on the older image. One can manually cancel and re-run this if necessary for checks for now.
- Inno Setup is already installed in the GitHub Windows runner, and unless I can figure how to uninstall it from the command line, we would need to follow the version that is present there. I don't anticipate this being an issue, since it hasn't changed much in the last few years.
- The artifacts are mostly a zip with a zip inside, this is due to how we used to name these artifacts, since they had a version number in them and I can't dynamically put this version number in the download artifact calls... The actual release would have the "naked" zip or tar.gz files directly.
- For now the base branch is hardcoded as master in the CI, so it doesn't break in different branches, the idea is to have it set as master, ags4 and so on. GitHub Actions has a base branch variable that appears to set a base branch when doing a PR, so perhaps I could move to use these when dealing with the docker images. For now hardcoding leads issues that arise to be easier to understand.
