### PR TITLE
Editor: automatically resolve UI questions in console mode

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -195,13 +195,30 @@ namespace AGS.Editor
             ShowMessage(message, icon);
         }
 
-        public DialogResult ShowQuestion(string message)
+        public DialogResult ShowQuestion(string message, DialogResult defaultResult = DialogResult.Yes)
         {
-            return ShowQuestion(message, MessageBoxIcon.Question);
+            return ShowQuestion(message, MessageBoxIcon.Question, defaultResult);
         }
 
-        public DialogResult ShowQuestion(string message, MessageBoxIcon icon)
+        public DialogResult ShowQuestion(string message, MessageBoxIcon icon, DialogResult defaultResult = DialogResult.Yes)
         {
+            if (StdConsoleWriter.IsEnabled)
+            {
+                StdConsoleWriter.WriteLine(message);
+                switch (defaultResult)
+                {
+                    case DialogResult.OK:
+                    case DialogResult.Retry:
+                    case DialogResult.Yes:
+                        StdConsoleWriter.WriteLine("\t- Yes");
+                        break;
+                    default:
+                        StdConsoleWriter.WriteLine("\t- No");
+                        break;
+                }
+                return defaultResult;
+            }
+
             return MessageBox.Show(message, "Adventure Game Studio", MessageBoxButtons.YesNo, icon);
         }
 


### PR DESCRIPTION
Resolves #2921

This adds an extra 'defaultResult' parameter to GUIControler.ShowQuestion(), which is returned automatically if editor is working in "console" mode. This parameter is "Yes" by default, in order to force current operation to proceed, but may be provided on per case basis if necessary.

I've made a quick search throughout the project, and I think that in practice this may affect only one question so far:
- Whether user wants to recreate a missing sprite file from available sources.

PS. I might also backport this to 3.6.2 or earlier versions, since this is a small change that only affects automatic game building by the editor.

