### PR TITLE
Add section markers into translation source

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1752,7 +1752,10 @@ namespace AGS.Editor.Components
             {
                 Room room = LoadRoomAsTemporary(unloadedRoom, errors, doLoadScript: true);
 
-                room.Script.Text = processor.ProcessText(room.Script.Text, GameTextType.Script);
+                string roomContext = $"Room{room.Number}";
+                string roomContextComment = room.Description;
+
+                room.Script.Text = processor.ProcessText(room.Script.Text, roomContext, roomContextComment, GameTextType.Script);
                 if (processor.MakesChanges)
                 {
                     room.Script.SaveToDisk();
@@ -1765,21 +1768,21 @@ namespace AGS.Editor.Components
                     {
                         charId = Character.NARRATOR_CHARACTER_ID;
                     }
-                    message.Text = processor.ProcessText(message.Text, GameTextType.Message, charId);
+                    message.Text = processor.ProcessText(new GameTextLine(charId, message.Text, roomContext, roomContextComment), GameTextType.Message);
                 }
 
-                TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, room.Properties, errors);
+                TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, room.Properties, roomContext, roomContextComment, errors);
 
                 foreach (RoomHotspot hotspot in room.Hotspots)
                 {
-                    hotspot.Description = processor.ProcessText(hotspot.Description, GameTextType.ItemDescription);
-                    TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, hotspot.Properties, errors);
+                    hotspot.Description = processor.ProcessText(hotspot.Description, roomContext, roomContextComment, GameTextType.ItemDescription);
+                    TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, hotspot.Properties, roomContext, roomContextComment, errors);
                 }
 
                 foreach (RoomObject obj in room.Objects)
                 {
-                    obj.Description = processor.ProcessText(obj.Description, GameTextType.ItemDescription);
-                    TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, obj.Properties, errors);
+                    obj.Description = processor.ProcessText(obj.Description, roomContext, roomContextComment, GameTextType.ItemDescription);
+                    TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, obj.Properties, roomContext, roomContextComment, errors);
                 }
 
                 if (processor.MakesChanges)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1768,7 +1768,7 @@ namespace AGS.Editor.Components
                     {
                         charId = Character.NARRATOR_CHARACTER_ID;
                     }
-                    message.Text = processor.ProcessText(new GameTextLine(charId, message.Text, roomContext, roomContextComment), GameTextType.Message);
+                    message.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(charId, message.Text, roomContext, roomContextComment), GameTextType.Message);
                 }
 
                 TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, room.Properties, roomContext, roomContextComment, errors);

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -282,31 +282,6 @@ namespace AGS.Editor.Components
             }
         }
 
-        private Dictionary<int, string> ConstructParserWordsList(TextParser parser)
-        {
-            var wordsPerID = new Dictionary<int, List<string>>();
-            foreach (var word in parser.Words)
-            {
-                if (!wordsPerID.ContainsKey(word.WordGroup))
-                    wordsPerID[word.WordGroup] = new List<string>();
-                wordsPerID[word.WordGroup].Add(word.Word);
-            }
-
-            var wordLists = new Dictionary<int, string>();
-            foreach (var wordList in wordsPerID)
-            {
-                StringBuilder sb = new StringBuilder();
-                foreach (var word in wordList.Value)
-                {
-                    if (sb.Length > 0)
-                        sb.Append(',');
-                    sb.Append(word);
-                }
-                wordLists[wordList.Key] = sb.ToString();
-            }
-            return wordLists;
-        }
-
         private object UpdateTranslationsProcess(IWorkProgress progress, object translationList)
         {
             List<Translation> translations = (List<Translation>)translationList;
@@ -314,29 +289,8 @@ namespace AGS.Editor.Components
             CompileMessages messages = generator.CreateTranslationList(_agsEditor.CurrentGame);
             if (messages.HasErrors)
                 return messages; // abort for avoiding corrupting translations
-            // (Optionally) prepare Text Parser's dictionary
-            Dictionary<int, string> parserWordLists = null;
-            if (_agsEditor.CurrentGame.Settings.TranslateTextParser)
-            {
-                parserWordLists = ConstructParserWordsList(_agsEditor.CurrentGame.TextParser);
-                // What we do here: because parser dictionary entry may match some
-                // generic game text (e.g. if it's a item's name), the cheap and dumb solution
-                // that we use is that we prefix the source line with a comma
-                // (this works as it's a comma-separated list).
-                var fixedWordLists = new Dictionary<int, string>();
-                foreach (var wordKey in parserWordLists.Keys)
-                {
-                    fixedWordLists[wordKey] = $",{parserWordLists[wordKey]}";
-                }
-                parserWordLists = fixedWordLists;
-            }
 
             HashSet<string> keyedTexts = new HashSet<string>(generator.LinesForTranslation.Select((l) => { return l.Text; }));
-            if (parserWordLists != null)
-            {
-                foreach (var list in parserWordLists)
-                    keyedTexts.Add(list.Value);
-            }
 
             // Merge game texts in
             foreach (Translation translation in translations)
@@ -406,34 +360,17 @@ namespace AGS.Editor.Components
 
                         translation.TranslatedLines.Add(line.Text, string.Empty);
                         currentSection.TranslationEntryKeys.Add(line.Text);
-                        translation.Modified = true;
-                    }
-                }
 
-                // (Optionally) add Text Parser's dictionary
-                if (parserWordLists != null)
-                {
-                    TranslationSection parserSection;
-                    if (!sectionsByKey.TryGetValue("Game Text Parser", out parserSection))
-                    {
-                        parserSection = new TranslationSection("Game Text Parser");
-                        translation.TranslationSections.Add(parserSection);
-                    }
-
-                    foreach (var list in parserWordLists)
-                    {
-                        int wordsKey = list.Key;
-                        string wordsValue = list.Value;
-                        if (!translation.TranslatedLines.ContainsKey(wordsValue))
+                        // For parser words, add respective annotation
+                        if (line.ParserWordID >= 0)
                         {
-                            translation.TranslatedLines.Add(wordsValue, string.Empty);
                             var entryOptions = new TranslationEntryOptions();
-                            entryOptions.Metadata.Add($"PARSERWORD={wordsKey}");
-                            entryOptions.ParserWordID = wordsKey;
-                            translation.TranslatedEntryOptions[wordsValue] = entryOptions;
-                            translation.Modified = true;
-                            parserSection.TranslationEntryKeys.Add(wordsValue);
+                            entryOptions.Metadata.Add($"PARSERWORD={line.ParserWordID}");
+                            entryOptions.ParserWordID = line.ParserWordID;
+                            translation.TranslatedEntryOptions[line.Text] = entryOptions;
                         }
+
+                        translation.Modified = true;
                     }
                 }
             }

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -331,7 +331,7 @@ namespace AGS.Editor.Components
                 parserWordLists = fixedWordLists;
             }
 
-            HashSet<string> keyedTexts = new HashSet<string>(generator.LinesForTranslation);
+            HashSet<string> keyedTexts = new HashSet<string>(generator.LinesForTranslation.Select((l) => { return l.Text; }));
             if (parserWordLists != null)
             {
                 foreach (var list in parserWordLists)
@@ -377,11 +377,11 @@ namespace AGS.Editor.Components
                 }
 
                 // Add current game texts
-                foreach (string line in generator.LinesForTranslation)
+                foreach (var line in generator.LinesForTranslation)
                 {
-                    if (!translation.TranslatedLines.ContainsKey(line))
+                    if (!translation.TranslatedLines.ContainsKey(line.Text))
                     {
-                        translation.TranslatedLines.Add(line, string.Empty);
+                        translation.TranslatedLines.Add(line.Text, string.Empty);
                         translation.Modified = true;
                     }
                 }

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -290,89 +290,10 @@ namespace AGS.Editor.Components
             if (messages.HasErrors)
                 return messages; // abort for avoiding corrupting translations
 
-            HashSet<string> keyedTexts = new HashSet<string>(generator.LinesForTranslation.Select((l) => { return l.Text; }));
-
             // Merge game texts in
             foreach (Translation translation in translations)
             {
-                // Remove or mark as obsolete those texts that are not found in game
-                List<string> removeLines = new List<string>();
-                foreach (var entry in translation.TranslatedLines)
-                {
-                    if (!keyedTexts.Contains(entry.Key))
-                    {
-                        if (string.IsNullOrEmpty(entry.Value))
-                        {
-                            removeLines.Add(entry.Key);
-                            translation.Modified = true;
-                        }
-                        else
-                        {
-                            TranslationEntryOptions entryOptions = null;
-                            if (translation.TranslatedEntryOptions.ContainsKey(entry.Key))
-                                entryOptions = translation.TranslatedEntryOptions[entry.Key];
-                            else
-                                entryOptions = new TranslationEntryOptions();
-                            if (!entryOptions.IsObsolete)
-                            {
-                                entryOptions.IsObsolete = true;
-                                entryOptions.Metadata.Add("OBSOLETE");
-                                translation.TranslatedEntryOptions[entry.Key] = entryOptions;
-                                translation.Modified = true;
-                            }
-                        }
-                    }
-                }
-
-                // Remove obsolete translation lines
-                foreach (var remKey in removeLines)
-                {
-                    translation.TranslatedLines.Remove(remKey);
-                    foreach (var section in translation.TranslationSections)
-                    {
-                        section.TranslationEntryKeys.Remove(remKey);
-                    }
-                }
-
-                // Add current game texts
-                var sectionsByKey = translation.TranslationSections.ToDictionary((ts) => ts.Name, (ts) => ts);
-                TranslationSection currentSection = null;
-                foreach (var line in generator.LinesForTranslation)
-                {
-                    // If this line is not in the translation, then add it
-                    if (!translation.TranslatedLines.ContainsKey(line.Text))
-                    {
-                        // Prepare a section for this line
-                        if (currentSection == null || currentSection.Name != line.Context)
-                        {
-                            string context = line.Context ?? string.Empty;
-                            if (sectionsByKey.TryGetValue(context, out currentSection))
-                            {
-                                currentSection.Comment = line.ContextComment;
-                            }
-                            else
-                            {
-                                currentSection = new TranslationSection(context, line.ContextComment);
-                                sectionsByKey.Add(context, currentSection);
-                                translation.TranslationSections.Add(currentSection);
-                            }
-                        }
-
-                        translation.TranslatedLines.Add(line.Text, string.Empty);
-                        currentSection.TranslationEntryKeys.Add(line.Text);
-
-                        // For parser words, add respective annotation
-                        if (line.ParserWordID >= 0)
-                        {
-                            var entryOptions = new TranslationEntryOptions();
-                            entryOptions.Metadata.Add($"PARSERWORD={line.ParserWordID}");
-                            entryOptions.ParserWordID = line.ParserWordID;
-                            translation.TranslatedEntryOptions[line.Text] = entryOptions;
-                        }
-
-                        translation.Modified = true;
-                    }
-                }
+                UpdateSingleTranslationProcess(translation, generator.LinesForTranslation, messages);
             }
 
             foreach (Translation translation in translations)
@@ -386,6 +307,96 @@ namespace AGS.Editor.Components
                 }
             }
             return messages;
+        }
+
+        private void UpdateSingleTranslationProcess(Translation translation, ICollection<GameTextLine> gameTexts, CompileMessages messages)
+        {
+            var oldLines = translation.TranslatedLines;
+            var oldOptions = translation.TranslatedEntryOptions;
+            var oldSections = translation.TranslationSections;
+
+            translation.TranslatedLines = new Dictionary<string, string>();
+            translation.TranslatedEntryOptions = new Dictionary<string, TranslationEntryOptions>();
+            translation.TranslationSections = new Dictionary<string, TranslationSection>();
+
+            // Add current game texts
+            var sectionByKey = new Dictionary<string, TranslationSection>();
+            TranslationSection currentSection = null;
+            bool translationModified = false;
+            foreach (var line in gameTexts)
+            {
+                // Prepare a section for this line
+                if (currentSection == null || currentSection.Name != line.Context)
+                {
+                    string context = line.Context ?? string.Empty;
+                    if (!sectionByKey.TryGetValue(context, out currentSection))
+                    {
+                        currentSection = new TranslationSection(context, line.ContextComment);
+                        sectionByKey.Add(context, currentSection);
+                    }
+                }
+
+                string translatedLine = string.Empty;
+                bool existingLine = oldLines.TryGetValue(line.Text, out translatedLine);
+                bool modified = !existingLine;
+
+                translation.TranslatedLines.Add(line.Text, translatedLine);
+                translation.TranslationSections.Add(line.Text, currentSection);
+
+                // For parser words, add respective annotation
+                if (line.ParserWordID >= 0)
+                {
+                    var entryOptions = new TranslationEntryOptions();
+                    entryOptions.Metadata.Add($"PARSERWORD={line.ParserWordID}");
+                    entryOptions.ParserWordID = line.ParserWordID;
+                    translation.TranslatedEntryOptions[line.Text] = entryOptions;
+
+                    if (!modified)
+                        modified = !oldOptions.ContainsKey(line.Text) || !oldOptions[line.Text].IsParserDictionary;
+                }
+
+                if (existingLine)
+                {
+                    oldLines.Remove(line.Text);
+                    // Also check if section has changed
+                    if (!modified)
+                        modified = !oldSections.ContainsKey(line.Text) || (oldSections[line.Text].Name != currentSection.Name);
+                }
+
+                translationModified |= modified;
+            }
+
+            // Handle the obsolete entries, remaining from an old translation file.
+            // If they contain translated lines - then keep them but mark as OBSOLETE.
+            // If they do not, then simply erase these.
+            translationModified |= oldLines.Count > 0;
+            foreach (var line in oldLines)
+            {
+                if (!string.IsNullOrEmpty(line.Value))
+                {
+                    TranslationSection section = null;
+                    oldSections.TryGetValue(line.Key, out section);
+                    if (!sectionByKey.TryGetValue(section != null ? section.Name : string.Empty, out currentSection))
+                    {
+                        currentSection = section ?? new TranslationSection(string.Empty);
+                        sectionByKey.Add(currentSection.Name, currentSection);
+                    }
+
+                    translation.TranslatedLines.Add(line.Key, line.Value);
+                    translation.TranslationSections.Add(line.Key, currentSection);
+                    TranslationEntryOptions entryOptions = null;
+                    if (!oldOptions.TryGetValue(line.Key, out entryOptions))
+                        entryOptions = new TranslationEntryOptions();
+                    if (!entryOptions.IsObsolete)
+                    {
+                        entryOptions.IsObsolete = true;
+                        entryOptions.Metadata.Add("OBSOLETE");
+                    }
+                    translation.TranslatedEntryOptions[line.Key] = entryOptions;
+                }
+            }
+
+            translation.Modified = translationModified;
         }
 
         private void DoTranslationUpdate(IList<Translation> translations)

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -374,24 +374,52 @@ namespace AGS.Editor.Components
                 foreach (var remKey in removeLines)
                 {
                     translation.TranslatedLines.Remove(remKey);
+                    foreach (var section in translation.TranslationSections)
+                    {
+                        section.TranslationEntryKeys.Remove(remKey);
+                    }
                 }
 
                 // Add current game texts
+                var sectionsByKey = translation.TranslationSections.ToDictionary((ts) => ts.Name, (ts) => ts);
+                TranslationSection currentSection = null;
                 foreach (var line in generator.LinesForTranslation)
                 {
+                    // If this line is not in the translation, then add it
                     if (!translation.TranslatedLines.ContainsKey(line.Text))
                     {
+                        // Prepare a section for this line
+                        if (currentSection == null || currentSection.Name != line.Context)
+                        {
+                            string context = line.Context ?? string.Empty;
+                            if (sectionsByKey.TryGetValue(context, out currentSection))
+                            {
+                                currentSection.Comment = line.ContextComment;
+                            }
+                            else
+                            {
+                                currentSection = new TranslationSection(context, line.ContextComment);
+                                sectionsByKey.Add(context, currentSection);
+                                translation.TranslationSections.Add(currentSection);
+                            }
+                        }
+
                         translation.TranslatedLines.Add(line.Text, string.Empty);
+                        currentSection.TranslationEntryKeys.Add(line.Text);
                         translation.Modified = true;
                     }
                 }
-            }
 
-            // (Optionally) add Text Parser's dictionary
-            if (parserWordLists != null)
-            {
-                foreach (Translation translation in translations)
+                // (Optionally) add Text Parser's dictionary
+                if (parserWordLists != null)
                 {
+                    TranslationSection parserSection;
+                    if (!sectionsByKey.TryGetValue("Game Text Parser", out parserSection))
+                    {
+                        parserSection = new TranslationSection("Game Text Parser");
+                        translation.TranslationSections.Add(parserSection);
+                    }
+
                     foreach (var list in parserWordLists)
                     {
                         int wordsKey = list.Key;
@@ -404,6 +432,7 @@ namespace AGS.Editor.Components
                             entryOptions.ParserWordID = wordsKey;
                             translation.TranslatedEntryOptions[wordsValue] = entryOptions;
                             translation.Modified = true;
+                            parserSection.TranslationEntryKeys.Add(wordsValue);
                         }
                     }
                 }

--- a/Editor/AGS.Editor/TextProcessing/GameSpeechProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/GameSpeechProcessor.cs
@@ -57,12 +57,12 @@ namespace AGS.Editor
 
         public string ProcessText(string text, string context, GameTextType textType)
         {
-            return ProcessText(new GameTextLine(-1, text, context), textType);
+            return ProcessText(new GameTextLine(text, context), textType);
         }
 
         public string ProcessText(string text, string context, string contextComment, GameTextType textType)
         {
-            return ProcessText(new GameTextLine(-1, text, context, contextComment), textType);
+            return ProcessText(new GameTextLine(text, context, contextComment), textType);
         }
 
         public string ProcessText(GameTextLine textLine, GameTextType textType)
@@ -87,6 +87,8 @@ namespace AGS.Editor
                         return CreateSpeechLine(textLine, textType);
                     }
                     break;
+                default:
+                    return CreateSpeechLine(textLine, textType);
             }
             return textLine.Text;
         }
@@ -144,7 +146,7 @@ namespace AGS.Editor
                         if (ParseFunctionCall(previousFuncCall, out charID))
                         {
                             string mainString = script.Substring(stringStartIndex + 1, (stringEndIndex - stringStartIndex) - 1);
-                            string modifiedString = CreateSpeechLine(new GameTextLine(charID, mainString, context, contextComment), GameTextType.Script);
+                            string modifiedString = CreateSpeechLine(GameTextLine.MakeSpeechLine(charID, mainString, context, contextComment), GameTextType.Script);
                             if (_makesChanges)
                             {
                                 string scriptBeforeString = script.Substring(0, stringStartIndex + 1);
@@ -196,7 +198,7 @@ namespace AGS.Editor
                     {
                         string lineText = thisLine.Substring(thisLine.IndexOf(":") + 1).Trim();
                         originalLine = string.Format("{0}: {1}", characterName,
-                            CreateSpeechLine(new GameTextLine(charID, lineText, context, contextComment), GameTextType.DialogScript));
+                            CreateSpeechLine(GameTextLine.MakeSpeechLine(charID, lineText, context, contextComment), GameTextType.DialogScript));
                     }
                 }
 

--- a/Editor/AGS.Editor/TextProcessing/GameSpeechProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/GameSpeechProcessor.cs
@@ -2,6 +2,7 @@ using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Remoting.Contexts;
 using System.Text;
 
 namespace AGS.Editor
@@ -18,7 +19,7 @@ namespace AGS.Editor
         private bool _lookupForFunctionCalls;
         private bool _lookupForOuterFunctionCalls;
 
-        protected abstract string CreateSpeechLine(int speakingCharacter, string text, GameTextType textType);
+        protected abstract string CreateSpeechLine(GameTextLine textLine, GameTextType textType);
         protected abstract bool ParseFunctionCall(string scriptCodeExtract, out int characterID);
 
         public GameSpeechProcessor(Game game, CompileMessages errors, bool makesChanges,
@@ -51,38 +52,43 @@ namespace AGS.Editor
 
         public string ProcessText(string text, GameTextType textType)
         {
-            return ProcessText(text, textType, -1);
+            return ProcessText(new GameTextLine(text), textType);
         }
 
-        public string ProcessText(string text, GameTextType textType, int characterID)
+        public string ProcessText(string text, string context, GameTextType textType)
         {
-            if (text == null)
+            return ProcessText(new GameTextLine(-1, text, context), textType);
+        }
+
+        public string ProcessText(string text, string context, string contextComment, GameTextType textType)
+        {
+            return ProcessText(new GameTextLine(-1, text, context, contextComment), textType);
+        }
+
+        public string ProcessText(GameTextLine textLine, GameTextType textType)
+        {
+            if (string.IsNullOrWhiteSpace(textLine.Text))
             {
                 return string.Empty;
-            }
-
-            if (text.Trim() == string.Empty)
-            {
-                return text;
             }
 
             switch (textType) 
             {
                 case GameTextType.DialogOption:
                 case GameTextType.Message:
-                    return CreateSpeechLine(characterID, text, textType);
+                    return CreateSpeechLine(textLine, textType);
                 case GameTextType.DialogScript:
-                    return ProcessDialogScript(text);
+                    return ProcessDialogScript(textLine.Text, textLine.Context, textLine.ContextComment);
                 case GameTextType.Script:
-                    return ProcessScript(text);
+                    return ProcessScript(textLine.Text, textLine.Context, textLine.ContextComment);
                 case GameTextType.ItemDescription:
                     if (_processHotspotAndObjectDescriptions)
                     {
-                        return CreateSpeechLine(characterID, text, textType);
+                        return CreateSpeechLine(textLine, textType);
                     }
                     break;
             }
-            return text;
+            return textLine.Text;
         }
 
         private bool DoesStringTerminateHere(string script, int index, char stringTerminator)
@@ -100,7 +106,7 @@ namespace AGS.Editor
             return false;
         }
 
-        private string ProcessScript(string script)
+        private string ProcessScript(string script, string context, string contextComment)
         {
             ScriptParsing.ParserState state = new ScriptParsing.ParserState(script);
             int index = 0;
@@ -138,7 +144,7 @@ namespace AGS.Editor
                         if (ParseFunctionCall(previousFuncCall, out charID))
                         {
                             string mainString = script.Substring(stringStartIndex + 1, (stringEndIndex - stringStartIndex) - 1);
-                            string modifiedString = CreateSpeechLine(charID, mainString, GameTextType.Script);
+                            string modifiedString = CreateSpeechLine(new GameTextLine(charID, mainString, context, contextComment), GameTextType.Script);
                             if (_makesChanges)
                             {
                                 string scriptBeforeString = script.Substring(0, stringStartIndex + 1);
@@ -158,7 +164,7 @@ namespace AGS.Editor
             return script;
         }
 
-        private string ProcessDialogScript(string script)
+        private string ProcessDialogScript(string script, string context, string contextComment)
         {
             StringBuilder sb = new StringBuilder(script.Length);
             StreamReader sr = new StreamReader(new MemoryStream(_game.TextEncoding.GetBytes(script), false), _game.TextEncoding);
@@ -171,7 +177,7 @@ namespace AGS.Editor
 
                 if (DialogScriptConverter.IsRealScriptLineInDialog(originalLine))
                 {
-                    originalLine = ProcessScript(originalLine);
+                    originalLine = ProcessScript(originalLine, context, contextComment);
                 }
                 else if (thisLine.IndexOf("//") >= 0)
                 {
@@ -189,7 +195,8 @@ namespace AGS.Editor
                     if (charID >= 0)
                     {
                         string lineText = thisLine.Substring(thisLine.IndexOf(":") + 1).Trim();
-                        originalLine = string.Format("{0}: {1}", characterName, CreateSpeechLine(charID, lineText, GameTextType.DialogScript));
+                        originalLine = string.Format("{0}: {1}", characterName,
+                            CreateSpeechLine(new GameTextLine(charID, lineText, context, contextComment), GameTextType.DialogScript));
                     }
                 }
 

--- a/Editor/AGS.Editor/TextProcessing/GameTextLine.cs
+++ b/Editor/AGS.Editor/TextProcessing/GameTextLine.cs
@@ -1,3 +1,4 @@
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -6,13 +7,49 @@ namespace AGS.Editor
 {
 	public struct GameTextLine
 	{
-		public int CharacterID;
 		public string Text;
+        public int CharacterID;
+        public string Context;
+		public string ContextComment;
 
-		public GameTextLine(int characterID, string text)
+        public GameTextLine(string text)
+        {
+            Text = text;
+            CharacterID = -1;
+            Context = string.Empty;
+            ContextComment = string.Empty;
+        }
+
+        public GameTextLine(string text, string context, string contextComment)
+        {
+            Text = text;
+            CharacterID = -1;
+            Context = context;
+            ContextComment = contextComment;
+        }
+
+        public GameTextLine(int characterID, string text)
 		{
-			CharacterID = characterID;
-			Text = text;
-		}
-	}
+            Text = text;
+            CharacterID = characterID;
+			Context = string.Empty;
+            ContextComment = string.Empty;
+        }
+
+        public GameTextLine(int characterID, string text, string context)
+        {
+            Text = text;
+            CharacterID = characterID;
+            Context = context;
+            ContextComment = string.Empty;
+        }
+
+        public GameTextLine(int characterID, string text, string context, string contextComment)
+        {
+            Text = text;
+            CharacterID = characterID;
+            Context = context;
+            ContextComment = contextComment;
+        }
+    }
 }

--- a/Editor/AGS.Editor/TextProcessing/GameTextLine.cs
+++ b/Editor/AGS.Editor/TextProcessing/GameTextLine.cs
@@ -9,6 +9,7 @@ namespace AGS.Editor
 	{
 		public string Text;
         public int CharacterID;
+        public int ParserWordID;
         public string Context;
 		public string ContextComment;
 
@@ -16,7 +17,17 @@ namespace AGS.Editor
         {
             Text = text;
             CharacterID = -1;
+            ParserWordID = -1;
             Context = string.Empty;
+            ContextComment = string.Empty;
+        }
+
+        public GameTextLine(string text, string context)
+        {
+            Text = text;
+            CharacterID = -1;
+            ParserWordID = -1;
+            Context = context;
             ContextComment = string.Empty;
         }
 
@@ -24,32 +35,37 @@ namespace AGS.Editor
         {
             Text = text;
             CharacterID = -1;
+            ParserWordID = -1;
             Context = context;
             ContextComment = contextComment;
         }
 
-        public GameTextLine(int characterID, string text)
-		{
-            Text = text;
-            CharacterID = characterID;
-			Context = string.Empty;
-            ContextComment = string.Empty;
+        public static GameTextLine MakeSpeechLine(int characterID, string text)
+        {
+            var line = new GameTextLine(text);
+            line.CharacterID = characterID;
+            return line;
         }
 
-        public GameTextLine(int characterID, string text, string context)
+        public static GameTextLine MakeSpeechLine(int characterID, string text, string context)
         {
-            Text = text;
-            CharacterID = characterID;
-            Context = context;
-            ContextComment = string.Empty;
+            var line = new GameTextLine(text, context, string.Empty);
+            line.CharacterID = characterID;
+            return line;
         }
 
-        public GameTextLine(int characterID, string text, string context, string contextComment)
+        public static GameTextLine MakeSpeechLine(int characterID, string text, string context, string contextComment)
         {
-            Text = text;
-            CharacterID = characterID;
-            Context = context;
-            ContextComment = contextComment;
+            var line = new GameTextLine(text, context, contextComment);
+            line.CharacterID = characterID;
+            return line;
+        }
+
+        public static GameTextLine MakeParserWord(int wordID, string text, string context)
+        {
+            var line = new GameTextLine(text, context, string.Empty);
+            line.ParserWordID = wordID;
+            return line;
         }
     }
 }

--- a/Editor/AGS.Editor/TextProcessing/IGameTextProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/IGameTextProcessor.cs
@@ -8,8 +8,10 @@ namespace AGS.Editor
     public interface IGameTextProcessor
     {
         string ProcessText(string text, GameTextType textType);
-        string ProcessText(string text, GameTextType textType, int characterID);
+        string ProcessText(string text, string context, GameTextType textType);
+        string ProcessText(string text, string context, string contextComment, GameTextType textType);
+        string ProcessText(GameTextLine textLine, GameTextType textType);
         // Whether the client needs to use the return value from ProcessText
-        bool MakesChanges { get; } 
+        bool MakesChanges { get; }
     }
 }

--- a/Editor/AGS.Editor/TextProcessing/SpeechLineProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/SpeechLineProcessor.cs
@@ -35,8 +35,11 @@ namespace AGS.Editor
             }
         }
 
-        protected override string CreateSpeechLine(int speakingCharacter, string text, GameTextType textType)
+        protected override string CreateSpeechLine(GameTextLine textLine, GameTextType textType)
         {
+            var speakingCharacter = textLine.CharacterID;
+            var text = textLine.Text;
+
             if ((speakingCharacter == Character.NARRATOR_CHARACTER_ID) && (!_includeNarrator))
             {
                 return text;

--- a/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
+++ b/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
@@ -55,7 +55,7 @@ namespace AGS.Editor
                 {
                     if (option.Say)
                     {
-                        option.Text = processor.ProcessText(new GameTextLine(game.PlayerCharacter.ID, option.Text), GameTextType.DialogOption);
+                        option.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(game.PlayerCharacter.ID, option.Text), GameTextType.DialogOption);
                     }
                 }
 
@@ -69,7 +69,7 @@ namespace AGS.Editor
 
 			for (int i = 0; i < game.GlobalMessages.Length; i++)
 			{
-				game.GlobalMessages[i] = processor.ProcessText(new GameTextLine(Character.NARRATOR_CHARACTER_ID, game.GlobalMessages[i]), GameTextType.Message);
+				game.GlobalMessages[i] = processor.ProcessText(GameTextLine.MakeSpeechLine(Character.NARRATOR_CHARACTER_ID, game.GlobalMessages[i]), GameTextType.Message);
 			}
 
             if (_errors.HasErrors)

--- a/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
+++ b/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
@@ -55,7 +55,7 @@ namespace AGS.Editor
                 {
                     if (option.Say)
                     {
-                        option.Text = processor.ProcessText(option.Text, GameTextType.DialogOption, game.PlayerCharacter.ID);
+                        option.Text = processor.ProcessText(new GameTextLine(game.PlayerCharacter.ID, option.Text), GameTextType.DialogOption);
                     }
                 }
 
@@ -69,7 +69,7 @@ namespace AGS.Editor
 
 			for (int i = 0; i < game.GlobalMessages.Length; i++)
 			{
-				game.GlobalMessages[i] = processor.ProcessText(game.GlobalMessages[i], GameTextType.Message, Character.NARRATOR_CHARACTER_ID);
+				game.GlobalMessages[i] = processor.ProcessText(new GameTextLine(Character.NARRATOR_CHARACTER_ID, game.GlobalMessages[i]), GameTextType.Message);
 			}
 
             if (_errors.HasErrors)

--- a/Editor/AGS.Editor/TextProcessing/TextImportProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/TextImportProcessor.cs
@@ -24,8 +24,9 @@ namespace AGS.Editor
             return true;
         }
 
-        protected override string CreateSpeechLine(int speakingCharacter, string text, GameTextType textType)
+        protected override string CreateSpeechLine(GameTextLine textLine, GameTextType textType)
         {
+            var text = textLine.Text;
             if ((_translationToUse.ContainsKey(text)) &&
                 (_translationToUse[text].Length > 0))
             {

--- a/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
+++ b/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
@@ -11,25 +11,27 @@ namespace AGS.Editor
         public static void ProcessAllGameText(IGameTextProcessor processor, Game game, CompileMessages errors)
         {
             // Game info
-            game.Settings.GameName = processor.ProcessText(game.Settings.GameName, GameTextType.ItemDescription);
-            game.Settings.Description = processor.ProcessText(game.Settings.Description, GameTextType.ItemDescription);
-            game.Settings.DeveloperName = processor.ProcessText(game.Settings.DeveloperName, GameTextType.ItemDescription);
-            game.Settings.DeveloperURL = processor.ProcessText(game.Settings.DeveloperURL, GameTextType.ItemDescription);
-            game.Settings.Genre = processor.ProcessText(game.Settings.Genre, GameTextType.ItemDescription);
+            game.Settings.GameName = processor.ProcessText(game.Settings.GameName, "Game info", GameTextType.ItemDescription);
+            game.Settings.Description = processor.ProcessText(game.Settings.Description, "Game info", GameTextType.ItemDescription);
+            game.Settings.DeveloperName = processor.ProcessText(game.Settings.DeveloperName, "Game info", GameTextType.ItemDescription);
+            game.Settings.DeveloperURL = processor.ProcessText(game.Settings.DeveloperURL, "Game info", GameTextType.ItemDescription);
+            game.Settings.Genre = processor.ProcessText(game.Settings.Genre, "Game info", GameTextType.ItemDescription);
 
             foreach (Dialog dialog in game.RootDialogFolder.AllItemsFlat)
             {
+                string context = $"Dialog{dialog.ID}";
+                string contextComment = dialog.Name;
                 foreach (DialogOption option in dialog.Options)
                 {
-                    option.Text = processor.ProcessText(option.Text, GameTextType.DialogOption, game.PlayerCharacter.ID);
+                    option.Text = processor.ProcessText(new GameTextLine(game.PlayerCharacter.ID, option.Text, context, contextComment), GameTextType.DialogOption);
                 }
 
-                dialog.Script = processor.ProcessText(dialog.Script, GameTextType.DialogScript);
+                dialog.Script = processor.ProcessText(dialog.Script, context, GameTextType.DialogScript);
             }
 
             foreach (ScriptAndHeader script in game.RootScriptFolder.AllItemsFlat)
             {                                
-                string newScript = processor.ProcessText(script.Script.Text, GameTextType.Script);
+                string newScript = processor.ProcessText(script.Script.Text, script.Script.FileName, GameTextType.Script);
                 if (newScript != script.Script.Text)
                 {
                     // Only cause it to flag Modified if we changed it
@@ -46,14 +48,14 @@ namespace AGS.Editor
                     GUILabel label = control as GUILabel;
                     if (label != null)
                     {
-                        label.Text = processor.ProcessText(label.Text, GameTextType.ItemDescription);
+                        label.Text = processor.ProcessText(label.Text, "GUI", GameTextType.ItemDescription);
                     }
                     else
                     {
                         GUIButton button = control as GUIButton;
                         if (button != null)
                         {
-                            button.Text = processor.ProcessText(button.Text, GameTextType.ItemDescription);
+                            button.Text = processor.ProcessText(button.Text, "GUI", GameTextType.ItemDescription);
                         }
                     }
                 }
@@ -61,19 +63,19 @@ namespace AGS.Editor
 
             foreach (Character character in game.RootCharacterFolder.AllItemsFlat)
             {
-                character.RealName = processor.ProcessText(character.RealName, GameTextType.ItemDescription);
-                ProcessProperties(processor, game.PropertySchema, character.Properties, errors);
+                character.RealName = processor.ProcessText(character.RealName, "Characters", GameTextType.ItemDescription);
+                ProcessProperties(processor, game.PropertySchema, character.Properties, "Characters", errors);
             }
 
             foreach (InventoryItem item in game.RootInventoryItemFolder.AllItemsFlat)
             {
-                item.Description = processor.ProcessText(item.Description, GameTextType.ItemDescription);
-                ProcessProperties(processor, game.PropertySchema, item.Properties, errors);
+                item.Description = processor.ProcessText(item.Description, "Inventory items", GameTextType.ItemDescription);
+                ProcessProperties(processor, game.PropertySchema, item.Properties, "Inventory items", errors);
             }
 
 			for (int i = 0; i < game.GlobalMessages.Length; i++)
 			{
-				game.GlobalMessages[i] = processor.ProcessText(game.GlobalMessages[i], GameTextType.Message);
+				game.GlobalMessages[i] = processor.ProcessText(game.GlobalMessages[i], "Global messages", GameTextType.Message);
 			}
 
             Factory.AGSEditor.RunProcessAllGameTextsEvent(processor, errors);
@@ -85,12 +87,18 @@ namespace AGS.Editor
             foreach (var def in schema.PropertyDefinitions.Where(
                 n => (n.Type == CustomPropertyType.Text) && n.Translated))
             {
-                def.DefaultValue = processor.ProcessText(def.DefaultValue, GameTextType.ItemDescription);
+                def.DefaultValue = processor.ProcessText(def.DefaultValue, "Custom properties", GameTextType.ItemDescription);
             }
         }
 
         public static void ProcessProperties(IGameTextProcessor processor, CustomPropertySchema schema,
-            CustomProperties props, CompileMessages errors)
+            CustomProperties props, string context, CompileMessages errors)
+        {
+            ProcessProperties(processor, schema, props, context, string.Empty, errors);
+        }
+
+        public static void ProcessProperties(IGameTextProcessor processor, CustomPropertySchema schema,
+            CustomProperties props, string context, string contextComment, CompileMessages errors)
         {
             foreach (var def in schema.PropertyDefinitions.Where(
                 n => (n.Type == CustomPropertyType.Text) && n.Translated))
@@ -98,7 +106,7 @@ namespace AGS.Editor
                 CustomProperty prop;
                 if (props.PropertyValues.TryGetValue(def.Name, out prop))
                 {
-                    prop.Value = processor.ProcessText(prop.Value, GameTextType.ItemDescription);
+                    prop.Value = processor.ProcessText(prop.Value, context, contextComment, GameTextType.ItemDescription);
                 }
             }
         }

--- a/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
+++ b/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
@@ -19,18 +19,17 @@ namespace AGS.Editor
 
             foreach (Dialog dialog in game.RootDialogFolder.AllItemsFlat)
             {
-                string context = $"Dialog{dialog.ID}";
-                string contextComment = dialog.Name;
+                string context = dialog.Name;
                 foreach (DialogOption option in dialog.Options)
                 {
-                    option.Text = processor.ProcessText(new GameTextLine(game.PlayerCharacter.ID, option.Text, context, contextComment), GameTextType.DialogOption);
+                    option.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(game.PlayerCharacter.ID, option.Text, context), GameTextType.DialogOption);
                 }
 
                 dialog.Script = processor.ProcessText(dialog.Script, context, GameTextType.DialogScript);
             }
 
             foreach (ScriptAndHeader script in game.RootScriptFolder.AllItemsFlat)
-            {                                
+            {
                 string newScript = processor.ProcessText(script.Script.Text, script.Script.FileName, GameTextType.Script);
                 if (newScript != script.Script.Text)
                 {
@@ -78,6 +77,20 @@ namespace AGS.Editor
 				game.GlobalMessages[i] = processor.ProcessText(game.GlobalMessages[i], "Global messages", GameTextType.Message);
 			}
 
+            if (game.Settings.TranslateTextParser)
+            {
+                var parserWordLists = ConstructParserWordsList(game.TextParser);
+                // What we do here: because parser dictionary entry may match some
+                // generic game text (e.g. if it's a item's name), the cheap and dumb solution
+                // that we use is that we prefix the source line with a comma
+                // (this works as it's a comma-separated list).
+                foreach (var wordKey in parserWordLists.Keys)
+                {
+                    string word = $",{parserWordLists[wordKey]}";
+                    processor.ProcessText(GameTextLine.MakeParserWord(wordKey, word, "Game Text Parser"), GameTextType.TextParserWord);
+                }
+            }
+
             Factory.AGSEditor.RunProcessAllGameTextsEvent(processor, errors);
         }
 
@@ -109,6 +122,31 @@ namespace AGS.Editor
                     prop.Value = processor.ProcessText(prop.Value, context, contextComment, GameTextType.ItemDescription);
                 }
             }
+        }
+
+        private static Dictionary<int, string> ConstructParserWordsList(TextParser parser)
+        {
+            var wordsPerID = new Dictionary<int, List<string>>();
+            foreach (var word in parser.Words)
+            {
+                if (!wordsPerID.ContainsKey(word.WordGroup))
+                    wordsPerID[word.WordGroup] = new List<string>();
+                wordsPerID[word.WordGroup].Add(word.Word);
+            }
+
+            var wordLists = new Dictionary<int, string>();
+            foreach (var wordList in wordsPerID)
+            {
+                StringBuilder sb = new StringBuilder();
+                foreach (var word in wordList.Value)
+                {
+                    if (sb.Length > 0)
+                        sb.Append(',');
+                    sb.Append(word);
+                }
+                wordLists[wordList.Key] = sb.ToString();
+            }
+            return wordLists;
         }
     }
 }

--- a/Editor/AGS.Editor/TextProcessing/TranslationGenerator.cs
+++ b/Editor/AGS.Editor/TextProcessing/TranslationGenerator.cs
@@ -8,9 +8,9 @@ namespace AGS.Editor
 {
     public class TranslationGenerator
     {
-        private ICollection<string> _linesForTranslation;
+        private ICollection<GameTextLine> _linesForTranslation;
 
-        public ICollection<string> LinesForTranslation
+        public ICollection<GameTextLine> LinesForTranslation
         {
             get { return _linesForTranslation; }
         }

--- a/Editor/AGS.Editor/TextProcessing/TranslationSourceProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/TranslationSourceProcessor.cs
@@ -7,7 +7,7 @@ namespace AGS.Editor
 {
     public class TranslationSourceProcessor : GameSpeechProcessor
     {
-        private Dictionary<string, string> _linesProcessed;
+        private Dictionary<string, GameTextLine> _linesProcessed;
         private string _includeScriptPrefix;
         private string _excludeScriptPrefix;
         private string[] _excludeFunctionCalls;
@@ -24,12 +24,12 @@ namespace AGS.Editor
             // Only parse function calls if there's a need to exclude any
             LookupForFunctionCalls = _excludeFunctionCalls.Length > 0;
 
-            _linesProcessed = new Dictionary<string, string>();
+            _linesProcessed = new Dictionary<string, GameTextLine>();
         }
 
-        public ICollection<string> LinesForTranslation
+        public ICollection<GameTextLine> LinesForTranslation
         {
-            get { return _linesProcessed.Keys; }
+            get { return _linesProcessed.Values; }
         }
 
         protected override bool ParseFunctionCall(string scriptCodeExtract, out int characterID)
@@ -48,8 +48,9 @@ namespace AGS.Editor
             return true;
         }
 
-        protected override string CreateSpeechLine(int speakingCharacter, string text, GameTextType textType)
+        protected override string CreateSpeechLine(GameTextLine textLine, GameTextType textType)
         {
+            var text = textLine.Text;
             // ignore blank strings and any that start with // (since they
             // conflict with comments in the translation file)
             if (!string.IsNullOrWhiteSpace(text) && (!text.StartsWith("//")))
@@ -68,7 +69,7 @@ namespace AGS.Editor
                 {
                     if (!_linesProcessed.ContainsKey(text))
                     {
-                        _linesProcessed.Add(text, text);
+                        _linesProcessed.Add(text, textLine);
                     }
                 }
             }

--- a/Editor/AGS.Editor/TextProcessing/VoiceActorScriptProcessor.cs
+++ b/Editor/AGS.Editor/TextProcessing/VoiceActorScriptProcessor.cs
@@ -28,9 +28,12 @@ namespace AGS.Editor
 			_linesInOrder = new List<GameTextLine>();
 		}
 
-		protected override string CreateSpeechLine(int speakingCharacter, string text, GameTextType textType)
+		protected override string CreateSpeechLine(GameTextLine textLine, GameTextType textType)
 		{
-			if (text.TrimStart().StartsWith("&"))
+			var speakingCharacter = textLine.CharacterID;
+			var text = textLine.Text;
+
+            if (text.TrimStart().StartsWith("&"))
 			{
 				if (speakingCharacter == -1)
 				{
@@ -46,10 +49,9 @@ namespace AGS.Editor
 					_linesByCharacter[speakingCharacter].Add(text, text);
 				}
 
-				_linesInOrder.Add(new GameTextLine(speakingCharacter, text));
+				_linesInOrder.Add(textLine);
 			}
 			return text;
 		}
-
 	}
 }

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -253,6 +253,7 @@
     <Compile Include="ScriptsAndHeaders.cs" />
     <Compile Include="Translation.cs" />
     <Compile Include="TranslationEntryOptions.cs" />
+    <Compile Include="TranslationSection.cs" />
     <Compile Include="TypesHelper.cs" />
     <Compile Include="UnloadedRoom.cs" />
     <Compile Include="TextParser.cs" />

--- a/Editor/AGS.Types/Enums/GameTextType.cs
+++ b/Editor/AGS.Types/Enums/GameTextType.cs
@@ -11,6 +11,7 @@ namespace AGS.Types
         DialogScript,
         Message,
         DialogOption,
-        ItemDescription
+        ItemDescription,
+        TextParserWord
     }
 }

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using static System.Collections.Specialized.BitVector32;
 
 namespace AGS.Types
 {
@@ -24,6 +25,7 @@ namespace AGS.Types
         private const string TAG_DIRECTION_RIGHT = "RIGHT";
         private const string TAG_ON = "ON";
         private const string TAG_OFF = "OFF";
+        private const string ANNOTATE_SECTION = "SECTION";
         private const string ANNOTATE_OBSOLETE = "OBSOLETE";
         private const string ANNOTATE_PARSERWORD = "PARSERWORD";
 
@@ -38,8 +40,9 @@ namespace AGS.Types
         private Encoding _encoding;
         private string _language;
         private Dictionary<int, Font> _fontOverrides = new Dictionary<int, Font>();
-        private Dictionary<string, string> _translatedLines;
-        private Dictionary<string, TranslationEntryOptions> _entryOptions;
+        private Dictionary<string, string> _translatedLines = new Dictionary<string, string>();
+        private Dictionary<string, TranslationEntryOptions> _entryOptions = new Dictionary<string, TranslationEntryOptions>();
+        private List<TranslationSection> _translationSections = new List<TranslationSection>();
 
         public Translation(string name)
         {
@@ -78,6 +81,12 @@ namespace AGS.Types
         {
             get { return _entryOptions; }
             set { _entryOptions = value; }
+        }
+
+        public List<TranslationSection> TranslationSections
+        {
+            get { return _translationSections; }
+            set { _translationSections = value; }
         }
 
         public int? NormalFont
@@ -206,16 +215,25 @@ namespace AGS.Types
                 sw.WriteLine("// ** NOT CHANGE THE EXISTING TEXT.");
 
                 TranslationEntryOptions entryOptions = null;
-                foreach (string key in _translatedLines.Keys)
+                foreach (var section in _translationSections)
                 {
-                    if (_entryOptions.TryGetValue(key, out entryOptions))
+                    sw.WriteLine("//-----------------------------------------------------------------------------");
+                    if (string.IsNullOrWhiteSpace(section.Comment))
+                        sw.WriteLine($"//$SECTION = {section.Name}");
+                    else
+                        sw.WriteLine($"//$SECTION = {section.Name}; {section.Comment}");
+                    sw.WriteLine("//-----------------------------------------------------------------------------");
+                    foreach (string key in section.TranslationEntryKeys)
                     {
-                        foreach (var a in entryOptions.Metadata)
-                            sw.WriteLine($"//${a}");
-                    }
+                        if (_entryOptions.TryGetValue(key, out entryOptions))
+                        {
+                            foreach (var a in entryOptions.Metadata)
+                                sw.WriteLine($"//${a}");
+                        }
 
-                    sw.WriteLine(key);
-                    sw.WriteLine(_translatedLines[key]);
+                        sw.WriteLine(key);
+                        sw.WriteLine(_translatedLines[key]);
+                    }
                 }
             }
             this.Modified = false;
@@ -258,7 +276,11 @@ namespace AGS.Types
             _fontOverrides = new Dictionary<int, Font>();
             _translatedLines = new Dictionary<string, string>();
             _entryOptions = new Dictionary<string, TranslationEntryOptions>();
+            _translationSections = new List<TranslationSection>();
             List<string> annotateNextLine = new List<string>();
+            var sectionsByKey = new Dictionary<string, TranslationSection>();
+            string currentSectionKey = string.Empty;
+            string currentSectionComment = string.Empty;
             string old_encoding = _encodingHint;
 
             using (StreamReader sr = new StreamReader(FileName, _encoding))
@@ -280,7 +302,18 @@ namespace AGS.Types
                         }
                         else if (line.Length > 2 && line[2] == '$')
                         {
-                            annotateNextLine.Add(line.Substring(3));
+                            string annotation = line.Substring(3);
+                            var keyValue = ParseKeyValue(annotation);
+                            if (keyValue.Item1 == ANNOTATE_SECTION)
+                            {
+                                int splitAt = keyValue.Item2.IndexOf(';');
+                                currentSectionKey = keyValue.Item2.Substring(0, splitAt >= 0 ? splitAt : keyValue.Item2.Length).Trim();
+                                currentSectionComment = splitAt >= 0 ? keyValue.Item2.Substring(splitAt + 1).Trim() : string.Empty;
+                            }
+                            else
+                            {
+                                annotateNextLine.Add(annotation);
+                            }
                         }
                         continue;
                     }
@@ -300,6 +333,13 @@ namespace AGS.Types
                             _entryOptions[originalText] = CreateEntryOptions(annotateNextLine);
                             annotateNextLine.Clear();
                         }
+                        if (!sectionsByKey.ContainsKey(currentSectionKey))
+                        {
+                            var section = new TranslationSection(currentSectionKey, currentSectionComment);
+                            sectionsByKey[currentSectionKey] = section;
+                            _translationSections.Add(section);
+                        }
+                        sectionsByKey[currentSectionKey].TranslationEntryKeys.Add(originalText);
 					}
                 }
             }

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -42,7 +42,7 @@ namespace AGS.Types
         private Dictionary<int, Font> _fontOverrides = new Dictionary<int, Font>();
         private Dictionary<string, string> _translatedLines = new Dictionary<string, string>();
         private Dictionary<string, TranslationEntryOptions> _entryOptions = new Dictionary<string, TranslationEntryOptions>();
-        private List<TranslationSection> _translationSections = new List<TranslationSection>();
+        private Dictionary<string, TranslationSection> _translationSections = new Dictionary<string, TranslationSection>();
 
         public Translation(string name)
         {
@@ -71,19 +71,32 @@ namespace AGS.Types
             get { return _name + TRANSLATION_COMPILED_FILE_EXTENSION; }
         }
 
+        /// <summary>
+        /// A map of translated lines, where the text in base game language is a key,
+        /// and the text in another language is a value.
+        /// </summary>
         public Dictionary<string, string> TranslatedLines
         {
             get { return _translatedLines; }
             set { _translatedLines = value; }
         }
 
+        /// <summary>
+        /// A map of options per particular lines of text.
+        /// </summary>
         public Dictionary<string, TranslationEntryOptions> TranslatedEntryOptions
         {
             get { return _entryOptions; }
             set { _entryOptions = value; }
         }
 
-        public List<TranslationSection> TranslationSections
+        /// <summary>
+        /// A map of sections per particular lines of text.
+        /// When translation source file is generated, the lines will be split up
+        /// depending on this map. If line does not have a corresponding section,
+        /// such line will be written as a part of the generic no-name section.
+        /// </summary>
+        public Dictionary<string, TranslationSection> TranslationSections
         {
             get { return _translationSections; }
             set { _translationSections = value; }
@@ -183,6 +196,37 @@ namespace AGS.Types
 
         public void SaveData()
         {
+            //
+            // Organize translated lines by sections
+            //
+            var sectionLists = new List<Tuple<TranslationSection, List<string>>>();
+            var sectionIndexByKey = new Dictionary<string, int>();
+            var nonameSection = new TranslationSection(string.Empty);
+            sectionLists.Add(new Tuple<TranslationSection, List<string>>(nonameSection, new List<string>()));
+            sectionIndexByKey.Add(string.Empty, 0);
+            foreach (var line in _translatedLines)
+            {
+                List<string> sectionList = null;
+                TranslationSection section = null;
+                _translationSections.TryGetValue(line.Key, out section);
+                section = (section != null && !string.IsNullOrEmpty(section.Name)) ? section : nonameSection;
+                int sectionIndex = 0;
+                if (sectionIndexByKey.TryGetValue(section.Name, out sectionIndex))
+                {
+                    sectionList = sectionLists[sectionIndex].Item2;
+                }
+                else
+                {
+                    sectionList = new List<string>();
+                    sectionLists.Add(new Tuple<TranslationSection, List<string>>(section, sectionList));
+                    sectionIndexByKey.Add(section.Name, sectionLists.Count - 1);
+                }
+                sectionList.Add(line.Key);
+            }
+
+            //
+            // Write translation source file
+            //
             using (StreamWriter sw = new StreamWriter(FileName, false, _encoding))
             {
                 sw.WriteLine("// AGS TRANSLATION SOURCE FILE");
@@ -215,15 +259,20 @@ namespace AGS.Types
                 sw.WriteLine("// ** NOT CHANGE THE EXISTING TEXT.");
 
                 TranslationEntryOptions entryOptions = null;
-                foreach (var section in _translationSections)
+                foreach (var sectionList in sectionLists)
                 {
+                    var section = sectionList.Item1;
+                    var lines = sectionList.Item2;
+                    if (lines.Count == 0)
+                        continue;
+
                     sw.WriteLine("//-----------------------------------------------------------------------------");
                     if (string.IsNullOrWhiteSpace(section.Comment))
                         sw.WriteLine($"//$SECTION = {section.Name}");
                     else
                         sw.WriteLine($"//$SECTION = {section.Name}; {section.Comment}");
                     sw.WriteLine("//-----------------------------------------------------------------------------");
-                    foreach (string key in section.TranslationEntryKeys)
+                    foreach (string key in lines)
                     {
                         if (_entryOptions.TryGetValue(key, out entryOptions))
                         {
@@ -236,7 +285,7 @@ namespace AGS.Types
                     }
                 }
             }
-            this.Modified = false;
+            Modified = false;
         }
 
         /// <summary>
@@ -276,7 +325,7 @@ namespace AGS.Types
             _fontOverrides = new Dictionary<int, Font>();
             _translatedLines = new Dictionary<string, string>();
             _entryOptions = new Dictionary<string, TranslationEntryOptions>();
-            _translationSections = new List<TranslationSection>();
+            _translationSections = new Dictionary<string, TranslationSection>();
             List<string> annotateNextLine = new List<string>();
             var sectionsByKey = new Dictionary<string, TranslationSection>();
             string currentSectionKey = string.Empty;
@@ -333,13 +382,14 @@ namespace AGS.Types
                             _entryOptions[originalText] = CreateEntryOptions(annotateNextLine);
                             annotateNextLine.Clear();
                         }
-                        if (!sectionsByKey.ContainsKey(currentSectionKey))
+                        TranslationSection section = null;
+                        if (!sectionsByKey.TryGetValue(currentSectionKey, out section))
                         {
-                            var section = new TranslationSection(currentSectionKey, currentSectionComment);
+                            section = new TranslationSection(currentSectionKey, currentSectionComment);
                             sectionsByKey[currentSectionKey] = section;
-                            _translationSections.Add(section);
+
                         }
-                        sectionsByKey[currentSectionKey].TranslationEntryKeys.Add(originalText);
+                        _translationSections[originalText] = section;
 					}
                 }
             }

--- a/Editor/AGS.Types/TranslationSection.cs
+++ b/Editor/AGS.Types/TranslationSection.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AGS.Types
+{
+    public class TranslationSection
+    {
+        public TranslationSection(string name)
+        {
+            Name = name;
+            TranslationEntryKeys = new HashSet<string>();
+        }
+
+        public TranslationSection(string name, string comment)
+        {
+            Name = name;
+            Comment = comment;
+            TranslationEntryKeys = new HashSet<string>();
+        }
+
+        public string Name { get; set; }
+        public string Comment { get; set; }
+        public HashSet<string> TranslationEntryKeys { get; set; }
+    }
+}

--- a/Editor/AGS.Types/TranslationSection.cs
+++ b/Editor/AGS.Types/TranslationSection.cs
@@ -8,18 +8,15 @@ namespace AGS.Types
         public TranslationSection(string name)
         {
             Name = name;
-            TranslationEntryKeys = new HashSet<string>();
         }
 
         public TranslationSection(string name, string comment)
         {
             Name = name;
             Comment = comment;
-            TranslationEntryKeys = new HashSet<string>();
         }
 
         public string Name { get; set; }
         public string Comment { get; set; }
-        public HashSet<string> TranslationEntryKeys { get; set; }
     }
 }


### PR DESCRIPTION
Resolves #2413

This adds section markers into TRS, thus dividing entries into groups by context, script, room, etc. The addition is purely meant to help TRS reading and editing, and has no impact on translation compilation, or on how it works at runtime.

The section markers are not ordinary comments, I had to make them special "tags" with "$SECTION" keyword. This is necessary for reading these sections back from TRS, because when Translation gets updated, it first parses TRS and reads its contents, and then merges only the new lines in.

Section's marker syntax is
```
//$SECTION = NAME; COMMENT
```
where NAME is a unique section identifier, and comment is any human-readable string. This separation is made to allow have descriptions, such as room names, which may be changed along with the development, without changing the section id.

Internally, the section names are gathered along with the text lines by IGameTextProcessor. For the global script texts the section name is the script filename. For rooms and their scripts it's "RoomN" and room's name is a comment. For dialogs - "DialogN" and dialog's script name is a comment.