### PR TITLE
Tool: CMake uses allegro library

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -91,7 +91,8 @@ endif()
 
 target_include_directories(libtools PUBLIC ../libsrc/allegro/include)
 set(TOOLS_MINIMAL_ALLEGRO_SOURCES
-        ../libsrc/allegro/src/color.c)
+        ../libsrc/allegro/src/color.c
+        data/minallegro_inline.c)
 target_compile_definitions(libtools PRIVATE ALLEGRO_STATICLINK)
 
 target_sources(libtools

--- a/Tools/data/minallegro_inline.c
+++ b/Tools/data/minallegro_inline.c
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+
+
+// similar to own allegro's inline.c
+// but minimal so it doesn't pull all allegro's inline functions
+// the idea here is to do minimal inline when building without optimizations (e.g. Debug)
+
+#define AL_INLINE(type, name, args, code)    type name args code
+
+#include "allegro/color.h"
+
+// unless we define ALLEGRO_DOS, color.inl needs a symbol for set_color from gfx.c
+// we don't use set_color at all in spritepak which is the reason we are writing this.
+// we fix the linker error with symbol not found for _set_color in libtools by having a dummy implementation
+
+void set_color(const int idx, AL_CONST RGB * p)
+{
+    // this should neve be called
+    (void) idx;
+    (void) p;
+}


### PR DESCRIPTION
The allegro library is not too big and it will go away when optimizing.

Without this fix I get a ton of undefined symbol erros in macOS  building spritepak, like:

```
: && /usr/bin/c++ -g -arch arm64 -mmacosx-version-min=10.9 -Wl,-search_paths_first -Wl,-headerpad_max_install_names Tools/CMakeFiles/spritepak.dir/spritepak/main.cpp.o Tools/CMakeFiles/spritepak.dir/spritepak/commands.cpp.o -o Tools/spritepak Tools/liblibtools.a libsrc/miniz/libminiz.a libsrc/tinyxml2/libtinyxml2.a && :
Undefined symbols for architecture arm64:
"_geta32", referenced from:
_geta_depth in liblibtools.a[38](color.c.o)
"_getb15", referenced from:
_getb_depth in liblibtools.a[38](color.c.o)
"_getb16", referenced from:
_getb_depth in liblibtools.a[38](color.c.o)
"_getb24", referenced from:
_getb_depth in liblibtools.a[38](color.c.o)
"_getb32", referenced from:
_getb_depth in liblibtools.a[38](color.c.o)
"_getb8", referenced from:
_getb_depth in liblibtools.a[38](color.c.o)
"_getg15", referenced from:
_getg_depth in liblibtools.a[38](color.c.o)
"_getg16", referenced from:
_getg_depth in liblibtools.a[38](color.c.o)
"_getg24", referenced from:
_getg_depth in liblibtools.a[38](color.c.o)
"_getg32", referenced from:
_getg_depth in liblibtools.a[38](color.c.o)
"_getg8", referenced from:
_getg_depth in liblibtools.a[38](color.c.o)
"_getr15", referenced from:
_getr_depth in liblibtools.a[38](color.c.o)
"_getr16", referenced from:
_getr_depth in liblibtools.a[38](color.c.o)
"_getr24", referenced from:
_getr_depth in liblibtools.a[38](color.c.o)
"_getr32", referenced from:
_getr_depth in liblibtools.a[38](color.c.o)
"_getr8", referenced from:
_getr_depth in liblibtools.a[38](color.c.o)
"_makeacol32", referenced from:
_makeacol_depth in liblibtools.a[38](color.c.o)
"_makecol15", referenced from:
_makecol_depth in liblibtools.a[38](color.c.o)
_makeacol_depth in liblibtools.a[38](color.c.o)
"_makecol16", referenced from:
_makecol_depth in liblibtools.a[38](color.c.o)
_makeacol_depth in liblibtools.a[38](color.c.o)
"_makecol24", referenced from:
_makecol_depth in liblibtools.a[38](color.c.o)
_makeacol_depth in liblibtools.a[38](color.c.o)
"_makecol32", referenced from:
_makecol_depth in liblibtools.a[38](color.c.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

I tried many other alternatives, but most of the time I get something working in my macOS computer it apparently breaks some other platform. This way is safe though, and actually works.

