### PR TITLE
Configurable runtime behavior switches

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -19,6 +19,7 @@
 #include "ac/common_defines.h" // constants
 #include "ac/game_version.h"
 #include "util/bbop.h"
+#include "util/string.h"
 
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -18,8 +18,6 @@
 #ifndef __AGS_CN_AC__GAMEVERSION_H
 #define __AGS_CN_AC__GAMEVERSION_H
 
-#include "util/version.h"
-
 /*
 
 Game data versions and changes:
@@ -200,8 +198,5 @@ enum GameDataVersion
     kGameVersion_363_10         = 3060310,
     kGameVersion_Current        = kGameVersion_363_10
 };
-
-// Data format version of the loaded game
-extern GameDataVersion loaded_game_file_version;
 
 #endif // __AGS_CN_AC__GAMEVERSION_H

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -175,11 +175,11 @@ void GameSetupStruct::WriteMouseCursors(Stream *out)
 //-----------------------------------------------------------------------------
 // Reading Part 2
 
-void GameSetupStruct::read_characters(Common::Stream *in)
+void GameSetupStruct::read_characters(Common::Stream *in, GameDataVersion data_ver)
 {
     chars.resize(numcharacters);
     chars2.resize(numcharacters);
-    ReadCharacters(in);
+    ReadCharacters(in, data_ver);
 }
 
 void GameSetupStruct::read_lipsync(Common::Stream *in, GameDataVersion data_ver)
@@ -208,11 +208,11 @@ void GameSetupStruct::read_messages(Common::Stream *in,
     }
 }
 
-void GameSetupStruct::ReadCharacters(Stream *in)
+void GameSetupStruct::ReadCharacters(Stream *in, GameDataVersion data_ver)
 {
     for (int i = 0; i < numcharacters; ++i)
     {
-        chars[i].ReadFromFile(chars2[i], in, loaded_game_file_version);
+        chars[i].ReadFromFile(chars2[i], in, data_ver);
     }
 }
 

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -52,9 +52,6 @@ struct GameSetupStruct : public GameSetupStructBase
     UInteraction intrInv[MAX_INV];
     std::vector<UInteractionEvents> charScripts;
     std::vector<UInteractionEvents> invScripts;
-    // TODO: use this everywhere in the engine instead of loaded_game_file_version!
-    GameDataVersion   filever = kGameVersion_Undefined;
-    Common::String    compiled_with; // version of AGS this data was created by
     char              lipSyncFrameLetters[MAXLIPSYNCFRAMES][50] = {{ 0 }};
     Common::PropertySchema propSchema;
     std::vector<Common::StringIMap> charProps;
@@ -105,7 +102,7 @@ struct GameSetupStruct : public GameSetupStructBase
     // Get game's native color depth (bits per pixel)
     inline int GetColorDepth() const { return color_depth * 8; }
     // Tells whether game respects alpha channel when doing primitive drawing operations
-    inline bool HasAlphaInDrawingOps() const { return filever > kGameVersion_272; }
+    inline bool HasAlphaInDrawingOps() const { return gamedataver > kGameVersion_272; }
 
 
     GameSetupStruct();
@@ -140,11 +137,11 @@ struct GameSetupStruct : public GameSetupStructBase
     void WriteMouseCursors(Common::Stream *out);
     //------------------------------
     // Part 2
-    void read_characters(Common::Stream *in);
+    void read_characters(Common::Stream *in, GameDataVersion data_ver);
     void read_lipsync(Common::Stream *in, GameDataVersion data_ver);
     void read_messages(Common::Stream *in, const std::array<int, MAXGLOBALMES> &load_messages, GameDataVersion data_ver);
 
-    void ReadCharacters(Common::Stream *in);
+    void ReadCharacters(Common::Stream *in, GameDataVersion data_ver);
     void WriteCharacters(Common::Stream *out);
     //------------------------------
     // Part 3

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -40,6 +40,8 @@ struct GameSetupStructBase
     static const int  NUM_INTS_RESERVED = 16;
 
     Common::String    gamename;
+    GameDataVersion   gamedataver = kGameVersion_Undefined;
+    Common::String    compiled_with; // version of AGS this data was created by
     int               options[MAX_OPTIONS] = { 0 };
     uint8_t           paluses[256] = { 0 };
     RGB               defpal[256] = {};
@@ -191,7 +193,7 @@ struct GameSetupStructBase
     // Test if the game is built around old audio system
     inline bool IsLegacyAudioSystem() const
     {
-        return loaded_game_file_version < kGameVersion_320;
+        return gamedataver < kGameVersion_320;
     }
 
     // Returns the expected filename of a digital audio package

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -82,6 +82,18 @@ void init_font_renderer(AssetManager *amgr)
     wfnRenderer.reset(new WFNFontRenderer(amgr));
 }
 
+void set_gamedata_version(GameDataVersion data_ver)
+{
+    if (ttfRenderer)
+    {
+        // Games made in AGS version range [3.2.0, 3.4.1) with TTF anti-aliasing
+        // had a different rule for the loaded font's height
+        // (the reason is uncertain, but this is to emulate old engine's behavior).
+        ttfRenderer->SetLegacyAntiaAliasedFontHeightFixup(
+            (data_ver >= kGameVersion_320) && (data_ver < kGameVersion_341));
+    }
+}
+
 void shutdown_font_renderer()
 {
     set_our_eip(9919);

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 #include "ac/gamestructdefines.h"
+#include "ac/game_version.h"
 #include "data/assetmanager.h"
 #include "gfx/bitmap.h"
 #include "util/string.h"
@@ -32,6 +33,7 @@ struct FontRenderParams;
 struct FontMetrics;
 
 void init_font_renderer(AGS::Common::AssetManager *amgr);
+void set_gamedata_version(GameDataVersion data_ver);
 void shutdown_font_renderer();
 void adjust_y_coordinate_for_text(int* ypos, int font_number);
 IAGSFontRenderer* font_replace_renderer(int font_number, IAGSFontRenderer* renderer);

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -33,6 +33,11 @@ TTFFontRenderer::~TTFFontRenderer()
     alfont_exit();
 }
 
+void TTFFontRenderer::SetLegacyAntiaAliasedFontHeightFixup(bool legacy_aa_height_fixup)
+{
+    _legacyAAHeightFixup = legacy_aa_height_fixup;
+}
+
 void TTFFontRenderer::AdjustYCoordinateForFont(int *ycoord, int /*fontNumber*/)
 {
   // TTF fonts already have space at the top, so try to remove the gap
@@ -85,14 +90,13 @@ bool TTFFontRenderer::IsBitmapFont()
     return false;
 }
 
-static int GetAlfontFlags(int load_mode)
+static int GetAlfontFlags(int load_mode, bool legacy_aa_height_fixup)
 {
     int flags = ALFONT_FLG_FORCE_RESIZE | ALFONT_FLG_SELECT_NOMINAL_SZ;
     // Compatibility: optionally adjust font ascender to the formal font's height;
     // EXCEPTION: not if it's a game made in AGS version range [3.2.0, 3.4.1) with TTF anti-aliasing
     // (the reason is uncertain, but this is to emulate old engine's behavior).
-    const bool aa_special_case = (loaded_game_file_version >= kGameVersion_320) && (loaded_game_file_version < kGameVersion_341);
-    if (((load_mode & FFLG_ASCENDERFIXUP) != 0) && !(ShouldAntiAliasText() && aa_special_case))
+    if (((load_mode & FFLG_ASCENDERFIXUP) != 0) && !(ShouldAntiAliasText() && legacy_aa_height_fixup))
     {
         flags |= ALFONT_FLG_ASCENDER_EQ_HEIGHT;
     }
@@ -163,7 +167,7 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const String 
         fontSize *= f_params.SizeMultiplier;
 
     ALFONT_FONT *alfptr = LoadTTF(use_filename, fontSize,
-        GetAlfontFlags(f_params.LoadMode));
+        GetAlfontFlags(f_params.LoadMode, _legacyAAHeightFixup));
     if (!alfptr)
         return false;
 
@@ -193,13 +197,13 @@ void TTFFontRenderer::GetFontMetrics(int fontNumber, FontMetrics *metrics)
 
 void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
 {
-  if (loaded_game_file_version < kGameVersion_341)
-  {
-    ALFONT_FONT *alfptr = _fontData[fontNumber].AlFont;
-    const FontRenderParams &params = _fontData[fontNumber].Params;
-    int old_height = alfont_get_font_height(alfptr);
-    alfont_set_font_size_ex(alfptr, old_height, GetAlfontFlags(params.LoadMode));
-  }
+    if (_legacyAAHeightFixup)
+    {
+        ALFONT_FONT *alfptr = _fontData[fontNumber].AlFont;
+        const FontRenderParams &params = _fontData[fontNumber].Params;
+        int old_height = alfont_get_font_height(alfptr);
+        alfont_set_font_size_ex(alfptr, old_height, GetAlfontFlags(params.LoadMode, _legacyAAHeightFixup));
+    }
 }
 
 void TTFFontRenderer::GetCharCodeRange(int fontNumber, std::pair<int, int> *char_codes)

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -53,6 +53,8 @@ public:
   TTFFontRenderer(AGS::Common::AssetManager *amgr);
   virtual ~TTFFontRenderer();
 
+  void SetLegacyAntiaAliasedFontHeightFixup(bool legacy_aa_height_fixup);
+
   //
   // Utility functions
   //
@@ -72,6 +74,7 @@ private:
     };
     std::map<int, FontData> _fontData;
     AGS::Common::AssetManager *_amgr = nullptr;
+    bool _legacyAAHeightFixup = false;
 };
 
 #endif // __AC_TTFFONTRENDERER_H

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -182,16 +182,11 @@ static HGameFileError OpenMainGameFileBase(MainGameSource &src)
         for (size_t i = 0; i < count; ++i)
             src.Caps.insert(StrUtil::ReadString(in));
     }
-    // Remember loaded game data version
-    // NOTE: this global variable is embedded in the code too much to get
-    // rid of it too easily; the easy way is to set it whenever the main
-    // game file is opened.
-    loaded_game_file_version = src.DataVersion;
     // Generate data version for certain game versions that did not have dedicated index;
     // rely on CompiledWith field. This lets distinguish some behavior differences.
     Version compiled_version(src.CompiledWith);
     if (compiled_version.AsNumber() == 30501)
-        loaded_game_file_version = kGameVersion_351;
+        src.DataVersion = kGameVersion_351;
     return HGameFileError::None();
 }
 
@@ -1098,7 +1093,7 @@ HError GameDataExtPreloader::ReadBlock(Stream *in, int /*block_id*/, const Strin
 HGameFileError ReadGameData(LoadedGameEntities &ents, std::unique_ptr<Stream> &&s_in, GameDataVersion data_ver, const String &compiled_with)
 {
     GameSetupStruct &game = ents.Game;
-    game.filever = data_ver;
+    game.gamedataver = data_ver;
     game.compiled_with = compiled_with;
     Stream *in = s_in.get(); // for convenience
 
@@ -1150,7 +1145,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, std::unique_ptr<Stream> &&
         in->Seek(count * 0x204);
     }
 
-    game.read_characters(in);
+    game.read_characters(in, data_ver);
     game.read_lipsync(in, data_ver);
     game.read_messages(in, sinfo.HasMessages, data_ver);
 
@@ -1210,6 +1205,8 @@ void PreReadGameData(GameSetupStruct &game, std::unique_ptr<Stream> &&s_in, Game
     GameSetupStruct::SerializeInfo sinfo;
     game.GameSetupStructBase::ReadFromFile(in, data_ver, sinfo);
     game.read_savegame_info(in, data_ver); // here we also read GUID in v3.* games
+    game.gamedataver = data_ver;
+    game.compiled_with = compiled_with;
 
     // Check for particular expansions that might have data necessary
     // for "preload" purposes
@@ -1220,8 +1217,6 @@ void PreReadGameData(GameSetupStruct &game, std::unique_ptr<Stream> &&s_in, Game
     LoadedGameEntities ents(game);
     GameDataExtPreloader reader(ents, data_ver, std::move(s_in));
     reader.Read();
-    game.filever = data_ver;
-    game.compiled_with = compiled_with;
 }
 
 } // namespace Common

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -315,6 +315,12 @@ struct GuiOptions
     bool GreyOutInvWindow = false;
     // Whether to graphically outline GUI controls
     bool OutlineControls = false;
+
+    //
+    // Backwards-compatibility options
+    //-------------------------------------------------------------------------
+    // Apply text direction for GUI controls (except Labels, where it's always applied)
+    bool ApplyTextDirection = true;
 };
 
 class SpriteCache;

--- a/Common/test/common_stubs.cpp
+++ b/Common/test/common_stubs.cpp
@@ -22,6 +22,7 @@
 #include "gui/guilabel.h"
 #include "gui/guilistbox.h"
 #include "gui/guitextbox.h"
+#include "util/version.h"
 
 using namespace AGS::Common;
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1580,7 +1580,7 @@ HAGSError init_game_after_import(const AGS::Common::LoadedGameEntities &ents, Ga
         reload_font(i);
 
     spritesModified = false;
-    thisgame.filever = data_ver;
+    thisgame.gamedataver = data_ver;
     return HAGSError::None();
 }
 
@@ -3650,7 +3650,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 		game->Characters->Add(character);
 
         // Custom properties are only for 2.6.0 and higher
-        if (thisgame.filever >= kGameVersion_260)
+        if (thisgame.gamedataver >= kGameVersion_260)
         {
             ConvertCustomProperties(character->Properties, &thisgame.charProps[i]);
         }

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -584,7 +584,7 @@ static int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int at_x, int at_
 {
     // Left-to-right text direction flag
     const bool ltr_position = (game.options[OPT_RIGHTLEFTWRITE] == 0)
-        || (loaded_game_file_version < kGameVersion_363);
+        || (!play.GetRBSwitches()[kRBO_ApplyDialogOptionTextDirection]);
 
     // Configure positioning settings
     const HorAlignment text_align = play.dialog_options_textalign;
@@ -1232,7 +1232,7 @@ void DialogOptions::Draw()
 
         // Left-to-right text direction flag
         const bool ltr_position = (game.options[OPT_RIGHTLEFTWRITE] == 0)
-            || (loaded_game_file_version < kGameVersion_363);
+            || (!play.GetRBSwitches()[kRBO_ApplyDialogOptionTextDirection]);
 
         parserInput->SetWidth(parserInput->GetWidth() - bullet_wid);
         if (ltr_position)

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -75,10 +75,6 @@ struct OverrideGameConfig
     int   KeyRestoreGame    = eAGSKeyCodeNone;
     // Optional override for the max save slot
     int   MaxSaveSlot       = 0;
-    // Force smooth walking behavior;
-    // this behavior is turned off in the old games by default, because
-    // it may cause random issues with coordinate checks in script.
-    bool  SmoothCharacterWalk = false;
 };
 
 

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -14,6 +14,7 @@
 #ifndef __AC_GAMESETUP_H
 #define __AC_GAMESETUP_H
 
+#include <array>
 #include "ac/game_version.h"
 #include "ac/runtime_defines.h"
 #include "ac/speech.h"
@@ -140,6 +141,10 @@ struct GameConfig
 
     // Accessibility options
     AccessibilityGameConfig Access;
+
+    // Overrides for runtime behavior;
+    // these are primarily meant to allow modern behavior when running old games.
+    std::array<bool, kNum_RBS> BehaviorOverrides = {{ 0 }};
 
     GameConfig() = default;
 };

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -38,6 +38,11 @@ extern RoomStruct thisroom;
 extern CharacterInfo *playerchar;
 extern ScriptSystem scsystem;
 
+std::array<const char*, kNum_RBS> RBSwitchNames =
+{{
+    "dummy",            // kRBS_Dummy
+}};
+
 GamePlayState::GamePlayState()
 {
 }
@@ -56,6 +61,11 @@ void GamePlayState::SetGameTextLanguage(const String &language)
     GUI::Context.TextLocaleName = _localeNameUTF8;
     Debug::Printf("Set game text language: %s", _gameTextLanguage.GetCStr());
     Debug::Printf("Set locale: %s", _localeNameUTF8.GetCStr());
+}
+
+void GamePlayState::SetRBSwitches(const std::array<bool, kNum_RBS> &overrides)
+{
+    std::copy(overrides.begin(), overrides.end(), _rbSwitches.begin());
 }
 
 bool GamePlayState::IsAutoRoomViewport() const

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -41,6 +41,7 @@ extern ScriptSystem scsystem;
 std::array<const char*, kNum_RBS> RBSwitchNames =
 {{
     "dummy",            // kRBS_Dummy
+    "smooth_walk",      // kRBO_SmoothWalkTransition
 }};
 
 GamePlayState::GamePlayState()

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -40,8 +40,10 @@ extern ScriptSystem scsystem;
 
 std::array<const char*, kNum_RBS> RBSwitchNames =
 {{
-    "dummy",            // kRBS_Dummy
-    "smooth_walk",      // kRBO_SmoothWalkTransition
+    "dummy",                        // kRBS_Dummy
+    "smooth_walk",                  // kRBO_SmoothWalkTransition
+    "gui_text_direction",           // kRBO_ApplyGUITextDirection
+    "dialog_opt_text_direction",    // kRBO_ApplyDialogOptionTextDirection 
 }};
 
 GamePlayState::GamePlayState()

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -235,7 +235,6 @@ struct GamePlayState
     char  walkable_areas_on[MAX_WALK_AREAS]{};
     short screen_flipped = 0;
     bool  enable_antialiasing = false; // enable sprite AA (linear) scaling
-    bool  smooth_walk = true; // enable smooth walk mode
     int   entered_at_x = 0;
     int   entered_at_y = 0;
     int   entered_edge = 0;
@@ -452,7 +451,7 @@ struct GamePlayState
     bool ShouldAASprites() const { return enable_antialiasing && (disable_antialiasing == 0); }
     // Tells if the smooth walk mode is enabled for characters
     // (this means - smooth transition between two separate walks, without stopping)
-    bool ShouldSmoothWalk() const { return smooth_walk; }
+    bool ShouldSmoothWalk() const { return _rbSwitches[kRBO_SmoothWalkTransition]; }
 
     //
     // User input management

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -14,6 +14,7 @@
 #ifndef __AC_GAMESTATE_H
 #define __AC_GAMESTATE_H
 
+#include <array>
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -363,6 +364,11 @@ struct GamePlayState
 
     void SetGameTextLanguage(const Common::String &language);
 
+    // Runtime behavior switches: allow to configure engine behavior
+    // for modern and backwards-compatibility mode on a per-operation basis.
+    const std::array<bool, kNum_RBS> &GetRBSwitches() const { return _rbSwitches; }
+    void SetRBSwitches(const std::array<bool, kNum_RBS> &rbs);
+
     //
     // Viewport and camera control.
     // Viewports are positioned in game screen coordinates, related to the "game size",
@@ -515,6 +521,8 @@ private:
     Common::String _gameTextLanguage;
     // Name of the current used locale for UTF8 text mode
     Common::String _localeNameUTF8;
+
+    std::array<bool, kNum_RBS> _rbSwitches = {{ 0 }};
 
     // Defines if the room viewport should be adjusted to the room size automatically.
     bool _isAutoRoomViewport = true;

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 #include "ac/game_version.h"
+#include "platform/types.h"
 #include "util/geometry.h"
 
 class MoveList;

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -15,6 +15,7 @@
 #define __AC_RUNTIMEDEFINES_H
 
 #include "ac/common_defines.h"
+#include "ac/game_version.h"
 
 // Max old-style script string length
 #define MAX_MAXSTRLEN 200
@@ -270,5 +271,9 @@ enum PluginEventID
     kPluginEvt_PostRestoreGame  = 0x00040000,
     kPluginEvt_PostRoomDraw     = 0x00080000,
 };
+
+// Data format version of the loaded game
+// TODO: get rid of this global variable, use one from GameSetupStruct
+extern GameDataVersion loaded_game_file_version;
 
 #endif // __AC_RUNTIMEDEFINES_H

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -14,6 +14,7 @@
 #ifndef __AC_RUNTIMEDEFINES_H
 #define __AC_RUNTIMEDEFINES_H
 
+#include <array>
 #include "ac/common_defines.h"
 #include "ac/game_version.h"
 
@@ -271,6 +272,17 @@ enum PluginEventID
     kPluginEvt_PostRestoreGame  = 0x00040000,
     kPluginEvt_PostRoomDraw     = 0x00080000,
 };
+
+// Runtime behavior switches.
+// The purpose is differentiating between modern and backwards-compatible behavior
+// on a per-operation basis.
+enum RuntimeBehaviorSwitch
+{
+    kRBS_Dummy = 0, // is here to have at least one valid constant
+    kNum_RBS
+};
+
+extern std::array<const char*, kNum_RBS> RBSwitchNames;
 
 // Data format version of the loaded game
 // TODO: get rid of this global variable, use one from GameSetupStruct

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -278,7 +278,10 @@ enum PluginEventID
 // on a per-operation basis.
 enum RuntimeBehaviorSwitch
 {
-    kRBS_Dummy = 0, // is here to have at least one valid constant
+    // Is here to have at least one valid constant
+    kRBS_Dummy = 0,
+    // Enables smooth transition between two consecutive walk orders
+    kRBO_SmoothWalkTransition,
     kNum_RBS
 };
 

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -282,6 +282,10 @@ enum RuntimeBehaviorSwitch
     kRBS_Dummy = 0,
     // Enables smooth transition between two consecutive walk orders
     kRBO_SmoothWalkTransition,
+    // Apply text direction for GUI controls (except Labels, where it's always applied)
+    kRBO_ApplyGUITextDirection,
+    // Apply text direction for dialog options
+    kRBO_ApplyDialogOptionTextDirection,
     kNum_RBS
 };
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -561,8 +561,8 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     // Apply accessibility options, must be done last, because some
     // may override startup game settings.
     ApplyAccessibilityOptions(play, usetup);
-    // Apply override settings, such as hacks and backwards compatibility fixes
-    ApplyOverrides(game, play, usetup);
+    // Applies behavior options, also hacks and backwards compatibility fixes
+    ApplyBehaviorOptions(game, play, usetup);
 
     return HGameInitError::None();
 }
@@ -585,8 +585,19 @@ void ApplyAccessibilityOptions(GamePlayState &play, const GameSetup &setup)
     }
 }
 
-void ApplyOverrides(GameSetupStruct &game, GamePlayState &play, const GameSetup &setup)
+void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const GameSetup &setup)
 {
+    // First designate the default behavior settings, depending on game data version
+    std::array<bool, kNum_RBS> rbo = {0};
+
+    // Now apply overrides from config, *BUT* these only enable disabled options,
+    // and never disable enabled ones (because that might break or "downgrade" modern games).
+    for (size_t i = 0; i < kNum_RBS; ++i)
+    {
+        rbo[i] |= setup.BehaviorOverrides[i];
+    }
+    play.SetRBSwitches(rbo);
+
     if (setup.Override.NewKeyHandling)
     {
         game.options[OPT_KEYHANDLEAPI] = 1;
@@ -595,6 +606,20 @@ void ApplyOverrides(GameSetupStruct &game, GamePlayState &play, const GameSetup 
     if (setup.Override.SmoothCharacterWalk)
     {
         play.smooth_walk = true;
+    }
+}
+
+void PrintBehaviorOptions(const GameSetupStruct &game, const GamePlayState &play)
+{
+    // Runtime Behavior Switches
+    {
+        Debug::Printf("Runtime behavior switches:");
+        const auto &rbs_values = play.GetRBSwitches();
+        for (size_t i = kRBS_Dummy + 1; i < kNum_RBS; ++i)
+        {
+            assert(RBSwitchNames[i] != nullptr);
+            Debug::Printf("\t%s = %d", RBSwitchNames[i], static_cast<int>(rbs_values[i]));
+        }
     }
 }
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -590,6 +590,8 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
     // First designate the default behavior settings, depending on game data version
     std::array<bool, kNum_RBS> rbo = {0};
     rbo[kRBO_SmoothWalkTransition] = (loaded_game_file_version >= kGameVersion_361);
+    rbo[kRBO_ApplyGUITextDirection] = (loaded_game_file_version >= kGameVersion_361);
+    rbo[kRBO_ApplyDialogOptionTextDirection]= (loaded_game_file_version >= kGameVersion_363);
 
     // Now apply overrides from config, *BUT* these only enable disabled options,
     // and never disable enabled ones (because that might break or "downgrade" modern games).
@@ -603,6 +605,8 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
     {
         game.options[OPT_KEYHANDLEAPI] = 1;
     }
+
+    GUI::Options.ApplyTextDirection = play.GetRBSwitches()[kRBO_ApplyGUITextDirection];
 }
 
 void PrintBehaviorOptions(const GameSetupStruct &game, const GamePlayState &play)

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -589,6 +589,7 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
 {
     // First designate the default behavior settings, depending on game data version
     std::array<bool, kNum_RBS> rbo = {0};
+    rbo[kRBO_SmoothWalkTransition] = (loaded_game_file_version >= kGameVersion_361);
 
     // Now apply overrides from config, *BUT* these only enable disabled options,
     // and never disable enabled ones (because that might break or "downgrade" modern games).
@@ -601,11 +602,6 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
     if (setup.Override.NewKeyHandling)
     {
         game.options[OPT_KEYHANDLEAPI] = 1;
-    }
-
-    if (setup.Override.SmoothCharacterWalk)
-    {
-        play.smooth_walk = true;
     }
 }
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -103,6 +103,8 @@ String GetGameInitErrorText(GameInitErrorType err)
     {
     case kGameInitErr_NoError:
         return "No error.";
+    case kGameInitErr_UnknownDataVersion:
+        return "Unknown game data version";
     case kGameInitErr_NoFonts:
         return "No fonts specified to be used in this game.";
     case kGameInitErr_EntityInitFail:
@@ -293,6 +295,7 @@ HError InitAndRegisterGameEntities(GameSetupStruct &game)
 
 void LoadFonts(GameSetupStruct &game, GameDataVersion data_ver)
 {
+    set_gamedata_version(data_ver);
     for (int i = 0; i < game.numfonts; ++i) 
     {
         if (load_game_font(i, game.fonts[i], data_ver))

--- a/Engine/game/game_init.h
+++ b/Engine/game/game_init.h
@@ -56,8 +56,11 @@ typedef ErrorHandle<GameInitError> HGameInitError;
 HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver);
 // Applies accessibility options, some of them may override game settings
 void ApplyAccessibilityOptions(GamePlayState &play, const GameSetup &setup);
-// Applies override settings, such as hacks and backwards compatibility fixes
-void ApplyOverrides(GameSetupStruct &game, GamePlayState &play, const GameSetup &setup);
+// Applies configurable behavior options for this game, including option overrides,
+// such as hacks and backwards compatibility fixes
+void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const GameSetup &setup);
+// Prints behavior options to the log
+void PrintBehaviorOptions(const GameSetupStruct &game, const GamePlayState &play);
 
 } // namespace Engine
 } // namespace AGS

--- a/Engine/game/game_init.h
+++ b/Engine/game/game_init.h
@@ -38,6 +38,7 @@ using namespace Common;
 enum GameInitErrorType
 {
     kGameInitErr_NoError,
+    kGameInitErr_UnknownDataVersion,
     // currently AGS requires at least one font to be present in game
     kGameInitErr_NoFonts,
     kGameInitErr_EntityInitFail,

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -954,7 +954,8 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data, SaveC
     // Apply accessibility options, must be done last, because some
     // may override restored game settings
     ApplyAccessibilityOptions(play, usetup);
-    ApplyOverrides(game, play, usetup);
+    // Applies behavior options, also hacks and backwards compatibility fixes
+    ApplyBehaviorOptions(game, play, usetup);
 
     play.ClearIgnoreInput(); // don't keep ignored input after save restore
     update_polled_stuff();

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -157,7 +157,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
     bool reverse = false;
     // Text boxes input is never "translated" in regular sense,
     // but they use this flag to apply text direction
-    if ((GUI::DataVersion >= kGameVersion_361) && ((_flags & kGUICtrl_Translated) != 0))
+    if ((GUI::Options.ApplyTextDirection) && ((_flags & kGUICtrl_Translated) != 0))
     {
         _textToDraw = GUI::ApplyTextDirection(_text);
         reverse = game.options[OPT_RIGHTLEFTWRITE] != 0;
@@ -165,7 +165,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
 
     FrameAlignment text_align = kAlignTopLeft;
     // 3.6.1 -> 3.6.2 applied text alignment based on text direction
-    if ((GUI::DataVersion >= kGameVersion_361) && (GUI::DataVersion < kGameVersion_363_04))
+    if ((GUI::Options.ApplyTextDirection) && (GUI::DataVersion < kGameVersion_363_04))
     {
         text_align = reverse ? kAlignTopRight : kAlignTopLeft;
     }
@@ -200,7 +200,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
      _textToDraw = GUI::TransformTextForDrawing(text, (_flags & kGUICtrl_Translated) != 0,
-         (GUI::DataVersion >= kGameVersion_361));
+         (GUI::Options.ApplyTextDirection));
 }
 
 void GUIButton::PrepareTextToDraw()
@@ -213,7 +213,7 @@ void GUIButton::PrepareTextToDraw()
     else
     {
         _textToDraw = GUI::TransformTextForDrawing(_text, (_flags & kGUICtrl_Translated) != 0,
-            (GUI::DataVersion >= kGameVersion_361));
+            (GUI::Options.ApplyTextDirection));
     }
 }
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -51,7 +51,7 @@ bool GUIMain::HasAlphaChannel() const
         // transparent background have alpha channel only since 3.2.0;
         // "classic" gui rendering mode historically had non-alpha transparent backgrounds
         // (3.2.0 broke the compatibility, now we restore it)
-        loaded_game_file_version >= kGameVersion_320 && game.options[OPT_NEWGUIALPHA] != kGuiAlphaRender_Legacy;
+        GUI::DataVersion >= kGameVersion_320 && game.options[OPT_NEWGUIALPHA] != kGuiAlphaRender_Legacy;
 }
 
 //=============================================================================
@@ -157,7 +157,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
     bool reverse = false;
     // Text boxes input is never "translated" in regular sense,
     // but they use this flag to apply text direction
-    if ((loaded_game_file_version >= kGameVersion_361) && ((_flags & kGUICtrl_Translated) != 0))
+    if ((GUI::DataVersion >= kGameVersion_361) && ((_flags & kGUICtrl_Translated) != 0))
     {
         _textToDraw = GUI::ApplyTextDirection(_text);
         reverse = game.options[OPT_RIGHTLEFTWRITE] != 0;
@@ -165,12 +165,12 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
 
     FrameAlignment text_align = kAlignTopLeft;
     // 3.6.1 -> 3.6.2 applied text alignment based on text direction
-    if ((loaded_game_file_version >= kGameVersion_361) && (loaded_game_file_version < kGameVersion_363_04))
+    if ((GUI::DataVersion >= kGameVersion_361) && (GUI::DataVersion < kGameVersion_363_04))
     {
         text_align = reverse ? kAlignTopRight : kAlignTopLeft;
     }
     // 3.6.3+ have explicit text alignment property
-    else if (loaded_game_file_version >= kGameVersion_363_04)
+    else if (GUI::DataVersion >= kGameVersion_363_04)
     {
         text_align = _textAlignment;
     }
@@ -200,7 +200,7 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y)
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
      _textToDraw = GUI::TransformTextForDrawing(text, (_flags & kGUICtrl_Translated) != 0,
-         (loaded_game_file_version >= kGameVersion_361));
+         (GUI::DataVersion >= kGameVersion_361));
 }
 
 void GUIButton::PrepareTextToDraw()
@@ -213,7 +213,7 @@ void GUIButton::PrepareTextToDraw()
     else
     {
         _textToDraw = GUI::TransformTextForDrawing(_text, (_flags & kGUICtrl_Translated) != 0,
-            (loaded_game_file_version >= kGameVersion_361));
+            (GUI::DataVersion >= kGameVersion_361));
     }
 }
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -475,7 +475,6 @@ void apply_config(const ConfigTree &cfg, GameSetup &setup)
     setup.Override.KeySaveGame = CfgReadInt(cfg, "override", "save_game_key", 0);
     setup.Override.KeyRestoreGame = CfgReadInt(cfg, "override", "restore_game_key", 0);
     setup.Override.MaxSaveSlot = CfgReadInt(cfg, "override", "max_save", 0);
-    setup.Override.SmoothCharacterWalk = CfgReadBoolInt(cfg, "override", "smooth_walk", setup.Override.SmoothCharacterWalk);
 
     // Behavior overrides switches
     if (cfg.count("override_behavior") > 0)

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -17,6 +17,7 @@
 #include <ctype.h> // toupper
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
+#include "ac/gamestate.h"
 #include "ac/global_translation.h"
 #include "ac/path_helper.h"
 #include "ac/spritecache.h"
@@ -475,6 +476,18 @@ void apply_config(const ConfigTree &cfg, GameSetup &setup)
     setup.Override.KeyRestoreGame = CfgReadInt(cfg, "override", "restore_game_key", 0);
     setup.Override.MaxSaveSlot = CfgReadInt(cfg, "override", "max_save", 0);
     setup.Override.SmoothCharacterWalk = CfgReadBoolInt(cfg, "override", "smooth_walk", setup.Override.SmoothCharacterWalk);
+
+    // Behavior overrides switches
+    if (cfg.count("override_behavior") > 0)
+    {
+        CstrArr<kNum_RBS> names;
+        std::copy(std::begin(RBSwitchNames), std::end(RBSwitchNames), names.begin());
+        const auto &rbo_opts = cfg.at("override_behavior");
+        for (const auto &opt : rbo_opts)
+        {
+            setup.BehaviorOverrides[StrUtil::ParseEnum(opt.first, names, kRBS_Dummy)] = StrUtil::StringToInt(opt.second, 0);
+        }
+    }
 
     // Apply logging configuration
     apply_debug_config(cfg, true);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -884,7 +884,9 @@ void engine_init_game_settings()
     // FIXME: this should be done once in InitGameState, but the code for default game settings
     // is spread across 2 or more functions; keep this extra call here until this nonsense is fixed.
     ApplyAccessibilityOptions(play, usetup);
-    ApplyOverrides(game, play, usetup);
+    // Applies behavior options, also hacks and backwards compatibility fixes
+    ApplyBehaviorOptions(game, play, usetup);
+    PrintBehaviorOptions(game, play);
 }
 
 void engine_setup_scsystem_auxiliary()

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -852,8 +852,6 @@ void engine_init_game_settings()
     if (debug_flags & DBG_DEBUGMODE)
         play.debug_mode = 1;
     play.shake_screen_yoff = 0;
-    // NOTE: unfortunately, some old game scripts might break because of smooth walk transition
-    play.smooth_walk = (loaded_game_file_version >= kGameVersion_361);
 
     GUI::DataVersion = loaded_game_file_version;
     GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -192,6 +192,9 @@ HError load_game_file()
     // Data overrides: for compatibility mode and custom engine support
     // NOTE: this must be done before UpdateGameData, or certain adjustments
     // won't be applied correctly.
+    if (src.DataVersion == kGameVersion_Undefined)
+        return new GameInitError(kGameInitErr_UnknownDataVersion);
+    loaded_game_file_version = src.DataVersion;
 
     // Custom engine detection (ugly hack, depends on the known game GUIDs)
     if (strcmp(game.guid, "{d6795d1c-3cfe-49ec-90a1-85c313bfccaf}" /* Kathy Rain */ ) == 0 ||

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -127,7 +127,7 @@ Locations of two latter files differ between running platforms:
 	* time - skip speech by time-out only;
 	* any - skip speech either by player's input or time-out.
   * textskip = \[string\] - assigns the text message skip style to a fixed value; values are the same as for "speechskip" option.
-* **\[override\]** - special options, overriding game behavior. These are purposed rather for emergency "hacks", in case something was not done "right" in a game, or when you like to enable certain compatibility mode.
+* **\[override\]** - special options, overriding standard engine behavior. These are purposed as emergency "hacks", when something prevents from playing a game properly.
   * noplugins = \[0; 1\] - disable plugin loading. Engine will fallback to built-in plugins or stubs, if they are available.
   * multitasking = \[0; 1\] - lock the game in the "single-tasking" or "multitasking" mode. In the nutshell, "multitasking" here means that the game will continue running when player switched away from game window; otherwise it will freeze until player switches back.
   * os = \[string\] - trick the game to think that it runs on a particular operating system. This may come handy if the game is scripted to play differently depending on OS. Possible choices are:
@@ -141,7 +141,10 @@ Locations of two latter files differ between running platforms:
   * upscale = \[0; 1\] - run game in the "upscale mode". The earlier versions of AGS provided support for "upscaling" low-res games to hi-res. The script API has means for detecting if the game is running upscaled, and game developer could use this opportunity to setup game accordingly (e.g. assign hi-res fonts, etc). This options works **only** for games created before AGS 3.1.0 with low-res native resolution, such as 320x200 or 320x240, and it may somewhat improve
   game looks.
   * new_key_mode = \[0; 1\] - enforce new key handling mode, where each button is firing separate event, and button codes do not depend on the keyboard layout. WARNING: may cause script errors in certain old games.
-  * smooth_walk = \[0; 1\] - enforce smooth character walking, which causes seamless transition between walk commands. WARNING: may cause script errors in certain old games.
+* **\[override_behavior\]** - options, overriding backwards-compatible engine behavior. When running old games, the engine tries to emulate old behavior as close as possible. This may include various restrictions and inconveniences. These options allow to enable *modern* behavior on a per-case basis. NOTE: you can only enable new behavior in old games, you won't be able to disable modern behavior in games where it is a standard.
+  * smooth_walk = \[0; 1\] - enable seamless transition between consecutive walk commands. WARNING: may cause script errors in certain old games.
+  * gui_text_direction = \[0; 1\] - enable applying text direction on gui controls other than labels (labels support it always).
+  * dialog_opt_text_direction = \[0; 1\] - enable applying text direction on dialog options.
 * **\[disabled\]** - special instructions for the setup program hinting to disable particular options or lock some in the certain state. Ignored by the engine.
   * gfxdrivers = \[0; 1\] - tells to lock "Graphics driver" selection in a default state;
   * \<gfxdriver id\> = \[0; 1\] - tells to remove particular graphics driver from the selection list;


### PR DESCRIPTION
This implements a general method for overriding old game behavior in config.

AGS supports running old games, but must emulate old engine behavior in a number of cases. Sometimes it may be wanted to override that, and use a "modern" behavior instead while running an old game. Good example is "smooth walk transition", which makes walking prettier, but is disabled for old games because it was found causing issues with coordinate checks in *certain* games. Another example is right-to-left mode which was not implemented for any guis besides Labels in the old engines.

How does the configuration works?

For now engine had behavior switches based on `loaded_game_data_version` variable. Instead, we now use an array of bools, where array index is a constant named after certain action. This lets engine to switch behavior on per-case basis. Current PR only implements 3 switches for 3 cases, but more could be added later, replacing uses of `loaded_game_data_version`.

Engine sets up default values for these switches on startup, based on the game version. But it also allows to read overriding values from config, where they are found in `[override_behavior]` section. IMPORTANT: config only allows to *enable* the new behavior, but never *disable* one (because that will break modern games).

Supported switches:
* smooth_walk - Enables smooth transition between two consecutive walk orders
* gui_text_direction - Apply text direction for GUI controls (except Labels, where it's always applied)
* dialog_opt_text_direction - Apply text direction for dialog options

Example of config:
```
[override_behavior]
smooth_walk=1
gui_text_direction=1
dialog_opt_text_direction=1
```
