### PR TITLE
AGS 4.0: add Pivot and PivotOffset for game objects and Camera

### DIFF
--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -165,7 +165,7 @@ void CharacterInfo::WriteToFile(Stream *out) const
     out->WriteInt8(0); // alignment padding to int32
 }
 
-void CharacterInfo::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
+void CharacterInfo::ReadFromSavegame(Stream *in, LegacyFields &old_fields, CharacterSvgVersion save_ver)
 {
     defview = in->ReadInt32();
     talkview = in->ReadInt32();
@@ -191,7 +191,7 @@ void CharacterInfo::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
     blinktimer = in->ReadInt16();
     blinkframe = in->ReadInt16();
     walkspeed_y = in->ReadInt16();
-    view_offset.Y = in->ReadInt16(); // legacy 16-bit view offset
+    old_fields.view_offset.Y = in->ReadInt16(); // legacy 16-bit view offset
     z = in->ReadInt32();
     walkwait = in->ReadInt32();
     speech_anim_speed = in->ReadInt16();
@@ -199,7 +199,7 @@ void CharacterInfo::ReadFromSavegame(Stream *in, CharacterSvgVersion save_ver)
     blocking_width = in->ReadInt16();
     blocking_height = in->ReadInt16();
     index_id = in->ReadInt32();
-    view_offset.X = in->ReadInt16(); // legacy 16-bit view offset
+    old_fields.view_offset.X = in->ReadInt16(); // legacy 16-bit view offset
     walkwaitcounter = in->ReadInt16();
     loop = in->ReadInt16();
     frame = in->ReadInt16();

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -118,7 +118,8 @@ enum CharacterSvgVersion
     kCharSvgVersion_400_20  = 4000020, // expanded and bit more consistent anim params serialization
     kCharSvgVersion_400_26  = 4000026, // sync with kCharSvgVersion_36304
     kCharSvgVersion_400_28  = 4000028, // sync with kCharSvgVersion_36310
-    kCharSvgVersion_Current = kCharSvgVersion_400_28
+    kCharSvgVersion_400_29  = 4000029, // rotation pivot
+    kCharSvgVersion_Current = kCharSvgVersion_400_29
 };
 
 // Character event indexes

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -174,8 +174,6 @@ struct CharacterInfo
     int16_t walking     = 0; // stores movelist index
     int16_t walkspeed   = 0;
     int16_t animspeed   = 0;
-    Point   view_offset; // fixed view offset (from locked view)
-    Pointf  view_anchor; // view anchor (from locked view)
     int16_t inv[MAX_INV] = { 0 }; // quantities of each inventory item in game
     AGS::Common::String scrname = {}; // script name
     AGS::Common::String name = {}; // regular name (aka description)
@@ -252,8 +250,14 @@ struct CharacterInfo
 
     void ReadFromFile(Common::Stream *in, GameDataVersion data_ver);
     void WriteToFile(Common::Stream *out) const;
+
     // TODO: move to runtime-only class and merge with its respective Read/Write save methods
-    void ReadFromSavegame(Common::Stream *in, CharacterSvgVersion save_ver);
+    struct LegacyFields
+    {
+        Point view_offset;
+    };
+
+    void ReadFromSavegame(Common::Stream *in, LegacyFields &old_fields, CharacterSvgVersion save_ver);
     void WriteToSavegame(Common::Stream *out) const;
 
 private:

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -335,7 +335,8 @@ enum GameStateSvgVersion
     kGSSvgVersion_400_24    = 4000024, // sync with kGSSvgVersion_363_02
     kGSSvgVersion_400_26    = 4000026, // sync with kGSSvgVersion_363_04
     kGSSvgVersion_400_27    = 4000027, // 32-bit inventory cursor hotspot colors
-    kGSSvgVersion_Current   = kGSSvgVersion_400_27
+    kGSSvgVersion_400_29    = 4000029, // rotation pivot
+    kGSSvgVersion_Current   = kGSSvgVersion_400_29
 };
 
 #endif // __AGS_CN_AC__GAMESTRUCTDEFINES_H

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -22,6 +22,7 @@
 #define __AGS_CN_GFX__GFXDEF_H
 
 #include <algorithm>
+#include <vector>
 #include "util/geometry.h"
 #include "util/matrix.h"
 
@@ -161,6 +162,28 @@ public:
     {
         glm::vec4 v = L2WTransform * glmex::vec4(static_cast<float>(x), static_cast<float>(y));
         return Point(static_cast<int>(v.x), static_cast<int>(v.y)); // TODO: better rounding
+    }
+
+    // Fills a std::vector with 4 corner positions of AABB, in the clockwise order
+    inline void GetAABBPoints(std::vector<Point> &points) const
+    {
+        points.resize(4);
+        points[0] = _AABB.GetLT();
+        points[1] = _AABB.GetRT();
+        points[2] = _AABB.GetRB();
+        points[3] = _AABB.GetLB();
+    }
+
+    // Fills a std::vector with 4 corner positions of the transformed object,
+    // in world coordinates, in the clockwise order.
+    // NOTE: GraphicSpace does not store object size, only transform, so we have to pass size as a argument
+    inline void GetTransformedCorners(std::vector<Point> &points, const Size &obj_size) const
+    {
+        points.resize(4);
+        points[0] = LocalToWorld(0, 0);
+        points[1] = LocalToWorld(obj_size.Width - 1, 0);
+        points[2] = LocalToWorld(obj_size.Width - 1, obj_size.Height - 1);
+        points[3] = LocalToWorld(0, obj_size.Height - 1);
     }
 
 private:

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -111,15 +111,17 @@ public:
     //          this is used to separate additional offsets for the object gfx,
     //          in case its image exceeds the "logical" rectangle.
     // rot      - rotation, clockwise, in degrees
-    //          this constructor makes a fixed pivot at the center of src_aabb.
+    // pivot    - pivot of rotation, in *relative* position (center is default)
+    // pivot_off - extra pivot offset, in local coordinates (zero is default)
     GraphicSpace(const int ox, const int oy, const Pointf &origin, const Size &src_size,
-                 const Size &dst_size, const Rect &g_aabb, const float rot)
+                 const Size &dst_size, const Rect &g_aabb, const float rot,
+                 const Pointf pivot = Pointf(.5f, .5f), const Point pivot_off = Point())
     {
         const int src_w = src_size.Width;
         const int src_h = src_size.Height;
         const float sx = src_w != 0.f ? static_cast<float>(dst_size.Width) / src_w : 1.f;
         const float sy = src_h != 0.f ? static_cast<float>(dst_size.Height) / src_h : 1.f;
-        Init(ox, oy, origin, src_size, dst_size, g_aabb, sx, sy, rot);
+        Init(ox, oy, origin, src_size, dst_size, g_aabb, sx, sy, rot, pivot, pivot_off);
     }
 
     // ox,oy    - position of the object's origin in world coordinates
@@ -130,13 +132,15 @@ public:
     //          in case its image exceeds the "logical" rectangle.
     // sx,sy    - scaling factors (along x and y axes)
     // rot      - rotation, clockwise, in degrees
-    //          this constructor makes a fixed pivot at the center of src_aabb.
+    // pivot    - pivot of rotation, in *relative* position (center is default)
+    // pivot_off - extra pivot offset, in local coordinates (zero is default)
     GraphicSpace(const int ox, const int oy, const Pointf &origin, const Size &src_size,
-                 const Rect &g_aabb, const float sx, const float sy, const float rot)
+                 const Rect &g_aabb, const float sx, const float sy, const float rot,
+                 const Pointf pivot = Pointf(.5f, .5f), const Point pivot_off = Point())
     {
         Init(ox, oy, origin, src_size,
              Size(static_cast<int>(src_size.Width * sx), static_cast<int>(src_size.Height * sy)),
-             g_aabb, sx, sy, rot);
+             g_aabb, sx, sy, rot, pivot, pivot_off);
     }
 
     // Get position of the top-left corner of this object in the world coordinates;
@@ -161,7 +165,8 @@ public:
 
 private:
     void Init(const int ox, const int oy, const Pointf &origin, const Size &src_size,
-              const Size &dst_size, const Rect &g_aabb, const float sx, const float sy, const float rot)
+              const Size &dst_size, const Rect &g_aabb, const float sx, const float sy,
+              const float rot, const Pointf pivot, const Point pivot_off)
     {
         const int local_srcx = -static_cast<int>((src_size.Width - 1) * origin.X);
         const int local_srcy = -static_cast<int>((src_size.Height - 1) * origin.Y);
@@ -171,9 +176,10 @@ private:
             ? 0.f : 1.f / sx;
         const float sy_inv = std::fabs(sy) < std::numeric_limits<float>::epsilon()
             ? 0.f : 1.f / sy;
-        // Pivot is relative to the local coordinate center
-        const float pivotx = (dst_size.Width) * 0.5f;
-        const float pivoty = (dst_size.Height) * 0.5f;
+        // Pivot is relative to the local coordinate center;
+        // here is calculated in coordinates of the *destination* rectangle (post-scaling)
+        const float pivotx = (dst_size.Width) * pivot.X + pivot_off.X * sx;
+        const float pivoty = (dst_size.Height) * pivot.Y + pivot_off.Y * sy;
         // World->local transform
         W2LTransform = glmex::make_inv_transform2d(
             -world_x, -world_y, sx_inv, sy_inv,

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -349,6 +349,16 @@ struct Rect
         return Point(Left, Top);
     }
 
+    inline Point GetRT() const
+    {
+        return Point(Right, Top);
+    }
+
+    inline Point GetLB() const
+    {
+        return Point(Left, Bottom);
+    }
+
     inline Point GetRB() const
     {
         return Point(Right, Bottom);

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -138,31 +138,55 @@ struct PointT
         return Pt(X - p.X, Y - p.Y);
     }
 
-    inline Pt operator *(T mul) const
+    inline Pt operator *(const Pt &p) const
+    {
+        return Pt(X * p.X, Y * p.Y);
+    }
+
+    inline Pt operator /(const Pt &p) const
+    {
+        return Pt(X / p.X, Y / p.Y);
+    }
+
+    inline Pt &operator *=(const Pt p)
+    {
+        X *= p.X;
+        Y *= p.Y;
+        return *this;
+    }
+
+    inline Pt &operator /=(const Pt p)
+    {
+        X /= p.X;
+        Y /= p.Y;
+        return *this;
+    }
+
+    inline Pt operator *(const T &mul) const
     {
         return Pt(X * mul, Y * mul);
     }
 
-    inline Pt operator /(T div) const
+    inline Pt operator /(const T &div) const
     {
         return Pt(X / div, Y / div);
     }
 
-    inline Pt &operator *=(T mul)
+    inline Pt &operator *=(const T &mul)
     {
         X *= mul;
         Y *= mul;
         return *this;
     }
 
-    inline Pt &operator /=(T div)
+    inline Pt &operator /=(const T &div)
     {
         X /= div;
         Y /= div;
         return *this;
     }
 
-    inline bool Equals(const T x, const T y) const
+    inline bool Equals(const T &x, const T &y) const
     {
         return X == x && Y == y;
     }

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1401,6 +1401,14 @@ builtin managed struct Overlay {
   import attribute int GraphicOffsetX;
   /// Gets/sets a Y offset of a graphic relative to the overlay's position, in pixels
   import attribute int GraphicOffsetY;
+  /// Gets/sets a graphic rotation pivot X in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotX;
+  /// Gets/sets a graphic rotation pivot Y in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotY;
+  /// Gets/sets a X offset of a graphic pivot relative to the overlay's position, in pixels
+  import attribute int GraphicPivotOffsetX;
+  /// Gets/sets a Y offset of a graphic pivot relative to the overlay's position, in pixels
+  import attribute int GraphicPivotOffsetY;
   /// Gets whether the overlay has a tint set.
   readonly import attribute bool HasTint;
   /// Gets whether the overlay has a light level set.
@@ -2792,6 +2800,14 @@ builtin managed struct Object {
   import attribute int GraphicOffsetX;
   /// Gets/sets a Y offset of a graphic relative to the object's position, in pixels
   import attribute int GraphicOffsetY;
+  /// Gets/sets a graphic rotation pivot X in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotX;
+  /// Gets/sets a graphic rotation pivot Y in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotY;
+  /// Gets/sets a X offset of a graphic pivot relative to the object's position, in pixels
+  import attribute int GraphicPivotOffsetX;
+  /// Gets/sets a Y offset of a graphic pivot relative to the object's position, in pixels
+  import attribute int GraphicPivotOffsetY;
   /// Gets this object's current MotionPath, or null if it's not moving.
   import readonly attribute MotionPath* MotionPath;
 #endif // SCRIPT_API_v400
@@ -3103,6 +3119,14 @@ builtin managed struct Character {
   import attribute int GraphicOffsetX;
   /// Gets/sets a Y offset of a graphic relative to the character's position, in pixels
   import attribute int GraphicOffsetY;
+  /// Gets/sets a graphic rotation pivot X in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotX;
+  /// Gets/sets a graphic rotation pivot Y in normalized relative coordinates (0.0 - 1.0)
+  import attribute float GraphicPivotY;
+  /// Gets/sets a X offset of a graphic pivot relative to the character's position, in pixels
+  import attribute int GraphicPivotOffsetX;
+  /// Gets/sets a Y offset of a graphic pivot relative to the character's position, in pixels
+  import attribute int GraphicPivotOffsetY;
   /// Gets this character's current MotionPath, or null if it's not moving.
   import readonly attribute MotionPath* MotionPath;
   /// Gets the effective graphic anchor X in normalized relative coordinates (0.0 - 1.0)
@@ -3453,6 +3477,16 @@ builtin managed struct Camera {
   /// Gets/sets the camera rotation in degrees.
   import attribute float Rotation;
 #endif // SCRIPT_API_v399
+#ifdef SCRIPT_API_v400
+  /// Gets/sets a rotation pivot X in normalized relative coordinates (0.0 - 1.0)
+  import attribute float PivotX;
+  /// Gets/sets a rotation pivot Y in normalized relative coordinates (0.0 - 1.0)
+  import attribute float PivotY;
+  /// Gets/sets a X offset of a rotation pivot relative to the camera's position, in pixels
+  import attribute int PivotOffsetX;
+  /// Gets/sets a Y offset of a rotation pivot relative to the camera's position, in pixels
+  import attribute int PivotOffsetY;
+#endif
 #ifdef SCRIPT_API_v400_18
   /// Gets/sets the shader of this camera.
   import attribute ShaderInstance* Shader;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1382,14 +1382,18 @@ builtin managed struct Overlay {
   import attribute float Rotation;
 #endif // SCRIPT_API_v399
 #ifdef SCRIPT_API_v400
-  /// Tints the overlay to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
-  import void Tint(int red, int green, int blue, int saturation, int luminance);
-  /// Sets the light level for this overlay, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
-  import void SetLightLevel(int light_level);
+  /// Gets position of the overlay's graphic in either screen or room coordinates (depending on which overlay this is). Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicPosition();
+  /// Gets overlay graphic's axis-aligned bounding box in either screen or room coordinates (depending on which overlay this is). Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicBoundBox();
   /// Removes an existing colour tint or light level from this overlay.
   import void RemoveTint();
+  /// Sets the light level for this overlay, from -100 to 100 (negative values darken the sprite, positive brighten the sprite).
+  import void SetLightLevel(int light_level);
   /// Sets this overlay's horizontal and vertical scaling
   import void SetScale(float x, float y);
+  /// Tints the overlay to the specified colour. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
+  import void Tint(int red, int green, int blue, int saturation, int luminance);
 
   /// Gets/sets whether overlay should resize itself whenever its graphic changes.
   import attribute bool AutoSize;
@@ -1737,6 +1741,10 @@ builtin managed struct GUIControl {
   import attribute bool Translated;
 #endif // SCRIPT_API_v363
 #ifdef SCRIPT_API_v400
+  /// Gets control's graphical position in parent GUI coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicPosition();
+  /// Gets control's graphical axis-aligned bounding box in parent GUI coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicBoundBox();
   /// Gets an integer custom property for this control.
   import int  GetProperty(const string property);
   /// Gets a text custom property for this control.
@@ -2055,16 +2063,21 @@ builtin managed struct GUI {
   import attribute float Rotation;
 #endif // SCRIPT_API_v399
 #ifdef SCRIPT_API_v400
+  /// Convert relative GUI coordinates to screen coordinates. Optionally clips position by GUI's bounds, in which case if the point lies outside of GUI, then this function will return null.
+  import Point *GUIToScreenPoint(int guix, int guiy, bool clipToGUI = true);
+  /// Convert screen coordinates to relative GUI coordinates. Optionally clips position by GUI's bounds, in which case if the point lies outside of GUI, then this function will return null.
+  import Point *ScreenToGUIPoint(int screenx, int screeny, bool clipToGUI = true);
+  /// Gets graphical GUI position in screen coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicPosition();
+  /// Gets GUI's graphical axis-aligned bounding box in screen coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicBoundBox();
+
   /// Gets/sets this GUI horizontal scaling.
   import attribute float ScaleX;
   /// Gets/sets this GUI vertical scaling.
   import attribute float ScaleY;
   /// Sets this GUI horizontal and vertical scaling
   import void SetScale(float x, float y);
-
-  import Point *GUIToScreenPoint(int guix, int guiy, bool clipToGUI = true);
-  import Point *ScreenToGUIPoint(int screenx, int screeny, bool clipToGUI = true);
-
   /// Gets an integer custom property for this GUI.
   import int  GetProperty(const string property);
   /// Gets a text custom property for this GUI.
@@ -2788,6 +2801,10 @@ builtin managed struct Object {
   import attribute int  BlockingRectY;
 #endif // SCRIPT_API_v363
 #ifdef SCRIPT_API_v400
+  /// Gets position of the object's graphic in room coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicPosition();
+  /// Gets object graphic's axis-aligned bounding box in room coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicBoundBox();
   /// Moves the object along the path, ignoring walkable areas.
   import void MovePath(Point*[], int speed, BlockingStyle=eNoBlock, RepeatStyle=eOnce, Direction=eForwards);
   /// Gets/sets whether the object will be drawn and updated during the game update.
@@ -3103,6 +3120,10 @@ builtin managed struct Character {
   import attribute bool UseRegionTint;
 #endif // SCRIPT_API_v399
 #ifdef SCRIPT_API_v400
+  /// Gets position of the character's graphic in room coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicPosition();
+  /// Gets object character's axis-aligned bounding box in room coordinates. Returns a dynamic array of 4 Points, one per graphic's corner, in the order: LT, RT, RB, LB.
+  import Point*[] GetGraphicBoundBox();
   /// Locks the character to this view, using specified anchor and offset for the duration of this lock.
   import void LockViewAnchored(int view, float xAnchor, float yAnchor, int xOffset=0, int yOffset=0, StopMovementStyle=eStopMoving);
   /// Gets/sets whether the character will be drawn and updated during the game update.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -16,6 +16,7 @@
 //
 //=============================================================================
 #include <cstdio>
+#include <math.h>
 #include "ac/character.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
@@ -49,12 +50,12 @@
 #include "ac/walkablearea.h"
 #include "ac/dynobj/scriptmotionpath.h"
 #include "ac/dynobj/scriptshader.h"
+#include "ac/dynobj/scriptuserobject.h"
 #include "debug/debug_log.h"
 #include "gui/guimain.h"
 #include "main/game_run.h"
 #include "main/update.h"
 #include "util/string_compat.h"
-#include <math.h>
 #include "gfx/graphicsdriver.h"
 #include "script/runtimescriptvalue.h"
 #include "script/script.h"
@@ -1250,9 +1251,23 @@ void Character_RunInteraction(CharacterInfo *chaa, int mood)
     run_event_script(obj_evt, &game.chars[chaa->index_id].GetEvents(), anyclick_evt);
 }
 
+void *Character_GetGraphicPosition(CharacterInfo *chaa)
+{
+    auto &chex = charextra[chaa->index_id];
+    chex.UpdateGraphicSpace(chaa);
+    std::vector<Point> points;
+    chex.GetGraphicSpace().GetTransformedCorners(points, Size(chex.spr_width, chex.spr_height));
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
 
-
-// **** CHARACTER: PROPERTIES ****
+void *Character_GetGraphicBoundBox(CharacterInfo *chaa)
+{
+    auto &chex = charextra[chaa->index_id];
+    chex.UpdateGraphicSpace(chaa);
+    std::vector<Point> points;
+    chex.GetGraphicSpace().GetAABBPoints(points);
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
 
 int Character_GetProperty(CharacterInfo *chaa, const char *property)
 {
@@ -3675,6 +3690,16 @@ RuntimeScriptValue Sc_Character_GetFollowing(void *self, const RuntimeScriptValu
     API_OBJCALL_OBJ(CharacterInfo, CharacterInfo, ccDynamicCharacter, Character_GetFollowing);
 }
 
+RuntimeScriptValue Sc_Character_GetGraphicPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(CharacterInfo, void, globalDynamicArray, Character_GetGraphicPosition);
+}
+
+RuntimeScriptValue Sc_Character_GetGraphicBoundBox(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(CharacterInfo, void, globalDynamicArray, Character_GetGraphicBoundBox);
+}
+
 // int (CharacterInfo *chaa, const char *property)
 RuntimeScriptValue Sc_Character_GetProperty(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -4743,6 +4768,8 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::FaceLocation^3",            API_FN_PAIR(Character_FaceLocation) },
         { "Character::FaceObject^2",              API_FN_PAIR(Character_FaceObject) },
         { "Character::FollowCharacter^3",         API_FN_PAIR(Character_FollowCharacter) },
+        { "Character::GetGraphicPosition^0",      API_FN_PAIR(Character_GetGraphicPosition) },
+        { "Character::GetGraphicBoundBox^0",      API_FN_PAIR(Character_GetGraphicBoundBox) },
         { "Character::GetProperty^1",             API_FN_PAIR(Character_GetProperty) },
         { "Character::GetPropertyText^2",         API_FN_PAIR(Character_GetPropertyText) },
         { "Character::GetTextProperty^1",         API_FN_PAIR(Character_GetTextProperty) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1990,6 +1990,46 @@ void Character_SetRotation(CharacterInfo *chaa, float degrees) {
     charextra[chaa->index_id].UpdateGraphicSpace(chaa);
 }
 
+float Character_GetGraphicPivotX(CharacterInfo *chaa)
+{
+    return charextra[chaa->index_id].pivot.X;
+}
+
+void Character_SetGraphicPivotX(CharacterInfo *chaa, float pivotx)
+{
+    charextra[chaa->index_id].pivot.X = pivotx;
+}
+
+float Character_GetGraphicPivotY(CharacterInfo *chaa)
+{
+    return charextra[chaa->index_id].pivot.Y;
+}
+
+void Character_SetGraphicPivotY(CharacterInfo *chaa, float pivoty)
+{
+    charextra[chaa->index_id].pivot.Y = pivoty;
+}
+
+int Character_GetGraphicPivotOffsetX(CharacterInfo *chaa)
+{
+    return charextra[chaa->index_id].pivot_offset.X;
+}
+
+void Character_SetGraphicPivotOffsetX(CharacterInfo *chaa, int px)
+{
+    charextra[chaa->index_id].pivot_offset.X = px;
+}
+
+int Character_GetGraphicPivotOffsetY(CharacterInfo *chaa)
+{
+    return charextra[chaa->index_id].pivot_offset.Y;
+}
+
+void Character_SetGraphicPivotOffsetY(CharacterInfo *chaa, int py)
+{
+    charextra[chaa->index_id].pivot_offset.Y = py;
+}
+
 float Character_GetFaceDirectionRatio(CharacterInfo *chaa) {
     return charextra[chaa->index_id].face_dir_ratio;
 }
@@ -4595,6 +4635,46 @@ RuntimeScriptValue Sc_Character_SetRotation(void *self, const RuntimeScriptValue
     API_OBJCALL_VOID_PFLOAT(CharacterInfo, Character_SetRotation);
 }
 
+RuntimeScriptValue Sc_Character_GetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(CharacterInfo, Character_GetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Character_SetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(CharacterInfo, Character_SetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Character_GetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(CharacterInfo, Character_GetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Character_SetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(CharacterInfo, Character_SetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Character_GetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Character_SetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Character_GetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetGraphicPivotOffsetY);
+}
+
+RuntimeScriptValue Sc_Character_SetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetGraphicPivotOffsetY);
+}
+
 RuntimeScriptValue Sc_Character_GetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_FLOAT(CharacterInfo, Character_GetFaceDirectionRatio);
@@ -4835,6 +4915,14 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::set_GraphicOffsetY",        API_FN_PAIR(Character_SetGraphicOffsetY) },
         { "Character::get_GraphicRotation",       API_FN_PAIR(Character_GetRotation) },
         { "Character::set_GraphicRotation",       API_FN_PAIR(Character_SetRotation) },
+        { "Character::get_GraphicPivotX",         API_FN_PAIR(Character_GetGraphicPivotX) },
+        { "Character::set_GraphicPivotX",         API_FN_PAIR(Character_SetGraphicPivotX) },
+        { "Character::get_GraphicPivotY",         API_FN_PAIR(Character_GetGraphicPivotY) },
+        { "Character::set_GraphicPivotY",         API_FN_PAIR(Character_SetGraphicPivotY) },
+        { "Character::get_GraphicPivotOffsetX",   API_FN_PAIR(Character_GetGraphicPivotOffsetX) },
+        { "Character::set_GraphicPivotOffsetX",   API_FN_PAIR(Character_SetGraphicPivotOffsetX) },
+        { "Character::get_GraphicPivotOffsetY",   API_FN_PAIR(Character_GetGraphicPivotOffsetY) },
+        { "Character::set_GraphicPivotOffsetY",   API_FN_PAIR(Character_SetGraphicPivotOffsetY) },
         { "Character::get_UseRegionTint",         API_FN_PAIR(Character_GetUseRegionTint) },
         { "Character::set_UseRegionTint",         API_FN_PAIR(Character_SetUseRegionTint) },
         { "Character::get_ViewAnchorX",           API_FN_PAIR(Character_GetViewAnchorX) },

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -93,8 +93,8 @@ void CharacterExtras::SetLockedView(CharacterInfo *chi, int view, int loop, int 
     chi->frame = frame;
     chi->wait = 0;
     chi->flags |= CHF_FIXVIEW;
-    chi->view_anchor = anchor;
-    chi->view_offset = off;
+    view_anchor = anchor;
+    view_offset = off;
     UpdateEffectiveValues(chi);
 }
 
@@ -103,8 +103,8 @@ void CharacterExtras::SetUnlockedView(CharacterInfo *chi)
     chi->flags &= ~CHF_FIXVIEW;
     chi->view = chi->defview;
     chi->frame = 0;
-    chi->view_anchor = CharacterInfo::GetDefaultSpriteAnchor();
-    chi->view_offset = Point();
+    view_anchor = CharacterInfo::GetDefaultSpriteAnchor();
+    view_offset = Point();
     UpdateEffectiveValues(chi);
 }
 
@@ -142,8 +142,8 @@ void CharacterExtras::SetFollowing(CharacterInfo *chi, int follow_who, int dista
 
 void CharacterExtras::UpdateEffectiveValues(const CharacterInfo *chin)
 {
-    eff_offset = chin->is_view_locked() ? chin->view_offset : spr_offset;
-    eff_anchor = chin->is_view_locked() ? chin->view_anchor : spr_anchor;
+    eff_offset = chin->is_view_locked() ? view_offset : spr_offset;
+    eff_anchor = chin->is_view_locked() ? view_anchor : spr_anchor;
 }
 
 void CharacterExtras::ReadFromSavegame(CharacterInfo *chin, Stream *in, CharacterSvgVersion save_ver)
@@ -282,10 +282,10 @@ void CharacterExtras::ReadFromSavegame(CharacterInfo *chin, Stream *in, Characte
         spr_offset = Point(offx, offy);
         float ax = in->ReadFloat32();
         float ay = in->ReadFloat32();
-        chin->view_anchor = Pointf(ax, ay);
+        view_anchor = Pointf(ax, ay);
         offx = in->ReadInt32();
         offy = in->ReadInt32();
-        chin->view_offset = Point(offx, offy);
+        view_offset = Point(offx, offy);
     }
     else
     {
@@ -365,8 +365,8 @@ void CharacterExtras::WriteToSavegame(const CharacterInfo *chin, Stream *out) co
     // kRoomStatSvgVersion_40026
     out->WriteInt32(spr_offset.X);
     out->WriteInt32(spr_offset.Y);
-    out->WriteFloat32(chin->view_anchor.X);
-    out->WriteFloat32(chin->view_anchor.Y);
-    out->WriteInt32(chin->view_offset.X);
-    out->WriteInt32(chin->view_offset.Y);
+    out->WriteFloat32(view_anchor.X);
+    out->WriteFloat32(view_anchor.Y);
+    out->WriteInt32(view_offset.X);
+    out->WriteInt32(view_offset.Y);
 }

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -42,7 +42,7 @@ void CharacterExtras::UpdateGraphicSpace(const CharacterInfo *chin)
         RectWH((eff_offset.X + frame_xoff),
                (-chin->z + eff_offset.Y + frame_yoff),
                spr_width, spr_height),
-        rotation // transforms
+        rotation, pivot, pivot_offset
     );
 }
 

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -227,11 +227,12 @@ void CharacterExtras::ReadFromSavegame(CharacterInfo *chin, Stream *in, Characte
         in->ReadInt32(); // transform skew x
         in->ReadInt32(); // transform skew y
         rotation = in->ReadFloat32(); // transform rotate
-        in->ReadInt32(); // sprite pivot x
-        in->ReadInt32(); // sprite pivot y
+        float px = in->ReadFloat32(); // sprite pivot x
+        float py = in->ReadFloat32(); // sprite pivot y
         float ax = in->ReadFloat32(); // sprite anchor x
         float ay = in->ReadFloat32(); // sprite anchor y
         spr_anchor = Pointf(ax, ay);
+        pivot = Pointf(px, py);
     }
     else
     {
@@ -293,6 +294,18 @@ void CharacterExtras::ReadFromSavegame(CharacterInfo *chin, Stream *in, Characte
         spr_offset = Point();
     }
 
+    if (save_ver >= kCharSvgVersion_400_29)
+    {
+        int pivot_offx = in->ReadInt32();
+        int pivot_offy = in->ReadInt32();
+        pivot_offset = Point(pivot_offx, pivot_offy);
+    }
+    else
+    {
+        pivot = Point(0.5f, 0.5f); // default: center
+        pivot_offset = Point();
+    }
+
     // NOTE: the legacy animating fields from old save fmt are applied externally,
     // because they are loaded into deprecated CharacterInfo fields
     anim = ViewAnimateParams(anim_flow, anim_dir_initial, anim_dir_current, anim_delay, cur_anim_volume);
@@ -343,8 +356,8 @@ void CharacterExtras::WriteToSavegame(const CharacterInfo *chin, Stream *out) co
     out->WriteInt32(0); // transform skew x
     out->WriteInt32(0); // transform skew y
     out->WriteFloat32(rotation); // transform rotate
-    out->WriteInt32(0); // sprite pivot x
-    out->WriteInt32(0); // sprite pivot y
+    out->WriteFloat32(pivot.X); // sprite pivot x
+    out->WriteFloat32(pivot.Y); // sprite pivot y
     out->WriteFloat32(spr_anchor.X); // sprite anchor x
     out->WriteFloat32(spr_anchor.Y); // sprite anchor y
     // -- kCharSvgVersion_400_03
@@ -369,4 +382,7 @@ void CharacterExtras::WriteToSavegame(const CharacterInfo *chin, Stream *out) co
     out->WriteFloat32(view_anchor.Y);
     out->WriteInt32(view_offset.X);
     out->WriteInt32(view_offset.Y);
+    // kRoomStatSvgVersion_40029
+    out->WriteInt32(pivot_offset.X);
+    out->WriteInt32(pivot_offset.Y);
 }

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -57,6 +57,9 @@ public:
     Point spr_offset;    // fixed sprite offset (translation)
     Pointf spr_anchor    // graphic anchor (relative alignment)
         = Pointf(0.5f, 1.f); // default: middle-bottom
+    Point view_offset;   // fixed view offset (from locked view)
+    Pointf view_anchor   // view anchor (from locked view)
+        = Pointf(0.5f, 1.f); // default: middle-bottom
     Point eff_offset;    // effective offset (depends on view state)
     Pointf eff_anchor;   // effective anchor (depends on view state)
     int   spr_width = 0; // current sprite size

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -62,6 +62,9 @@ public:
         = Pointf(0.5f, 1.f); // default: middle-bottom
     Point eff_offset;    // effective offset (depends on view state)
     Pointf eff_anchor;   // effective anchor (depends on view state)
+    Pointf pivot         // relative rotation pivot
+        = Pointf(0.5f, 0.5f); // default: center
+    Point pivot_offset;  // relative rotation pivot offset (in pixels)
     int   spr_width = 0; // current sprite size
     int   spr_height = 0;
     int   frame_xoff = 0; // current frame offset

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -227,6 +227,7 @@ struct ObjectCache
     short tintr = 0, tintg = 0, tintb = 0, tintamnt = 0, tintlight = 0;
     short lightlev = 0, zoom = 0;
     float rotation = 0.f;
+    float pivotx = 0.f, pivoty = 0.f;
     GraphicFlip flip = kFlip_None;
     int   x = 0, y = 0;
 
@@ -2066,6 +2067,8 @@ static bool construct_object_gfx(const ViewFrame *vf, int pic,
         objsav.lightlev = light_level;
         objsav.zoom = objsrc.zoom;
         objsav.rotation = objsrc.rotation;
+        objsav.pivotx = objsrc.pivotx;
+        objsav.pivoty = objsrc.pivoty;
         objsav.flip = use_flip;
         return is_texture_intact;
     }
@@ -2092,6 +2095,8 @@ static bool construct_object_gfx(const ViewFrame *vf, int pic,
         (objsav.lightlev == light_level) &&
         (objsav.zoom == objsrc.zoom) &&
         (objsav.rotation == objsrc.rotation) &&
+        (objsav.pivotx == objsrc.pivotx) &&
+        (objsav.pivoty == objsrc.pivoty) &&
         (objsav.flip == use_flip))
     {
         // If the image is the same, we can use it cached
@@ -2159,6 +2164,8 @@ static bool construct_object_gfx(const ViewFrame *vf, int pic,
     objsav.lightlev = light_level;
     objsav.zoom = objsrc.zoom;
     objsav.rotation = objsrc.rotation;
+    objsav.pivotx = objsrc.pivotx;
+    objsav.pivoty = objsrc.pivoty;
     objsav.flip = use_flip;
     objsav.x = objsrc.x;
     objsav.y = objsrc.y;
@@ -2216,6 +2223,7 @@ void prepare_and_add_object_gfx(
     {
         actsp.Ddb->SetStretch(scale_size.Width, scale_size.Height);
         actsp.Ddb->SetRotation(objsav.rotation);
+        actsp.Ddb->SetPivot(objsav.pivotx, objsav.pivoty);
         actsp.Ddb->SetFlip(objsav.flip);
         apply_tint_or_light_ddb(actsp, objsav.lightlev, objsav.tintamnt, objsav.tintr, objsav.tintg, objsav.tintb, objsav.tintlight);
     }
@@ -2236,6 +2244,8 @@ bool construct_object_gfx(int objid, bool force_software)
     ObjectCache objsrc(sprite_id, obj.tint_r, obj.tint_g, obj.tint_b,
         obj.tint_level, obj.tint_light, 0 /* skip */, obj.zoom, obj.rotation,
         kFlip_None /* skip */, obj.x, obj.y);
+    objsrc.pivotx = obj.pivot.X + (static_cast<float>(obj.pivot_offset.X) / obj.width);
+    objsrc.pivoty = obj.pivot.Y + (static_cast<float>(obj.pivot_offset.Y) / obj.height);
 
     return construct_object_gfx(
         (obj.view != UINT16_MAX) ? &views[obj.view].loops[obj.loop].frames[obj.frame] : nullptr,
@@ -2350,6 +2360,8 @@ bool construct_char_gfx(int charid, bool force_software)
     ObjectCache chsrc(pic, chex.tint_r, chex.tint_g, chex.tint_b,
         chex.tint_level, chex.tint_light, 0 /* skip */, chex.zoom, chex.rotation,
         kFlip_None /* skip */, chin.x, chin.y);
+    chsrc.pivotx = chex.pivot.X + (static_cast<float>(chex.pivot_offset.X) / chex.width);
+    chsrc.pivoty = chex.pivot.Y + (static_cast<float>(chex.pivot_offset.Y) / chex.height);
 
     return construct_object_gfx(
         vf,
@@ -2911,7 +2923,7 @@ static void construct_roomview_hw(const Viewport *viewport)
     if (render_room_as_texture)
     {
         const SpriteTransform cam_trans(-cam_rc.Left, -cam_rc.Top, 1.f, 1.f,
-                                        camera->GetRotation(), Point(cam_rc.GetWidth() / 2, cam_rc.GetHeight() / 2));
+            camera->GetRotation(), camera->GetEffectivePivot());
 
         auto &cam_data = CameraDrawData[viewport->GetID()];
         cam_data.CamRenderTarget = recycle_render_target(cam_data.CamRenderTarget,
@@ -2952,7 +2964,7 @@ static void construct_roomview_hw(const Viewport *viewport)
         const float view_sy = (float)view_rc.GetHeight() / (float)cam_rc.GetHeight();
         const SpriteTransform view_trans(view_rc.Left, view_rc.Top, view_sx, view_sy);
         const SpriteTransform cam_trans(-cam_rc.Left, -cam_rc.Top, 1.f, 1.f,
-                                        camera->GetRotation(), Point(cam_rc.GetWidth() / 2, cam_rc.GetHeight() / 2));
+            camera->GetRotation(), camera->GetEffectivePivot());
 
         gfxDriver->BeginSpriteBatch(view_rc, view_trans, RENDER_BATCH_ROOM_LAYER);
         gfxDriver->BeginSpriteBatch(Rect(), cam_trans);
@@ -3123,6 +3135,8 @@ static void construct_overlays()
         overtx.Ddb->SetStretch(over.GetScaledWidth(), over.GetScaledHeight());
         overtx.Ddb->SetFlip(over.GetFlip());
         overtx.Ddb->SetRotation(over.GetRotation());
+        const auto pivot = over.GetEffectivePivot();
+        overtx.Ddb->SetPivot(pivot.X, pivot.Y);
         overtx.Ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.GetTransparency()));
         overtx.Ddb->SetBlendMode(over.GetBlendMode());
         overtx.Ddb->SetShader(shaderInstances[over.GetShaderID()]);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2967,7 +2967,7 @@ static void construct_roomview_hw(const Viewport *viewport)
             camera->GetRotation(), camera->GetEffectivePivot());
 
         gfxDriver->BeginSpriteBatch(view_rc, view_trans, RENDER_BATCH_ROOM_LAYER);
-        gfxDriver->BeginSpriteBatch(Rect(), cam_trans);
+        gfxDriver->BeginSpriteBatch(Rect(), cam_trans, cam_rc.GetSize());
         gfxDriver->SetStageScreen(cam_rc.GetSize(), cam_rc.Left, cam_rc.Top);
         put_sprite_list_on_screen(true);
         gfxDriver->EndSpriteBatch();

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -36,10 +36,12 @@
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
 #include "ac/system.h"
+#include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/cc_gui.h"
 #include "ac/dynobj/cc_guicontrol.h"
 #include "ac/dynobj/scriptshader.h"
 #include "ac/dynobj/scriptobjects.h"
+#include "ac/dynobj/scriptuserobject.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "debug/debug_log.h"
 #include "device/mousew32.h"
@@ -327,6 +329,24 @@ void GUI_SetZOrder(ScriptGUI *tehgui, int z) {
 
 int GUI_GetZOrder(ScriptGUI *tehgui) {
   return guis[tehgui->id].GetZOrder();
+}
+
+void *GUI_GetGraphicPosition(ScriptGUI *tehgui)
+{
+    auto &gui = guis[tehgui->id];
+    gui.UpdateGraphicSpace();
+    std::vector<Point> points;
+    gui.GetGraphicSpace().GetTransformedCorners(points, gui.GetSize());
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
+void *GUI_GetGraphicBoundBox(ScriptGUI *tehgui)
+{
+    auto &gui = guis[tehgui->id];
+    gui.UpdateGraphicSpace();
+    std::vector<Point> points;
+    gui.GetGraphicSpace().GetAABBPoints(points);
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
 }
 
 void GUI_SetClickable(ScriptGUI *tehgui, int clickable) {
@@ -1352,6 +1372,16 @@ RuntimeScriptValue Sc_GUI_SetZOrder(void *self, const RuntimeScriptValue *params
     API_OBJCALL_VOID_PINT(ScriptGUI, GUI_SetZOrder);
 }
 
+RuntimeScriptValue Sc_GUI_GetGraphicPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptGUI, void, globalDynamicArray, GUI_GetGraphicPosition);
+}
+
+RuntimeScriptValue Sc_GUI_GetGraphicBoundBox(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptGUI, void, globalDynamicArray, GUI_GetGraphicBoundBox);
+}
+
 RuntimeScriptValue Sc_GUI_AsTextWindow(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_OBJ(ScriptGUI, ScriptGUI, ccDynamicGUI, GUI_AsTextWindow);
@@ -1524,10 +1554,12 @@ void RegisterGUIAPI()
         { "GUI::Click^1",                 API_FN_PAIR(GUI_Click) },
         { "GUI::SetPosition^2",           API_FN_PAIR(GUI_SetPosition) },
         { "GUI::SetSize^2",               API_FN_PAIR(GUI_SetSize) },
-        { "GUI::GetProperty^1",             API_FN_PAIR(GUI_GetProperty) },
-        { "GUI::GetTextProperty^1",         API_FN_PAIR(GUI_GetTextProperty) },
-        { "GUI::SetProperty^2",             API_FN_PAIR(GUI_SetProperty) },
-        { "GUI::SetTextProperty^2",         API_FN_PAIR(GUI_SetTextProperty) },
+        { "GUI::GetGraphicPosition^0",    API_FN_PAIR(GUI_GetGraphicPosition) },
+        { "GUI::GetGraphicBoundBox^0",    API_FN_PAIR(GUI_GetGraphicBoundBox) },
+        { "GUI::GetProperty^1",           API_FN_PAIR(GUI_GetProperty) },
+        { "GUI::GetTextProperty^1",       API_FN_PAIR(GUI_GetTextProperty) },
+        { "GUI::SetProperty^2",           API_FN_PAIR(GUI_SetProperty) },
+        { "GUI::SetTextProperty^2",       API_FN_PAIR(GUI_SetTextProperty) },
         { "GUI::get_BackgroundGraphic",   API_FN_PAIR(GUI_GetBackgroundGraphic) },
         { "GUI::set_BackgroundGraphic",   API_FN_PAIR(GUI_SetBackgroundGraphic) },
         { "GUI::get_BackgroundColor",     API_FN_PAIR(GUI_GetBackgroundColor) },

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -22,9 +22,11 @@
 #include "ac/object.h"
 #include "ac/properties.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/cc_gui.h"
 #include "ac/dynobj/cc_guicontrol.h"
 #include "ac/dynobj/scriptshader.h"
+#include "ac/dynobj/scriptuserobject.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "debug/debug_log.h"
 #include "script/runtimescriptvalue.h"
@@ -242,6 +244,22 @@ void GUIControl_SetSize(GUIControl *guio, int newwid, int newhit) {
   GUIControl_SetHeight(guio, newhit);
 }
 
+void *GUIControl_GetGraphicPosition(GUIControl *guio)
+{
+    guio->UpdateGraphicSpace();
+    std::vector<Point> points;
+    guio->GetGraphicSpace().GetTransformedCorners(points, guio->GetSize());
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
+void *GUIControl_GetGraphicBoundBox(GUIControl *guio)
+{
+    guio->UpdateGraphicSpace();
+    std::vector<Point> points;
+    guio->GetGraphicSpace().GetAABBPoints(points);
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
 void GUIControl_SendToBack(GUIControl *guio) {
   guis[guio->GetParentID()].SendControlToBack(guio->GetID());
 }
@@ -448,6 +466,16 @@ RuntimeScriptValue Sc_GUIControl_SetPosition(void *self, const RuntimeScriptValu
 RuntimeScriptValue Sc_GUIControl_SetSize(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT2(GUIControl, GUIControl_SetSize);
+}
+
+RuntimeScriptValue Sc_GUIControl_GetGraphicPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(GUIControl, void, globalDynamicArray, GUIControl_GetGraphicPosition);
+}
+
+RuntimeScriptValue Sc_GUIControl_GetGraphicBoundBox(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(GUIControl, void, globalDynamicArray, GUIControl_GetGraphicBoundBox);
 }
 
 // GUIButton* (GUIControl *guio)
@@ -774,6 +802,8 @@ void RegisterGUIControlAPI()
         { "GUIControl::SendToBack^0",     API_FN_PAIR(GUIControl_SendToBack) },
         { "GUIControl::SetPosition^2",    API_FN_PAIR(GUIControl_SetPosition) },
         { "GUIControl::SetSize^2",        API_FN_PAIR(GUIControl_SetSize) },
+        { "GUIControl::GetGraphicPosition^0", API_FN_PAIR(GUIControl_GetGraphicPosition) },
+        { "GUIControl::GetGraphicBoundBox^0", API_FN_PAIR(GUIControl_GetGraphicBoundBox) },
         { "GUIControl::GetProperty^1",    API_FN_PAIR(GUIControl_GetProperty) },
         { "GUIControl::GetTextProperty^1", API_FN_PAIR(GUIControl_GetTextProperty) },
         { "GUIControl::SetProperty^2",    API_FN_PAIR(GUIControl_SetProperty) },

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -958,6 +958,46 @@ void Object_SetRotation(ScriptObject *objj, float degrees) {
     objs[objj->id].UpdateGraphicSpace();
 }
 
+float Object_GetGraphicPivotX(ScriptObject *objj)
+{
+    return objs[objj->id].pivot.X;
+}
+
+void Object_SetGraphicPivotX(ScriptObject *objj, float pivotx)
+{
+    objs[objj->id].pivot.X = pivotx;
+}
+
+float Object_GetGraphicPivotY(ScriptObject *objj)
+{
+    return objs[objj->id].pivot.Y;
+}
+
+void Object_SetGraphicPivotY(ScriptObject *objj, float pivoty)
+{
+    objs[objj->id].pivot.Y = pivoty;
+}
+
+int Object_GetGraphicPivotOffsetX(ScriptObject *objj)
+{
+    return objs[objj->id].pivot_offset.X;
+}
+
+void Object_SetGraphicPivotOffsetX(ScriptObject *objj, int px)
+{
+    objs[objj->id].pivot_offset.X = px;
+}
+
+int Object_GetGraphicPivotOffsetY(ScriptObject *objj)
+{
+    return objs[objj->id].pivot_offset.Y;
+}
+
+void Object_SetGraphicPivotOffsetY(ScriptObject *objj, int py)
+{
+    objs[objj->id].pivot_offset.Y = py;
+}
+
 void move_object(int objj, const std::vector<Point> *path, int tox, int toy, int speed, bool ignwal,
     const RunPathParams &run_params)
 {
@@ -2008,6 +2048,46 @@ RuntimeScriptValue Sc_Object_SetRotation(void *self, const RuntimeScriptValue *p
     API_OBJCALL_VOID_PFLOAT(ScriptObject, Object_SetRotation);
 }
 
+RuntimeScriptValue Sc_Object_GetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptObject, Object_GetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Object_SetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptObject, Object_SetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Object_GetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptObject, Object_GetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Object_SetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptObject, Object_SetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Object_GetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Object_SetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptObject, Object_SetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Object_GetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetGraphicPivotOffsetY);
+}
+
+RuntimeScriptValue Sc_Object_SetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptObject, Object_SetGraphicPivotOffsetY);
+}
+
 RuntimeScriptValue Sc_Object_GetMotionPath(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_OBJAUTO(ScriptObject, ScriptMotionPath, Object_GetMotionPath);
@@ -2115,6 +2195,14 @@ void RegisterObjectAPI()
         { "Object::set_GraphicOffsetY",       API_FN_PAIR(Object_SetGraphicOffsetY) },
         { "Object::get_GraphicRotation",      API_FN_PAIR(Object_GetRotation) },
         { "Object::set_GraphicRotation",      API_FN_PAIR(Object_SetRotation) },
+        { "Object::get_GraphicPivotX",        API_FN_PAIR(Object_GetGraphicPivotX) },
+        { "Object::set_GraphicPivotX",        API_FN_PAIR(Object_SetGraphicPivotX) },
+        { "Object::get_GraphicPivotY",        API_FN_PAIR(Object_GetGraphicPivotY) },
+        { "Object::set_GraphicPivotY",        API_FN_PAIR(Object_SetGraphicPivotY) },
+        { "Object::get_GraphicPivotOffsetX",  API_FN_PAIR(Object_GetGraphicPivotOffsetX) },
+        { "Object::set_GraphicPivotOffsetX",  API_FN_PAIR(Object_SetGraphicPivotOffsetX) },
+        { "Object::get_GraphicPivotOffsetY",  API_FN_PAIR(Object_GetGraphicPivotOffsetY) },
+        { "Object::set_GraphicPivotOffsetY",  API_FN_PAIR(Object_SetGraphicPivotOffsetY) },
         { "Object::get_UseRegionTint",        API_FN_PAIR(Object_GetUseRegionTint) },
         { "Object::set_UseRegionTint",        API_FN_PAIR(Object_SetUseRegionTint) },
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -1066,6 +1066,22 @@ void Object_RunInteraction(ScriptObject *objj, int mode) {
     RunObjectInteraction(objj->id, mode);
 }
 
+void *Object_GetGraphicPosition(ScriptObject *objj)
+{
+    objs[objj->id].UpdateGraphicSpace();
+    std::vector<Point> points;
+    objs[objj->id].GetGraphicSpace().GetTransformedCorners(points, Size(objs[objj->id].spr_width, objs[objj->id].spr_height));
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
+void *Object_GetGraphicBoundBox(ScriptObject *objj)
+{
+    objs[objj->id].UpdateGraphicSpace();
+    std::vector<Point> points;
+    objs[objj->id].GetGraphicSpace().GetAABBPoints(points);
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
 int GetObjectProperty(int hss, const char *property)
 {
     if (!is_valid_object(hss))
@@ -1542,6 +1558,16 @@ RuntimeScriptValue Sc_Object_Animate(void *self, const RuntimeScriptValue *param
 RuntimeScriptValue Sc_Object_IsCollidingWithObject(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT_POBJ(ScriptObject, Object_IsCollidingWithObject, ScriptObject);
+}
+
+RuntimeScriptValue Sc_Object_GetGraphicPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptObject, void, globalDynamicArray, Object_GetGraphicPosition);
+}
+
+RuntimeScriptValue Sc_Object_GetGraphicBoundBox(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptObject, void, globalDynamicArray, Object_GetGraphicBoundBox);
 }
 
 // int (ScriptObject *objj, const char *property)
@@ -2107,6 +2133,8 @@ void RegisterObjectAPI()
         { "Object::Animate^6",                API_FN_PAIR(Object_Animate6) },
         { "Object::Animate^7",                API_FN_PAIR(Object_Animate) },
         { "Object::IsCollidingWithObject^1",  API_FN_PAIR(Object_IsCollidingWithObject) },
+        { "Object::GetGraphicPosition^0",     API_FN_PAIR(Object_GetGraphicPosition) },
+        { "Object::GetGraphicBoundBox^0",     API_FN_PAIR(Object_GetGraphicBoundBox) },
         { "Object::GetProperty^1",            API_FN_PAIR(Object_GetProperty) },
         { "Object::GetPropertyText^2",        API_FN_PAIR(Object_GetPropertyText) },
         { "Object::GetTextProperty^1",        API_FN_PAIR(Object_GetTextProperty) },

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -430,6 +430,54 @@ void Overlay_SetRotation(ScriptOverlay *scover, float degrees) {
     over->SetRotation(Math::ClampAngle360(degrees));
 }
 
+float Overlay_GetGraphicPivotX(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotX", scover);
+    return over->GetPivot().X;
+}
+
+void Overlay_SetGraphicPivotX(ScriptOverlay *scover, float pivotx)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotX", scover);
+    over->SetPivot(Pointf(pivotx, over->GetPivot().Y));
+}
+
+float Overlay_GetGraphicPivotY(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotY", scover);
+    return over->GetPivot().Y;
+}
+
+void Overlay_SetGraphicPivotY(ScriptOverlay *scover, float pivoty)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotY", scover);
+    over->SetPivot(Pointf(over->GetPivot().X, pivoty));
+}
+
+int Overlay_GetGraphicPivotOffsetX(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotOffsetX", scover);
+    return over->GetPivotOffset().X;
+}
+
+void Overlay_SetGraphicPivotOffsetX(ScriptOverlay *scover, int px)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotOffsetX", scover);
+    over->SetPivotOffset(Point(px, over->GetPivotOffset().Y));
+}
+
+int Overlay_GetGraphicPivotOffsetY(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotOffsetY", scover);
+    return over->GetPivotOffset().Y;
+}
+
+void Overlay_SetGraphicPivotOffsetY(ScriptOverlay *scover, int py)
+{
+    auto *over = GetOverlayValidate("Overlay.GraphicPivotOffsetY", scover);
+    over->SetPivotOffset(Point(over->GetPivotOffset().X, py));
+}
+
 int Overlay_GetZOrder(ScriptOverlay *scover)
 {
     auto *over = GetOverlayValidate("Overlay.ZOrder", scover);
@@ -1216,6 +1264,46 @@ RuntimeScriptValue Sc_Overlay_SetRotation(void *self, const RuntimeScriptValue *
     API_OBJCALL_VOID_PFLOAT(ScriptOverlay, Overlay_SetRotation);
 }
 
+RuntimeScriptValue Sc_Overlay_GetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptOverlay, Overlay_GetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Overlay_SetGraphicPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptOverlay, Overlay_SetGraphicPivotX);
+}
+
+RuntimeScriptValue Sc_Overlay_GetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptOverlay, Overlay_GetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Overlay_SetGraphicPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptOverlay, Overlay_SetGraphicPivotY);
+}
+
+RuntimeScriptValue Sc_Overlay_GetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Overlay_SetGraphicPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetGraphicPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Overlay_GetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetGraphicPivotOffsetY);
+}
+
+RuntimeScriptValue Sc_Overlay_SetGraphicPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetGraphicPivotOffsetY);
+}
+
 RuntimeScriptValue Sc_Overlay_GetScaleX(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_FLOAT(ScriptOverlay, Overlay_GetScaleX);
@@ -1468,6 +1556,14 @@ void RegisterOverlayAPI()
         { "Overlay::set_GraphicOffsetY",  API_FN_PAIR(Overlay_SetGraphicOffsetY) },
         { "Overlay::get_Rotation",        API_FN_PAIR(Overlay_GetRotation) },
         { "Overlay::set_Rotation",        API_FN_PAIR(Overlay_SetRotation) },
+        { "Overlay::get_GraphicPivotX",   API_FN_PAIR(Overlay_GetGraphicPivotX) },
+        { "Overlay::set_GraphicPivotX",   API_FN_PAIR(Overlay_SetGraphicPivotX) },
+        { "Overlay::get_GraphicPivotY",   API_FN_PAIR(Overlay_GetGraphicPivotY) },
+        { "Overlay::set_GraphicPivotY",   API_FN_PAIR(Overlay_SetGraphicPivotY) },
+        { "Overlay::get_GraphicPivotOffsetX", API_FN_PAIR(Overlay_GetGraphicPivotOffsetX) },
+        { "Overlay::set_GraphicPivotOffsetX", API_FN_PAIR(Overlay_SetGraphicPivotOffsetX) },
+        { "Overlay::get_GraphicPivotOffsetY", API_FN_PAIR(Overlay_GetGraphicPivotOffsetY) },
+        { "Overlay::set_GraphicPivotOffsetY", API_FN_PAIR(Overlay_SetGraphicPivotOffsetY) },
         { "Overlay::get_ScaleX",          API_FN_PAIR(Overlay_GetScaleX) },
         { "Overlay::set_ScaleX",          API_FN_PAIR(Overlay_SetScaleX) },
         { "Overlay::get_ScaleY",          API_FN_PAIR(Overlay_GetScaleY) },

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -30,8 +30,10 @@
 #include "ac/screenoverlay.h"
 #include "ac/spritecache.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/dynobj_manager.h"
 #include "ac/dynobj/scriptshader.h"
+#include "ac/dynobj/scriptuserobject.h"
 #include "debug/debug_log.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
@@ -267,6 +269,24 @@ void Overlay_SetGraphicOffsetY(ScriptOverlay *scover, int y)
 {
     auto *over = GetOverlayValidate("Overlay.GraphicOffsetY", scover);
     over->SetSpriteOffset(Point(over->GetSpriteOffset().X, y));
+}
+
+void *Overlay_GetGraphicPosition(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GetGraphicPosition", scover);
+    over->UpdateGraphicSpace();
+    std::vector<Point> points;
+    over->GetGraphicSpace().GetTransformedCorners(points, over->GetGraphicSize());
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
+}
+
+void *Overlay_GetGraphicBoundBox(ScriptOverlay *scover)
+{
+    auto *over = GetOverlayValidate("Overlay.GetGraphicBoundBox", scover);
+    over->UpdateGraphicSpace();
+    std::vector<Point> points;
+    over->GetGraphicSpace().GetAABBPoints(points);
+    return ScriptStructHelpers::CreateArrayOfPoints(points).Obj();
 }
 
 int Overlay_GetValid(ScriptOverlay *scover)
@@ -1214,6 +1234,16 @@ RuntimeScriptValue Sc_Overlay_SetFlip(void *self, const RuntimeScriptValue *para
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetFlip);
 }
 
+RuntimeScriptValue Sc_Overlay_GetGraphicPosition(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptOverlay, void, globalDynamicArray, Overlay_GetGraphicPosition);
+}
+
+RuntimeScriptValue Sc_Overlay_GetGraphicBoundBox(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptOverlay, void, globalDynamicArray, Overlay_GetGraphicBoundBox);
+}
+
 RuntimeScriptValue Sc_Overlay_GetGraphicAnchorX(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_FLOAT(ScriptOverlay, Overlay_GetGraphicAnchorX);
@@ -1501,6 +1531,8 @@ void RegisterOverlayAPI()
         { "Overlay::CreateRoomGraphical^4", API_FN_PAIR(Overlay_CreateRoomGraphical) },
         { "Overlay::CreateRoomGraphical^5", API_FN_PAIR(Overlay_CreateRoomGraphical5) },
         { "Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual, ScPl_Overlay_CreateRoomTextual },
+        { "Overlay::GetGraphicPosition^0", API_FN_PAIR(Overlay_GetGraphicPosition) },
+        { "Overlay::GetGraphicBoundBox^0", API_FN_PAIR(Overlay_GetGraphicBoundBox) },
         { "Overlay::SetText^104",         Sc_Overlay_SetText, ScPl_Overlay_SetText },
         { "Overlay::Remove^0",            API_FN_PAIR(Overlay_Remove) },
         { "Overlay::SetPosition^4",       API_FN_PAIR(Overlay_SetPosition) },

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -239,11 +239,12 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
         in->ReadInt32(); // transform skew x
         in->ReadInt32(); // transform skew y
         rotation = in->ReadFloat32(); // transform rotate
-        in->ReadInt32(); // sprite pivot x
-        in->ReadInt32(); // sprite pivot y
+        float px = in->ReadFloat32(); // sprite pivot x
+        float py = in->ReadFloat32(); // sprite pivot y
         float ax = in->ReadFloat32(); // sprite anchor x
         float ay = in->ReadFloat32(); // sprite anchor y
         spr_anchor = Pointf(ax, ay);
+        pivot = Pointf(px, py);
     }
     else
     {
@@ -293,6 +294,18 @@ void RoomObject::ReadFromSavegame(Stream *in, int cmp_ver)
     {
         spr_anchor = Pointf(0.f, 1.f); // default: left-bottom
         spr_offset = Point();
+    }
+
+    if (cmp_ver >= kRoomStatSvgVersion_40029)
+    {
+        int pivot_offx = in->ReadInt32();
+        int pivot_offy = in->ReadInt32();
+        pivot_offset = Point(pivot_offx, pivot_offy);
+    }
+    else
+    {
+        pivot = Point(0.5f, 0.5f); // default: center
+        pivot_offset = Point();
     }
 
     // Apply animation params either from old or new save
@@ -367,8 +380,8 @@ void RoomObject::WriteToSavegame(Stream *out) const
     out->WriteInt32(0); // transform skew x
     out->WriteInt32(0); // transform skew y
     out->WriteFloat32(rotation); // transform rotate
-    out->WriteInt32(0); // sprite pivot x
-    out->WriteInt32(0); // sprite pivot y
+    out->WriteFloat32(pivot.X); // sprite pivot x
+    out->WriteFloat32(pivot.Y); // sprite pivot y
     out->WriteFloat32(spr_anchor.X); // sprite anchor x
     out->WriteFloat32(spr_anchor.Y); // sprite anchor y
     // kRoomStatSvgVersion_40016
@@ -389,6 +402,9 @@ void RoomObject::WriteToSavegame(Stream *out) const
     // kRoomStatSvgVersion_40026
     out->WriteInt32(spr_offset.X);
     out->WriteInt32(spr_offset.Y);
+    // kRoomStatSvgVersion_40029
+    out->WriteInt32(pivot_offset.X);
+    out->WriteInt32(pivot_offset.Y);
 }
 
 void RoomObject::UpdateGraphicSpace()

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -399,6 +399,6 @@ void RoomObject::UpdateGraphicSpace()
         Size(width, height), // destination size (scaled)
         // real graphical aabb (maybe with extra offsets)
         RectWH(frame_xoff + spr_offset.X, frame_yoff + spr_offset.Y, spr_width, spr_height),
-        rotation // transforms
+        rotation, pivot, pivot_offset
     );
 }

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -48,6 +48,9 @@ public:
     Point spr_offset;       // fixed sprite offset (translation)
     Pointf spr_anchor       // graphic anchor (relative alignment)
         = Pointf(0.f, 1.f); // default: left-bottom
+    Pointf pivot            // relative rotation pivot
+        = Pointf(0.5f, 0.5f); // default: center
+    Point pivot_offset;     // relative rotation pivot offset (in pixels)
     int   spr_width, spr_height; // last used sprite's size
     int   frame_xoff, frame_yoff; // frame offsets (when using a view)
     int16_t width, height;  // width/height based on a scaled sprite

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -47,7 +47,8 @@ enum RoomStatSvgVersion
     kRoomStatSvgVersion_40024    = 4000024, // sync with kRoomStatSvgVersion_36214
     kRoomStatSvgVersion_40026    = 4000026, // sync with kRoomStatSvgVersion_36304
     kRoomStatSvgVersion_40028    = 4000028, // sync with kRoomStatSvgVersion_36310
-    kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_40028
+    kRoomStatSvgVersion_40029    = 4000029, // objects rotation pivot
+    kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_40029
 };
 
 struct HotspotState

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -48,6 +48,13 @@ ScreenOverlay &ScreenOverlay::operator =(ScreenOverlay &&over)
     return *this;
 }
 
+Pointf ScreenOverlay::GetEffectivePivot() const
+{
+    return _pivot +
+        Pointf((static_cast<float>(_pivotOff.X) / _scaledSize.Width),
+               (static_cast<float>(_pivotOff.Y) / _scaledSize.Height));
+}
+
 Bitmap *ScreenOverlay::GetImage() const
 {
     return spriteset[_sprnum];
@@ -117,6 +124,18 @@ void ScreenOverlay::SetScale(float sx, float sy)
 void ScreenOverlay::SetRotation(float rotation)
 {
     _rotation = rotation;
+    MarkChanged();
+}
+
+void ScreenOverlay::SetPivot(const Pointf &pivot)
+{
+    _pivot = pivot;
+    MarkChanged();
+}
+
+void ScreenOverlay::SetPivotOffset(const Point &pivot_offset)
+{
+    _pivotOff = pivot_offset;
     MarkChanged();
 }
 
@@ -329,7 +348,7 @@ void ScreenOverlay::UpdateGraphicSpace()
         _scaledSize,
         // real graphical aabb (maybe with extra offsets)
         RectWH(_sprOffset.X, _sprOffset.Y, pic->GetWidth(), pic->GetHeight()),
-        _rotation // transforms
+        _rotation, _pivot, _pivotOff
     );
 }
 

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -441,11 +441,12 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
         in->ReadInt32(); // transform skew x
         in->ReadInt32(); // transform skew y
         _rotation = in->ReadFloat32(); // transform rotate
-        in->ReadInt32(); // sprite pivot x
-        in->ReadInt32(); // sprite pivot y
+        float px = in->ReadFloat32(); // sprite pivot x
+        float py = in->ReadFloat32(); // sprite pivot y
         float ax = in->ReadFloat32(); // sprite anchor x
         float ay = in->ReadFloat32(); // sprite anchor y
         _sprAnchor = Pointf(ax, ay);
+        _pivot = Pointf(px, py);
     }
 
     // Some of the fields above were not valid in previous versions,
@@ -459,14 +460,22 @@ void ScreenOverlay::ReadFromSavegame(Stream *in, bool &has_bitmap, int32_t cmp_v
     {
         _shaderID = in->ReadInt32();
         _shaderHandle = in->ReadInt32();
-        in->ReadInt32(); // reserved
-        in->ReadInt32();
+        // valid since kOverSvgVersion_40029
+        int pivot_offx = in->ReadInt32();
+        int pivot_offy = in->ReadInt32();
+        _pivotOff = Point(pivot_offx, pivot_offy);
     }
     else
     {
         _shaderID = 0;
         _shaderHandle = 0;
         _sprOffset = Point();
+    }
+
+    if (cmp_ver < kOverSvgVersion_40029)
+    {
+        _pivot = Pointf(0.5f, 0.5f);
+        _pivotOff = Point();
     }
 
     // Convert magic x,y values from the older saves
@@ -522,15 +531,16 @@ void ScreenOverlay::WriteToSavegame(Stream *out) const
     out->WriteInt32(0); // transform skew x
     out->WriteInt32(0); // transform skew y
     out->WriteFloat32(_rotation); // transform rotate
-    out->WriteInt32(0); // sprite pivot x
-    out->WriteInt32(0); // sprite pivot y
+    out->WriteFloat32(_pivot.X); // sprite pivot x
+    out->WriteFloat32(_pivot.Y); // sprite pivot y
     out->WriteFloat32(_sprAnchor.X); // sprite anchor x
     out->WriteFloat32(_sprAnchor.Y); // sprite anchor y
     // kOverSvgVersion_40018
     out->WriteInt32(_shaderID);
     out->WriteInt32(_shaderHandle);
-    out->WriteInt32(0); // reserved
-    out->WriteInt32(0);
+    // valid since kOverSvgVersion_40029
+    out->WriteInt32(_pivotOff.X);
+    out->WriteInt32(_pivotOff.Y);
 }
 
 const ViewFrame *AnimatedOverlay::GetViewFrame() const

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -72,7 +72,8 @@ enum OverlaySvgVersion
     kOverSvgVersion_40024   = 4000024, // sync with kOverSvgVersion_36303
     kOverSvgVersion_40026   = 4000026, // sync with kOverSvgVersion_36304
     kOverSvgVersion_40028   = 4000028, // autosize flag, scale field is valid
-    kOverSvgVersion_Current = kOverSvgVersion_40028
+    kOverSvgVersion_40029   = 4000029, // rotation pivot
+    kOverSvgVersion_Current = kOverSvgVersion_40029
 };
 
 class ScreenOverlay

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -103,6 +103,9 @@ public:
     int  GetScaledWidth() const { return _scaledSize.Width; }
     int  GetScaledHeight() const { return _scaledSize.Height; }
     float GetRotation() const { return _rotation; }
+    const Pointf &GetPivot() const { return _pivot; }
+    const Point &GetPivotOffset() const { return _pivotOff;}
+    Pointf GetEffectivePivot() const;
     bool IsSpriteShared() const { return (_flags & kOver_SpriteShared) != 0; }
     bool IsAutoPosition() const { return (_flags & kOver_AutoPosition) != 0; }
     bool IsAutoSize() const  { return (_flags & kOver_AutoSize) != 0; }
@@ -150,6 +153,8 @@ public:
     void SetDestinationSize(int w, int h);
     void SetScale(float sx, float sy);
     void SetRotation(float rotation);
+    void SetPivot(const Pointf &pivot);
+    void SetPivotOffset(const Point &pivot_offset);
     // Assigns a shader to overlay
     void SetZOrder(int zorder);
     // Assigns an exclusive image to this overlay; the image will be stored as a dynamic sprite
@@ -238,7 +243,11 @@ private:
     // also used as a border/padding offset for the tiled text windows
     Point _sprOffset;
     // Graphic anchor (relative alignment)
-    Pointf _sprAnchor;
+    Pointf _sprAnchor; // default: top-left
+    // Relative rotation pivot
+    Pointf _pivot = Pointf(0.5f, 0.5f); // default: center
+    // Relative rotation pivot offset (in pixels)
+    Point _pivotOff;
     // The size to stretch the texture to
     // TODO: figure out what to do with this, considering the "scale" property, keep or deprecate?
     Size _destSize;

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -102,15 +102,71 @@ void Camera_SetHeight(ScriptCamera *scam, int height)
 
 float Camera_GetRotation(ScriptCamera *scam)
 {
-    if (scam->GetID() < 0) { debug_script_warn("Camera.Height: trying to use deleted camera"); return 0; }
+    if (scam->GetID() < 0) { debug_script_warn("Camera.Rotation: trying to use deleted camera"); return 0; }
     return play.GetRoomCamera(scam->GetID())->GetRotation();
 }
 
 void Camera_SetRotation(ScriptCamera *scam, float rotation)
 {
-    if (scam->GetID() < 0) { debug_script_warn("Camera.Height: trying to use deleted camera"); return; }
+    if (scam->GetID() < 0) { debug_script_warn("Camera.Rotation: trying to use deleted camera"); return; }
     auto cam = play.GetRoomCamera(scam->GetID());
     cam->SetRotation(rotation);
+}
+
+float Camera_GetPivotX(ScriptCamera *scam)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotX: trying to use deleted camera"); return 0.f; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    return cam->GetPivot().X;
+}
+
+void Camera_SetPivotX(ScriptCamera *scam, float pivotx)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotX: trying to use deleted camera"); return; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetPivot(Pointf(pivotx, cam->GetPivot().Y));
+}
+
+float Camera_GetPivotY(ScriptCamera *scam)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotY: trying to use deleted camera"); return 0.f; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    return cam->GetPivot().Y;
+}
+
+void Camera_SetPivotY(ScriptCamera *scam, float pivoty)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotY: trying to use deleted camera"); return; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetPivot(Pointf(cam->GetPivot().X, pivoty));
+}
+
+int Camera_GetPivotOffsetX(ScriptCamera *scam)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotOffsetX: trying to use deleted camera"); return 0; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    return cam->GetPivotOffset().X;
+}
+
+void Camera_SetPivotOffsetX(ScriptCamera *scam, int px)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotOffsetX: trying to use deleted camera"); return; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetPivotOffset(Point(px, cam->GetPivotOffset().Y));
+}
+
+int Camera_GetPivotOffsetY(ScriptCamera *scam)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotOffsetY: trying to use deleted camera"); return 0; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    return cam->GetPivotOffset().Y;
+}
+
+void Camera_SetPivotOffsetY(ScriptCamera *scam, int py)
+{
+    if (scam->GetID() < 0) { debug_script_warn("Camera.PivotOffsetY: trying to use deleted camera"); return; }
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetPivotOffset(Point(cam->GetPivotOffset().X, py));
 }
 
 bool Camera_GetAutoTracking(ScriptCamera *scam)
@@ -214,6 +270,46 @@ RuntimeScriptValue Sc_Camera_GetRotation(void *self, const RuntimeScriptValue *p
 RuntimeScriptValue Sc_Camera_SetRotation(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PFLOAT(ScriptCamera, Camera_SetRotation);
+}
+
+RuntimeScriptValue Sc_Camera_GetPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptCamera, Camera_GetPivotX);
+}
+
+RuntimeScriptValue Sc_Camera_SetPivotX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptCamera, Camera_SetPivotX);
+}
+
+RuntimeScriptValue Sc_Camera_GetPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT(ScriptCamera, Camera_GetPivotY);
+}
+
+RuntimeScriptValue Sc_Camera_SetPivotY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PFLOAT(ScriptCamera, Camera_SetPivotY);
+}
+
+RuntimeScriptValue Sc_Camera_GetPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptCamera, Camera_GetPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Camera_SetPivotOffsetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptCamera, Camera_SetPivotOffsetX);
+}
+
+RuntimeScriptValue Sc_Camera_GetPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptCamera, Camera_GetPivotOffsetY);
+}
+
+RuntimeScriptValue Sc_Camera_SetPivotOffsetY(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptCamera, Camera_SetPivotOffsetY);
 }
 
 RuntimeScriptValue Sc_Camera_GetAutoTracking(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -549,6 +645,14 @@ void RegisterViewportAPI()
         { "Camera::set_Height",         API_FN_PAIR(Camera_SetHeight) },
         { "Camera::get_Rotation",       API_FN_PAIR(Camera_GetRotation) },
         { "Camera::set_Rotation",       API_FN_PAIR(Camera_SetRotation) },
+        { "Camera::get_PivotX",         API_FN_PAIR(Camera_GetPivotX) },
+        { "Camera::set_PivotX",         API_FN_PAIR(Camera_SetPivotX) },
+        { "Camera::get_PivotY",         API_FN_PAIR(Camera_GetPivotY) },
+        { "Camera::set_PivotY",         API_FN_PAIR(Camera_SetPivotY) },
+        { "Camera::get_PivotOffsetX",   API_FN_PAIR(Camera_GetPivotOffsetX) },
+        { "Camera::set_PivotOffsetX",   API_FN_PAIR(Camera_SetPivotOffsetX) },
+        { "Camera::get_PivotOffsetY",   API_FN_PAIR(Camera_GetPivotOffsetY) },
+        { "Camera::set_PivotOffsetY",   API_FN_PAIR(Camera_SetPivotOffsetY) },
         { "Camera::get_AutoTracking",   API_FN_PAIR(Camera_GetAutoTracking) },
         { "Camera::set_AutoTracking",   API_FN_PAIR(Camera_SetAutoTracking) },
         { "Camera::SetAt",              API_FN_PAIR(Camera_SetAt) },

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -159,8 +159,6 @@ void InitAndRegisterCharacters(GameSetupStruct &game, const LoadedGameEntities &
     {
         // TODO: move this to Character's "init" method
         game.chars[i].walking = 0;
-        game.chars[i].view_anchor = CharacterInfo::GetDefaultSpriteAnchor();
-        game.chars[i].view_offset = Point();
         game.chars[i].blinkinterval = 140;
         game.chars[i].blinktimer = game.chars[i].blinkinterval;
         game.chars[i].index_id = i;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -630,6 +630,9 @@ static void RestoreViewportsAndCameras(const RestoredData &r_data)
         // Set size first, or offset position may clamp to the room
         cam->SetSize(Size(cam_dat.Width, cam_dat.Height));
         cam->SetAt(cam_dat.Left, cam_dat.Top);
+        cam->SetRotation(cam_dat.Rotation);
+        cam->SetPivot(cam_dat.Pivot);
+        cam->SetPivotOffset(cam_dat.PivotOffset);
     }
     for (size_t i = 0; i < r_data.Viewports.size(); ++i)
     {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -663,7 +663,10 @@ HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, soff_t cmp_size, const Pr
     {
         auto &chi = game.chars[i];
         auto &chex = charextra[i];
-        chi.ReadFromSavegame(in, svg_ver);
+        // TODO: this is ugly reading old fields like that, might either join Read methods in one, or drop old format at some point
+        CharacterInfo::LegacyFields old_fields;
+        chi.ReadFromSavegame(in, old_fields, svg_ver);
+        chex.view_offset = old_fields.view_offset;
         chex.ReadFromSavegame(&chi, in, svg_ver);
         Properties::ReadValues(play.charProps[i], in);
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -291,8 +291,15 @@ void WriteCameraState(const Camera &cam, Stream *out)
     // kGSSvgVersion_400_18
     out->WriteInt32(cam.GetShaderID());
     out->WriteInt32(cam.GetShaderHandle());
+    out->WriteFloat32(cam.GetRotation());
     out->WriteInt32(0); // reserved
-    out->WriteInt32(0);
+    // kGSSvgVersion_400_29
+    const auto &pivot = cam.GetPivot();
+    const auto &pivot_off = cam.GetPivotOffset();
+    out->WriteFloat32(pivot.X);
+    out->WriteFloat32(pivot.Y);
+    out->WriteInt32(pivot_off.X);
+    out->WriteInt32(pivot_off.Y);
 }
 
 void WriteViewportState(const Viewport &view, Stream *out)
@@ -366,8 +373,17 @@ void ReadCameraState(GameStateSvgVersion svg_ver, RestoredData &r_data, Stream *
     {
         cam.ShaderID = in->ReadInt32();
         cam.ShaderHandle = in->ReadInt32();
+        cam.Rotation = in->ReadFloat32();
         in->ReadInt32(); // reserved
-        in->ReadInt32();
+    }
+    if (svg_ver >= kGSSvgVersion_400_29)
+    {
+        float pivotx = in->ReadFloat32();
+        float pivoty = in->ReadFloat32();
+        int pivot_offx = in->ReadInt32();
+        int pivot_offy = in->ReadInt32();
+        cam.Pivot = Pointf(pivotx, pivoty);
+        cam.PivotOffset = Point(pivot_offx, pivot_offy);
     }
     r_data.Cameras.push_back(cam);
 }

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -234,6 +234,9 @@ struct RestoredData
         int Height = 0;
         int ShaderID = 0;
         int ShaderHandle = 0;
+        float Rotation = 0.f;
+        Pointf Pivot;
+        Point PivotOffset;
     };
     std::vector<ViewportData> Viewports;
     std::vector<CameraData> Cameras;

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -86,6 +86,37 @@ void Camera::SetRotation(float degrees)
     _hasChangedSize = true;
 }
 
+Pointf Camera::GetPivot() const
+{
+    return _pivot;
+}
+
+void Camera::SetPivot(const Pointf &pivot)
+{
+    _pivot = pivot;
+    AdjustTransformations();
+    _hasChangedPosition = true; // changing pivot shifts camera but does not change the rotation angle
+}
+
+Point Camera::GetPivotOffset() const
+{
+    return _pivotOff;
+}
+
+void Camera::SetPivotOffset(const Point &pivot_off)
+{
+    _pivotOff = pivot_off;
+    AdjustTransformations();
+    _hasChangedPosition = true; // changing pivot shifts camera but does not change the rotation angle
+}
+
+Pointf Camera::GetEffectivePivot() const
+{
+    return _pivot +
+        Pointf((static_cast<float>(_pivotOff.X) / _position.GetWidth()),
+               (static_cast<float>(_pivotOff.Y) / _position.GetHeight()));
+}
+
 void Camera::AdjustTransformations()
 {
     for (auto vp = _viewportRefs.begin(); vp != _viewportRefs.end(); ++vp)

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -259,14 +259,19 @@ void Viewport::AdjustTransformation()
         float scale_x = (float)_position.GetWidth() / (float)cam_rc.GetWidth();
         float scale_y = (float)_position.GetHeight() / (float)cam_rc.GetHeight();
         float rotate = locked_cam->GetRotation();
+        Pointf pivot = locked_cam->GetEffectivePivot();
 
         glm::mat4 mat_v2c = glmex::make_transform2d(cam_rc.Left, cam_rc.Top,
-            1.f / scale_x, 1.f / scale_y, -Math::DegreesToRadians(rotate), -0.5 * cam_rc.GetWidth(), -0.5 * cam_rc.GetHeight());
+            1.f / scale_x, 1.f / scale_y, Math::DegreesToRadians(rotate),
+            -cam_rc.GetWidth() * pivot.X, -cam_rc.GetHeight() * pivot.Y
+            );
         _v2cTransform = glmex::translate(mat_v2c, -_position.Left, -_position.Top);
 
         glm::mat4 mat_c2v = glmex::translate(_position.Left, _position.Top);
         _c2vTransform = glmex::inv_transform2d(mat_c2v, -cam_rc.Left, -cam_rc.Top,
-            scale_x, scale_y, Math::DegreesToRadians(rotate), 0.5 * cam_rc.GetWidth(), 0.5 * cam_rc.GetHeight());;
+            scale_x, scale_y, -Math::DegreesToRadians(rotate),
+            cam_rc.GetWidth() * pivot.X, cam_rc.GetHeight() * pivot.Y
+            );
     }
 }
 

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -65,6 +65,11 @@ public:
     float GetRotation() const;
     // Sets camera's rotation, in degrees
     void SetRotation(float degrees);
+    Pointf GetPivot() const;
+    void SetPivot(const Pointf &pivot);
+    Point GetPivotOffset() const;
+    void SetPivotOffset(const Point &pivot_off);
+    Pointf GetEffectivePivot() const;
     int GetShaderID() const { return _shaderID; }
     int GetShaderHandle() const { return _shaderHandle; }
     void SetShader(int shader_id, int shader_handle) { _shaderID = shader_id; _shaderHandle = shader_handle; }
@@ -103,6 +108,8 @@ private:
     Rect _position;
     // Rotation in degrees
     float _rotation = 0.0;
+    Pointf _pivot = Pointf(.5f, .5f); // default: center
+    Point _pivotOff;
     // TODO: a RAII wrapper over managed handle, that auto releases the reference
     int _shaderID = 0;
     int _shaderHandle = 0;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1939,13 +1939,13 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     // Translate scaled node into Top-Left screen coordinates
     float scaled_offx = _srcRect.GetWidth() * ((1.f - desc.Transform.ScaleX) * 0.5f);
     float scaled_offy = _srcRect.GetHeight() * ((1.f - desc.Transform.ScaleY) * 0.5f);
-    float pivotx = _srcRect.GetWidth() / 2.f - (_srcRect.GetWidth() * desc.Transform.Pivot.X);
-    float pivoty = _srcRect.GetHeight() / 2.f - (_srcRect.GetHeight() * desc.Transform.Pivot.Y);
+    float pivotx = -_srcRect.GetWidth() * 0.5f + desc.SizeRef.Width * desc.Transform.ScaleX * desc.Transform.Pivot.X;
+    float pivoty = -_srcRect.GetHeight() * 0.5f + desc.SizeRef.Height * desc.Transform.ScaleY * desc.Transform.Pivot.Y;
     model = glmex::translate(model, -scaled_offx, -(-scaled_offy));
-    // Classic Scale-Rotate-Translate, but inverse, because it's GLM
-    glm::mat4 msrt = glmex::make_transform2d((float)desc.Transform.X, (float)-desc.Transform.Y,
+    // Inverse transformation, because it should affect the textures drawn within this batch
+    glm::mat4 msrt = glmex::make_inv_transform2d((float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
+        Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     model = model * msrt;
 
     // Also create separate viewport transformation matrix:
@@ -1954,7 +1954,7 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     glm::mat4 mat_viewport = glmex::make_transform2d(
         (float)desc.Transform.X, (float)desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY, // CHECKME: rotation args here
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
+        Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     glm::mat4 vp_flip_off = glmex::translate(
         _srcRect.GetWidth() * ((1.f - flip_sx) * 0.5f),
         _srcRect.GetHeight() * ((1.f - flip_sy) * 0.5f));

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1490,7 +1490,8 @@ void OGLGraphicsDriver::RenderTexture(OGLBitmap *bmpToDraw, int draw_x, int draw
 
     // Setup rotation and pivot
     float rotZ = bmpToDraw->GetRotation();
-    float pivotX = -(widthToScale * 0.5), pivotY = (heightToScale * 0.5);
+    const Pointf &pivot = bmpToDraw->GetPivot();
+    float pivotX = -(widthToScale * pivot.X), pivotY = (heightToScale * pivot.Y);
 
     //
     // IMPORTANT: in OpenGL order of transformation is REVERSE to the order of commands!
@@ -1938,13 +1939,13 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     // Translate scaled node into Top-Left screen coordinates
     float scaled_offx = _srcRect.GetWidth() * ((1.f - desc.Transform.ScaleX) * 0.5f);
     float scaled_offy = _srcRect.GetHeight() * ((1.f - desc.Transform.ScaleY) * 0.5f);
-    float pivotx = _srcRect.GetWidth() / 2.f - desc.Transform.Pivot.X;
-    float pivoty = _srcRect.GetHeight() / 2.f - desc.Transform.Pivot.Y;
+    float pivotx = _srcRect.GetWidth() / 2.f - (_srcRect.GetWidth() * desc.Transform.Pivot.X);
+    float pivoty = _srcRect.GetHeight() / 2.f - (_srcRect.GetHeight() * desc.Transform.Pivot.Y);
     model = glmex::translate(model, -scaled_offx, -(-scaled_offy));
     // Classic Scale-Rotate-Translate, but inverse, because it's GLM
     glm::mat4 msrt = glmex::make_transform2d((float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, pivoty);
+        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     model = model * msrt;
 
     // Also create separate viewport transformation matrix:
@@ -1953,7 +1954,7 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     glm::mat4 mat_viewport = glmex::make_transform2d(
         (float)desc.Transform.X, (float)desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY, // CHECKME: rotation args here
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, pivoty);
+        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     glm::mat4 vp_flip_off = glmex::translate(
         _srcRect.GetWidth() * ((1.f - flip_sx) * 0.5f),
         _srcRect.GetHeight() * ((1.f - flip_sy) * 0.5f));

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -105,6 +105,8 @@ public:
     virtual void SetFlip(Common::GraphicFlip flip) = 0;
     virtual float GetRotation() const = 0; // in degrees
     virtual void SetRotation(float rotation) = 0; // in degrees
+    virtual Pointf GetPivot() const = 0;
+    virtual void SetPivot(float pivotx, float pivoty) = 0;
     virtual int  GetAlpha() const = 0;
     virtual void SetAlpha(int alpha) = 0; // 0-255
     virtual int  GetLightLevel() const = 0; // 0-255

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -91,13 +91,24 @@ bool GraphicsDriverBase::GetVsync() const
 
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, uint32_t filter_flags)
 {
-    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, kFlip_None, nullptr, filter_flags));
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, Size(), kFlip_None, nullptr, filter_flags));
+}
+
+void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref, uint32_t filter_flags)
+{
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, size_ref, kFlip_None, nullptr, filter_flags));
 }
 
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
     GraphicFlip flip, PBitmap surface, uint32_t filter_flags)
 {
-    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface, filter_flags));
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, Size(), flip, surface, filter_flags));
+}
+
+void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref,
+    GraphicFlip flip, PBitmap surface, uint32_t filter_flags)
+{
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, size_ref, flip, surface, filter_flags));
 }
 
 void GraphicsDriverBase::BeginSpriteBatch(IDriverDependantBitmap *render_target,

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -258,6 +258,11 @@ public:
     // Rotation input is in degrees clockwise, but the implementation may store it in radians internally
     float GetRotation() const override { return _rotation; }
     void SetRotation(float rotation) override { _rotation = rotation; }
+    virtual Pointf GetPivot() const { return _pivot; }
+    virtual void SetPivot(float pivotx, float pivoty)
+    {
+        _pivot = Pointf(pivotx, pivoty);
+    }
     int  GetAlpha() const override { return _alpha; }
     void SetAlpha(int alpha) override { _alpha = alpha; }
     int  GetLightLevel() const override { return _lightLevel; }
@@ -302,6 +307,7 @@ protected:
     Size _scaledSize;
     Common::GraphicFlip _flip = Common::kFlip_None;
     float _rotation = 0.f; // either in degrees or radians, depending on impl
+    Pointf _pivot = Pointf(.5f, .5f);
     int _alpha = 255;
     Common::BlendMode _blendMode = Common::kBlend_Normal;
     IShaderInstance *_shader = nullptr;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -47,6 +47,8 @@ struct SpriteBatchDesc
     SpriteTransform          Transform;
     // Optional flip, applied to the whole batch as the last transform
     Common::GraphicFlip      Flip = Common::kFlip_None;
+    // Reference size, used mainly for deducing absolute rotation pivot
+    Size                     SizeRef;
     // Optional bitmap to draw sprites upon. Used exclusively by the software rendering mode.
     // TODO: merge with the RenderTexture?
     PBitmap                  Surface;
@@ -58,11 +60,12 @@ struct SpriteBatchDesc
 
     SpriteBatchDesc() = default;
     SpriteBatchDesc(uint32_t parent, const Rect viewport, const SpriteTransform &transform,
-        Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr,
+        Size size_ref = Size(), Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr,
         uint32_t filter_flags = 0)
         : Parent(parent)
         , Viewport(viewport)
         , Transform(transform)
+        , SizeRef(size_ref)
         , Flip(flip)
         , Surface(surface)
         , FilterFlags(filter_flags)
@@ -75,6 +78,7 @@ struct SpriteBatchDesc
         : Parent(parent)
         , Viewport(viewport)
         , Transform(transform)
+        , SizeRef(render_target ? Size(render_target->GetWidth(), render_target->GetHeight()) : Size())
         , Flip(flip)
         , RenderTarget(render_target)
         , FilterFlags(filter_flags)
@@ -145,15 +149,18 @@ public:
     //
     // Prepares next sprite batch, a list of sprites with defined viewport and optional
     // global model transformation.
-    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, uint32_t filter_flags = 0) override;
+    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, uint32_t filter_flags) override;
+    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref, uint32_t filter_flags) override;
     // Begins a sprite batch with defined viewport and a global model transformation
     // and a global flip setting. Optionally provides a surface which should be rendered
     // underneath the rest of the sprites.
     void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
-                    Common::GraphicFlip flip, PBitmap surface = nullptr, uint32_t filter_flags = 0) override;
+                    Common::GraphicFlip flip, PBitmap surface, uint32_t filter_flags) override;
+    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref,
+                    Common::GraphicFlip flip, PBitmap surface, uint32_t filter_flags) override;
     // Begins a sprite batch which will be rendered on a target texture.
     void        BeginSpriteBatch(IDriverDependantBitmap *render_target, const Rect &viewport, const SpriteTransform &transform,
-                    Common::GraphicFlip flip = Common::kFlip_None, uint32_t filter_flags = 0) override;
+                    Common::GraphicFlip flip, uint32_t filter_flags) override;
     // Ends current sprite batch
     void        EndSpriteBatch() override;
     // Clears all sprite batches, resets batch counter

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -329,12 +329,15 @@ public:
     // Optionally you can assign "filter flags" to this batch; this lets to filter certain
     // batches out during some operations, such as fading effects or making screenshots.
     virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, uint32_t filter_flags = 0) = 0;
+    virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref, uint32_t filter_flags = 0) = 0;
     // Begins a sprite batch with defined viewport and a global model transformation
     // and a global flip setting. Optionally provides a surface which should be rendered
     // underneath the rest of the sprites.
     // TODO: merge GraphicFlip with SpriteTransform.
     // TODO: can we merge PBitmap surface and render_target from overriden method?
     virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
+        Common::GraphicFlip flip, PBitmap surface = nullptr, uint32_t filter_flags = 0) = 0;
+    virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, const Size &size_ref,
         Common::GraphicFlip flip, PBitmap surface = nullptr, uint32_t filter_flags = 0) = 0;
     // Begins a sprite batch which will be rendered on a target texture.
     // This batch will ignore any parent transforms, regardless whether it's nested

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -61,12 +61,12 @@ struct SpriteTransform
     int X = 0, Y = 0;
     float ScaleX = 1.f, ScaleY = 1.f;
     float Rotate = 0.f; // angle, in degrees, clockwise
-    Point Pivot = Point(); // rotation pivot
+    Pointf Pivot = Pointf(); // rotation pivot
     SpriteColorTransform Color;
 
     SpriteTransform() = default;
     SpriteTransform(int x, int y, float scalex = 1.0f, float scaley = 1.0f,
-        float rotate = 0.0f, Point pivot = Point(),
+        float rotate = 0.0f, const Pointf &pivot = Point(),
         SpriteColorTransform color = SpriteColorTransform())
         : X(x), Y(y), ScaleX(scalex), ScaleY(scaley),
           Rotate(rotate), Pivot(pivot),

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1942,13 +1942,14 @@ size_t D3DGraphicsDriver::RenderSpriteBatch(const D3DSpriteBatch &batch, size_t 
 void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &desc)
 {
     // Create transformation matrix for this batch
-    // Classic Scale-Rotate-Translate, but inverse, because it's GLM
-    float pivotx = _srcRect.GetWidth() / 2.f - _srcRect.GetWidth() * desc.Transform.Pivot.X;
-    float pivoty = _srcRect.GetHeight() / 2.f - _srcRect.GetHeight() * desc.Transform.Pivot.Y;
-    glm::mat4 msrt = glmex::make_transform2d(
+    float pivotx = -_srcRect.GetWidth() * 0.5f + desc.SizeRef.Width * desc.Transform.ScaleX * desc.Transform.Pivot.X;
+    float pivoty = -_srcRect.GetHeight() * 0.5f + desc.SizeRef.Height * desc.Transform.ScaleY * desc.Transform.Pivot.Y;
+
+    // Inverse transformation, because it should affect the textures drawn within this batch
+    glm::mat4 msrt = glmex::make_inv_transform2d(
         (float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
+        Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     // Translate scaled node into Top-Left screen coordinates
     float scaled_offx = _srcRect.GetWidth() * ((1.f - desc.Transform.ScaleX) * 0.5f);
     float scaled_offy = _srcRect.GetHeight() * ((1.f - desc.Transform.ScaleY) * 0.5f);
@@ -1974,7 +1975,7 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     glm::mat4 mat_viewport = glmex::make_transform2d(
         (float)desc.Transform.X, (float)desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
+        Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     glm::mat4 vp_flip_off = glmex::translate(
         _srcRect.GetWidth() * ((1.f - flip_sx) * 0.5f),
         _srcRect.GetHeight() * ((1.f - flip_sy) * 0.5f));

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1517,7 +1517,8 @@ void D3DGraphicsDriver::RenderTexture(D3DBitmap *bmpToDraw, int draw_x, int draw
 
     // Setup rotation and pivot
     float rotZ = bmpToDraw->GetRotation();
-    float pivotX = -(widthToScale * 0.5), pivotY = (heightToScale * 0.5);
+    const Pointf &pivot = bmpToDraw->GetPivot();
+    float pivotX = -(widthToScale * pivot.X), pivotY = (heightToScale * pivot.Y);
 
     // Self sprite transform (first scale, then rotate and then translate, reversed)
     glm::mat4 transform = glmex::make_transform2d(
@@ -1942,12 +1943,12 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
 {
     // Create transformation matrix for this batch
     // Classic Scale-Rotate-Translate, but inverse, because it's GLM
-    float pivotx = _srcRect.GetWidth() / 2.f - desc.Transform.Pivot.X;
-    float pivoty = _srcRect.GetHeight() / 2.f - desc.Transform.Pivot.Y;
+    float pivotx = _srcRect.GetWidth() / 2.f - _srcRect.GetWidth() * desc.Transform.Pivot.X;
+    float pivoty = _srcRect.GetHeight() / 2.f - _srcRect.GetHeight() * desc.Transform.Pivot.Y;
     glm::mat4 msrt = glmex::make_transform2d(
         (float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, pivoty);
+        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     // Translate scaled node into Top-Left screen coordinates
     float scaled_offx = _srcRect.GetWidth() * ((1.f - desc.Transform.ScaleX) * 0.5f);
     float scaled_offy = _srcRect.GetHeight() * ((1.f - desc.Transform.ScaleY) * 0.5f);
@@ -1973,7 +1974,7 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     glm::mat4 mat_viewport = glmex::make_transform2d(
         (float)desc.Transform.X, (float)desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY,
-        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, pivoty);
+        -Math::DegreesToRadians(desc.Transform.Rotate), pivotx, -pivoty);
     glm::mat4 vp_flip_off = glmex::translate(
         _srcRect.GetWidth() * ((1.f - flip_sx) * 0.5f),
         _srcRect.GetHeight() * ((1.f - flip_sy) * 0.5f));


### PR DESCRIPTION
This adds following properties:
```
float Character.GraphicPivotX
float Character.GraphicPivotY
int Character.GraphicPivotOffsetX
int Character.GraphicPivotOffsetY
```
```
float Object.GraphicPivotX
float Object.GraphicPivotY
int Object.GraphicPivotOffsetX
int Object.GraphicPivotOffsetY
```
```
float Overlay.GraphicPivotX
float Overlay.GraphicPivotY
int Overlay.GraphicPivotOffsetX
int Overlay.GraphicPivotOffsetY
```
```
float Camera.PivotX
float Camera.PivotY
int Camera.PivotOffsetX
int Camera.PivotOffsetY
```

PivotX,Y are pivot positions in normalized relative coordinates (0.0 - 1.0). This is useful when you need to align a pivot to the sprite's edge, or fraction of its size.
PivotOffsetX,Y are relative offsets in pixels. This is useful when you need to align a pivot to exact pixel within the sprite.
These two may be used simultaneously (they are combined internally).

Furthermore added 2 functions to all the graphic objects: Character, GUI, GUIControl, Object and Overlay:
* GetGraphicPosition() - returns array of Points with coordinates of the object graphic's corners
* GetGraphicBoundBox() - returns array of Points with coordinates of the object graphic's AABB (axis-aligned bounding box).
