### PR TITLE
AGS4 Engine: remove CursorRole Look condition when evaluating OPT_WALKONLOOK

### DIFF
--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -161,7 +161,7 @@ void RunHotspotInteraction(int hotspothere, int mood)
         play.usedinv = playerchar->activeinv;
     }
 
-    if ((game.options[OPT_WALKONLOOK] == 0) && (game.HasCursorRole(mood, kCursorRole_Look)));
+    if (game.options[OPT_WALKONLOOK] == 0);
     else if (play.auto_use_walkto_points == 0);
     else if ((!game.HasCursorRole(mood, kCursorRole_Walk)) && (play.check_interaction_only == 0))
         MoveCharacterToHotspot(game.playercharacter, hotspothere);


### PR DESCRIPTION
The `OPT_WALKONLOOK` config property is tied to the usage of Cursor Roles. This means if I want to use the `WalkTo` for a hotspot for an Interact but NOT a Look, then I have to use Cursor Roles.

This PR decouples that condition and makes `OPT_WALKONLOOK` more absolute, and more reflective of the Editor description:

> Automatically walk to hotspots in Look mode
Whenever the player clicks somewhere in Look mode, the player character will automatically be moved there