### PR TITLE
Advanced game text direction, based on U control chars

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -449,6 +449,82 @@ size_t StrUtil::ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t 
     return len;
 }
 
+String StrUtil::ApplyTextDirection(const String &text, bool default_rtl)
+{
+    const Utf8::Rune LRE = 0x202A;
+    const Utf8::Rune RLE = 0x202B;
+
+    // We may only cut control characters, but not add any new ones,
+    // therefore we allocate a buffer which is at least as large as the input.
+    // NOTE: we don't allocate a buffer unless meet control chars (or RTL section);
+    // in case whole string is LTR, we just return original string.
+    char *dst_buf = nullptr;
+
+    bool is_rtl = default_rtl;
+    const char *src_ptr = text.GetCStr();
+    const char *sec_begin = src_ptr;
+    char *dst_ptr = nullptr;
+    for (Utf8::Rune r = Utf8::RuneInvalid; r != 0;)
+    {
+        size_t c_len = Utf8::GetChar(src_ptr, Utf8::UtfSz, &r);
+
+        if (is_rtl)
+        {
+            // Right-to-left section goes until a LRE control char or end of string
+            if (r == LRE || r == 0)
+            {
+                if (!dst_buf)
+                {
+                    dst_buf = new char[text.GetLength() + 1];
+                    dst_ptr = dst_buf;
+                }
+
+                // RTL section is copied char by char in reverse direction
+                // TODO: pick this out to a separate helper function?
+                const char *copy_from = src_ptr, *copy_to;
+                do
+                {
+                    copy_to = copy_from;
+                    copy_from = Utf8::BackOneChar(copy_to, sec_begin);
+                    size_t copy_len = copy_to - copy_from;
+                    memcpy(dst_ptr, copy_from, copy_len);
+                    dst_ptr += copy_len;
+                }
+                while (copy_from != sec_begin);
+                is_rtl = false;
+                sec_begin = src_ptr + c_len;
+            }
+        }
+        else
+        {
+            // Left-to-right section goes until a LRE control char or end of string
+            if (r == RLE || r == 0)
+            {
+                // Optimization: if we reached end of string without seeing any control chars,
+                // then just return the original string as-is.
+                if (r == 0 && (sec_begin == text.GetCStr()))
+                    return text;
+
+                if (!dst_buf)
+                {
+                    dst_buf = new char[text.GetLength() + 1];
+                    dst_ptr = dst_buf;
+                }
+
+                // LTR section is copied plainly as a sequence of bytes
+                size_t sec_length = src_ptr - sec_begin;
+                memcpy(dst_ptr, sec_begin, sec_length);
+                dst_ptr += sec_length;
+                is_rtl = true;
+                sec_begin = src_ptr + c_len;
+            }
+        }
+        src_ptr += c_len;
+    }
+    *dst_ptr = 0;
+    return String(dst_buf);
+}
+
 static bool TryUTF8LocaleName(const String &try_name, String &got_name)
 {
     try

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -201,6 +201,13 @@ namespace StrUtil
     // writes into out_mbstr buffer limited by out_sz *bytes*; returns *bytes* written.
     size_t ConvertWstrToUtf8(const wchar_t *wcstr, char *out_mbstr, size_t out_sz);
 
+    // Applies text directon using LTR and RTL instructions. Allows to have LTR and RTL
+    // sequences in any order, using respective Unicode control characters.
+    // Control characters are not copied, but removed from the final string.
+    // Returns a new resulting string.
+    // IMPORTANT: Assumes that the input string contains UTF-8 data.
+    String ApplyTextDirection(const String &text, bool default_rtl = false);
+
     // Tries to find a UTF8 locale name for the given language name,
     // suitable for the current runtime backend. Returns the locale name found,
     // or empty string if none was found.

--- a/Common/util/utf8.h
+++ b/Common/util/utf8.h
@@ -109,6 +109,13 @@ inline size_t GetLength(const char *c)
     return len;
 }
 
+// Takes a utf8 string pointer and advances it one char forward, unless it hits the end of the string
+inline const char *ForwardOneChar(const char *c, const char *end)
+{
+    for (; c < end && ((*(++c) & 0xC0) == 0x80););
+    return c;
+}
+
 // Takes a utf8 string pointer and rolls it back one char, unless it hits the head of same string
 inline const char *BackOneChar(const char *c, const char *front)
 {

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -27,6 +27,7 @@
 #include "debug/debug_log.h"
 #include "script/runtimescriptvalue.h"
 #include "util/string_compat.h"
+#include "util/string_utils.h"
 #include "util/utf8.h"
 
 using namespace AGS::Common;
@@ -326,13 +327,18 @@ size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLi
     bool compat_mode = loaded_game_file_version < kGameVersion_360;
     split_lines(todis, lines, wii, fonnt, compat_mode, max_lines);
 
-    // Reverse the text if requested
-    if (apply_direction && (game.options[OPT_RIGHTLEFTWRITE] != 0))
+    // Apply text direction if requested
+    bool rtl_mode = game.options[OPT_RIGHTLEFTWRITE] != 0;
+    if (apply_direction)
     {
-        for (size_t rr = 0; rr < lines.Count(); rr++)
+        if (get_uformat() == U_UTF8)
         {
-            (get_uformat() == U_UTF8) ?
-                lines[rr].ReverseUTF8() :
+            for (size_t rr = 0; rr < lines.Count(); rr++)
+                lines[rr] = StrUtil::ApplyTextDirection(lines[rr], rtl_mode);
+        }
+        else if (rtl_mode)
+        {
+            for (size_t rr = 0; rr < lines.Count(); rr++)
                 lines[rr].Reverse();
         }
     }

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -90,11 +90,18 @@ namespace Common
 
 String GUI::ApplyTextDirection(const String &text)
 {
-    if (game.options[OPT_RIGHTLEFTWRITE] == 0)
-        return text;
-    String res_text = text;
-    (get_uformat() == U_UTF8) ? res_text.ReverseUTF8() : res_text.Reverse();
-    return res_text;
+    const bool rtl_mode = game.options[OPT_RIGHTLEFTWRITE] != 0;
+    if (get_uformat() == U_UTF8)
+    {
+        return StrUtil::ApplyTextDirection(text, rtl_mode);
+    }
+    else if (rtl_mode)
+    {
+        String res_text = text;
+        res_text.Reverse();
+        return res_text;
+    }
+    return text;
 }
 
 String GUI::TransformTextForDrawing(const String &text, bool translate, bool apply_direction)


### PR DESCRIPTION
This implements a rather basic text direction handling based on Unicode control characters such as LRE (U+202A) and RLE (U+202B). Whenever one of these chars are met, the next section of the text will be applied a respective direction. This allows to have sections with different directions even in one string.

In this mode the OPT_RIGHTLEFTWRITE option serves only as the starting direction, but if any control char is met in the string, they will override the direction.

This rule is applied only when the game is in Unicode mode, naturally, as ASCII/ANSI does not have such control characters.

There are following common use cases:
* Combine languages which have different directions in the same game, simultaneously.
* When using RTL game texts, or translation, still allow some parts of the text to be LTR, because not everything is reversed in RTL languages. Primary example is numbers.

This feature is likely superseded by the use of text rendering libraries, such as HarfBuzz, in the future AGS 4.x.