### PR TITLE
4.0: Fix Joystick button events breaking input processing

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1372,7 +1372,7 @@ bool DialogOptions::Run()
 bool DialogOptions::RunControls()
 {
     bool state_handled = false;
-    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    for (InputType type = kInputNone; ags_hasinputevent_ready(type);)
     {
         switch (type)
         {

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -349,7 +349,7 @@ std::unique_ptr<Bitmap> create_textual_image(const char *text, const DisplayText
 bool display_check_user_input(int skip)
 {
     bool state_handled = false;
-    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    for (InputType type = kInputNone; ags_hasinputevent_ready(type);)
     { // NOTE: must handle them all in case there were engine's hotkeys too
         switch (type)
         {

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -309,6 +309,14 @@ int sys_keydown_count = 0; // counter of keys pressed down
 int sys_modkeys = 0; // saved accumulated key mods
 bool sys_modkeys_fired = false; // saved mod key combination already fired
 
+bool ags_hasinputevent_ready(InputType &type)
+{
+    if (g_inputEvtQueue.empty())
+        return false;
+    type = ags_inputevent_ready();
+    return true;
+}
+
 InputType ags_inputevent_ready()
 {
     if (g_inputEvtQueue.empty())

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -330,6 +330,7 @@ InputType ags_inputevent_ready()
     case SDL_MOUSEBUTTONDOWN:
     case SDL_MOUSEBUTTONUP:
         return kInputMouse;
+    case SDL_JOYBUTTONDOWN:
     case SDL_CONTROLLERBUTTONDOWN:
         return kInputGamepad;
     case AGS_SDL_EVT_TOUCHDOWN:
@@ -1080,7 +1081,12 @@ void ags_clear_mouse_movement()
 
 static void on_sdl_joystick_button(const SDL_Event &event)
 {
-    g_inputEvtQueue.push_back(event);
+    // Skip button events for joysticks that are gamepads, because
+    // these have their own gamepad button events
+    if (!SDL_IsGameController(event.jbutton.which))
+    {
+        g_inputEvtQueue.push_back(event);
+    }
 }
 
 static void on_sdl_joystick_device(const SDL_JoyDeviceEvent &event)

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -92,7 +92,10 @@ inline int make_sdl_merged_mod(int mod)
 }
 
 // Tells if there are any buffered input events;
-// return the InputType corresponding to the first queued event.
+// returns the InputType corresponding to the first queued event.
+bool ags_hasinputevent_ready(InputType &type);
+// Returns the InputType corresponding to the first queued event;
+// returns kInputNone if the queue is empty.
 InputType ags_inputevent_ready();
 // Queries for the next input event in buffer; returns uninitialized data if none was queued
 SDL_Event ags_get_next_inputevent();

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -873,7 +873,7 @@ static void GameUpdateCheckControls()
     check_mouse_state(was_mouse_on_iface); // NOTE: this also polls mousewheel
 
     // Handle all the buffered input events
-    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    for (InputType type = kInputNone; ags_hasinputevent_ready(type);)
     {
         switch (type)
         {

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -382,7 +382,7 @@ std::unique_ptr<BlockingVideoPlayer> gl_Video;
 // Checks input events, tells if the video should be skipped
 static bool video_check_user_input(VideoSkipType skip)
 {
-    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    for (InputType type = kInputNone; ags_hasinputevent_ready(type);)
     {
         if (type == kInputKeyboard)
         {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -372,11 +372,12 @@ void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)
     rotate_sprite(ds->GetAllegroBitmap(), bmp, x, y, itofix(angle));
 }
 
-void IAGSEngine::PollSystem () {
+void IAGSEngine::PollSystem ()
+{
     update_polled_stuff();
     ags_domouse();
     // Handle all the buffered input events
-    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    for (InputType type = kInputNone; ags_hasinputevent_ready(type);)
     {
         eAGSMouseButton mbut;
         KeyInput ki;
@@ -391,8 +392,8 @@ void IAGSEngine::PollSystem () {
                 pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut);
         }
     }
-    
 }
+
 AGSCharacter* IAGSEngine::GetCharacter (int32 charnum) {
     if (charnum >= game.numcharacters)
         quit("!AGSEngine::GetCharacter: invalid character request");


### PR DESCRIPTION
Fix #2979

1. Fix Joystick button events not registering as a proper input type (kInputGamepad). Skip them if the joystick is "gamepad controller", because in that case we also receive gamepad button events. This will avoid duplicates.
2. Remake input event processing loop, don't rely on the loop ending when there's kInputNone met, because in theory it might appear in the queue by mistake, leading to never flushing queue.