### PR TITLE
Joystick Skipping dialog fix

### DIFF
--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -395,15 +395,15 @@ bool display_check_user_input(int skip)
             GamepadInput gbut;
             if (!run_service_gamepad_controls(gbut) || play.fast_forward || state_handled)
                 continue; // handled by engine layer, or fast-forwarded, or resolved
-            eAGSGamepad_Button gbn = gbut.Button;
-            if (check_skip_cutscene_gamepad(gbn))
+            
+            if (check_skip_cutscene_gamepad(gbut))
             {
                 state_handled = true; // stop display
             }
             else if ((skip & SKIP_GAMEPAD) != 0 && !play.IsIgnoringInput() &&
-                    is_default_gamepad_skip_button_pressed(gbn))
+                    is_default_gamepad_skip_button_pressed(gbut))
             {
-                play.SetWaitSkipResult(SKIP_GAMEPAD, gbn);
+                play.SetWaitSkipResult(SKIP_GAMEPAD, get_gamepadkey(gbut));
                 state_handled = true; // stop display
             }
             break;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1606,10 +1606,11 @@ bool check_skip_cutscene_mclick(int mbut)
     return false;
 }
 
-bool check_skip_cutscene_gamepad(int gbut)
+bool check_skip_cutscene_gamepad(const GamepadInput &getinput)
 {
     CutsceneSkipStyle skip = get_cutscene_skipstyle();
-    if (gbut>0 && skip == eSkipSceneAnyKey)
+    
+    if (getinput.IsAnyButtonDown() && skip == eSkipSceneAnyKey)
     {
         start_skipping_cutscene();
         return true;

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -26,6 +26,7 @@
 #include "gfx/bitmap.h"
 #include "main/game_file.h"
 #include "util/string.h"
+#include "joystick.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class AssetManager; class Stream; } }
@@ -178,7 +179,7 @@ CutsceneSkipStyle get_cutscene_skipstyle();
 void start_skipping_cutscene ();
 bool check_skip_cutscene_keypress(int kgn);
 bool check_skip_cutscene_mclick(int mbut);
-bool check_skip_cutscene_gamepad(int gbut);
+bool check_skip_cutscene_gamepad(const GamepadInput &getinput);
 void initialize_skippable_cutscene();
 void stop_fast_forwarding();
 

--- a/Engine/ac/joystick.cpp
+++ b/Engine/ac/joystick.cpp
@@ -22,12 +22,20 @@
 #include "script/script_api.h"
 #include "ac/dynobj/dynobj_manager.h"
 
-bool is_default_gamepad_skip_button_pressed(eAGSGamepad_Button gbn)
+bool is_default_gamepad_skip_button_pressed(const GamepadInput &getinput)
 {
-    return (gbn == eAGSGamepad_ButtonA) ||
-    (gbn == eAGSGamepad_ButtonB) ||
-    (gbn == eAGSGamepad_ButtonX) ||
-    (gbn == eAGSGamepad_ButtonY);
+    if (getinput.isGamepad)
+    {
+        eAGSGamepad_Button gbn = getinput.GamepadButton;
+        return (gbn == eAGSGamepad_ButtonA) ||
+            (gbn == eAGSGamepad_ButtonB) ||
+            (gbn == eAGSGamepad_ButtonX) ||
+            (gbn == eAGSGamepad_ButtonY);
+    }
+    else
+    {
+        return getinput.JoystickButton >= 0 && getinput.JoystickButton<=3;
+    }
 }
 
 // clamps to -1.0 to 1.0, taking into account a dead-zone from 0.0

--- a/Engine/ac/joystick.h
+++ b/Engine/ac/joystick.h
@@ -81,13 +81,19 @@ enum eAGSGamepad_InputType
 struct GamepadInput
 {
     SDL_JoystickID JoystickID = -1;
-    eAGSGamepad_Button Button = eAGSGamepad_Button::eAGSGamepad_ButtonInvalid;
+    eAGSGamepad_Button GamepadButton = eAGSGamepad_Button::eAGSGamepad_ButtonInvalid;
     eAGSGamepad_Axis Axis = eAGSGamepad_Axis::eAGSGamepad_AxisInvalid;
     eAGSGamepad_InputType Type = eAGSGamepad_InputType::eAGSGamepad_InputTypeNone;
+    int JoystickButton = -1;
+    bool isGamepad = false;
+    inline bool IsAnyButtonDown() const
+    {
+        return GamepadButton != eAGSGamepad_ButtonInvalid || JoystickButton >= 0;
+    }
 };
 
 void JoystickConnectionEvent(const SDL_JoyDeviceEvent &event);
-bool is_default_gamepad_skip_button_pressed(eAGSGamepad_Button gbn);
+bool is_default_gamepad_skip_button_pressed(const GamepadInput &getinput);
 void init_joystick();
 
 SDL_GameControllerAxis Gamepad_Axis_AGStoSDL(eAGSGamepad_Axis ags_axis);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -726,39 +726,50 @@ static void check_keyboard_controls()
     }
 }
 
+int get_gamepadkey(const GamepadInput &getinput)
+{
+    if (getinput.isGamepad) return getinput.GamepadButton;
+    else return getinput.JoystickButton;
+}
+
 bool run_service_gamepad_controls(GamepadInput &out_key)
 {
-    out_key.JoystickID = -1;
-    out_key.Type = eAGSGamepad_InputTypeNone;
-    out_key.Button = eAGSGamepad_ButtonInvalid;
-    out_key.Axis = eAGSGamepad_AxisInvalid;
-
+    out_key = GamepadInput();
     if (ags_inputevent_ready() != kInputGamepad)
         return false; // there was no gamepad event
 
     const auto gp_evt = ags_get_next_inputevent();
     switch (gp_evt.type)
     {
+        case SDL_JOYBUTTONDOWN:
+                out_key.JoystickID = gp_evt.cbutton.which;
+                out_key.Type = eAGSGamepad_InputTypeButton;
+                out_key.GamepadButton = eAGSGamepad_ButtonInvalid;
+                out_key.JoystickButton = gp_evt.jbutton.button;
+                out_key.isGamepad = false;            
+        break;
         case SDL_CONTROLLERBUTTONDOWN:
             out_key.JoystickID = gp_evt.cbutton.which;
             out_key.Type = eAGSGamepad_InputTypeButton;
-            out_key.Button = Gamepad_Button_SDLtoAGS(static_cast<SDL_GameControllerButton>(gp_evt.cbutton.button));
+            out_key.GamepadButton = Gamepad_Button_SDLtoAGS(static_cast<SDL_GameControllerButton>(gp_evt.cbutton.button));
+            out_key.JoystickButton = -1;
+            out_key.isGamepad = true;
             break;
     }
-    return out_key.Button != eAGSGamepad_ButtonInvalid;
+    return out_key.GamepadButton != eAGSGamepad_ButtonInvalid || out_key.JoystickButton >= 0;
 }
 
 // Runs default gamepad handling
 static void check_gamepad_controls()
 {
     // First check for service engine's combinations (mouse lock, display mode switch, and so forth)
-    GamepadInput gi;
-    if (!run_service_gamepad_controls(gi)) {
+    GamepadInput gbut;
+    if (!run_service_gamepad_controls(gbut)) {
         return;
     }
-    eAGSGamepad_Button gbn = gi.Button;
+    
     // Then, check cutscene skip
-    check_skip_cutscene_gamepad(gbn);
+    check_skip_cutscene_gamepad(gbut);
     if (play.fast_forward) {
         return;
     }
@@ -771,20 +782,20 @@ static void check_gamepad_controls()
         // only allow a key to remove the overlay if the icon bar isn't up
         if (IsGamePaused() == 0) {
             remove_screen_overlay(play.text_overlay_on);
-            play.SetWaitSkipResult(SKIP_GAMEPAD, gbn);
+            play.SetWaitSkipResult(SKIP_GAMEPAD, get_gamepadkey(gbut));
         }
 
         return;
     }
 
     if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
-        play.SetWaitSkipResult(SKIP_GAMEPAD, gbn);
+        play.SetWaitSkipResult(SKIP_GAMEPAD, get_gamepadkey(gbut));
         return;
     }
 
     if (is_inside_script()) {
         // Don't queue up another button press if it can't be run instantly
-        debug_script_log("Gamepad button %d ignored (game blocked)", gbn);
+        debug_script_log("Gamepad button %d ignored (game blocked)", get_gamepadkey(gbut));
         return;
     }
 }

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -82,6 +82,8 @@ bool is_runtime_set();
 // Gets real runtime duration in ms, for diagnostic purposes
 uint32_t get_runtime_ms();
 
+//Gets controller key [gamepad or joystick]
+int get_gamepadkey(GamepadInput &getinput);
 // Runs service key controls, returns false if no key was pressed or key input was claimed by the engine,
 // otherwise returns true and provides a keycode.
 bool run_service_key_controls(KeyInput &kgn);

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -404,9 +404,13 @@ static bool video_check_user_input(VideoSkipType skip)
         else if (type == kInputGamepad)
         {
             GamepadInput gbut;
-            if (run_service_gamepad_controls(gbut) && (skip == VideoSkipAnyKey) &&
-                is_default_gamepad_skip_button_pressed(gbut.Button))
-                return true; // skip on ABXY
+            if (run_service_gamepad_controls(gbut) && (skip == VideoSkipAnyKey))
+            {
+                if (is_default_gamepad_skip_button_pressed(gbut))
+                {
+                    return true; // skip on gamepad/joystic
+                }
+            }
         }
     }
     return false;


### PR DESCRIPTION
Engine: 4.0.0.29
-Fixing the issue where a joystick button couldn't skip dialog.
-Changed a few naming conventions and mostly made several functions use GamepadInput instead of an int, to be able to adjust things better down the line