### PR TITLE
4.0: implement DrawingSurface.GetPixelsCopy, SetPixels

### DIFF
--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -584,6 +584,13 @@ int AGSColorToBitmapColor(int color, int /*color_depth*/)
     return color;
 }
 
+int BitmapColorToAGSColor(int color, int /*color_depth*/)
+{
+    // no conversion necessary, we assume that "ags color" is matching
+    // palette index in 8-bit mode and 32-bit A8R8G8B8 in 32-bit mode
+    return color;
+}
+
 void AGSColorToRGB(int color, int color_depth, RGB &rgb)
 {
     if (color_depth == 8)

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -304,6 +304,8 @@ namespace BitmapHelper
 {
     // Remaps AGS color number to a color value compatible to a bitmap of certain color depth
     int AGSColorToBitmapColor(int color, int color_depth);
+    // Remaps a bitmap pixel of certain color depth to AGS color number
+    int BitmapColorToAGSColor(int color, int color_depth);
     // Remaps AGS color number in certain color depth mode to a actual RGB
     void AGSColorToRGB(int color, int color_depth, RGB &rgb);
     // TODO: revise those functions later (currently needed in a few very specific cases)

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -104,8 +104,9 @@ Bitmap *CreateBitmapFromPixels(int width, int height, int dst_color_depth,
     if (!bitmap)
         return nullptr;
 
-    if (!PixelOp::CopyConvert(bitmap->GetDataForWriting(), ColorDepthToPixelFormat(dst_color_depth),
-            bitmap->GetLineLength(), width, height, pixels, ColorDepthToPixelFormat(src_col_depth), src_pitch))
+    if (!PixelOp::CopyConvert(pixels, ColorDepthToPixelFormat(src_col_depth), src_pitch,
+            width, height, bitmap->GetDataForWriting(), ColorDepthToPixelFormat(dst_color_depth),
+            bitmap->GetLineLength()))
         return nullptr;
 
     return bitmap.release();
@@ -294,10 +295,10 @@ void CopyTransparency(Bitmap *dst, const Bitmap *mask, bool dst_has_alpha, bool 
         ApplyMask(dst_ptr, src_ptr, pitch, height, PixelTransCpy32(), PixelTransSkip32(), mask_color, dst_has_alpha, mask_has_alpha);
 }
 
-void ReadPixelsFromMemory(Bitmap *dst, const uint8_t *src_buffer, const size_t src_pitch, const size_t src_px_offset)
+void ReadPixelsFromMemory(Bitmap *dst, const uint8_t *src_buffer, const size_t src_pitch)
 {
-    PixelOp::CopyPixels(dst->GetDataForWriting(), dst->GetLineLength(), 0u,
-        dst->GetBPP(), dst->GetHeight(), src_buffer, src_pitch, src_px_offset);
+    PixelOp::CopyPixels(src_buffer, dst->GetBPP(), src_pitch, dst->GetWidth(), dst->GetHeight(),
+        dst->GetDataForWriting(), dst->GetLineLength());
 }
 
 // Converts loaded bitmap to the requested color depth,

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -144,8 +144,8 @@ namespace BitmapHelper
     // Copy pixel data into bitmap from memory buffer. It is required that the
     // source matches bitmap format and has enough data.
     // Pitch is given in bytes and defines the length of the source scan line.
-    // Offset is optional and defines horizontal offset, in pixels.
-    void    ReadPixelsFromMemory(Bitmap *dst, const uint8_t *src_buffer, const size_t src_pitch, const size_t src_px_offset = 0);
+    // FIXME: a safer version that requires to assert buffer size
+    void    ReadPixelsFromMemory(Bitmap *dst, const uint8_t *src_buffer, const size_t src_pitch);
 
 } // namespace BitmapHelper
 

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -43,22 +43,30 @@ uint32_t BitmapData::GetPixel(int x, int y) const
 namespace PixelOp
 {
 
-void CopyPixels(uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_offset,
-    const int bpp, const int height, const uint8_t *src_buffer, const size_t src_pitch, const size_t src_px_offset)
+void CopyPixels(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
+    const int width, const int height, uint8_t *dst_buffer, const size_t dst_pitch)
 {
-    const size_t src_bpp_offset = src_px_offset * bpp;
-    const size_t dst_bpp_offset = dst_px_offset * bpp;
-    if (src_bpp_offset >= src_pitch || dst_bpp_offset >= dst_pitch)
-        return; // nothing to copy
-    Memory::BlockCopy(dst_buffer, dst_pitch, src_bpp_offset, src_buffer, src_pitch, dst_bpp_offset, height);
+    CopyPixelsRegion(src_buffer, bpp, src_pitch, 0u, width, height, dst_buffer, dst_pitch, 0u);
 }
 
-bool CopyConvert(uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch,
-    const int width, const int height, const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch)
+void CopyPixelsRegion(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
+    const size_t src_px_off, const int width_px, const int height_px,
+    uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off)
+{
+    const size_t src_off = src_px_off * bpp;
+    const size_t dst_off = dst_px_off * bpp;
+    const size_t width = width_px * bpp;
+    const size_t height = height_px * bpp;
+    // NOTE: all assertions are done further in Memory::BlockCopy
+    Memory::BlockCopy(src_buffer, src_pitch, src_off, width, height, dst_buffer, dst_pitch, dst_off);
+}
+
+bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,
+    const int width, const int height, uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch)
 {
     if (dst_fmt == src_fmt)
     {
-        CopyPixels(dst_buffer, dst_pitch, 0u, src_fmt, height, src_buffer, src_pitch, 0u);
+        CopyPixels(src_buffer, src_fmt, src_pitch, width, height, dst_buffer, dst_pitch);
         return true;
     }
 

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -53,12 +53,11 @@ void CopyPixelsRegion(const uint8_t *src_buffer, const int bpp, const size_t src
     const size_t src_px_off, const int width_px, const int height_px,
     uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off)
 {
-    const size_t src_off = src_px_off * bpp;
-    const size_t dst_off = dst_px_off * bpp;
-    const size_t width = width_px * bpp;
-    const size_t height = height_px * bpp;
+    const size_t src_boff = src_px_off * bpp;
+    const size_t dst_boff = dst_px_off * bpp;
+    const size_t width_b = width_px * bpp;
     // NOTE: all assertions are done further in Memory::BlockCopy
-    Memory::BlockCopy(src_buffer, src_pitch, src_off, width, height, dst_buffer, dst_pitch, dst_off);
+    Memory::BlockCopy(src_buffer, src_pitch, src_boff, width_b, height_px, dst_buffer, dst_pitch, dst_boff);
 }
 
 bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -212,14 +212,29 @@ namespace PixelOp
     // Copy pixel data from one memory buffer to another. It is required that the
     // buffers match same format, and have enough size.
     // Pitches are given in bytes and define the length of the source and dest scan lines.
-    // Offsets are optional and define horizontal dest and source offsets, *in pixels*.
-    void CopyPixels(uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_offset,
-        const int bpp, const int height, const uint8_t *src_buffer, const size_t src_pitch, const size_t src_px_offset);
-    inline void CopyPixels(uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_offset,
-        const PixelFormat fmt, const int height, const uint8_t *src_buffer, const size_t src_pitch, const size_t src_px_offset)
+    // Width and height of the rectangle are *in pixels*.
+    void CopyPixels(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
+        const int width, const int height, uint8_t *dst_buffer, const size_t dst_pitch);
+    inline void CopyPixels(const uint8_t *src_buffer, const PixelFormat fmt, const size_t src_pitch,
+        const int width_px, const int height_px, uint8_t *dst_buffer, const size_t dst_pitch)
     {
-        CopyPixels(dst_buffer, dst_pitch, dst_px_offset, PixelFormatToPixelBytes(fmt), height, src_buffer, src_pitch, src_px_offset);
+        CopyPixels(src_buffer, PixelFormatToPixelBytes(fmt), src_pitch, width_px, height_px, dst_buffer, dst_pitch);
     }
+    // Copy a portion of pixel data from one memory buffer to another. It is required that the
+    // buffers match same format, and have enough size.
+    // Pitches are given in bytes and define the length of the source and dest scan lines.
+    // Width and height of the rectangle, as well as source and destination offsets are *in pixels*.
+    void CopyPixelsRegion(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
+        const size_t src_px_off, const int width_px, const int height_px,
+        uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off);
+    inline void CopyPixelsRegion(const uint8_t *src_buffer, const PixelFormat fmt, const size_t src_pitch,
+        const size_t src_px_off, const int width_px, const int height_px,
+        uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off)
+    {
+        CopyPixelsRegion(src_buffer, PixelFormatToPixelBytes(fmt), src_pitch,
+            src_px_off, width_px, height_px, dst_buffer, dst_pitch, dst_px_off);
+    }
+
     // Copies pixels from source to dest buffer, possibly converting between source
     // and dest pixel format. The destination buffer must be properly allocated
     //     (see GetDataSizeForPixelFormat()).
@@ -231,8 +246,8 @@ namespace PixelOp
     //          * 16-bit    => 32-bit
     //          add more common conversions later!
     // FIXME: this would require a palette if conversion goes from indexed to non-indexed!
-    bool CopyConvert(uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch,
-        const int width, const int height, const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch);
+    bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,
+        const int width, const int height, uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch);
     // Copies pixels from source to dest buffer, swapping the RGB components, according
     // to the provided RGB shifts. This operation requires that pixel format is kept the same.
     // It is actually possible to swap in-place (where src and dst are the same buffers).

--- a/Common/gfx/image_png.cpp
+++ b/Common/gfx/image_png.cpp
@@ -249,8 +249,8 @@ bool SavePNG(const BitmapData &bmp, bool skip_alpha, const RGB *pal, Stream *out
         || ((bmp.GetBytesPerPixel() == 4) && skip_alpha))
     {
         png_buf = PixelBuffer(bmp.GetWidth(), bmp.GetHeight(), kPxFmt_R8G8B8);
-        PixelOp::CopyConvert(png_buf.GetData(), kPxFmt_R8G8B8, png_buf.GetStride(), bmp.GetWidth(), bmp.GetHeight(),
-            bmp.GetData(), bmp.GetFormat(), bmp.GetStride());
+        PixelOp::CopyConvert(bmp.GetData(), bmp.GetFormat(), bmp.GetStride(),
+            bmp.GetWidth(), bmp.GetHeight(), png_buf.GetData(), kPxFmt_R8G8B8, png_buf.GetStride());
         // Swap RGB(A) components if necessary (in-place)
         if (_rgb_r_shift_32 != PNG_SHIFT_R32 || _rgb_g_shift_32 != PNG_SHIFT_G32 || _rgb_b_shift_32 != PNG_SHIFT_B32)
         {

--- a/Common/util/memory.h
+++ b/Common/util/memory.h
@@ -254,13 +254,17 @@ namespace Memory
     //-------------------------------------------------------------------------
     // Memory data manipulation
     //-------------------------------------------------------------------------
-    // Copies block of 2d data from source into destination.
-    inline void BlockCopy(uint8_t *dst, const size_t dst_pitch, const size_t dst_offset,
-                   const uint8_t *src, const size_t src_pitch, const size_t src_offset,
-                   const size_t height)
+    // Copies a block of 2D data from source buffer into destination buffer.
+    // FIXME: a safer version that requires to assert buffer size
+    inline void BlockCopy( const uint8_t *src, const size_t src_pitch, const size_t src_offset,
+        const size_t width, const size_t height,
+        uint8_t *dst, const size_t dst_pitch, const size_t dst_offset)
     {
+        if (src_offset >= src_pitch || dst_offset >= dst_pitch || width == 0u || height == 0u)
+            return; // nothing to copy
+        const size_t copy_width = std::min(width, std::min(dst_pitch - dst_offset, src_pitch - src_offset));
         for (size_t y = 0; y < height; ++y, src += src_pitch, dst += dst_pitch)
-            memcpy(dst + dst_offset, src + src_offset, std::min(dst_pitch - dst_offset, src_pitch - src_offset));
+            memcpy(dst + dst_offset, src + src_offset, copy_width);
     }
 
 } // namespace Memory

--- a/Common/util/memory.h
+++ b/Common/util/memory.h
@@ -255,6 +255,7 @@ namespace Memory
     // Memory data manipulation
     //-------------------------------------------------------------------------
     // Copies a block of 2D data from source buffer into destination buffer.
+    // Pitches, offsets and width are in bytes, height is a number of lines.
     // FIXME: a safer version that requires to assert buffer size
     inline void BlockCopy( const uint8_t *src, const size_t src_pitch, const size_t src_offset,
         const size_t width, const size_t height,
@@ -263,8 +264,15 @@ namespace Memory
         if (src_offset >= src_pitch || dst_offset >= dst_pitch || width == 0u || height == 0u)
             return; // nothing to copy
         const size_t copy_width = std::min(width, std::min(dst_pitch - dst_offset, src_pitch - src_offset));
-        for (size_t y = 0; y < height; ++y, src += src_pitch, dst += dst_pitch)
-            memcpy(dst + dst_offset, src + src_offset, copy_width);
+        if (copy_width == src_pitch && copy_width == dst_pitch)
+        {
+            memcpy(dst, src, height * copy_width);
+        }
+        else
+        {
+            for (size_t y = 0; y < height; ++y, src += src_pitch, dst += dst_pitch)
+                memcpy(dst + dst_offset, src + src_offset, copy_width);
+        }
     }
 
 } // namespace Memory

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -910,8 +910,16 @@ builtin managed struct DrawingSurface {
   import readonly attribute bool Valid;
 #endif
 #ifdef SCRIPT_API_v400
+  /// Returns a dynamic array of bytes, containing a copy of this surface's pixels from the specified region, in respective format.
+  import char[] GetPixelsCopy(int x = 0, int y = 0, int width = -1, int height = -1);
+  /// Returns a dynamic array of ints, containing a copy of this surface's pixels from the specified region, in ARGB format.
+  import int[] GetPixelsCopy32(int x = 0, int y = 0, int width = -1, int height = -1);
   /// Changes the colour of a single pixel on the surface. This operation ignores drawing settings, and simply sets the color value.
   import void SetPixel(int x, int y, int color);
+  /// Pastes an array of pixels onto the surface at the specified position. The pixels format must match the surface's.
+  import void SetPixels(char pixels[], int x = 0, int y = 0, int width = -1, int height = -1);
+  /// Pastes an array of pixels onto the surface at the specified position. The image must have a 32-bit color depth (ARGB format).
+  import void SetPixels32(int pixels[], int x = 0, int y = 0, int width = -1, int height = -1);
   /// Gets/sets the current BlendMode that will be used for drawing onto this surface.
   import attribute BlendMode BlendMode;
   /// Gets the colour depth of this surface.

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -23,16 +23,17 @@
 #include "ac/room.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
+#include "ac/spritecache.h"
 #include "ac/string.h"
 #include "ac/walkbehind.h"
 #include "ac/dynobj/dynobj_manager.h"
+#include "ac/dynobj/cc_dynamicarray.h"
 #include "debug/debug_log.h"
 #include "font/fonts.h"
-#include "gui/guimain.h"
-#include "ac/spritecache.h"
-#include "script/runtimescriptvalue.h"
 #include "gfx/gfx_def.h"
 #include "gfx/gfx_util.h"
+#include "gui/guimain.h"
+#include "script/runtimescriptvalue.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -405,6 +406,84 @@ void DrawingSurface_SetPixel(ScriptDrawingSurface *sds, int x, int y, int color)
     sds->FinishedDrawing();
 }
 
+void *DrawingSurface_GetPixelsCopyImpl(ScriptDrawingSurface *sds, int x, int y, int width, int height, uint8_t dest_elem_size)
+{
+    Bitmap *ds = AssertBitmapSurface(sds->GetBitmapSurface(), "DrawingSurface.GetPixelsCopy");
+    if (!ds)
+        return nullptr;
+
+    if (x < 0 || y < 0 || x >= ds->GetWidth() || y >= ds->GetHeight())
+    {
+        debug_script_warn("DrawingSurface.GetPixelsCopy: invalid region %d,%d %dx%d", x, y, width, height);
+        return nullptr;
+    }
+
+    if (width < 0)
+        width = ds->GetWidth();
+    if (height < 0)
+        height = ds->GetHeight();
+    width = std::min(width, ds->GetWidth() - x);
+    height = std::min(height, ds->GetHeight() - y);
+    auto arr = DynamicArrayHelpers::CreateArray(dest_elem_size, (width * height * ds->GetBPP()) / dest_elem_size);
+    if (arr)
+    {
+        const int src_pitch = ds->GetWidth() * ds->GetBPP();
+        const int dst_pitch = width * ds->GetBPP();
+        PixelOp::CopyPixelsRegion(ds->GetData() + y * src_pitch, ds->GetBPP(), src_pitch,
+            x, width, height, static_cast<uint8_t*>(arr.Obj()), dst_pitch, 0u);
+    }
+    return arr.Obj();
+}
+
+void *DrawingSurface_GetPixelsCopy(ScriptDrawingSurface *sds, int x, int y, int width, int height)
+{
+    return DrawingSurface_GetPixelsCopyImpl(sds, x, y, width, height, sizeof(uint8_t));
+}
+
+void *DrawingSurface_GetPixelsCopy32(ScriptDrawingSurface *sds, int x, int y, int width, int height)
+{
+    return DrawingSurface_GetPixelsCopyImpl(sds, x, y, width, height, sizeof(uint32_t));
+}
+
+void DrawingSurface_SetPixelsImpl(ScriptDrawingSurface *sds, void *arrobj, int x, int y, int width, int height)
+{
+    Bitmap *ds = AssertBitmapSurface(sds->StartDrawing(), "DrawingSurface.GetPixels");
+    if (!ds)
+        return;
+
+    if (arrobj == nullptr)
+        return;
+    if (x < 0 || y < 0 || x >= ds->GetWidth() || y >= ds->GetHeight())
+    {
+        debug_script_warn("DrawingSurface.SetPixels: invalid region %d,%d", x, y);
+        return;
+    }
+
+    if (width < 0)
+        width = ds->GetWidth();
+    if (height < 0)
+        height = ds->GetHeight();
+    const auto &arr_header = CCDynamicArray::GetHeader(arrobj);
+    const uint8_t *arr_ptr = static_cast<uint8_t*>(arrobj);
+    const int src_pitch = width * ds->GetBPP();
+    const int dst_pitch = ds->GetWidth() * ds->GetBPP();
+    const int copy_width = std::min(width, ds->GetWidth() - x);
+    const int copy_height = std::min(height, std::min<int>(arr_header.TotalSize / (src_pitch), ds->GetHeight()));
+    PixelOp::CopyPixelsRegion(arr_ptr, ds->GetBPP(), src_pitch, 0u, copy_width, copy_height,
+        ds->GetDataForWriting() + y * dst_pitch, dst_pitch, x);
+    sds->FinishedDrawing();
+}
+
+void DrawingSurface_SetPixels(ScriptDrawingSurface *sds, void *arrobj, int x, int y, int width, int height)
+{
+    DrawingSurface_SetPixelsImpl(sds, arrobj, x, y, width, height);
+}
+
+void DrawingSurface_SetPixels32(ScriptDrawingSurface *sds, void *arrobj, int x, int y, int width, int height)
+{
+    DrawingSurface_SetPixelsImpl(sds, arrobj, x, y, width, height);
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -521,6 +600,26 @@ RuntimeScriptValue Sc_DrawingSurface_SetPixel(void *self, const RuntimeScriptVal
     API_OBJCALL_VOID_PINT3(ScriptDrawingSurface, DrawingSurface_SetPixel);
 }
 
+RuntimeScriptValue Sc_DrawingSurface_GetPixelsCopy(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ_PINT4(ScriptDrawingSurface, void, globalDynamicArray, DrawingSurface_GetPixelsCopy);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_GetPixelsCopy32(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ_PINT4(ScriptDrawingSurface, void, globalDynamicArray, DrawingSurface_GetPixelsCopy32);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_SetPixels(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PINT4(ScriptDrawingSurface, DrawingSurface_SetPixels, void);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_SetPixels32(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ_PINT4(ScriptDrawingSurface, DrawingSurface_SetPixels32, void);
+}
+
 // void (ScriptDrawingSurface* sds)
 RuntimeScriptValue Sc_DrawingSurface_Release(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -606,7 +705,11 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /
         { "DrawingSurface::DrawSurface^10",       API_FN_PAIR(DrawingSurface_DrawSurface) },
         { "DrawingSurface::DrawTriangle^6",       API_FN_PAIR(DrawingSurface_DrawTriangle) },
         { "DrawingSurface::GetPixel^2",           API_FN_PAIR(DrawingSurface_GetPixel) },
+        { "DrawingSurface::GetPixelsCopy^4",      API_FN_PAIR(DrawingSurface_GetPixelsCopy) },
+        { "DrawingSurface::GetPixelsCopy32^4",    API_FN_PAIR(DrawingSurface_GetPixelsCopy32) },
         { "DrawingSurface::SetPixel^3",           API_FN_PAIR(DrawingSurface_SetPixel) },
+        { "DrawingSurface::SetPixels^5",          API_FN_PAIR(DrawingSurface_SetPixels) },
+        { "DrawingSurface::SetPixels32^5",        API_FN_PAIR(DrawingSurface_SetPixels32) },
         { "DrawingSurface::Release^0",            API_FN_PAIR(DrawingSurface_Release) },
         { "DrawingSurface::get_DrawingColor",     API_FN_PAIR(DrawingSurface_GetDrawingColor) },
         { "DrawingSurface::set_DrawingColor",     API_FN_PAIR(DrawingSurface_SetDrawingColor) },

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -361,7 +361,8 @@ void DrawingSurface_DrawLine(ScriptDrawingSurface *sds, int fromx, int fromy, in
     sds->FinishedDrawingWithBrush();
 }
 
-void DrawingSurface_DrawPixel(ScriptDrawingSurface *sds, int x, int y) {
+void DrawingSurface_DrawPixel(ScriptDrawingSurface *sds, int x, int y)
+{
     Bitmap *ds = AssertBitmapSurface(sds->StartDrawingWithBrush(), "DrawingSurface.DrawPixel");
     if (!ds)
         return;
@@ -376,34 +377,22 @@ void DrawingSurface_DrawPixel(ScriptDrawingSurface *sds, int x, int y) {
     sds->FinishedDrawing();
 }
 
-int DrawingSurface_GetPixel(ScriptDrawingSurface *sds, int x, int y) {
+int DrawingSurface_GetPixel(ScriptDrawingSurface *sds, int x, int y)
+{
     Bitmap *ds = AssertBitmapSurface(sds->GetBitmapSurface(), "DrawingSurface.GetPixel");
-    if (!ds)
-        return 0;
-    int rawPixel = ds->GetPixel(x, y);
-    int maskColor = ds->GetMaskColor();
-    int colDepth = ds->GetColorDepth();
-
-    if (rawPixel == maskColor)
-    {
-        rawPixel = SCR_COLOR_TRANSPARENT;
-    }
-    else if (colDepth > 8)
-    {
-        int r = getr_depth(colDepth, rawPixel);
-        int g = getg_depth(colDepth, rawPixel);
-        int b = getb_depth(colDepth, rawPixel);
-        rawPixel = Game_GetColorFromRGB(r, g, b);
-    }
-
-    return rawPixel;
+    if (ds)
+        return BitmapHelper::BitmapColorToAGSColor(ds->GetPixel(x, y), ds->GetColorDepth());
+    return 0;
 }
 
 void DrawingSurface_SetPixel(ScriptDrawingSurface *sds, int x, int y, int color)
 {
     Bitmap *ds = AssertBitmapSurface(sds->StartDrawing(), "DrawingSurface.SetPixel");
-    ds->PutPixel(x, y, ds->GetCompatibleColor(color));
-    sds->FinishedDrawing();
+    if (ds)
+    {
+        ds->PutPixel(x, y, ds->GetCompatibleColor(color));
+        sds->FinishedDrawing();
+    }
 }
 
 void *DrawingSurface_GetPixelsCopyImpl(ScriptDrawingSurface *sds, int x, int y, int width, int height, uint8_t dest_elem_size)

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -160,6 +160,26 @@ void CCDynamicArray::TraverseRefs(void *address, PfnTraverseRefOp traverse_op)
 CCDynamicArray globalDynamicArray;
 
 
+DynObjectRef DynamicArrayHelpers::CreateArray(size_t data_sz)
+{
+    return globalDynamicArray.CreateOld(data_sz, sizeof(uint8_t), false);
+}
+
+DynObjectRef DynamicArrayHelpers::CreateArray(size_t elem_size, size_t length)
+{
+    return globalDynamicArray.CreateOld(length, elem_size, false);
+}
+
+DynObjectRef DynamicArrayHelpers::CreateArray(const std::vector<uint8_t> &data)
+{
+    DynObjectRef arr = globalDynamicArray.CreateOld(data.size(), sizeof(uint8_t), false);
+    if (arr.Obj())
+    {
+        std::copy(data.begin(), data.end(), static_cast<uint8_t*>(arr.Obj()));
+    }
+    return arr;
+}
+
 DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char*> &items)
 {
     // FIXME: create using CreateNew, but need to pass String's type id somehow! (just lookup for "String" in rtti?)

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -93,6 +93,12 @@ extern CCDynamicArray globalDynamicArray;
 // TODO: move to the separate source file and merge with script struct helpers?!
 namespace DynamicArrayHelpers
 {
+    // Create array of the requested size in bytes
+    DynObjectRef CreateArray(size_t data_sz);
+    // Create array of the requested length and size of element
+    DynObjectRef CreateArray(size_t elem_size, size_t length);
+    // Create array, initializing with the provided bytes
+    DynObjectRef CreateArray(const std::vector<uint8_t> &data);
     // Create array of managed strings from strings that exists somewhere
     DynObjectRef CreateStringArray(const std::vector<const char*> &);
     DynObjectRef CreateStringArray(const std::vector<AGS::Common::String> &);


### PR DESCRIPTION
Suddenly realized that we never implemented the functions for working with arrays of pixels from DrawingSurface, discussed as an alternative to #1997, so doing this now (#1997 is still under question, i might revisit it once i get more spare time, and see if there are opportunities to implement it in AGS 4).

This adds two script functions:
```
char[] DrawingSurface.GetPixelsCopy(int x = 0, int y = 0, int width = -1, int height = -1);
void DrawingSurface.SetPixels(char pixels[], int x = 0, int y = 0, int width = -1, int height = -1);
```

`GetPixelsCopy` copies a surface region and returns as a dynamic array of bytes (remember, in AGS script `char` is a *unsigned byte*, so capable of storing full range value 0-255). The meaning of bytes depends on the image format. In 8-bit images each byte is a pixel which value equals a palette index. In 32-bit images each byte is a component of RGBA (so 4 bytes make a pixel). We do not support 16-bit images in AGS 4.0 anymore, but if we did their case would be complicated, as RGB are encoded in 2 bytes as R5G6B5 and must be retrieved using bitwise operations.

`SetPixels` does the opposite, it copies the contents of the dynamic array of bytes onto the requested position in the image.
The `width` parameter there is very important as engine must know how much to copy per line. Height may be provided, but the height's limit is also calculated from the total length of the array, so that array is not exceeded when copying data.

Couple of simple examples:
```
void noloopcheck DoPixels()
{
  DrawingSurface* ds = Room.GetDrawingSurfaceForBackground();
  char pixels[] = ds.GetPixelsCopy(100, 100, 50, 50);
  for (int i = 0; i < pixels.Length; i++)
    pixels[i] = pixels[i] + 10;
  ds.SetPixels(pixels, 150, 100, 50);
  ds.Release();
}
```
this will make a copy of a 50x50 rect and paste it next to the original position, while slightly adjusting color values.

```
void noloopcheck DoPixels32()
{
  DrawingSurface* ds = Room.GetDrawingSurfaceForBackground();
  int pixels[] = ds.GetPixelsCopy32(100, 100, 50, 50);
  for (int i = 0; i < pixels.Length; i++)
    pixels[i] = pixels[i] & 0x00FF0000;
  ds.SetPixels32(pixels, 150, 100, 50);
  ds.Release();
}
```
this will make a copy of a 50x50 rect and paste it next to the original position, while turning all pixels into hues of red.

@ericoporto do you think we may need variants of functions that work with 32-bit int arrays, so that you can handle each pixel as a int number? These could be implemented as wrappers, calling base ones internally.

PS. I might actually backport this to 3.6.3 too, since this is a simple enough function.