### PR TITLE
Editor: Copy/Paste commands for global game items

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -460,6 +460,7 @@
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
     <Compile Include="Utils\BitmapExtensions.cs" />
+    <Compile Include="Utils\ClipboardUtils.cs" />
     <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\Debounce.cs" />

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -143,16 +143,21 @@ namespace AGS.Editor.Components
 
         protected string AddSingleItem(ItemType item)
         {
+            return AddSingleItem(item, _rightClickedID);
+        }
+
+        protected string AddSingleItem(ItemType item, string parentFolderID)
+        {
             if (CreateItemsAtTop)
             {
-                _folders[_rightClickedID].Items.Insert(0, item);
+                _folders[parentFolderID].Items.Insert(0, item);
             }
             else
             {
-                _folders[_rightClickedID].Items.Add(item);
+                _folders[parentFolderID].Items.Add(item);
             }
 
-            _guiController.ProjectTree.StartFromNode(this, _rightClickedID);
+            _guiController.ProjectTree.StartFromNode(this, parentFolderID);
             string newNodeID = AddTreeNodeForItem(item);
             return newNodeID;
         }
@@ -545,18 +550,18 @@ namespace AGS.Editor.Components
             return true;
         }
 
-        protected FolderType FindFolderThatContainsItem(FolderType rootFolder, ItemType view)
+        protected FolderType FindFolderThatContainsItem(FolderType rootFolder, ItemType item)
         {
             foreach (FolderType subFolder in rootFolder.SubFolders)
             {
-                FolderType result = FindFolderThatContainsItem(subFolder, view);
+                FolderType result = FindFolderThatContainsItem(subFolder, item);
                 if (result != null)
                 {
                     return result;
                 }
             }
 
-            if (rootFolder.Items.Contains(view))
+            if (rootFolder.Items.Contains(item))
             {
                 return rootFolder;
             }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -1,3 +1,5 @@
+using AGS.Editor.TextProcessing;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -5,8 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
-using AGS.Types;
-using AGS.Editor.TextProcessing;
 
 namespace AGS.Editor.Components
 {
@@ -14,8 +14,10 @@ namespace AGS.Editor.Components
     {
         private const string CHARACTERS_COMMAND_ID = "Characters";
         private const string COMMAND_NEW_ITEM = "NewCharacter";
-        private const string COMMAND_IMPORT = "ImportCharacter";
         private const string COMMAND_DELETE_ITEM = "DeleteCharacter";
+        private const string COMMAND_COPY_ITEM = "CopyCharacter";
+        private const string COMMAND_PASTE_ITEM = "PasteCharacter";
+        private const string COMMAND_IMPORT = "ImportCharacter";
         private const string COMMAND_EXPORT = "ExportCharacter";
         private const string COMMAND_CHANGE_ID = "ChangeCharacterID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
@@ -49,18 +51,28 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.Characters; }
         }
 
+        private Character AddNewCharacter(Character newItem, string baseScriptName)
+        {
+            newItem.ID = _agsEditor.CurrentGame.RootCharacterFolder.GetAllItemsCount();
+            newItem.ScriptName = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            string newNodeID;
+            if (_itemRightClicked != null)
+                newNodeID = AddSingleItem(newItem, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _itemRightClicked)));
+            else
+                newNodeID = AddSingleItem(newItem, _rightClickedID);
+            _guiController.ProjectTree.SelectNode(this, newNodeID);
+            ShowOrAddPane(newItem);
+            return newItem;
+        }
+
         protected override void ItemCommandClick(string controlID)
         {
             if (controlID == COMMAND_NEW_ITEM)
             {                
                 Character newItem = new Character();
-                newItem.ID = _agsEditor.CurrentGame.RootCharacterFolder.GetAllItemsCount();
-                newItem.ScriptName = _agsEditor.GetFirstAvailableScriptName("cChar");
                 newItem.RealName = "New character";
                 newItem.StartingRoom = -1;
-                string newNodeID = AddSingleItem(newItem);
-                _guiController.ProjectTree.SelectNode(this, newNodeID);
-				ShowOrAddPane(newItem);
+                AddNewCharacter(newItem, "cChar");
             }
             else if (controlID == COMMAND_IMPORT)
             {
@@ -94,6 +106,18 @@ namespace AGS.Editor.Components
                     OnCharacterRoomChanged?.Invoke(this, new CharacterRoomChangedEventArgs(c, oldRoom));
                     DeleteSingleItem(_itemRightClicked);
                 }
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_itemRightClicked);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                Character newItem = ClipboardUtils.PasteFromClipboard(typeof(Character)) as Character;
+                if (newItem == null)
+                    return;
+                newItem.Interactions.Schema = Character.InteractionSchema; // schema reference is lost when deserializing
+                AddNewCharacter(newItem, newItem.ScriptName);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -167,7 +191,7 @@ namespace AGS.Editor.Components
             }            
         }
 
-		private void ShowOrAddPane(Character chosenItem)
+        private void ShowOrAddPane(Character chosenItem)
 		{
             ContentDocument document;
 			if (!_documents.TryGetValue(chosenItem, out document)
@@ -265,6 +289,7 @@ namespace AGS.Editor.Components
         public override IList<MenuCommand> GetContextMenu(string controlID)
         {
             IList<MenuCommand> menu = base.GetContextMenu(controlID);
+            _itemRightClicked = null;
             if ((controlID.StartsWith(ITEM_COMMAND_PREFIX)) &&
                 (!IsFolderNode(controlID)))
             {
@@ -273,6 +298,9 @@ namespace AGS.Editor.Components
                 if (_itemRightClicked != null)
                 {
                     menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change character ID", null));
+                    menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy character", null));
+                    if (ClipboardUtils.IsAvailableOnClipboard(typeof(Character)))
+                        menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste character", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this character", null));
                     menu.Add(new MenuCommand(COMMAND_EXPORT, "Export character...", null));
                     menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.ScriptName, null));
@@ -384,7 +412,9 @@ namespace AGS.Editor.Components
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
             menu.Add(new MenuCommand(COMMAND_NEW_ITEM, "New character", null));
-            menu.Add(new MenuCommand(COMMAND_IMPORT, "Import character...", null));  
+            menu.Add(new MenuCommand(COMMAND_IMPORT, "Import character...", null));
+            if (ClipboardUtils.IsAvailableOnClipboard(typeof(Character)))
+                menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste character", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)

--- a/Editor/AGS.Editor/Components/CursorsComponent.cs
+++ b/Editor/AGS.Editor/Components/CursorsComponent.cs
@@ -13,6 +13,8 @@ namespace AGS.Editor.Components
         private const string TOP_LEVEL_COMMAND_ID = "Cursors";
         private const string COMMAND_NEW_ITEM = "NewCursor";
         private const string COMMAND_DELETE_ITEM = "DeleteCursor";
+        private const string COMMAND_COPY_ITEM = "CopyCursor";
+        private const string COMMAND_PASTE_ITEM = "PasteCursor";
         private const int BUILT_IN_CURSORS = 8;
         private const string ICON_KEY = "CursorsIcon";
 
@@ -34,19 +36,25 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.Cursors; }
         }
 
+        private MouseCursor AddNewCursor(MouseCursor newItem)
+        {
+            IList<MouseCursor> items = _agsEditor.CurrentGame.Cursors;
+            newItem.ID = items.Count;
+            newItem.Name = "Cursor" + newItem.ID;
+            items.Add(newItem);
+            _guiController.ProjectTree.StartFromNode(this, TOP_LEVEL_COMMAND_ID);
+            _guiController.ProjectTree.AddTreeLeaf(this, GetNodeID(newItem), GetNodeLabel(newItem), "CursorIcon");
+            _guiController.ProjectTree.SelectNode(this, GetNodeID(newItem));
+            ShowOrAddPane(newItem);
+            return newItem;
+        }
+
         public override void CommandClick(string controlID)
         {
             if (controlID == COMMAND_NEW_ITEM)
             {
-                IList<MouseCursor> items = _agsEditor.CurrentGame.Cursors;
                 MouseCursor newItem = new MouseCursor();
-                newItem.ID = items.Count;
-                newItem.Name = "Cursor" + newItem.ID;
-                items.Add(newItem);
-                _guiController.ProjectTree.StartFromNode(this, TOP_LEVEL_COMMAND_ID);
-                _guiController.ProjectTree.AddTreeLeaf(this, GetNodeID(newItem), GetNodeLabel(newItem), "CursorIcon");
-                _guiController.ProjectTree.SelectNode(this, GetNodeID(newItem));
-				ShowOrAddPane(newItem);
+                AddNewCursor(newItem);
             }
             else if (controlID == COMMAND_DELETE_ITEM)
             {
@@ -68,6 +76,17 @@ namespace AGS.Editor.Components
                     _agsEditor.CurrentGame.Cursors.Remove(_itemRightClicked);
                     RePopulateTreeView();
                 }
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_itemRightClicked);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                MouseCursor newItem = ClipboardUtils.PasteFromClipboard(typeof(MouseCursor)) as MouseCursor;
+                if (newItem == null)
+                    return;
+                AddNewCursor(newItem);
             }
             else if (controlID != TOP_LEVEL_COMMAND_ID)
             {
@@ -129,9 +148,12 @@ namespace AGS.Editor.Components
         public override IList<MenuCommand> GetContextMenu(string controlID)
         {
             IList<MenuCommand> menu = new List<MenuCommand>();
+            _itemRightClicked = null;
             if (controlID == TOP_LEVEL_COMMAND_ID)
             {
                 menu.Add(new MenuCommand(COMMAND_NEW_ITEM, "New Cursor", null));
+                if (ClipboardUtils.IsAvailableOnClipboard(typeof(MouseCursor)))
+                    menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste Cursor", null));
             }
             else
             {
@@ -139,6 +161,9 @@ namespace AGS.Editor.Components
                 _itemRightClicked = _agsEditor.CurrentGame.Cursors[cursorID];
                 if (_itemRightClicked != null)
                 {
+                    menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy cursor", null));
+                    if (ClipboardUtils.IsAvailableOnClipboard(typeof(MouseCursor)))
+                        menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste cursor", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this cursor", null));
                     if (cursorID < BUILT_IN_CURSORS)
                     {

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor.Components
         private const string DIALOGS_COMMAND_ID = "Dialogs";
         private const string COMMAND_NEW_ITEM = "NewDialog";
         private const string COMMAND_DELETE_ITEM = "DeleteDialog";
+        private const string COMMAND_COPY_ITEM = "CopyDialog";
+        private const string COMMAND_PASTE_ITEM = "PasteDialog";
         private const string COMMAND_CHANGE_ID = "ChangeDialogID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
         private const string COMMAND_GO_TO_DIALOG_NUMBER = "GoToDialogNumber";
@@ -51,16 +53,26 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.Dialogs; }
         }
 
+        private Dialog AddNewDialog(Dialog newItem, string baseScriptName)
+        {
+            newItem.ID = _agsEditor.CurrentGame.RootDialogFolder.GetAllItemsCount();
+            newItem.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            string newNodeID;
+            if (_itemRightClicked != null)
+                newNodeID = AddSingleItem(newItem, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _itemRightClicked)));
+            else
+                newNodeID = AddSingleItem(newItem, _rightClickedID);
+            _guiController.ProjectTree.SelectNode(this, newNodeID);
+            ShowPaneForDialog(newItem);
+            return newItem;
+        }
+
         protected override void ItemCommandClick(string controlID)
         {
             if (controlID == COMMAND_NEW_ITEM)
             {
                 Dialog newItem = new Dialog();
-                newItem.ID = _agsEditor.CurrentGame.RootDialogFolder.GetAllItemsCount();
-                newItem.Name = _agsEditor.GetFirstAvailableScriptName("dDialog");
-                string newNodeID = AddSingleItem(newItem);
-                _guiController.ProjectTree.SelectNode(this, newNodeID);
-				ShowPaneForDialog(newItem);
+                AddNewDialog(newItem, "dDialog");
             }
             else if (controlID == COMMAND_DELETE_ITEM)
             {
@@ -68,6 +80,17 @@ namespace AGS.Editor.Components
                 {
                     DeleteSingleItem(_itemRightClicked);
                 }
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_itemRightClicked);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                Dialog newItem = ClipboardUtils.PasteFromClipboard(typeof(Dialog)) as Dialog;
+                if (newItem == null)
+                    return;
+                AddNewDialog(newItem, newItem.Name);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -193,6 +216,8 @@ namespace AGS.Editor.Components
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
             menu.Add(new MenuCommand(COMMAND_NEW_ITEM, "New Dialog", null));
+            if (ClipboardUtils.IsAvailableOnClipboard(typeof(Dialog)))
+                menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste Dialog", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
@@ -209,6 +234,7 @@ namespace AGS.Editor.Components
         public override IList<MenuCommand> GetContextMenu(string controlID)
         {
             IList<MenuCommand> menu = base.GetContextMenu(controlID);
+            _itemRightClicked = null;
             if ((controlID.StartsWith(ITEM_COMMAND_PREFIX)) &&
                 (!IsFolderNode(controlID)))            
             {
@@ -217,6 +243,9 @@ namespace AGS.Editor.Components
                 if (_itemRightClicked != null)
                 {
                     menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change dialog ID", null));
+                    menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy dialog", null));
+                    if (ClipboardUtils.IsAvailableOnClipboard(typeof(Dialog)))
+                        menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste dialog", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this dialog", null));
                     menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.Name, null));
                 }

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -21,6 +21,8 @@ namespace AGS.Editor.Components
         private const string COMMAND_NEW_TEXTWINDOW = "NewTextWindow";
         private const string COMMAND_IMPORT_GUI = "ImportGUI";
         private const string COMMAND_DELETE_GUI = "DeleteGUI";
+        private const string COMMAND_COPY_ITEM = "CopyGUI";
+        private const string COMMAND_PASTE_ITEM = "PasteGUI";
         private const string COMMAND_EXPORT_GUI = "ExportGUI";
         private const string COMMAND_CHANGE_ID = "ChangeGUIID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
@@ -69,19 +71,34 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.GUIs; }
         }
 
+        private GUI AddNewGUI(GUI newGui, string baseScriptName)
+        {
+            newGui.ID = _agsEditor.CurrentGame.RootGUIFolder.GetAllItemsCount();
+            newGui.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            string newNodeID;
+            if (_guiRightClicked != null)
+                newNodeID = AddSingleItem(newGui, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _guiRightClicked)));
+            else
+                newNodeID = AddSingleItem(newGui, _rightClickedID);
+            GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
+            _guiController.ProjectTree.SelectNode(this, newNodeID);
+            ShowOrAddPane(newGui);
+            return newGui;
+        }
+
         protected override void ItemCommandClick(string controlID)
         {
             if (controlID == COMMAND_NEW_GUI)
             {
                 Size gameRes = _agsEditor.CurrentGame.Settings.CustomResolution;
                 GUI newGUI = new NormalGUI(Math.Min(gameRes.Width, GUI_DEFAULT_WIDTH_MAX), Math.Min(gameRes.Height, GUI_DEFAULT_HEIGHT_MAX));
-                AddNewGUI(newGUI);
+                AddNewGUI(newGUI, "gGui");
                 _agsEditor.CurrentGame.NotifyClientsGUIAddedOrRemoved(newGUI);
             }
             else if (controlID == COMMAND_NEW_TEXTWINDOW)
             {
                 GUI newGUI = new TextWindowGUI();
-                AddNewGUI(newGUI);
+                AddNewGUI(newGUI, "gGui");
                 _agsEditor.CurrentGame.NotifyClientsGUIAddedOrRemoved(newGUI);
             }
             else if (controlID == COMMAND_IMPORT_GUI)
@@ -131,6 +148,22 @@ namespace AGS.Editor.Components
                     DeleteSingleItem(_guiRightClicked);
                     GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
                 }
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_guiRightClicked);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                GUI newGUI = null;
+                if (ClipboardUtils.IsAvailableOnClipboard(typeof(NormalGUI)))
+                    newGUI = ClipboardUtils.PasteFromClipboard(typeof(NormalGUI)) as NormalGUI;
+                else if (ClipboardUtils.IsAvailableOnClipboard(typeof(TextWindowGUI)))
+                    newGUI = ClipboardUtils.PasteFromClipboard(typeof(TextWindowGUI)) as TextWindowGUI;
+                if (newGUI == null)
+                    return;
+                AddNewGUI(newGUI, newGUI.Name);
+                _agsEditor.CurrentGame.NotifyClientsGUIAddedOrRemoved(newGUI);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -299,6 +332,9 @@ namespace AGS.Editor.Components
             menu.Add(new MenuCommand(COMMAND_NEW_GUI, "New GUI", null));
             menu.Add(new MenuCommand(COMMAND_NEW_TEXTWINDOW, "New Text Window GUI", null));
             menu.Add(new MenuCommand(COMMAND_IMPORT_GUI, "Import GUI...", null));
+            if (ClipboardUtils.IsAvailableOnClipboard(typeof(NormalGUI)) ||
+                    ClipboardUtils.IsAvailableOnClipboard(typeof(TextWindowGUI)))
+                menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste GUI", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
@@ -315,6 +351,7 @@ namespace AGS.Editor.Components
         public override IList<MenuCommand> GetContextMenu(string controlID)
         {
             IList<MenuCommand> menu = base.GetContextMenu(controlID);
+            _guiRightClicked = null;
             if ((controlID.StartsWith(ITEM_COMMAND_PREFIX)) &&
                 (!IsFolderNode(controlID)))
             {
@@ -322,6 +359,10 @@ namespace AGS.Editor.Components
                 GUI gui = _agsEditor.CurrentGame.RootGUIFolder.FindGUIByID(guiID, true);
                 _guiRightClicked = gui;
                 menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change GUI ID", null));
+                menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy GUI", null));
+                if (ClipboardUtils.IsAvailableOnClipboard(typeof(NormalGUI)) ||
+                        ClipboardUtils.IsAvailableOnClipboard(typeof(TextWindowGUI)))
+                    menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste GUI", null));
                 menu.Add(new MenuCommand(COMMAND_DELETE_GUI, "Delete " + gui.Name, null));
                 menu.Add(new MenuCommand(COMMAND_EXPORT_GUI, "Export GUI...", null));
                 menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + gui.Name, null));
@@ -362,16 +403,6 @@ namespace AGS.Editor.Components
             toolbarIcons.Add(new MenuCommand(MODE_ADD_INVENTORY, "Add Inventory Window", "GUIInvWindowIcon"));
             toolbarIcons[0].Checked = true;
             return toolbarIcons;
-        }
-
-        private void AddNewGUI(GUI newGui)
-        {            
-            newGui.ID = _agsEditor.CurrentGame.RootGUIFolder.GetAllItemsCount();
-            newGui.Name = _agsEditor.GetFirstAvailableScriptName("gGui");
-            string newNodeId = AddSingleItem(newGui);
-            GUIIndexTypeConverter.SetGUIList(_agsEditor.CurrentGame.GUIs);
-            _guiController.ProjectTree.SelectNode(this, newNodeId);
-			ShowOrAddPane(newGui);
         }
 
         private void _guiEditor_OnControlsChanged(GUI editingGui)

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor.Components
         private const string INVENTORY_COMMAND_ID = "Inventory";
         private const string COMMAND_NEW_ITEM = "NewInventory";
         private const string COMMAND_DELETE_ITEM = "DeleteInventory";
+        private const string COMMAND_COPY_ITEM = "CopyInventory";
+        private const string COMMAND_PASTE_ITEM = "PasteInventory";
         private const string COMMAND_CHANGE_ID = "ChangeInventoryID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
         private const string COMMAND_GO_TO_ITEM_NUMBER = "GoToItemNumber";
@@ -39,6 +41,19 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.Inventory; }
         }
 
+        private InventoryItem AddNewItem(InventoryItem newItem, string baseScriptName)
+        {
+            newItem.ID = _agsEditor.CurrentGame.RootInventoryItemFolder.GetAllItemsCount() + 1;
+            newItem.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            string newNodeID;
+            if (_itemRightClicked != null)
+                newNodeID = AddSingleItem(newItem, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _itemRightClicked)));
+            else
+                newNodeID = AddSingleItem(newItem, _rightClickedID);
+            _guiController.ProjectTree.SelectNode(this, newNodeID);
+            ShowOrAddPane(newItem);
+            return newItem;
+        }
         protected override void ItemCommandClick(string controlID)
         {
             if (controlID == COMMAND_NEW_ITEM)
@@ -49,12 +64,8 @@ namespace AGS.Editor.Components
                     return;
                 }
                 InventoryItem newItem = new InventoryItem();
-                newItem.ID = _agsEditor.CurrentGame.RootInventoryItemFolder.GetAllItemsCount() + 1;
-                newItem.Name = _agsEditor.GetFirstAvailableScriptName("iInvItem");
+                AddNewItem(newItem, "iInvItem");
                 newItem.Description = "New inventory item";
-                string newNodeID = AddSingleItem(newItem);
-                _guiController.ProjectTree.SelectNode(this, newNodeID);                
-				ShowOrAddPane(newItem);
             }
             else if (controlID == COMMAND_DELETE_ITEM)
             {
@@ -62,6 +73,18 @@ namespace AGS.Editor.Components
                 {
                     DeleteSingleItem(_itemRightClicked);                    
                 }
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_itemRightClicked);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                InventoryItem newItem = ClipboardUtils.PasteFromClipboard(typeof(InventoryItem)) as InventoryItem;
+                if (newItem == null)
+                    return;
+                newItem.Interactions.Schema = InventoryItem.InteractionSchema; // schema reference is lost when deserializing
+                AddNewItem(newItem, newItem.Name);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -211,6 +234,8 @@ namespace AGS.Editor.Components
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
             menu.Add(new MenuCommand(COMMAND_NEW_ITEM, "New Inventory Item", null));
+            if (ClipboardUtils.IsAvailableOnClipboard(typeof(InventoryItem)))
+                menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste Inventory Item", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
@@ -227,6 +252,7 @@ namespace AGS.Editor.Components
         public override IList<MenuCommand> GetContextMenu(string controlID)
         {
             IList<MenuCommand> menu = base.GetContextMenu(controlID);
+            _itemRightClicked = null;
             if ((controlID.StartsWith(ITEM_COMMAND_PREFIX)) &&
                 (!IsFolderNode(controlID)))
             {
@@ -235,6 +261,9 @@ namespace AGS.Editor.Components
                 if (_itemRightClicked != null)
                 {
                     menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change inventory ID", null));
+                    menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy item", null));
+                    if (ClipboardUtils.IsAvailableOnClipboard(typeof(InventoryItem)))
+                        menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste item", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this item", null));
                     menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.Name, null));
                 }

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor.Components
         private const string COMMAND_NEW_VIEW = "NewView";
         private const string COMMAND_RENAME = "RenameView";
 		private const string COMMAND_DELETE = "DeleteView";
+        private const string COMMAND_COPY_ITEM = "CopyView";
+        private const string COMMAND_PASTE_ITEM = "PasteView";
         private const string COMMAND_CHANGE_ID = "ChangeViewID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
         private const string COMMAND_GO_TO_VIEW_NUMBER = "GoToViewNumber";
@@ -39,6 +41,25 @@ namespace AGS.Editor.Components
         public override string ComponentID
         {
             get { return ComponentIDs.ViewEditor; }
+        }
+
+        private View AddNewView(View newView, string baseScriptName)
+        {
+            newView.ID = _agsEditor.CurrentGame.FindAndAllocateAvailableViewID();
+            if (string.IsNullOrEmpty(baseScriptName))
+                newView.Name = "View" + newView.ID;
+            else
+                newView.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            string newNodeID;
+            View viewClicked;
+            _items.TryGetValue(_rightClickedID, out viewClicked);
+            if (viewClicked != null)
+                newNodeID = AddSingleItem(newView, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), viewClicked)));
+            else
+                newNodeID = AddSingleItem(newView, _rightClickedID);
+            _guiController.ProjectTree.SelectNode(this, newNodeID);
+            ShowOrAddPane(newView);
+            return newView;
         }
 
         protected override void ItemCommandClick(string controlID)
@@ -90,12 +111,18 @@ namespace AGS.Editor.Components
             else if (controlID == COMMAND_NEW_VIEW)
             {
                 View newView = new View();
-                newView.ID = _agsEditor.CurrentGame.FindAndAllocateAvailableViewID();
-                newView.Name = "View" + newView.ID;
-
-                string newNodeID = AddSingleItem(newView);
-                ShowOrAddPane(newView);
-                _guiController.ProjectTree.BeginLabelEdit(this, newNodeID);
+                AddNewView(newView, null);
+            }
+            else if (controlID == COMMAND_COPY_ITEM)
+            {
+                ClipboardUtils.CopyToClipboard(_items[_rightClickedID]);
+            }
+            else if (controlID == COMMAND_PASTE_ITEM)
+            {
+                View newView = ClipboardUtils.PasteFromClipboard(typeof(View)) as View;
+                if (newView == null)
+                    return;
+                AddNewView(newView, newView.Name);
             }
             else if (controlID == COMMAND_RENAME)
             {
@@ -248,8 +275,11 @@ namespace AGS.Editor.Components
                 (!IsFolderNode(controlID)))
             {
                 menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change View ID", null));
-                menu.Add(new MenuCommand(COMMAND_RENAME, "Rename", null));
-				menu.Add(new MenuCommand(COMMAND_DELETE, "Delete", null));
+                menu.Add(new MenuCommand(COMMAND_RENAME, "Rename View", null));
+                menu.Add(new MenuCommand(COMMAND_COPY_ITEM, "Copy View", null));
+                if (ClipboardUtils.IsAvailableOnClipboard(typeof(View)))
+                    menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste View", null));
+                menu.Add(new MenuCommand(COMMAND_DELETE, "Delete View", null));
                 View view = _items[_rightClickedID];
                 menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find all usages of " + view.Name, null));
             }
@@ -362,6 +392,8 @@ namespace AGS.Editor.Components
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
             menu.Add(new MenuCommand(COMMAND_NEW_VIEW, "New View", null));
+            if (ClipboardUtils.IsAvailableOnClipboard(typeof(View)))
+                menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste View", null));
         }
 
         protected override void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -891,35 +891,7 @@ namespace AGS.Editor
             bgPanel.Invalidate();
         }
 
-        private string _guiControlsClipboardFormat = string.Format($"{typeof(GUIControl).FullName}List");
-
-        private void SaveControlsToClipboard(List<GUIControl> controls)
-        {
-            DataFormats.Format format = DataFormats.GetFormat(_guiControlsClipboardFormat);
-
-            IDataObject dataObj = new DataObject();
-            dataObj.SetData(format.Name, false, controls);
-            Clipboard.SetDataObject(dataObj, true);
-        }
-
-        private bool AvailableControlsOnClipboard()
-        {
-            IDataObject dataObj = Clipboard.GetDataObject();
-            if (dataObj != null)
-                return dataObj.GetDataPresent(_guiControlsClipboardFormat);
-            return false;
-        }
-
-        private List<GUIControl> GetControlsFromClipBoard()
-        {
-            List<GUIControl> controls = null;
-            IDataObject dataObj = Clipboard.GetDataObject();
-            if (dataObj.GetDataPresent(_guiControlsClipboardFormat))
-            {
-                controls = dataObj.GetData(_guiControlsClipboardFormat) as List<GUIControl>;
-            }
-            return controls;
-        }
+        private string _guiControlsClipboardFormat = $"{typeof(GUIControl).FullName}List";
 
         private void CopyControlClick(object sender, EventArgs e)
         {
@@ -928,13 +900,13 @@ namespace AGS.Editor
                 List<GUIControl> _copyBuffer = new List<GUIControl>();
                 foreach (var control in _selected)
                     _copyBuffer.Add((GUIControl)control.Clone());
-                SaveControlsToClipboard(_copyBuffer);
+                ClipboardUtils.MoveToClipboard(_copyBuffer, _guiControlsClipboardFormat);
             }
         }
 
         private void PasteControlClick(object sender, EventArgs e)
         {
-            List<GUIControl> newControls = GetControlsFromClipBoard();
+            List<GUIControl> newControls = (List<GUIControl>)ClipboardUtils.PasteFromClipboard(typeof(List<GUIControl>), _guiControlsClipboardFormat);
             if (newControls == null)
                 return;
 
@@ -1063,7 +1035,7 @@ namespace AGS.Editor
                 menu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler(DeleteControlClick), Keys.Delete));
                 }
 
-                if (AvailableControlsOnClipboard())
+                if (ClipboardUtils.IsAvailableOnClipboard(_guiControlsClipboardFormat))
                 {
                     menu.Items.Add(new ToolStripMenuItem("Paste", null, new EventHandler(PasteControlClick), Keys.Control | Keys.V));
                 }

--- a/Editor/AGS.Editor/Utils/ClipboardUtils.cs
+++ b/Editor/AGS.Editor/Utils/ClipboardUtils.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public static class ClipboardUtils
+    {
+        public static string GetFormatName(Type type)
+        {
+            return type.FullName;
+        }
+
+        public static string GetFormatName(object thing)
+        {
+            return thing.GetType().FullName;
+        }
+
+        public static void CopyToClipboard(ICloneable thing)
+        {
+            object thingCopy = thing.Clone();
+            MoveToClipboard(thingCopy, GetFormatName(thing));
+        }
+
+        public static void CopyToClipboard(ICloneable thing, string formatName)
+        {
+            object thingCopy = thing.Clone();
+            MoveToClipboard(thingCopy, formatName);
+        }
+
+        public static void MoveToClipboard(object thing)
+        {
+            MoveToClipboard(thing, GetFormatName(thing));
+        }
+
+        public static void MoveToClipboard(object thing, string formatName)
+        {
+            DataFormats.Format format = DataFormats.GetFormat(formatName);
+            IDataObject dataObj = new DataObject();
+            dataObj.SetData(format.Name, false, thing);
+            Clipboard.SetDataObject(dataObj, true);
+        }
+
+        public static object PasteFromClipboard(Type expectType)
+        {
+            return PasteFromClipboard(expectType, GetFormatName(expectType));
+        }
+
+        public static object PasteFromClipboard(Type expectType, string formatName)
+        {
+            IDataObject dataObj = Clipboard.GetDataObject();
+            if (dataObj != null && dataObj.GetDataPresent(formatName))
+            {
+                object thing = dataObj.GetData(formatName);
+                if (thing != null && thing.GetType() == expectType)
+                    return thing;
+            }
+            return null;
+        }
+
+        public static bool IsAvailableOnClipboard(Type expectType)
+        {
+            return IsAvailableOnClipboard(GetFormatName(expectType));
+        }
+
+        public static bool IsAvailableOnClipboard(string formatName)
+        {
+            IDataObject dataObj = Clipboard.GetDataObject();
+            if (dataObj != null)
+                return dataObj.GetDataPresent(formatName);
+            return false;
+        }
+    }
+}

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -7,9 +7,10 @@ using System.Drawing;
 
 namespace AGS.Types
 {
+    [Serializable]
     [PropertyTab(typeof(PropertyTabInteractions), PropertyTabScope.Component)]
     [DefaultProperty("StartingRoom")]
-    public class Character : ICustomTypeDescriptor, IToXml, IComparable<Character>
+    public class Character : ICustomTypeDescriptor, IToXml, IComparable<Character>, ICloneable
     {
         public const string PROPERTY_NAME_SCRIPTNAME = "ScriptName";
         public const string PROPERTY_NAME_DESCRIPTION = "RealName";
@@ -423,6 +424,13 @@ namespace AGS.Types
             get { return _interactions; }
         }
 
+        [AGSNoSerialize()]
+        [Browsable(false)]
+        public static InteractionSchema InteractionSchema
+        {
+            get { return _interactionSchema; }
+        }
+
         [Browsable(false)]
         public string PropertyGridTitle
         {
@@ -540,6 +548,18 @@ namespace AGS.Types
         public int CompareTo(Character other)
         {
             return ID.CompareTo(other.ID);
+        }
+
+        #endregion
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            Character copy = this.MemberwiseClone() as Character;
+            copy._interactions = this._interactions.Clone() as Interactions;
+            copy._properties = this._properties.Clone() as CustomProperties;
+            return copy;
         }
 
         #endregion

--- a/Editor/AGS.Types/CustomProperties.cs
+++ b/Editor/AGS.Types/CustomProperties.cs
@@ -5,12 +5,13 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [Category("Custom Properties")]
     [DisplayName("Custom Properties")]
     [TypeConverter(typeof(ExpandableObjectConverter))]
     [EditorAttribute(typeof(CustomPropertiesUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
 
-    public class CustomProperties : ICustomTypeDescriptor
+    public class CustomProperties : ICustomTypeDescriptor, ICloneable
     {
         private Dictionary<string,CustomProperty> _properties = new Dictionary<string,CustomProperty>(
             StringComparer.InvariantCultureIgnoreCase);
@@ -182,5 +183,17 @@ namespace AGS.Types
             return this;
         }
         #endregion // ICustomTypeDescriptor
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            CustomProperties copy = new CustomProperties(_appliesTo);
+            foreach (var prop in this._properties)
+                copy._properties.Add(prop.Key, new CustomProperty(prop.Value.Name, prop.Value.Value));
+            return copy;
+        }
+
+        #endregion
     }
 }

--- a/Editor/AGS.Types/CustomProperty.cs
+++ b/Editor/AGS.Types/CustomProperty.cs
@@ -5,6 +5,7 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     public class CustomProperty
     {
         private string _name;

--- a/Editor/AGS.Types/Dialog.cs
+++ b/Editor/AGS.Types/Dialog.cs
@@ -7,14 +7,17 @@ using AGS.Types.Interfaces;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("Name")]
-    public class Dialog : IScript, IToXml, IComparable<Dialog>
+    public class Dialog : IScript, IToXml, IComparable<Dialog>, ICloneable
     {
         private int _id;
         private string _name;
         private bool _showTextParser;
         private string _script;
+        [NonSerialized]
         private bool _scriptChangedSinceLastCompile;
+        [NonSerialized]
         private string _cachedConvertedScript;
         private List<DialogOption> _options = new List<DialogOption>();
 
@@ -152,6 +155,19 @@ namespace AGS.Types
         public int CompareTo(Dialog other)
         {
             return ID.CompareTo(other.ID);
+        }
+
+        #endregion
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            Dialog copy = this.MemberwiseClone() as Dialog;
+            copy._options = new List<DialogOption>();
+            foreach (var option in this._options)
+                copy._options.Add(option.Clone() as DialogOption);
+            return copy;
         }
 
         #endregion

--- a/Editor/AGS.Types/DialogOption.cs
+++ b/Editor/AGS.Types/DialogOption.cs
@@ -6,8 +6,9 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("Text")]
-    public class DialogOption
+    public class DialogOption : ICloneable
     {
         private int _id;
         private string _text = string.Empty;
@@ -66,5 +67,13 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
+        #region IClonable Members
+
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+
+        #endregion
     }
 }

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -10,7 +10,7 @@ namespace AGS.Types
     [Serializable]
     [PropertyTab(typeof(PropertyTabEvents), PropertyTabScope.Component)]
     [DefaultProperty("BackgroundImage")]
-    public abstract class GUI : IToXml, IComparable<GUI>
+    public abstract class GUI : IToXml, IComparable<GUI>, ICloneable
     {
         public GUI()
         {
@@ -223,6 +223,19 @@ namespace AGS.Types
         public int CompareTo(GUI other)
         {
             return ID.CompareTo(other.ID);
+        }
+
+        #endregion
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            GUI copy = this.MemberwiseClone() as GUI;
+            copy._controls = new List<GUIControl>();
+            foreach (var ctrl in _controls)
+                copy._controls.Add(ctrl.Clone() as GUIControl);
+            return copy;
         }
 
         #endregion

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Text;
 using System.Xml;
 using System.Drawing;
-using System.Windows.Forms;
 
 namespace AGS.Types
 {
@@ -286,41 +285,9 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
-        public void SaveToClipboard()
-        {
-            DataFormats.Format format = DataFormats.GetFormat(typeof(GUIControl).FullName);
-
-            IDataObject dataObj = new DataObject();
-            dataObj.SetData(format.Name, false, this);
-            Clipboard.SetDataObject(dataObj, true);
-        }
-
-        public static bool AvailableOnClipboard()
-        {
-            IDataObject dataObj = Clipboard.GetDataObject();
-            string format = typeof(GUIControl).FullName;
-            if (dataObj != null) return dataObj.GetDataPresent(format);
-            else return false;
-
-        }
-
         public Rectangle GetRectangle()
         {
             return new Rectangle(Left, Top, Width, Height);
-        }
-
-        public static GUIControl GetFromClipBoard()
-        {
-            GUIControl toreturn = null;
-            IDataObject dataObj = Clipboard.GetDataObject();
-            string format = typeof(GUIControl).FullName;
-
-            if (dataObj.GetDataPresent(format))
-            {
-                toreturn = dataObj.GetData(format) as GUIControl;
-            }
-
-            return toreturn;
         }
 
         public object Clone()

--- a/Editor/AGS.Types/Interactions.cs
+++ b/Editor/AGS.Types/Interactions.cs
@@ -1,13 +1,12 @@
 using System;
-using System.ComponentModel;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
 
 namespace AGS.Types
 {
-    public class Interactions
+    [Serializable]
+    public class Interactions : ICloneable
     {
+        [NonSerialized]
         private InteractionSchema _schema;
         private string _scriptModule = string.Empty;
         private string[] _scriptFunctionNames;
@@ -58,6 +57,19 @@ namespace AGS.Types
         public InteractionSchema Schema
         {
             get { return _schema; }
+            // Schema setter is required for random data deserialization,
+            // such as when reading an object from clipboard.
+            set
+            {
+                _schema = value;
+                if (_scriptFunctionNames.Length != _schema.EventNames.Length)
+                {
+                    var newFnNames = new string[_schema.EventNames.Length];
+                    var newImpScripts = new string[_schema.EventNames.Length];
+                    Array.Copy(_scriptFunctionNames, newFnNames, Math.Min(_scriptFunctionNames.Length, _schema.EventNames.Length));
+                    Array.Copy(_importedScripts, newImpScripts, Math.Min(_importedScripts.Length, _schema.EventNames.Length));
+                }
+            }
         }
 
         //[Category("(Basic)")]
@@ -132,5 +144,17 @@ namespace AGS.Types
             writer.WriteEndElement();
         }
 
+        #region IClonable Members
+
+        public object Clone()
+        {
+            Interactions copy = new Interactions(_schema);
+            copy._scriptModule = this._scriptModule;
+            copy._scriptFunctionNames = this._scriptFunctionNames.Clone() as string[];
+            copy._importedScripts = this._importedScripts.Clone() as string[];
+            return copy;
+        }
+
+        #endregion
     }
 }

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -1,14 +1,13 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Text;
 using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [PropertyTab(typeof(PropertyTabInteractions), PropertyTabScope.Component)]
     [DefaultProperty("Image")]
-    public class InventoryItem : IToXml, IComparable<InventoryItem>
+    public class InventoryItem : IToXml, IComparable<InventoryItem>, ICloneable
     {
         private static InteractionSchema _interactionSchema;
 
@@ -21,6 +20,7 @@ namespace AGS.Types
         private int _hotspotX, _hotspotY;
         private CustomProperties _properties = new CustomProperties(CustomPropertyAppliesTo.InventoryItems);
         private Interactions _interactions = new Interactions(_interactionSchema);
+        [NonSerialized]
         private bool _currentlyDeserializing = false;
 
         static InventoryItem()
@@ -157,6 +157,13 @@ namespace AGS.Types
             get { return _interactions; }
         }
 
+        [AGSNoSerialize()]
+        [Browsable(false)]
+        public static InteractionSchema InteractionSchema
+        {
+            get { return _interactionSchema; }
+        }
+
         public InventoryItem(XmlNode node)
         {
             _currentlyDeserializing = true;
@@ -187,6 +194,18 @@ namespace AGS.Types
         public int CompareTo(InventoryItem other)
         {
             return ID.CompareTo(other.ID);
+        }
+
+        #endregion
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            InventoryItem copy = this.MemberwiseClone() as InventoryItem;
+            copy._interactions = this._interactions.Clone() as Interactions;
+            copy._properties = this._properties.Clone() as CustomProperties;
+            return copy;
         }
 
         #endregion

--- a/Editor/AGS.Types/MouseCursor.cs
+++ b/Editor/AGS.Types/MouseCursor.cs
@@ -6,8 +6,9 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("Image")]
-    public class MouseCursor
+    public class MouseCursor : ICloneable
     {
         private string _name = string.Empty;
         private bool _standardMode = false;
@@ -177,6 +178,15 @@ namespace AGS.Types
         {
             SerializeUtils.SerializeToXML(this, writer);
         }
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+
+        #endregion
 
     }
 }

--- a/Editor/AGS.Types/NormalGUI.cs
+++ b/Editor/AGS.Types/NormalGUI.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 
 namespace AGS.Types
 {
+    [Serializable]
     public class NormalGUI : GUI
     {
         public const string XML_ELEMENT_NAME = "NormalGUI";

--- a/Editor/AGS.Types/TextWindowGUI.cs
+++ b/Editor/AGS.Types/TextWindowGUI.cs
@@ -6,6 +6,7 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("TextColor")]
     public class TextWindowGUI : GUI
     {

--- a/Editor/AGS.Types/View.cs
+++ b/Editor/AGS.Types/View.cs
@@ -6,8 +6,9 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("Name")]
-    public class View : IToXml, IComparable<View>
+    public class View : IToXml, IComparable<View>, ICloneable
     {
         public delegate void ViewUpdatedHandler(View view);
         public event ViewUpdatedHandler ViewUpdated;
@@ -114,6 +115,19 @@ namespace AGS.Types
         public int CompareTo(View other)
         {
             return ID.CompareTo(other.ID);
+        }
+
+        #endregion
+
+        #region IClonable Members
+
+        public object Clone()
+        {
+            View copy = this.MemberwiseClone() as View;
+            copy._loops = new List<ViewLoop>();
+            foreach (var loop in _loops)
+                copy._loops.Add(loop.Clone());
+            return copy;
         }
 
         #endregion

--- a/Editor/AGS.Types/ViewFrame.cs
+++ b/Editor/AGS.Types/ViewFrame.cs
@@ -6,6 +6,7 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     [DefaultProperty("Image")]
     public class ViewFrame
     {

--- a/Editor/AGS.Types/ViewLoop.cs
+++ b/Editor/AGS.Types/ViewLoop.cs
@@ -6,8 +6,10 @@ using System.Xml;
 
 namespace AGS.Types
 {
+    [Serializable]
     public class ViewLoop
     {
+        [NonSerialized]
         public static readonly string[] DirectionNames = new string[]{"down", "left", "right", "up", "down-right", "up-right", "down-left", "up-left"};
 
         private int _id;


### PR DESCRIPTION
Resolve #601

Implement Copy/Paste context menu commands for global game items.

This allows to copy/paste:
* Characters
* Cursors
* Dialogs
* GUIs
* Inventory Items
* Views
