### PR TITLE
4.0: add optional script names to Regions, WalkableAreas and Walkbehinds

### DIFF
--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -468,6 +468,43 @@ HError ReadExt_400_ObjectOptions2(RoomStruct* room, Stream* in, RoomFileVersion 
     return HError::None();
 }
 
+HError ReadExt_400_AreaNames(RoomStruct* room, Stream* in, RoomFileVersion data_ver)
+{
+    // NOTE: Object names and script names were historically written in
+    // blocks kRoomFblk_ObjectNames and kRoomFblk_ObjectScNames, but limited
+    // to 255 objects. Here they are limited to UINT32_MAX objects.
+    HError err;
+    if (!ReadAndAssertCount(in, "objects", room->Objects.size(), err))
+        return err;
+    for (auto &obj : room->Objects)
+    {
+        obj.ScriptName = StrUtil::ReadString(in);
+        obj.Name = StrUtil::ReadString(in);
+    }
+    // NOTE: Hotspot names and script names are written in the Main block,
+    // so they are skipped here.
+    //
+    if (!ReadAndAssertCount(in, "regions", MAX_ROOM_REGIONS, err))
+        return err;
+    for (uint8_t i = 0; i < MAX_ROOM_REGIONS; ++i)
+    {
+        room->Regions[i].ScriptName = StrUtil::ReadString(in);
+    }
+    if (!ReadAndAssertCount(in, "walkable areas", MAX_WALK_AREAS, err))
+        return err;
+    for (uint8_t i = 0; i < MAX_WALK_AREAS; ++i)
+    {
+        room->WalkAreas[i].ScriptName = StrUtil::ReadString(in);
+    }
+    if (!ReadAndAssertCount(in, "walk-behinds", MAX_WALK_BEHINDS, err))
+        return err;
+    for (uint8_t i = 0; i < MAX_WALK_BEHINDS; ++i)
+    {
+        room->WalkBehinds[i].ScriptName = StrUtil::ReadString(in);
+    }
+    return HError::None();
+}
+
 HError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const String &ext_id,
     soff_t block_len, RoomFileVersion data_ver)
 {
@@ -537,6 +574,10 @@ HError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const St
     {
         return ReadExt_400_ObjectOptions2(room, in, data_ver);
     }
+    else if (ext_id.CompareNoCase("v400_areanames") == 0)
+    {
+        return ReadExt_400_AreaNames(room, in, data_ver);
+    }
 
     return new RoomFileError(kRoomFileErr_UnknownBlockType,
         String::FromFormat("Type: %s", ext_id.GetCStr()));
@@ -591,6 +632,18 @@ HRoomFileError ReadRoomData(RoomStruct *room, std::unique_ptr<Stream> &&in, Room
 
 HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, const std::vector<SpriteInfo> &sprinfos)
 {
+    // Enforce sequential numeric IDs
+    for (int id = 0; id < room->Objects.size(); ++id)
+        room->Objects[id].ID = id;
+    for (int id = 0; id < MAX_ROOM_HOTSPOTS; ++id)
+        room->Hotspots[id].ID = id;
+    for (int id = 0; id < MAX_ROOM_REGIONS; ++id)
+        room->Regions[id].ID = id;
+    for (int id = 0; id < MAX_WALK_AREAS; ++id)
+        room->WalkAreas[id].ID = id;
+    for (int id = 0; id < MAX_WALK_BEHINDS; ++id)
+        room->WalkBehinds[id].ID = id;
+
     // For objects loaded from an older room, mark everything as
     // Enabled, because there's no good way to distinct if it was
     // disabled or only made invisible by setting "on" property.
@@ -673,9 +726,9 @@ void WriteMainBlock(const RoomStruct *room, Stream *out)
     }
     // Hotspots names and script names
     for (uint32_t i = 0; i < room->HotspotCount; ++i)
-        Common::StrUtil::WriteString(room->Hotspots[i].Name, out);
+        StrUtil::WriteString(room->Hotspots[i].Name, out);
     for (uint32_t i = 0; i < room->HotspotCount; ++i)
-        Common::StrUtil::WriteString(room->Hotspots[i].ScriptName, out);
+        StrUtil::WriteString(room->Hotspots[i].ScriptName, out);
 
     out->WriteInt32(0); // legacy poly-point areas
 
@@ -766,14 +819,14 @@ void WriteObjNamesBlock(const RoomStruct *room, Stream *out)
 {
     out->WriteByte((uint8_t)room->Objects.size());
     for (const auto &obj : room->Objects)
-        Common::StrUtil::WriteString(obj.Name, out);
+        StrUtil::WriteString(obj.Name, out);
 }
 
 void WriteObjScNamesBlock(const RoomStruct *room, Stream *out)
 {
     out->WriteByte((uint8_t)room->Objects.size());
     for (const auto &obj : room->Objects)
-        Common::StrUtil::WriteString(obj.ScriptName, out);
+        StrUtil::WriteString(obj.ScriptName, out);
 }
 
 void WriteAnimBgBlock(const RoomStruct *room, Stream *out)
@@ -915,6 +968,37 @@ void WriteExt_400_ObjectOptions2(const RoomStruct* room, Stream* out)
     }
 }
 
+void WriteExt_400_AreaNames(const RoomStruct *room, Stream *out)
+{
+    // NOTE: Object names and script names were historically written in
+    // blocks kRoomFblk_ObjectNames and kRoomFblk_ObjectScNames, but limited
+    // to 255 objects. Here they are limited to UINT32_MAX objects.
+    out->WriteInt32(room->Objects.size());
+    for (const auto &obj : room->Objects)
+    {
+        StrUtil::WriteString(obj.ScriptName, out);
+        StrUtil::WriteString(obj.Name, out);
+    }
+    // NOTE: Hotspot names and script names are written in the Main block,
+    // so they are skipped here.
+    //
+    out->WriteInt32(MAX_ROOM_REGIONS);
+    for (uint8_t i = 0; i < MAX_ROOM_REGIONS; ++i)
+    {
+        StrUtil::WriteString(room->Regions[i].ScriptName, out);
+    }
+    out->WriteInt32(MAX_WALK_AREAS);
+    for (uint8_t i = 0; i < MAX_WALK_AREAS; ++i)
+    {
+        StrUtil::WriteString(room->WalkAreas[i].ScriptName, out);
+    }
+    out->WriteInt32(MAX_WALK_BEHINDS);
+    for (uint8_t i = 0; i < MAX_WALK_BEHINDS; ++i)
+    {
+        StrUtil::WriteString(room->WalkBehinds[i].ScriptName, out);
+    }
+}
+
 HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersion data_ver, const String &compiled_with)
 {
     if (data_ver < kRoomVersion_Current)
@@ -928,12 +1012,6 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
     // Compiled script
     if (room->CompiledScript)
         WriteRoomBlock(room, kRoomFblk_CompScript3, WriteCompSc3Block, out);
-    // Object names
-    if (room->Objects.size() > 0)
-    {
-        WriteRoomBlock(room, kRoomFblk_ObjectNames, WriteObjNamesBlock, out);
-        WriteRoomBlock(room, kRoomFblk_ObjectScNames, WriteObjScNamesBlock, out);
-    }
     // Secondary background frames
     if (room->BgFrameCount > 1)
         WriteRoomBlock(room, kRoomFblk_AnimBg, WriteAnimBgBlock, out);
@@ -952,6 +1030,7 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
     WriteRoomBlock(room, "v400_roomnames", WriteExt_400_RoomNames, out);
     WriteRoomBlock(room, "v400_eventtables", WriteExt_400_EventTables, out);
     WriteRoomBlock(room, "v400_objopts2", WriteExt_400_ObjectOptions2, out);
+    WriteRoomBlock(room, "v400_areanames", WriteExt_400_AreaNames, out);
 
     // Write end of room file
     out->WriteByte(kRoomFile_EOF);

--- a/Common/game/room_version.h
+++ b/Common/game/room_version.h
@@ -55,6 +55,7 @@ v4.0.0: Raised for org purposes without format changes
 v4.0.0.17: Raised for org purposes, because forgot to rise each time a new ext was added
 v4.0.0.24: Remade events tables
 v4.0.0.26: sync with 3.6.3.6
+v4.0.0.30: area script names
 */
 enum RoomFileVersion
 {
@@ -66,8 +67,9 @@ enum RoomFileVersion
     kRoomVersion_400_17     = 4000017,
     kRoomVersion_400_24     = 4000024,
     kRoomVersion_400_26     = 4000026,
+    kRoomVersion_400_30     = 4000030,
     kRoomVersion_LowSupport = kRoomVersion_3508,
-    kRoomVersion_Current    = kRoomVersion_400_26
+    kRoomVersion_Current    = kRoomVersion_400_30
 };
 
 #endif // __AGS_CN_AC__ROOMVERSION_H

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -80,20 +80,6 @@ void RoomHotspot::RemapOldInteractions()
     _events.SetHandler(kHotspotEvent_MouseOver, old_interactions[6].FunctionName);
 }
 
-RoomObjectInfo::RoomObjectInfo()
-    : RoomObjectBase(&RoomObjectInfo::_eventSchema)
-    , Room(-1)
-    , X(0)
-    , Y(0)
-    , Sprite(0)
-    , Baseline(0)
-    , Transparency(0)
-    , Flags(0)
-    , BlendMode(kBlend_Normal)
-    , GraphicAnchor(0.f, 1.f) // bottom-left
-{
-}
-
 /* static */ ScriptEventSchema RoomObjectInfo::_eventSchema = {{
         { "OnAnyClick", kRoomObjectEvent_AnyClick },
         { "OnFrameEvent", kRoomObjectEvent_OnFrameEvent },
@@ -120,13 +106,6 @@ void RoomObjectInfo::RemapOldInteractions()
     _events.SetHandler(kRoomObjectEvent_AnyClick, old_interactions[4].FunctionName);
 }
 
-RoomRegion::RoomRegion()
-    : RoomObjectBase(&RoomRegion::_eventSchema)
-    , Light(0)
-    , Tint(0)
-{
-}
-
 /* static */ ScriptEventSchema RoomRegion::_eventSchema = {{
         { "OnStanding", kRegionEvent_Standing },
         { "OnWalksOnto", kRegionEvent_WalkOn },
@@ -143,22 +122,6 @@ void RoomRegion::RemapOldInteractions()
     _events.SetHandler(kRegionEvent_WalkOn, old_interactions[1].FunctionName);
     _events.SetHandler(kRegionEvent_WalkOff, old_interactions[2].FunctionName);
     Interactions = {};
-}
-
-WalkArea::WalkArea()
-    : CharacterView(0)
-    , ScalingFar(0)
-    , ScalingNear(NOT_VECTOR_SCALED)
-    , PlayerView(0)
-    , FaceDirectionRatio(0.f)
-    , Top(-1)
-    , Bottom(-1)
-{
-}
-
-WalkBehind::WalkBehind()
-    : Baseline(0)
-{
 }
 
 RoomStruct::RoomStruct()

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -195,9 +195,14 @@ struct RoomEdges
 struct RoomObjectBase
 {
 public:
+    RoomObjectBase()
+    {}
     RoomObjectBase(const ScriptEventSchema *schema)
         : _events(schema)
     {}
+
+    int    ID = -1;
+    String ScriptName;
 
     // Provides a script events table
     const ScriptEventTable &GetEvents() const { return _events; }
@@ -213,8 +218,8 @@ protected:
 // Room hotspot description
 struct RoomHotspot : public RoomObjectBase
 {
+    // Human-readable name (description)
     String      Name;
-    String      ScriptName;
     // Custom properties
     StringIMap  Properties;
     // Interaction events (cursor-based)
@@ -239,26 +244,29 @@ private:
 // Room object description
 struct RoomObjectInfo : public RoomObjectBase
 {
-    int32_t         Room;
-    int32_t         X;
-    int32_t         Y;
-    int32_t         Sprite;
-    Common::BlendMode BlendMode;
+    int32_t         Room = -1;
+    int32_t         X = 0;
+    int32_t         Y = 0;
+    int32_t         Sprite = 0;
+    Common::BlendMode BlendMode = kBlend_Normal;
     // Object's z-order in the room, or -1 (use Y)
-    int32_t         Baseline;
-    int32_t         Transparency;
-    int32_t         Flags;
+    int32_t         Baseline = 0;
+    int32_t         Transparency = 0;
+    int32_t         Flags = 0;
+    // Human-readable name (description)
     String          Name;
-    String          ScriptName;
     Rect            BlockingRect;
-    Pointf          GraphicAnchor;
+    Pointf          GraphicAnchor = Pointf(0.f, 1.f); // bottom-left
     Point           GraphicOffset;
     // Custom properties
     StringIMap      Properties;
     // Interaction events (cursor-based)
     ScriptEventHandlers Interactions = {};
 
-    RoomObjectInfo();
+    RoomObjectInfo()
+        : RoomObjectBase(&RoomObjectInfo::_eventSchema)
+    {
+    }
 
     static ScriptEventSchema &GetEventSchema() { return _eventSchema; }
     // Remaps old-format interaction list into new event table
@@ -273,15 +281,18 @@ private:
 struct RoomRegion : public RoomObjectBase
 {
     // Light level (-100 -> +100) or Tint luminance (0 - 255)
-    int32_t         Light;
+    int32_t         Light = 0;
     // Tint setting (R-B-G-S)
-    int32_t         Tint;
+    int32_t         Tint = 0;
     // Custom properties
     StringIMap      Properties;
     // Interaction events (old-style event storage, kept of loading old data)
     ScriptEventHandlers Interactions = {};
 
-    RoomRegion();
+    RoomRegion()
+        : RoomObjectBase(&RoomRegion::_eventSchema)
+    {
+    }
 
     static ScriptEventSchema &GetEventSchema() { return _eventSchema; }
     // Remaps old-format interaction list into new event table
@@ -293,35 +304,31 @@ private:
 };
 
 // Walkable area description
-struct WalkArea
+struct WalkArea : public RoomObjectBase
 {
     // Apply player character's normal view on this area
-    int32_t     CharacterView;
+    int32_t     CharacterView = 0;
     // Character's scaling (-100 -> +100 %)
     // General scaling, or scaling at the farthest point
-    int32_t     ScalingFar;
+    int32_t     ScalingFar = 0;
     // Scaling at the nearest point, or NOT_VECTOR_SCALED for uniform scaling
-    int32_t     ScalingNear;
+    int32_t     ScalingNear = NOT_VECTOR_SCALED;
     // Optional override for player character view
-    int32_t     PlayerView;
+    int32_t     PlayerView = 0;
     // Optional character face direction ratio, 0 = ignore
-    float       FaceDirectionRatio;
+    float       FaceDirectionRatio = 0.f;
     // Top and bottom Y of the area
-    int32_t     Top;
-    int32_t     Bottom;
+    int32_t     Top = -1;
+    int32_t     Bottom = -1;
     // Custom properties
     StringIMap  Properties;
-
-    WalkArea();
 };
 
 // Walk-behind description
-struct WalkBehind
+struct WalkBehind : public RoomObjectBase
 {
     // Object's z-order in the room
-    int32_t Baseline;
-
-    WalkBehind();
+    int32_t Baseline = 0;
 };
 
 // Room's legacy resolution type

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -148,6 +148,7 @@ namespace AGS.Editor
          *                  and other properties (BlockingRectangle etc)
          * 4.00.00.27     - Character.GraphicAnchor/Offset.
          * 4.00.00.29     - Sync with 3.6.3.10.
+         * 4.00.00.30     - Script names for Regions, Walkable areas and Walk-behinds.
         */
         public const string LATEST_XML_VERSION = "4.0.0.29";
 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -1005,13 +1005,16 @@ namespace AGS.Editor
                 }
             }
 
-            if (propertyName == RoomHotspot.PROPERTY_NAME_SCRIPT_NAME ||
+            if (needRefresh ||
+                propertyName == RoomHotspot.PROPERTY_NAME_SCRIPT_NAME ||
                 propertyName == RoomHotspot.PROPERTY_NAME_DESCRIPTION ||
                 propertyName == RoomObject.PROPERTY_NAME_SCRIPT_NAME ||
                 propertyName == RoomObject.PROPERTY_NAME_DESCRIPTION ||
                 propertyName == Character.PROPERTY_NAME_SCRIPTNAME ||
                 propertyName == Character.PROPERTY_NAME_DESCRIPTION ||
-                needRefresh)
+                propertyName == RoomRegion.PROPERTY_NAME_SCRIPT_NAME ||
+                propertyName == RoomWalkableArea.PROPERTY_NAME_SCRIPT_NAME ||
+                propertyName == RoomWalkBehind.PROPERTY_NAME_SCRIPT_NAME)
             {
                 if (_layer != null)
                 {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2242,6 +2242,10 @@ builtin managed struct Hotspot {
 builtin managed struct Region {
   /// Returns the region at the specified position within this room.
   import static Region* GetAtRoomXY(int x, int y, HitTestOptions hitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v400
+  /// Gets the region by its script name
+  import static Region* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400
   /// Runs the event handler for the specified event for this region.
   import void RunInteraction(int event);
   /// Sets the region tint which will apply to characters that are standing on the region. RGB values must be in 0-255 range, saturation and luminance in 0-100 range.
@@ -2281,6 +2285,8 @@ builtin managed struct Region {
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this region.
   import bool SetTextProperty(const string property, const string value);
+  /// Gets the script name of this region.
+  import readonly attribute String ScriptName;
 #endif // SCRIPT_API_v400
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
@@ -2291,6 +2297,8 @@ builtin managed struct WalkableArea {
   import static WalkableArea* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
   /// Returns the walkable area at the specified position within this room.
   import static WalkableArea* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Gets the walkable area by its script name
+  import static WalkableArea* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
   /// Gets the drawing surface for the 8-bit walkable mask
   import static DrawingSurface* GetDrawingSurface();  // $AUTOCOMPLETESTATICONLY$
   /// Changes this walkable area's scaling level.
@@ -2314,6 +2322,8 @@ builtin managed struct WalkableArea {
   import readonly attribute int ScalingMax;
   /// Gets/sets the optional y/x ratio of character's facing directions, determining directional loop selection for each Character while on this area.
   import static attribute float FaceDirectionRatio;
+  /// Gets the script name of this walkable area.
+  import readonly attribute String ScriptName;
 };
 #endif // SCRIPT_API_v400
 
@@ -2323,12 +2333,16 @@ builtin managed struct Walkbehind {
   import static Walkbehind* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
   /// Returns the walk-behind at the specified position within this room.
   import static Walkbehind* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+  /// Gets the walk-behind by its script name
+  import static Walkbehind* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
   /// Gets the drawing surface for the 8-bit walk-behind mask
   import static DrawingSurface* GetDrawingSurface();  // $AUTOCOMPLETESTATICONLY$
   /// Gets the ID number for this walk-behind.
   import readonly attribute int ID;
   /// Gets/sets this walk-behind's baseline.
   import attribute int Baseline;
+  /// Gets the script name of this walk-behind.
+  import readonly attribute String ScriptName;
 };
 #endif // SCRIPT_API_v400
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -696,13 +696,13 @@ namespace AGS.Editor
 
             if (currentRoom != null)
             {
-                AppendRoomObjectsAndHotspotsToHeader(sb, currentRoom);
+                AppendRoomContentsToHeader(sb, currentRoom);
             }
 
             return new Script(AUTO_GENERATED_HEADER_NAME, sb.ToString(), true);
         }
 
-        private void AppendRoomObjectsAndHotspotsToHeader(StringBuilder sb, Room room)
+        private void AppendRoomContentsToHeader(StringBuilder sb, Room room)
         {
             foreach (RoomObject obj in room.Objects)
             {
@@ -717,6 +717,30 @@ namespace AGS.Editor
                 if (hotspot.ScriptName.Length > 0)
                 {
                     sb.AppendLine("import readonly Hotspot *" + hotspot.ScriptName + ";");
+                }
+            }
+
+            foreach (RoomRegion region in room.Regions)
+            {
+                if (region.ScriptName.Length > 0)
+                {
+                    sb.AppendLine("import readonly Region *" + region.ScriptName + ";");
+                }
+            }
+
+            foreach (RoomWalkableArea area in room.WalkableAreas)
+            {
+                if (area.ScriptName.Length > 0)
+                {
+                    sb.AppendLine("import readonly WalkableArea *" + area.ScriptName + ";");
+                }
+            }
+
+            foreach (RoomWalkBehind area in room.WalkBehinds)
+            {
+                if (area.ScriptName.Length > 0)
+                {
+                    sb.AppendLine("import readonly Walkbehind *" + area.ScriptName + ";");
                 }
             }
         }

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3223,6 +3223,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 	{
 		RoomWalkableArea ^area = room->WalkableAreas[i];
 		area->ID = i;
+        area->ScriptName = TextHelper::ConvertASCII(rs.WalkAreas[i].ScriptName);
 		area->AreaSpecificView = rs.WalkAreas[i].PlayerView;
         area->FaceDirectionRatio = rs.WalkAreas[i].FaceDirectionRatio;
 		area->UseContinuousScaling = !(rs.WalkAreas[i].ScalingNear == NOT_VECTOR_SCALED);
@@ -3243,6 +3244,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 	{
 		RoomWalkBehind ^area = room->WalkBehinds[i];
 		area->ID = i;
+        area->ScriptName = TextHelper::ConvertASCII(rs.WalkBehinds[i].ScriptName);
 		area->Baseline = rs.WalkBehinds[i].Baseline;
 	}
 
@@ -3250,6 +3252,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 	{
 		RoomRegion ^area = room->Regions[i];
 		area->ID = i;
+        area->ScriptName = TextHelper::ConvertASCII(rs.Regions[i].ScriptName);
 		// NOTE: Region's light level value exposed in editor is always 100 units higher,
 		// for compatibility with older versions of the editor.
 		// TODO: probably we could remove this behavior? Need to consider possible compat mode
@@ -3309,6 +3312,7 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
     {
         RoomObject ^obj = room->Objects[i];
         auto &robj = rs.Objects[i];
+        robj.ID = i;
         robj.ScriptName = TextHelper::ConvertASCII(obj->Name);
         robj.Sprite = obj->Image;
         robj.Transparency = AGS::Common::GfxDef::Trans100ToLegacyTrans255(obj->Transparency);
@@ -3335,6 +3339,7 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 	for (size_t i = 0; i < rs.HotspotCount; ++i)
 	{
 		RoomHotspot ^hotspot = room->Hotspots[i];
+        rs.Hotspots[i].ID = i;
 		rs.Hotspots[i].Name = tcv->ConvertTextProperty(hotspot->Description);
 		rs.Hotspots[i].ScriptName = TextHelper::ConvertASCII(hotspot->Name);
 		rs.Hotspots[i].WalkTo.X = hotspot->WalkToPoint.X;
@@ -3346,6 +3351,8 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 	for (size_t i = 0; i < rs.WalkAreaCount; ++i)
 	{
 		RoomWalkableArea ^area = room->WalkableAreas[i];
+        rs.WalkAreas[i].ID = i;
+        rs.WalkAreas[i].ScriptName = TextHelper::ConvertASCII(area->ScriptName);
 		rs.WalkAreas[i].PlayerView = area->AreaSpecificView;
         rs.WalkAreas[i].FaceDirectionRatio = area->FaceDirectionRatio;
 
@@ -3367,6 +3374,8 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 	for (size_t i = 0; i < rs.WalkBehindCount; ++i)
 	{
 		RoomWalkBehind ^area = room->WalkBehinds[i];
+        rs.WalkBehinds[i].ID = i;
+        rs.WalkBehinds[i].ScriptName = TextHelper::ConvertASCII(area->ScriptName);
 		rs.WalkBehinds[i].Baseline = area->Baseline;
 	}
 
@@ -3374,6 +3383,8 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 	for (size_t i = 0; i < rs.RegionCount; ++i)
 	{
 		RoomRegion ^area = room->Regions[i];
+        rs.Regions[i].ID = i;
+        rs.Regions[i].ScriptName = TextHelper::ConvertASCII(area->ScriptName);
 		rs.Regions[i].Tint = 0;
 		if (area->UseColourTint) 
 		{

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
@@ -69,7 +69,8 @@ namespace AGS.Types
             }
             else if (context.Instance is RoomRegion)
             {
-                itemName = "region" + ((RoomRegion)context.Instance).ID;
+                itemName = string.IsNullOrEmpty(((RoomRegion)context.Instance).ScriptName) ?
+                    "region" + ((RoomRegion)context.Instance).ID : ((RoomRegion)context.Instance).ScriptName;
                 scriptModule = ((RoomRegion)context.Instance).Room.ScriptFileName;
             }
             else

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -11,7 +11,10 @@ namespace AGS.Types
     [DefaultProperty("LightLevel")]
     public class RoomRegion : IChangeNotification, ICustomTypeDescriptor, IToXml
     {
+        public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
+
         private int _id;
+        private string _scriptName = string.Empty;
         private int _lightLevel = 100;
         private bool _useTint = false;
         private int _redTint = 0;
@@ -49,6 +52,16 @@ namespace AGS.Types
         {
             get { return _id; }
             set { _id = value; }
+        }
+
+        [DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
+        [Description("The script name of the region")]
+        [Category("Design")]
+        [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
         [Description("Use a coloured tint for characters and objects on this region, rather than adjusting their brightness")]

--- a/Editor/AGS.Types/RoomWalkBehind.cs
+++ b/Editor/AGS.Types/RoomWalkBehind.cs
@@ -10,7 +10,10 @@ namespace AGS.Types
     [DefaultProperty("Baseline")]
     public class RoomWalkBehind : IToXml
     {
+        public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
+
         private int _id;
+        private string _scriptName = string.Empty;
         private int _baseline;
         private Room _room;
 
@@ -40,6 +43,16 @@ namespace AGS.Types
         {
             get { return _id; }
             set { _id = value; }
+        }
+
+        [DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
+        [Description("The script name of the walk-behind")]
+        [Category("Design")]
+        [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
         [Description("Characters standing above this baseline will be drawn behind the walk-behind")]

--- a/Editor/AGS.Types/RoomWalkableArea.cs
+++ b/Editor/AGS.Types/RoomWalkableArea.cs
@@ -10,7 +10,10 @@ namespace AGS.Types
     [DefaultProperty("ScalingLevel")]
     public class RoomWalkableArea : IChangeNotification, ICustomTypeDescriptor, IToXml
     {
+        public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
+
         private int _id;
+        private string _scriptName = string.Empty;
         private int _areaSpecificView;
         private float _faceDirectionRatio = 0.0f;
         private int _scalingLevel = 100;
@@ -46,6 +49,16 @@ namespace AGS.Types
         {
             get { return _id; }
             set { _id = value; }
+        }
+
+        [DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
+        [Description("The script name of the walkable area")]
+        [Category("Design")]
+        [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
         [Description("The player character's walking view will switch to this when he is standing on the area")]

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -29,6 +29,7 @@
 #include "gfx/bitmap.h"
 #include "script/runtimescriptvalue.h"
 #include "script/script.h"
+#include "script/script_runtime.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -133,6 +134,11 @@ ScriptHotspot *Hotspot_GetAtScreenXY2(int x, int y)
     return Hotspot_GetAtScreenXY(x, y, kHit_Interactable);
 }
 
+ScriptHotspot *Hotspot_GetByName(const char *name)
+{
+    return static_cast<ScriptHotspot*>(ccGetScriptObjectAddress(name, ccDynamicHotspot.GetType()));
+}
+
 const char* Hotspot_GetName_New(ScriptHotspot *hss) {
     if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
         quit("!Hotspot.Name: invalid hotspot number");
@@ -231,20 +237,7 @@ int GetHotspotIDAtRoom(int xpp, int ypp, int hit_options)
 
 #include "debug/out.h"
 #include "script/script_api.h"
-#include "script/script_runtime.h"
-#include "ac/dynobj/scriptstring.h"
 
-
-ScriptHotspot *Hotspot_GetByName(const char *name)
-{
-    return static_cast<ScriptHotspot*>(ccGetScriptObjectAddress(name, ccDynamicHotspot.GetType()));
-}
-
-
-RuntimeScriptValue Sc_Hotspot_GetByName(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_OBJ_POBJ(ScriptHotspot, ccDynamicHotspot, Hotspot_GetByName, const char);
-}
 
 RuntimeScriptValue Sc_Hotspot_GetAtRoomXY(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -264,6 +257,11 @@ RuntimeScriptValue Sc_Hotspot_GetAtScreenXY(const RuntimeScriptValue *params, in
 RuntimeScriptValue Sc_Hotspot_GetAtScreenXY2(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, Hotspot_GetAtScreenXY2);
+}
+
+RuntimeScriptValue Sc_Hotspot_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptHotspot, ccDynamicHotspot, Hotspot_GetByName, const char);
 }
 
 RuntimeScriptValue Sc_Hotspot_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -19,6 +19,7 @@
 #include "ac/properties.h"
 #include "ac/room.h"
 #include "ac/roomstatus.h"
+#include "ac/string.h"
 #include "ac/dynobj/cc_region.h"
 #include "ac/dynobj/scriptdrawingsurface.h"
 #include "ac/dynobj/scriptstring.h"
@@ -26,6 +27,7 @@
 #include "game/roomstruct.h"
 #include "script/runtimescriptvalue.h"
 #include "script/script.h"
+#include "script/script_runtime.h"
 
 using namespace AGS::Common;
 
@@ -84,6 +86,11 @@ ScriptRegion *Region_GetAtScreenXY2(int x, int y)
     return Region_GetAtScreenXY(x, y, kHit_Interactable);
 }
 
+ScriptRegion *Region_GetByName(const char *name)
+{
+    return static_cast<ScriptRegion*>(ccGetScriptObjectAddress(name, ccDynamicRegion.GetType()));
+}
+
 void SetAreaLightLevel(int area, int brightness) {
     if ((area < 0) || (area > MAX_ROOM_REGIONS))
         quit("!SetAreaLightLevel: invalid region");
@@ -101,6 +108,11 @@ void Region_SetLightLevel(ScriptRegion *ssr, int brightness) {
 
 int Region_GetLightLevel(ScriptRegion *ssr) {
     return thisroom.GetRegionLightLevel(ssr->id);
+}
+
+const char *Region_GetScriptName(ScriptRegion *ssr)
+{
+    return CreateNewScriptString(thisroom.Regions[ssr->id].ScriptName);
 }
 
 int Region_GetTintEnabled(ScriptRegion *srr) {
@@ -307,6 +319,11 @@ RuntimeScriptValue Sc_Region_GetAtScreenXY(const RuntimeScriptValue *params, int
     API_SCALL_OBJ_PINT3(ScriptRegion, ccDynamicRegion, Region_GetAtScreenXY);
 }
 
+RuntimeScriptValue Sc_Region_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptRegion, ccDynamicRegion, Region_GetByName, const char);
+}
+
 RuntimeScriptValue Sc_Region_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO(ScriptDrawingSurface, Region_GetDrawingSurface);
@@ -357,6 +374,11 @@ RuntimeScriptValue Sc_Region_GetLightLevel(void *self, const RuntimeScriptValue 
 RuntimeScriptValue Sc_Region_SetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptRegion, Region_SetLightLevel);
+}
+
+RuntimeScriptValue Sc_Region_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptRegion, const char, myScriptStringImpl, Region_GetScriptName);
 }
 
 // int (ScriptRegion *srr)
@@ -423,20 +445,22 @@ void RegisterRegionAPI()
         { "Region::GetAtRoomXY^3",        API_FN_PAIR(Region_GetAtRoomXY) },
         { "Region::GetAtScreenXY^2",      API_FN_PAIR(Region_GetAtScreenXY2) },
         { "Region::GetAtScreenXY^3",      API_FN_PAIR(Region_GetAtScreenXY) },
+        { "Region::GetByScriptName^1",    API_FN_PAIR(Region_GetByName) },
         { "Region::GetDrawingSurface",    API_FN_PAIR(Region_GetDrawingSurface) },
 
         { "Region::Tint^4",               API_FN_PAIR(Region_TintNoLum) },
         { "Region::Tint^5",               API_FN_PAIR(Region_Tint) },
         { "Region::RunInteraction^1",     API_FN_PAIR(Region_RunInteraction) },
-        { "Region::GetProperty^1",             API_FN_PAIR(Region_GetProperty) },
-        { "Region::GetTextProperty^1",         API_FN_PAIR(Region_GetTextProperty) },
-        { "Region::SetProperty^2",             API_FN_PAIR(Region_SetProperty) },
-        { "Region::SetTextProperty^2",         API_FN_PAIR(Region_SetTextProperty) },
+        { "Region::GetProperty^1",        API_FN_PAIR(Region_GetProperty) },
+        { "Region::GetTextProperty^1",    API_FN_PAIR(Region_GetTextProperty) },
+        { "Region::SetProperty^2",        API_FN_PAIR(Region_SetProperty) },
+        { "Region::SetTextProperty^2",    API_FN_PAIR(Region_SetTextProperty) },
         { "Region::get_Enabled",          API_FN_PAIR(Region_GetEnabled) },
         { "Region::set_Enabled",          API_FN_PAIR(Region_SetEnabled) },
         { "Region::get_ID",               API_FN_PAIR(Region_GetID) },
         { "Region::get_LightLevel",       API_FN_PAIR(Region_GetLightLevel) },
         { "Region::set_LightLevel",       API_FN_PAIR(Region_SetLightLevel) },
+        { "Region::get_ScriptName",       API_FN_PAIR(Region_GetScriptName) },
         { "Region::get_TintEnabled",      API_FN_PAIR(Region_GetTintEnabled) },
         { "Region::get_TintBlue",         API_FN_PAIR(Region_GetTintBlue) },
         { "Region::get_TintGreen",        API_FN_PAIR(Region_GetTintGreen) },

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -103,6 +103,9 @@ extern ScriptWalkableArea scrWalkarea[MAX_WALK_AREAS];
 extern ScriptWalkbehind scrWalkbehind[MAX_WALK_BEHINDS];
 extern std::vector<int> StaticObjectArray;
 extern std::vector<int> StaticHotspotArray;
+extern std::vector<int> StaticRegionArray;
+extern std::vector<int> StaticWalkareaArray;
+extern std::vector<int> StaticWalkbehindArray;
 
 std::unique_ptr<MaskRouteFinder> room_pathfinder;
 RGB_MAP rgb_table;  // for 256-col antialiasing
@@ -420,19 +423,35 @@ void unload_old_room()
     play.swap_portrait_lastchar = -1;
     play.swap_portrait_lastlastchar = -1;
 
-    for (uint32_t ff = 0; ff < croom->numobj; ff++) {
-        // un-export the object's script object
-        if (thisroom.Objects[ff].ScriptName.IsEmpty())
-            continue;
-
-        ccRemoveExternalSymbol(thisroom.Objects[ff].ScriptName);
+    // Remove named room elements from script
+    for (uint32_t i = 0; i < thisroom.Objects.size(); ++i)
+    {
+        if (!thisroom.Objects[i].ScriptName.IsEmpty())
+            ccRemoveExternalSymbol(thisroom.Objects[i].ScriptName);
     }
 
-    for (int ff = 0; ff < MAX_ROOM_HOTSPOTS; ff++) {
-        if (thisroom.Hotspots[ff].ScriptName.IsEmpty())
-            continue;
+    for (uint32_t i = 0; i < MAX_ROOM_HOTSPOTS; ++i)
+    {
+        if (!thisroom.Hotspots[i].ScriptName.IsEmpty())
+            ccRemoveExternalSymbol(thisroom.Hotspots[i].ScriptName);
+    }
 
-        ccRemoveExternalSymbol(thisroom.Hotspots[ff].ScriptName);
+    for (uint32_t i = 0; i < MAX_ROOM_REGIONS; ++i)
+    {
+        if (!thisroom.Regions[i].ScriptName.IsEmpty())
+            ccRemoveExternalSymbol(thisroom.Regions[i].ScriptName);
+    }
+
+    for (uint32_t i = 0; i < MAX_WALK_AREAS; ++i)
+    {
+        if (!thisroom.WalkAreas[i].ScriptName.IsEmpty())
+            ccRemoveExternalSymbol(thisroom.WalkAreas[i].ScriptName);
+    }
+
+    for (uint32_t i = 0; i < MAX_WALK_BEHINDS; ++i)
+    {
+        if (!thisroom.WalkBehinds[i].ScriptName.IsEmpty())
+            ccRemoveExternalSymbol(thisroom.WalkBehinds[i].ScriptName);
     }
 
     croom_ptr_clear();
@@ -706,18 +725,35 @@ void load_new_room(int newnum, CharacterInfo *forchar)
 
     objs = croom->obj.size() > 0 ? &croom->obj[0] : nullptr;
 
-    // Register named Objects and Hotspots
-    for (uint32_t cc = 0; cc < thisroom.Objects.size(); cc++)
+    // Export named room elements to script
+    for (uint32_t i = 0; i < thisroom.Objects.size(); ++i)
     {
-        // export the object's script object
-        if (!thisroom.Objects[cc].ScriptName.IsEmpty())
-            ccAddExternalScriptObjectHandle(thisroom.Objects[cc].ScriptName, &StaticObjectArray[cc]);
+        if (!thisroom.Objects[i].ScriptName.IsEmpty())
+            ccAddExternalScriptObjectHandle(thisroom.Objects[i].ScriptName, &StaticObjectArray[i]);
     }
 
-    for (int cc = 0; cc < MAX_ROOM_HOTSPOTS; cc++)
+    for (uint32_t i = 0; i < MAX_ROOM_HOTSPOTS; ++i)
     {
-        if (!thisroom.Hotspots[cc].ScriptName.IsEmpty())
-            ccAddExternalScriptObjectHandle(thisroom.Hotspots[cc].ScriptName, &StaticHotspotArray[cc]);
+        if (!thisroom.Hotspots[i].ScriptName.IsEmpty())
+            ccAddExternalScriptObjectHandle(thisroom.Hotspots[i].ScriptName, &StaticHotspotArray[i]);
+    }
+
+    for (uint32_t i = 0; i < MAX_ROOM_REGIONS; ++i)
+    {
+        if (!thisroom.Regions[i].ScriptName.IsEmpty())
+            ccAddExternalScriptObjectHandle(thisroom.Regions[i].ScriptName, &StaticRegionArray[i]);
+    }
+
+    for (uint32_t i = 0; i < MAX_WALK_AREAS; ++i)
+    {
+        if (!thisroom.WalkAreas[i].ScriptName.IsEmpty())
+            ccAddExternalScriptObjectHandle(thisroom.WalkAreas[i].ScriptName, &StaticWalkareaArray[i]);
+    }
+
+    for (uint32_t i = 0; i < MAX_WALK_BEHINDS; ++i)
+    {
+        if (!thisroom.WalkBehinds[i].ScriptName.IsEmpty())
+            ccAddExternalScriptObjectHandle(thisroom.WalkBehinds[i].ScriptName, &StaticWalkbehindArray[i]);
     }
 
     set_our_eip(210);

--- a/Engine/ac/walkablearea.cpp
+++ b/Engine/ac/walkablearea.cpp
@@ -17,15 +17,16 @@
 #include "ac/gamestate.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/global_walkablearea.h"
-#include "ac/object.h"
 #include "ac/properties.h"
 #include "ac/room.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
+#include "ac/string.h"
 #include "ac/walkablearea.h"
 #include "ac/dynobj/cc_walkablearea.h"
 #include "game/roomstruct.h"
 #include "gfx/bitmap.h"
+#include "script/script_runtime.h"
 
 using namespace AGS::Common;
 
@@ -227,6 +228,11 @@ ScriptWalkableArea *Walkarea_GetAtScreenXY(int x, int y)
     return &scrWalkarea[area];
 }
 
+ScriptWalkableArea *Walkarea_GetByName(const char *name)
+{
+    return static_cast<ScriptWalkableArea*>(ccGetScriptObjectAddress(name, ccDynamicWalkarea.GetType()));
+}
+
 int Walkarea_GetID(ScriptWalkableArea *wa)
 {
     return wa->id;
@@ -261,6 +267,11 @@ int Walkarea_GetScalingMax(ScriptWalkableArea *wa)
 {
     return thisroom.WalkAreas[wa->id].ScalingNear;
 }
+const char *Walkarea_GetScriptName(ScriptWalkableArea *wa)
+{
+    return CreateNewScriptString(thisroom.WalkAreas[wa->id].ScriptName);
+}
+
 
 float Walkarea_GetFaceDirectionRatio(ScriptWalkableArea *wa)
 {
@@ -316,6 +327,11 @@ RuntimeScriptValue Sc_Walkarea_GetAtScreenXY(const RuntimeScriptValue *params, i
     API_SCALL_OBJ_PINT2(ScriptWalkableArea, ccDynamicWalkarea, Walkarea_GetAtScreenXY);
 }
 
+RuntimeScriptValue Sc_Walkarea_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptWalkableArea, ccDynamicWalkarea, Walkarea_GetByName, const char);
+}
+
 RuntimeScriptValue Sc_Walkarea_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO(ScriptDrawingSurface, GetDrawingSurfaceForWalkableArea);
@@ -349,6 +365,11 @@ RuntimeScriptValue Sc_Walkarea_GetScalingMin(void *self, const RuntimeScriptValu
 RuntimeScriptValue Sc_Walkarea_GetScalingMax(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptWalkableArea, Walkarea_GetScalingMax);
+}
+
+RuntimeScriptValue Sc_Walkarea_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptWalkableArea, const char, myScriptStringImpl, Walkarea_GetScriptName);
 }
 
 RuntimeScriptValue Sc_Walkarea_GetFaceDirectionRatio(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -387,18 +408,20 @@ void RegisterWalkareaAPI()
     ScFnRegister walkarea_api[] = {
         { "WalkableArea::GetAtRoomXY^2",       API_FN_PAIR(Walkarea_GetAtRoomXY) },
         { "WalkableArea::GetAtScreenXY^2",     API_FN_PAIR(Walkarea_GetAtScreenXY) },
+        { "WalkableArea::GetByScriptName^1",   API_FN_PAIR(Walkarea_GetByName) },
         { "WalkableArea::GetDrawingSurface",   API_FN_PAIR(GetDrawingSurfaceForWalkableArea) },
 
         { "WalkableArea::SetScaling^2",        API_FN_PAIR(Walkarea_SetScaling) },
-        { "WalkableArea::GetProperty^1",             API_FN_PAIR(Walkarea_GetProperty) },
-        { "WalkableArea::GetTextProperty^1",         API_FN_PAIR(Walkarea_GetTextProperty) },
-        { "WalkableArea::SetProperty^2",             API_FN_PAIR(Walkarea_SetProperty) },
-        { "WalkableArea::SetTextProperty^2",         API_FN_PAIR(Walkarea_SetTextProperty) },
+        { "WalkableArea::GetProperty^1",       API_FN_PAIR(Walkarea_GetProperty) },
+        { "WalkableArea::GetTextProperty^1",   API_FN_PAIR(Walkarea_GetTextProperty) },
+        { "WalkableArea::SetProperty^2",       API_FN_PAIR(Walkarea_SetProperty) },
+        { "WalkableArea::SetTextProperty^2",   API_FN_PAIR(Walkarea_SetTextProperty) },
         { "WalkableArea::get_Enabled",         API_FN_PAIR(Walkarea_GetEnabled) },
         { "WalkableArea::set_Enabled",         API_FN_PAIR(Walkarea_SetEnabled) },
         { "WalkableArea::get_ID",              API_FN_PAIR(Walkarea_GetID) },
         { "WalkableArea::get_ScalingMin",      API_FN_PAIR(Walkarea_GetScalingMin) },
         { "WalkableArea::get_ScalingMax",      API_FN_PAIR(Walkarea_GetScalingMax) },
+        { "WalkableArea::get_ScriptName",      API_FN_PAIR(Walkarea_GetScriptName) },
         { "WalkableArea::get_FaceDirectionRatio", API_FN_PAIR(Walkarea_GetFaceDirectionRatio) },
         { "WalkableArea::set_FaceDirectionRatio", API_FN_PAIR(Walkarea_SetFaceDirectionRatio) },
     };

--- a/Engine/ac/walkbehind.cpp
+++ b/Engine/ac/walkbehind.cpp
@@ -17,10 +17,12 @@
 #include "ac/gamestate.h"
 #include "ac/room.h"
 #include "ac/roomstatus.h"
+#include "ac/string.h"
 #include "ac/dynobj/scriptobjects.h"
 #include "ac/dynobj/cc_walkbehind.h"
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
+#include "script/script_runtime.h"
 
 
 using namespace AGS::Common;
@@ -211,6 +213,11 @@ ScriptWalkbehind *Walkbehind_GetAtScreenXY(int x, int y)
     return Walkbehind_GetAtRoomXY(vpt.first.X, vpt.first.Y);
 }
 
+ScriptWalkbehind *Walkbehind_GetByName(const char *name)
+{
+    return static_cast<ScriptWalkbehind*>(ccGetScriptObjectAddress(name, ccDynamicWalkbehind.GetType()));
+}
+
 int Walkbehind_GetID(ScriptWalkbehind *wb)
 {
     return wb->id;
@@ -224,6 +231,11 @@ int Walkbehind_GetBaseline(ScriptWalkbehind *wb)
 void Walkbehind_SetBaseline(ScriptWalkbehind *wb, int baseline)
 {
     croom->walkbehind_base[wb->id] = baseline;
+}
+
+const char *Walkbehind_GetScriptName(ScriptWalkbehind *wb)
+{
+    return CreateNewScriptString(thisroom.WalkBehinds[wb->id].ScriptName);
 }
 
 //=============================================================================
@@ -242,12 +254,17 @@ extern RuntimeScriptValue Sc_GetDrawingSurfaceForWalkbehind(const RuntimeScriptV
 
 RuntimeScriptValue Sc_Walkbehind_GetAtRoomXY(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(ScriptWalkableArea, ccDynamicWalkbehind, Walkbehind_GetAtRoomXY);
+    API_SCALL_OBJ_PINT2(ScriptWalkbehind, ccDynamicWalkbehind, Walkbehind_GetAtRoomXY);
 }
 
 RuntimeScriptValue Sc_Walkbehind_GetAtScreenXY(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(ScriptWalkableArea, ccDynamicWalkbehind, Walkbehind_GetAtScreenXY);
+    API_SCALL_OBJ_PINT2(ScriptWalkbehind, ccDynamicWalkbehind, Walkbehind_GetAtScreenXY);
+}
+
+RuntimeScriptValue Sc_Walkbehind_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptWalkbehind, ccDynamicWalkbehind, Walkbehind_GetByName, const char);
 }
 
 extern RuntimeScriptValue Sc_GetDrawingSurfaceForWalkableArea(const RuntimeScriptValue *params, int32_t param_count);
@@ -272,17 +289,24 @@ RuntimeScriptValue Sc_Walkbehind_GetID(void *self, const RuntimeScriptValue *par
     API_OBJCALL_INT(ScriptWalkbehind, Walkbehind_GetID);
 }
 
+RuntimeScriptValue Sc_Walkbehind_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptWalkbehind, const char, myScriptStringImpl, Walkbehind_GetScriptName);
+}
+
 
 void RegisterWalkbehindAPI()
 {
     ScFnRegister walkbehind_api[] = {
         { "Walkbehind::GetAtRoomXY^2",       API_FN_PAIR(Walkbehind_GetAtRoomXY) },
         { "Walkbehind::GetAtScreenXY^2",     API_FN_PAIR(Walkbehind_GetAtScreenXY) },
+        { "Walkbehind::GetByScriptName^1",   API_FN_PAIR(Walkbehind_GetByName) },
         { "Walkbehind::GetDrawingSurface",   API_FN_PAIR(GetDrawingSurfaceForWalkbehind) },
 
         { "Walkbehind::get_Baseline",        API_FN_PAIR(Walkbehind_GetBaseline) },
         { "Walkbehind::set_Baseline",        API_FN_PAIR(Walkbehind_SetBaseline) },
         { "Walkbehind::get_ID",              API_FN_PAIR(Walkbehind_GetID) },
+        { "Walkbehind::get_ScriptName",      API_FN_PAIR(Walkbehind_GetScriptName) },
     };
 
     ccAddExternalFunctions(walkbehind_api);


### PR DESCRIPTION
Resolve #2951

1. In the Editor: adds ScriptName property to Region, WalkableArea and Walkbehind, meaning a script name. This is an optional property, initialized with empty string by default. They follow same rule as other script name properties in the project: they must be unique and suitable for a variable name.
2. Editor generates script variables of respective pointer types using these names (for those which have one set).
3. Engine exports the respective room elements as script variables (when the room is loaded).
4. Script API: added ScriptName readonly property and GetByScriptName() static function for Region, WalkableArea and Walkbehind types.