### PR TITLE
4.0: Bring "script name" and "name/description" properties to naming consistency

### DIFF
--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -149,6 +149,7 @@ const char *GetScriptAPIName(ScriptAPIVersion v)
     case kScriptAPI_v400_16: return "4.0.0-alpha20";
     case kScriptAPI_v400_18: return "4.0.0-alpha22";
     case kScriptAPI_v400_24: return "4.0.0-alpha28";
+    case kScriptAPI_v400_30: return "4.0.0-alpha34";
     default: return "unknown";
     }
 }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -208,7 +208,8 @@ enum ScriptAPIVersion
     kScriptAPI_v400_16 = 4000016,
     kScriptAPI_v400_18 = 4000018,
     kScriptAPI_v400_24 = 4000024,
-    kScriptAPI_Current = kScriptAPI_v400_24
+    kScriptAPI_v400_30 = 4000030,
+    kScriptAPI_Current = kScriptAPI_v400_30
 };
 
 const char *GetScriptAPIName(ScriptAPIVersion v);

--- a/Editor/AGS.Editor.Tests/Editor/ConvertToNative/NativeRoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Editor/ConvertToNative/NativeRoomTests.cs
@@ -77,11 +77,11 @@ namespace AGS.Editor
             srcRoom.Properties.PropertyValues.Add("AnotherRoomProperty", new CustomProperty("AnotherRoomProperty", "also readme"));
 
             RoomHotspot h = new RoomHotspot(srcRoom);
-            h.Description = "This is some hotspot";
+            h.DisplayName = "This is some hotspot";
             h.ID = 0;
             h.Interactions.ScriptFunctionNames.Add("Look", "hSomeHotspot_Look");
             h.Interactions.ScriptFunctionNames.Add("Interact", "hSomeHotspot_Interact");
-            h.Name = "hSomeHotspot";
+            h.ScriptName = "hSomeHotspot";
             h.OnAnyClick = "hSomeHotspot_OnAnyClick";
             h.OnMouseMove = "hSomeHotspot_OnMouseMove";
             h.OnWalkOn = "hSomeHotspot_OnWalkOn";
@@ -90,11 +90,11 @@ namespace AGS.Editor
             h.WalkToPoint = new System.Drawing.Point(11, 22);
             srcRoom.Hotspots[0] = h;
             h = new RoomHotspot(srcRoom);
-            h.Description = "Absolutely different hotspot";
+            h.DisplayName = "Absolutely different hotspot";
             h.ID = 1;
             h.Interactions.ScriptFunctionNames.Add("Look", "hDifferentHotspot_Look");
             h.Interactions.ScriptFunctionNames.Add("Interact", "hDifferentHotspot_Interact");
-            h.Name = "hDifferentHotspot";
+            h.ScriptName = "hDifferentHotspot";
             h.OnAnyClick = "hDifferentHotspot_OnAnyClick";
             h.OnMouseMove = "hDifferentHotspot_OnMouseMove";
             h.OnWalkOn = "hDifferentHotspot_OnWalkOn";
@@ -109,7 +109,7 @@ namespace AGS.Editor
             o.BlendMode = BlendMode.Darken;
             o.BlockingRectangle = new System.Drawing.Rectangle(1, 4, 12, 11);
             o.Clickable = true;
-            o.Description = "The table";
+            o.DisplayName = "The table";
             o.Enabled = false;
             o.GraphicAnchor = new GraphicAnchor(FrameAlignment.BottomRight);
             o.GraphicOffset = new System.Drawing.Point(1, 4);
@@ -117,7 +117,7 @@ namespace AGS.Editor
             o.Image = 33;
             o.Interactions.ScriptFunctionNames.Add("Look", "oTable_Look");
             o.Interactions.ScriptFunctionNames.Add("Interact", "oTable_Interact");
-            o.Name = "oTable";
+            o.ScriptName = "oTable";
             o.OnAnyClick = "oTable_AnyClick";
             o.OnFrameEvent = "oTable_OnFrameEvent";
             o.Properties.PropertyValues.Add("MyProperty", new CustomProperty("MyProperty", "xxx"));
@@ -136,7 +136,7 @@ namespace AGS.Editor
             o.BlendMode = BlendMode.CopyAlpha;
             o.BlockingRectangle = new System.Drawing.Rectangle(-5, 0, 8, 16);
             o.Clickable = false;
-            o.Description = "The chair";
+            o.DisplayName = "The chair";
             o.Enabled = true;
             o.GraphicAnchor = new GraphicAnchor(FrameAlignment.TopCenter);
             o.GraphicOffset = new System.Drawing.Point(-5, 1);
@@ -144,7 +144,7 @@ namespace AGS.Editor
             o.Image = 44;
             o.Interactions.ScriptFunctionNames.Add("Look", "oChair_Look");
             o.Interactions.ScriptFunctionNames.Add("Interact", "oChair_Interact");
-            o.Name = "oChair";
+            o.ScriptName = "oChair";
             o.OnAnyClick = "oChair_AnyClick";
             o.OnFrameEvent = "oChair_OnFrameEvent";
             o.Properties.PropertyValues.Add("MyProperty", new CustomProperty("MyProperty", "aaa"));
@@ -256,9 +256,9 @@ namespace AGS.Editor
 
             Assert.That(dstRoom.HotspotCount, Is.EqualTo(50)); // Hotspots count is always fixed
             h = dstRoom.Hotspots[0];
-            Assert.That(h.Description, Is.EqualTo("This is some hotspot"));
+            Assert.That(h.DisplayName, Is.EqualTo("This is some hotspot"));
             Assert.That(h.ID, Is.EqualTo(0));
-            Assert.That(h.Name, Is.EqualTo("hSomeHotspot"));
+            Assert.That(h.ScriptName, Is.EqualTo("hSomeHotspot"));
             Assert.That(h.OnAnyClick, Is.EqualTo("hSomeHotspot_OnAnyClick"));
             Assert.That(h.OnMouseMove, Is.EqualTo("hSomeHotspot_OnMouseMove"));
             Assert.That(h.OnWalkOn, Is.EqualTo("hSomeHotspot_OnWalkOn"));
@@ -273,9 +273,9 @@ namespace AGS.Editor
             Assert.That(h.Properties.PropertyValues["MySecondProperty"].Value, Is.EqualTo("value2"));
 
             h = dstRoom.Hotspots[1];
-            Assert.That(h.Description, Is.EqualTo("Absolutely different hotspot"));
+            Assert.That(h.DisplayName, Is.EqualTo("Absolutely different hotspot"));
             Assert.That(h.ID, Is.EqualTo(1));
-            Assert.That(h.Name, Is.EqualTo("hDifferentHotspot"));
+            Assert.That(h.ScriptName, Is.EqualTo("hDifferentHotspot"));
             Assert.That(h.OnAnyClick, Is.EqualTo("hDifferentHotspot_OnAnyClick"));
             Assert.That(h.OnMouseMove, Is.EqualTo("hDifferentHotspot_OnMouseMove"));
             Assert.That(h.OnWalkOn, Is.EqualTo("hDifferentHotspot_OnWalkOn"));
@@ -296,13 +296,13 @@ namespace AGS.Editor
             Assert.That(o.BlendMode, Is.EqualTo(BlendMode.Darken));
             Assert.That(o.BlockingRectangle, Is.EqualTo(new System.Drawing.Rectangle(1, 4, 12, 11)));
             Assert.That(o.Clickable, Is.EqualTo(true));
-            Assert.That(o.Description, Is.EqualTo("The table"));
+            Assert.That(o.DisplayName, Is.EqualTo("The table"));
             Assert.That(o.Enabled, Is.EqualTo(false));
             Assert.That(o.GraphicAnchor, Is.EqualTo(new GraphicAnchor(FrameAlignment.BottomRight)));
             Assert.That(o.GraphicOffset, Is.EqualTo(new System.Drawing.Point(1, 4)));
             Assert.That(o.ID, Is.EqualTo(0));
             Assert.That(o.Image, Is.EqualTo(33));
-            Assert.That(o.Name, Is.EqualTo("oTable"));
+            Assert.That(o.ScriptName, Is.EqualTo("oTable"));
             Assert.That(o.OnAnyClick, Is.EqualTo("oTable_AnyClick"));
             Assert.That(o.OnFrameEvent, Is.EqualTo("oTable_OnFrameEvent"));
             Assert.That(o.Solid, Is.EqualTo(true));
@@ -327,13 +327,13 @@ namespace AGS.Editor
             Assert.That(o.BlendMode, Is.EqualTo(BlendMode.CopyAlpha));
             Assert.That(o.BlockingRectangle, Is.EqualTo(new System.Drawing.Rectangle(-5, 0, 8, 16)));
             Assert.That(o.Clickable, Is.EqualTo(false));
-            Assert.That(o.Description, Is.EqualTo("The chair"));
+            Assert.That(o.DisplayName, Is.EqualTo("The chair"));
             Assert.That(o.Enabled, Is.EqualTo(true));
             Assert.That(o.GraphicAnchor, Is.EqualTo(new GraphicAnchor(FrameAlignment.TopCenter)));
             Assert.That(o.GraphicOffset, Is.EqualTo(new System.Drawing.Point(-5, 1)));
             Assert.That(o.ID, Is.EqualTo(1));
             Assert.That(o.Image, Is.EqualTo(44));
-            Assert.That(o.Name, Is.EqualTo("oChair"));
+            Assert.That(o.ScriptName, Is.EqualTo("oChair"));
             Assert.That(o.OnAnyClick, Is.EqualTo("oChair_AnyClick"));
             Assert.That(o.OnFrameEvent, Is.EqualTo("oChair_OnFrameEvent"));
             Assert.That(o.Solid, Is.EqualTo(false));

--- a/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
@@ -100,8 +100,8 @@ namespace AGS.Types
         {
             string xml = $@"
             <RoomHotspot>
-              <Description xml:space=""preserve"">{description}</Description>
-              <Name>{name}</Name>
+              <DisplayName xml:space=""preserve"">{description}</DisplayName>
+              <ScriptName>{name}</ScriptName>
               <WalkToPoint>{walkToX},{walkToY}</WalkToPoint>
               <Properties />
               <Interactions />
@@ -118,15 +118,15 @@ namespace AGS.Types
 
         [TestCase("Hotspot 1", "hHotspot1", 0, 0)]
         [TestCase("Hotspot 2", "hHotspot2", 5, 5)]
-        public void SerializeToXml(string description, string name, int walkToX, int walkToY)
+        public void SerializeToXml(string displayName, string scriptName, int walkToX, int walkToY)
         {
-            _roomHotspot.DisplayName = description;
-            _roomHotspot.ScriptName = name;
+            _roomHotspot.DisplayName = displayName;
+            _roomHotspot.ScriptName = scriptName;
             _roomHotspot.WalkToPoint = new Point(walkToX, walkToY);
             XmlDocument doc = _roomHotspot.ToXmlDocument();
 
-            Assert.That(doc.SelectSingleNode("/RoomHotspot/Description").InnerText, Is.EqualTo(description));
-            Assert.That(doc.SelectSingleNode("/RoomHotspot/Name").InnerText, Is.EqualTo(name));
+            Assert.That(doc.SelectSingleNode("/RoomHotspot/DisplayName").InnerText, Is.EqualTo(displayName));
+            Assert.That(doc.SelectSingleNode("/RoomHotspot/ScriptName").InnerText, Is.EqualTo(scriptName));
             Assert.That(doc.SelectSingleNode("/RoomHotspot/WalkToPoint").InnerText, Is.EqualTo($"{walkToX},{walkToY}"));
         }
     }

--- a/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
@@ -34,23 +34,23 @@ namespace AGS.Types
         [TestCase("TestDescription")]
         public void GetsAndSetsDescription(string description)
         {
-            _roomHotspot.Description = description;
-            Assert.That(_roomHotspot.Description, Is.EqualTo(description));
+            _roomHotspot.DisplayName = description;
+            Assert.That(_roomHotspot.DisplayName, Is.EqualTo(description));
         }
 
         [TestCase("")]
         [TestCase("TestName")]
         public void GetsAndSetsName(string name)
         {
-            _roomHotspot.Name = name;
-            Assert.That(_roomHotspot.Name, Is.EqualTo(name));
+            _roomHotspot.ScriptName = name;
+            Assert.That(_roomHotspot.ScriptName, Is.EqualTo(name));
         }
 
         [TestCase("6TestName")]
         [TestCase("Test#Name")]
         public void SetNameThrowsInvalidDataExceptionWhenNameIsInvalid(string name)
         {
-            Assert.Throws<InvalidDataException>(() => _roomHotspot.Name = name);
+            Assert.Throws<InvalidDataException>(() => _roomHotspot.ScriptName = name);
         }
 
         [TestCase(0, 0)]
@@ -69,7 +69,7 @@ namespace AGS.Types
         [TestCase("TestName", int.MaxValue)]
         public void GetsPropertyGridTitle(string name, int id)
         {
-            _roomHotspot.Name = name;
+            _roomHotspot.ScriptName = name;
             _roomHotspot.ID = id;
             Assert.That(_roomHotspot.PropertyGridTitle, Is.EqualTo($"{name} (Hotspot; ID {id})"));
         }
@@ -110,8 +110,8 @@ namespace AGS.Types
             doc.LoadXml(xml);
             _roomHotspot = new RoomHotspot(_room, doc.SelectSingleNode("RoomHotspot"));
 
-            Assert.That(_roomHotspot.Description, Is.EqualTo(description));
-            Assert.That(_roomHotspot.Name, Is.EqualTo(name));
+            Assert.That(_roomHotspot.DisplayName, Is.EqualTo(description));
+            Assert.That(_roomHotspot.ScriptName, Is.EqualTo(name));
             Assert.That(_roomHotspot.WalkToPoint.X, Is.EqualTo(walkToX));
             Assert.That(_roomHotspot.WalkToPoint.Y, Is.EqualTo(walkToY));
         }
@@ -120,8 +120,8 @@ namespace AGS.Types
         [TestCase("Hotspot 2", "hHotspot2", 5, 5)]
         public void SerializeToXml(string description, string name, int walkToX, int walkToY)
         {
-            _roomHotspot.Description = description;
-            _roomHotspot.Name = name;
+            _roomHotspot.DisplayName = description;
+            _roomHotspot.ScriptName = name;
             _roomHotspot.WalkToPoint = new Point(walkToX, walkToY);
             XmlDocument doc = _roomHotspot.ToXmlDocument();
 

--- a/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
@@ -115,8 +115,8 @@ namespace AGS.Types
         [TestCase(null)]
         public void GetsAndSetsDescription(string description)
         {
-            _roomObject.Description = description;
-            Assert.That(_roomObject.Description, Is.EqualTo(description));
+            _roomObject.DisplayName = description;
+            Assert.That(_roomObject.DisplayName, Is.EqualTo(description));
         }
 
         //Name tests
@@ -188,8 +188,8 @@ namespace AGS.Types
             Assert.That(_roomObject.Clickable, Is.EqualTo(clickable));
             Assert.That(_roomObject.StartX, Is.EqualTo(startX));
             Assert.That(_roomObject.StartY, Is.EqualTo(startY));
-            Assert.That(_roomObject.Description, Is.EqualTo(description));
-            Assert.That(_roomObject.Name, Is.EqualTo(name));
+            Assert.That(_roomObject.DisplayName, Is.EqualTo(description));
+            Assert.That(_roomObject.ScriptName, Is.EqualTo(name));
             Assert.That(_roomObject.UseRoomAreaScaling, Is.EqualTo(useRoomAreaScaling));
             Assert.That(_roomObject.UseRoomAreaLighting, Is.EqualTo(useRoomAreaLighting));
         }
@@ -205,8 +205,8 @@ namespace AGS.Types
             _roomObject.Clickable = clickable;
             _roomObject.StartX = startX;
             _roomObject.StartY = startY;
-            _roomObject.Description = description;
-            _roomObject.Name = name;
+            _roomObject.DisplayName = description;
+            _roomObject.ScriptName = name;
             _roomObject.UseRoomAreaScaling = useRoomAreaScaling;
             _roomObject.UseRoomAreaLighting = useRoomAreaLighting;
             XmlDocument doc = _roomObject.ToXmlDocument();

--- a/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
@@ -159,7 +159,7 @@ namespace AGS.Types
 
         [TestCase(230, BlendMode.Normal, false, -1, false, 200, 100, "description1", "name1", false, false)]
         [TestCase(220, BlendMode.Add, true, 0, true, 190, 90, "description2", "name2", true, true)]
-        public void DeserializesFromXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        public void DeserializesFromXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string displayName, string scriptName, bool useRoomAreaScaling, bool useRoomAreaLighting)
         {
             string xml = $@"
             <RoomObject>
@@ -170,8 +170,8 @@ namespace AGS.Types
                 <Clickable>{clickable}</Clickable>
                 <StartX>{startX}</StartX>
                 <StartY>{startY}</StartY>
-                <Description>{description}</Description>
-                <Name>{name}</Name>
+                <DisplayName>{displayName}</DisplayName>
+                <ScriptName>{scriptName}</ScriptName>
                 <UseRoomAreaScaling>{useRoomAreaScaling}</UseRoomAreaScaling>
                 <UseRoomAreaLighting>{useRoomAreaLighting}</UseRoomAreaLighting>
                 <Properties />
@@ -188,15 +188,15 @@ namespace AGS.Types
             Assert.That(_roomObject.Clickable, Is.EqualTo(clickable));
             Assert.That(_roomObject.StartX, Is.EqualTo(startX));
             Assert.That(_roomObject.StartY, Is.EqualTo(startY));
-            Assert.That(_roomObject.DisplayName, Is.EqualTo(description));
-            Assert.That(_roomObject.ScriptName, Is.EqualTo(name));
+            Assert.That(_roomObject.DisplayName, Is.EqualTo(displayName));
+            Assert.That(_roomObject.ScriptName, Is.EqualTo(scriptName));
             Assert.That(_roomObject.UseRoomAreaScaling, Is.EqualTo(useRoomAreaScaling));
             Assert.That(_roomObject.UseRoomAreaLighting, Is.EqualTo(useRoomAreaLighting));
         }
 
         [TestCase(230, BlendMode.Normal, false, -1, false, 200, 100, "description1", "name1", false, false)]
         [TestCase(220, BlendMode.Add, true, 0, true, 190, 90, "description2", "name2", true, true)]
-        public void SerializesToXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        public void SerializesToXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string displayName, string scriptName, bool useRoomAreaScaling, bool useRoomAreaLighting)
         {
             _roomObject.Image = image;
             _roomObject.BlendMode = blendMode;
@@ -205,8 +205,8 @@ namespace AGS.Types
             _roomObject.Clickable = clickable;
             _roomObject.StartX = startX;
             _roomObject.StartY = startY;
-            _roomObject.DisplayName = description;
-            _roomObject.ScriptName = name;
+            _roomObject.DisplayName = displayName;
+            _roomObject.ScriptName = scriptName;
             _roomObject.UseRoomAreaScaling = useRoomAreaScaling;
             _roomObject.UseRoomAreaLighting = useRoomAreaLighting;
             XmlDocument doc = _roomObject.ToXmlDocument();
@@ -218,8 +218,8 @@ namespace AGS.Types
             Assert.That(doc.SelectSingleNode("/RoomObject/Clickable").InnerText, Is.EqualTo(clickable.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/StartX").InnerText, Is.EqualTo(startX.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/StartY").InnerText, Is.EqualTo(startY.ToString()));
-            Assert.That(doc.SelectSingleNode("/RoomObject/Description").InnerText, Is.EqualTo(description.ToString()));
-            Assert.That(doc.SelectSingleNode("/RoomObject/Name").InnerText, Is.EqualTo(name.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/DisplayName").InnerText, Is.EqualTo(displayName.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/ScriptName").InnerText, Is.EqualTo(scriptName.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/UseRoomAreaScaling").InnerText, Is.EqualTo(useRoomAreaScaling.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/UseRoomAreaLighting").InnerText, Is.EqualTo(useRoomAreaLighting.ToString()));
         }

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1369,7 +1369,7 @@ namespace AGS.Editor
 				AGS.Types.View view = _game.FindViewByID(character.NormalView);
 				if (view == null)
 				{
-					errors.Add(new CompileError("Character " + character.ID + " (" + character.RealName + ") has invalid normal view."));
+					errors.Add(new CompileError("Character " + character.ID + " (" + character.ScriptName + ") has invalid normal view."));
 				}
 			}
 
@@ -1407,15 +1407,15 @@ namespace AGS.Editor
 
 			foreach (AGS.Types.View view in folder.Views)
 			{
-				if (!string.IsNullOrEmpty(view.Name))
+				if (!string.IsNullOrEmpty(view.ScriptName))
 				{
-					if (viewNames.ContainsKey(view.Name.ToLowerInvariant()))
+					if (viewNames.ContainsKey(view.ScriptName.ToLowerInvariant()))
 					{
-						errors.Add(new CompileError("There are two or more views with the same name '" + view.Name + "'"));
+						errors.Add(new CompileError("There are two or more views with the same name '" + view.ScriptName + "'"));
 					}
 					else
 					{
-						viewNames.Add(view.Name.ToLowerInvariant(), view);
+						viewNames.Add(view.ScriptName.ToLowerInvariant(), view);
 					}
 				}
 			}

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -70,7 +70,7 @@ namespace AGS.Editor.Components
             if (controlID == COMMAND_NEW_ITEM)
             {                
                 Character newItem = new Character();
-                newItem.RealName = "New character";
+                newItem.DisplayName = "New character";
                 newItem.StartingRoom = -1;
                 // Default Character colors are set as palette indexes, remap them to proper colors
                 Tasks.RemapCharacterColours(newItem, _agsEditor.CurrentGame, GameColorDepth.Palette);
@@ -162,7 +162,7 @@ namespace AGS.Editor.Components
                 Text = "Go To Character",
                 NodeTypeName = "Character",
                 List = characters
-                    .Select(c => Tuple.Create(c.ID, string.Format("({0}) {1}",c.ScriptName, c.RealName)))
+                    .Select(c => Tuple.Create(c.ID, string.Format("({0}) {1}",c.ScriptName, c.DisplayName)))
                     .ToList()
             };
             if (goToCharacterDialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -56,7 +56,7 @@ namespace AGS.Editor.Components
         private Dialog AddNewDialog(Dialog newItem, string baseScriptName)
         {
             newItem.ID = _agsEditor.CurrentGame.RootDialogFolder.GetAllItemsCount();
-            newItem.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            newItem.ScriptName = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
             string newNodeID;
             if (_itemRightClicked != null)
                 newNodeID = AddSingleItem(newItem, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _itemRightClicked)));
@@ -90,7 +90,7 @@ namespace AGS.Editor.Components
                 Dialog newItem = ClipboardUtils.PasteFromClipboard(typeof(Dialog)) as Dialog;
                 if (newItem == null)
                     return;
-                AddNewDialog(newItem, newItem.Name);
+                AddNewDialog(newItem, newItem.ScriptName);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -113,7 +113,7 @@ namespace AGS.Editor.Components
             else if (controlID == COMMAND_FIND_ALL_USAGES)
             {
                 FindAllUsages findAllUsages = new FindAllUsages(null, null, null, _agsEditor);
-                findAllUsages.Find(null, _itemRightClicked.Name);
+                findAllUsages.Find(null, _itemRightClicked.ScriptName);
             }
             else if (controlID == COMMAND_GO_TO_DIALOG_NUMBER)
             {
@@ -136,7 +136,7 @@ namespace AGS.Editor.Components
                 Text = "Go To Dialog",
                 NodeTypeName = "Dialog",
                 List = dialogs
-                    .Select(d => Tuple.Create(d.ID, d.Name))
+                    .Select(d => Tuple.Create(d.ID, d.ScriptName))
                     .ToList()
             };
             if (goToDialogDialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
@@ -201,10 +201,10 @@ namespace AGS.Editor.Components
 
             if (propertyName == "Name")
             {
-                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.Name, itemBeingEdited))
+                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.ScriptName, itemBeingEdited))
                 {
                     _guiController.ShowMessage("This script name is already used by another item.", MessageBoxIcon.Warning);
-                    itemBeingEdited.Name = (string)oldValue;
+                    itemBeingEdited.ScriptName = (string)oldValue;
                 }
                 else
                 {
@@ -247,7 +247,7 @@ namespace AGS.Editor.Components
                     if (ClipboardUtils.IsAvailableOnClipboard(typeof(Dialog)))
                         menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste dialog", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this dialog", null));
-                    menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.Name, null));
+                    menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.ScriptName, null));
                 }
             }
             return menu;
@@ -304,7 +304,7 @@ namespace AGS.Editor.Components
             IList<Dialog> dialogs = GetFlatList();
             foreach (Dialog d in dialogs)
             {
-                if (d.Name == name)
+                if (d.ScriptName == name)
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(d));
                     ShowPaneForDialog(d);
@@ -406,7 +406,7 @@ namespace AGS.Editor.Components
 
         private string GetNodeLabel(Dialog item)
         {
-            return item.ID.ToString() + ": " + item.Name;
+            return item.ID.ToString() + ": " + item.ScriptName;
         }
 
         protected override ProjectTreeItem CreateTreeItemForItem(Dialog item)

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -285,7 +285,7 @@ namespace AGS.Editor.Components
                 
                 foreach(GUIControl gctrl in g.Controls)
                 {
-                    if(gctrl.Name == name)
+                    if(gctrl.ScriptName == name)
                     {
                         _guiController.ProjectTree.SelectNode(this, GetNodeID(g));
                         ShowOrAddPane(g);
@@ -479,22 +479,22 @@ namespace AGS.Editor.Components
 
                 foreach (var button in buttons)
                 {
-                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(button, button.ControlType, button.ControlType, button.Name, button.ID, objectContext, ngui.ScriptModule, true, errors);
+                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(button, button.ControlType, button.ControlType, button.ScriptName, button.ID, objectContext, ngui.ScriptModule, true, errors);
                 }
 
                 foreach (var listbox in listboxes)
                 {
-                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(listbox, listbox.ControlType, listbox.ControlType, listbox.Name, listbox.ID, objectContext, ngui.ScriptModule, true, errors);
+                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(listbox, listbox.ControlType, listbox.ControlType, listbox.ScriptName, listbox.ID, objectContext, ngui.ScriptModule, true, errors);
                 }
 
                 foreach (var slider in sliders)
                 {
-                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(slider, slider.ControlType, slider.ControlType, slider.Name, slider.ID, objectContext, ngui.ScriptModule, true, errors);
+                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(slider, slider.ControlType, slider.ControlType, slider.ScriptName, slider.ID, objectContext, ngui.ScriptModule, true, errors);
                 }
 
                 foreach (var textbox in textboxes)
                 {
-                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(textbox, textbox.ControlType, textbox.ControlType, textbox.Name, textbox.ID, objectContext, ngui.ScriptModule, true, errors);
+                    _agsEditor.Tasks.ScanAndReportMissingEventHandlers(textbox, textbox.ControlType, textbox.ControlType, textbox.ScriptName, textbox.ID, objectContext, ngui.ScriptModule, true, errors);
                 }
             }
         }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -44,7 +44,7 @@ namespace AGS.Editor.Components
         private InventoryItem AddNewItem(InventoryItem newItem, string baseScriptName)
         {
             newItem.ID = _agsEditor.CurrentGame.RootInventoryItemFolder.GetAllItemsCount() + 1;
-            newItem.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+            newItem.ScriptName = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
             string newNodeID;
             if (_itemRightClicked != null)
                 newNodeID = AddSingleItem(newItem, GetNodeIDForFolder(FindFolderThatContainsItem(GetRootFolder(), _itemRightClicked)));
@@ -65,7 +65,7 @@ namespace AGS.Editor.Components
                 }
                 InventoryItem newItem = new InventoryItem();
                 AddNewItem(newItem, "iInvItem");
-                newItem.Description = "New inventory item";
+                newItem.DisplayName = "New inventory item";
             }
             else if (controlID == COMMAND_DELETE_ITEM)
             {
@@ -84,7 +84,7 @@ namespace AGS.Editor.Components
                 if (newItem == null)
                     return;
                 newItem.Interactions.Schema = InteractionSchema.Instance; // schema reference is lost when deserializing
-                AddNewItem(newItem, newItem.Name);
+                AddNewItem(newItem, newItem.ScriptName);
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -108,7 +108,7 @@ namespace AGS.Editor.Components
             else if (controlID == COMMAND_FIND_ALL_USAGES)
             {
                 FindAllUsages findAllUsages = new FindAllUsages(null, null, null, _agsEditor);
-                findAllUsages.Find(null, _itemRightClicked.Name);
+                findAllUsages.Find(null, _itemRightClicked.ScriptName);
             }
             else if (controlID == COMMAND_GO_TO_ITEM_NUMBER)
             {
@@ -132,7 +132,7 @@ namespace AGS.Editor.Components
                 Text = "Go To Inventory Item",
                 NodeTypeName = "Inventory Item",
                 List = items
-                    .Select(i => Tuple.Create(i.ID, string.Format("({0}) {1}", i.Name, i.Description)))
+                    .Select(i => Tuple.Create(i.ID, string.Format("({0}) {1}", i.ScriptName, i.DisplayName)))
                     .ToList()
             };
             if (goToItemDialog.ShowDialog() != DialogResult.OK) return;
@@ -219,10 +219,10 @@ namespace AGS.Editor.Components
             {
                 InventoryItem itemToChange = ((InventoryEditor)_guiController.ActivePane.Control).ItemToEdit;
 
-                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemToChange.Name, itemToChange))
+                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemToChange.ScriptName, itemToChange))
                 {
                     _guiController.ShowMessage("This script name is already used by another item.", MessageBoxIcon.Warning);
-                    itemToChange.Name = (string)oldValue;
+                    itemToChange.ScriptName = (string)oldValue;
                 }
                 else
                 {
@@ -265,7 +265,7 @@ namespace AGS.Editor.Components
                     if (ClipboardUtils.IsAvailableOnClipboard(typeof(InventoryItem)))
                         menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste item", null));
                     menu.Add(new MenuCommand(COMMAND_DELETE_ITEM, "Delete this item", null));
-                    menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.Name, null));
+                    menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find All Usages of " + _itemRightClicked.ScriptName, null));
                 }
             }
             return menu;
@@ -298,7 +298,7 @@ namespace AGS.Editor.Components
 
         private string GetNodeLabel(InventoryItem item)
         {
-            return item.ID.ToString() + ": " + item.Name;
+            return item.ID.ToString() + ": " + item.ScriptName;
         }
 
         protected override ProjectTreeItem CreateTreeItemForItem(InventoryItem item)
@@ -343,7 +343,7 @@ namespace AGS.Editor.Components
             foreach (InventoryItem inv in _agsEditor.CurrentGame.InventoryItems)
             {
                 _agsEditor.Tasks.ScanAndReportMissingEventHandlers(inv, "Inventory", "InventoryItem",
-                    inv.Name, inv.ID, inv.ScriptModule, true, errors);
+                    inv.ScriptName, inv.ID, inv.ScriptModule, true, errors);
             }
         }
     }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -877,22 +877,22 @@ namespace AGS.Editor.Components
         {
             foreach (RoomHotspot hotspot in room.Hotspots)
             {
-                if (string.IsNullOrEmpty(hotspot.Name))
+                if (string.IsNullOrEmpty(hotspot.ScriptName))
                     continue;
-                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(hotspot.Name, hotspot) ||
-                    room.IsScriptNameAlreadyUsed(hotspot.Name, hotspot))
+                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(hotspot.ScriptName, hotspot) ||
+                    room.IsScriptNameAlreadyUsed(hotspot.ScriptName, hotspot))
                 {
-                    errors.Add(new CompileError("Hotspot '" + hotspot.Name + "' script name conflicts with other game item"));
+                    errors.Add(new CompileError("Hotspot '" + hotspot.ScriptName + "' script name conflicts with other game item"));
                 }
             }
             foreach (RoomObject obj in room.Objects)
             {
-                if (string.IsNullOrEmpty(obj.Name))
+                if (string.IsNullOrEmpty(obj.ScriptName))
                     continue;
-                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(obj.Name, obj) ||
-                    room.IsScriptNameAlreadyUsed(obj.Name, obj))
+                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(obj.ScriptName, obj) ||
+                    room.IsScriptNameAlreadyUsed(obj.ScriptName, obj))
                 {
-                    errors.Add(new CompileError("Object '" + obj.Name + "' script name conflicts with other game item"));
+                    errors.Add(new CompileError("Object '" + obj.ScriptName + "' script name conflicts with other game item"));
                 }
             }
             return !errors.HasErrors;
@@ -1990,13 +1990,13 @@ namespace AGS.Editor.Components
 
                 foreach (RoomHotspot hotspot in room.Hotspots)
                 {
-                    hotspot.Description = processor.ProcessText(new GameTextLine(hotspot.Description, roomContext), GameTextType.ItemDescription);
+                    hotspot.DisplayName = processor.ProcessText(new GameTextLine(hotspot.DisplayName, roomContext), GameTextType.ItemDescription);
                     TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, hotspot.Properties, roomContext, errors);
                 }
 
                 foreach (RoomObject obj in room.Objects)
                 {
-                    obj.Description = processor.ProcessText(new GameTextLine(obj.Description, roomContext), GameTextType.ItemDescription);
+                    obj.DisplayName = processor.ProcessText(new GameTextLine(obj.DisplayName, roomContext), GameTextType.ItemDescription);
                     TextProcessingHelper.ProcessProperties(processor, _agsEditor.CurrentGame.PropertySchema, obj.Properties, roomContext, errors);
                 }
 
@@ -2410,13 +2410,13 @@ namespace AGS.Editor.Components
             foreach (var obj in room.Objects)
             {
                 _agsEditor.Tasks.ScanAndReportMissingEventHandlers(obj, "Object", "Object",
-                    string.IsNullOrEmpty(obj.Name) ? $"Object{obj.ID}" : obj.Name, obj.ID, room.Number, room.ScriptFileName, false, room.Script.AutoCompleteData, true, errors);
+                    string.IsNullOrEmpty(obj.ScriptName) ? $"Object{obj.ID}" : obj.ScriptName, obj.ID, room.Number, room.ScriptFileName, false, room.Script.AutoCompleteData, true, errors);
             }
 
             foreach (var hot in room.Hotspots)
             {
                 _agsEditor.Tasks.ScanAndReportMissingEventHandlers(hot, "Hotspot", "Hotspot",
-                    string.IsNullOrEmpty(hot.Name) ? $"Hotspot{hot.ID}" : hot.Name, hot.ID, room.Number, room.ScriptFileName, false, room.Script.AutoCompleteData, true, errors);
+                    string.IsNullOrEmpty(hot.ScriptName) ? $"Hotspot{hot.ID}" : hot.ScriptName, hot.ID, room.Number, room.ScriptFileName, false, room.Script.AutoCompleteData, true, errors);
 
             }
 

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -45,9 +45,9 @@ namespace AGS.Editor.Components
         {
             newView.ID = _agsEditor.CurrentGame.FindAndAllocateAvailableViewID();
             if (string.IsNullOrEmpty(baseScriptName))
-                newView.Name = "View" + newView.ID;
+                newView.ScriptName = "View" + newView.ID;
             else
-                newView.Name = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
+                newView.ScriptName = _agsEditor.GetFirstAvailableScriptName(baseScriptName);
             string newNodeID;
             View viewClicked;
             _items.TryGetValue(_rightClickedID, out viewClicked);
@@ -65,7 +65,7 @@ namespace AGS.Editor.Components
 			if (controlID == COMMAND_DELETE)
 			{
 				View viewToDelete = _items[_rightClickedID];
-				if (_guiController.ShowQuestion("Are you sure you want to delete view '" + viewToDelete.Name + "'?" + Environment.NewLine + Environment.NewLine + "If it is used as an animation anywhere it could cause crashes in the game.") == System.Windows.Forms.DialogResult.Yes)
+				if (_guiController.ShowQuestion("Are you sure you want to delete view '" + viewToDelete.ScriptName + "'?" + Environment.NewLine + Environment.NewLine + "If it is used as an animation anywhere it could cause crashes in the game.") == System.Windows.Forms.DialogResult.Yes)
 				{
 					string usage = GetViewUsageReport(viewToDelete.ID);
 					if (usage != null)
@@ -104,7 +104,7 @@ namespace AGS.Editor.Components
             {
                 FindAllUsages findAllUsages = new FindAllUsages(null, null, null, _agsEditor);
                 View viewToFind = _items[_rightClickedID];
-                findAllUsages.Find(null, viewToFind.Name);
+                findAllUsages.Find(null, viewToFind.ScriptName);
             }
             else if (controlID == COMMAND_NEW_VIEW)
             {
@@ -120,7 +120,7 @@ namespace AGS.Editor.Components
                 View newView = ClipboardUtils.PasteFromClipboard(typeof(View)) as View;
                 if (newView == null)
                     return;
-                AddNewView(newView, newView.Name);
+                AddNewView(newView, newView.ScriptName);
             }
             else if (controlID == COMMAND_RENAME)
             {
@@ -148,7 +148,7 @@ namespace AGS.Editor.Components
                 Text = "Go To View",
                 NodeTypeName = "View",
                 List = views
-                    .Select(v => Tuple.Create(v.ID, v.Name))
+                    .Select(v => Tuple.Create(v.ID, v.ScriptName))
                     .ToList()
             };
             if (goToViewDialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
@@ -224,10 +224,10 @@ namespace AGS.Editor.Components
                 {
                     View itemBeingEdited = (View)treeItem.LabelTextDataSource;
 
-                    if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.Name.ToUpperInvariant(), itemBeingEdited))
+                    if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.ScriptName.ToUpperInvariant(), itemBeingEdited))
                     {
                         _guiController.ShowMessage("This script name is already used by another item.", MessageBoxIconType.Warning);
-                        itemBeingEdited.Name = treeItem.LabelTextBeforeLabelEdit;
+                        itemBeingEdited.ScriptName = treeItem.LabelTextBeforeLabelEdit;
                         treeItem.TreeNode.Text = itemBeingEdited.NameAndID;
                         return;
                     }
@@ -253,10 +253,10 @@ namespace AGS.Editor.Components
             if (propertyName == "Name")
             {
                 View itemBeingEdited = ((ViewEditor)_guiController.ActivePane.Control).ViewToEdit;
-                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.Name.ToUpperInvariant(), itemBeingEdited))
+                if (_agsEditor.CurrentGame.IsScriptNameAlreadyUsed(itemBeingEdited.ScriptName.ToUpperInvariant(), itemBeingEdited))
                 {
                     _guiController.ShowMessage("This script name is already used by another item.", MessageBoxIconType.Warning);
-                    itemBeingEdited.Name = (string)oldValue;
+                    itemBeingEdited.ScriptName = (string)oldValue;
                 }
                 else
                 {
@@ -279,7 +279,7 @@ namespace AGS.Editor.Components
                     menu.Add(new MenuCommand(COMMAND_PASTE_ITEM, "Paste View", null));
                 menu.Add(new MenuCommand(COMMAND_DELETE, "Delete View", null));
                 View view = _items[_rightClickedID];
-                menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find all usages of " + view.Name, null));
+                menu.Add(new MenuCommand(COMMAND_FIND_ALL_USAGES, "Find all usages of " + view.ScriptName, null));
             }
             return menu;
         }
@@ -316,7 +316,7 @@ namespace AGS.Editor.Components
 
             foreach (Character character in game.RootCharacterFolder.AllItemsFlat)
 			{
-				string charText = "character " + character.ID + " (" + character.RealName + ")";
+				string charText = "character " + character.ID + " (" + character.DisplayName + ")";
 
 				if (character.BlinkingView == viewNumber)
 				{
@@ -364,7 +364,7 @@ namespace AGS.Editor.Components
 
         private string GetNodeLabel(View item)
         {
-            return item.ID.ToString() + ": " + item.Name;
+            return item.ID.ToString() + ": " + item.ScriptName;
         }
 
         protected override ViewFolder GetRootFolder()

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1285,7 +1285,7 @@ namespace AGS.Editor
                 writer.Write(control.Width);
                 writer.Write(control.Height);
                 writer.Write(control.ZOrder);
-                FilePutNullTerminatedString(control.Name, writer);
+                FilePutNullTerminatedString(control.ScriptName, writer);
                 // Old style events table; now unused so write size 0 always
                 writer.Write(0);
             }
@@ -1687,7 +1687,7 @@ namespace AGS.Editor
             for (int i = 0; i < game.InventoryItems.Count; ++i)
             {
                 // legacy name field of fixed length
-                WriteString(TextProperty(game.InventoryItems[i].Description), 24, writer);
+                WriteString(TextProperty(game.InventoryItems[i].DisplayName), 24, writer);
                 writer.Write(new byte[4]); // null terminator plus 3 bytes padding
                 writer.Write(game.InventoryItems[i].Image);
                 writer.Write(game.InventoryItems[i].CursorImage);
@@ -1830,7 +1830,7 @@ namespace AGS.Editor
                 writer.Write((short)0);                                // [UNUSED] (actx)
                 writer.Write((short)0);                                // [UNUSED] (acty)
                 // legacy name and scriptname fields of fixed length
-                WriteString(TextProperty(character.RealName), 40, writer); // name
+                WriteString(TextProperty(character.DisplayName), 40, writer); // name
                 WriteString(character.ScriptName, NativeConstants.MAX_SCRIPT_NAME_LEN, writer); // scrname
                 writer.Write((byte)0);                                 // deprecated "on" flag (replaced by ENABLED and VISIBLE flags)
                 writer.Write((byte)0);                                 // alignment padding
@@ -1875,14 +1875,14 @@ namespace AGS.Editor
             {
                 View view = game.FindViewByID(i + 1);
                 if (view != null)
-                    FilePutNullTerminatedString(view.Name, writer);
+                    FilePutNullTerminatedString(view.ScriptName, writer);
                 else
                     writer.Write((byte)0); // view is null, so its name is just a single NUL byte
             }
             writer.Write((byte)0); // inventory slot 0 is unused, so its name is just a single NUL byte
             for (int i = 0; i < game.InventoryItems.Count; ++i)
             {
-                FilePutNullTerminatedString(game.InventoryItems[i].Name, writer);
+                FilePutNullTerminatedString(game.InventoryItems[i].ScriptName, writer);
             }
             /* [DEPRECATED] -- now written as a part of "v363_dialogsnew" extension
             for (int i = 0; i < game.Dialogs.Count; ++i)
@@ -2046,14 +2046,14 @@ namespace AGS.Editor
             for (int i = 0; i < game.Characters.Count; ++i)
             {
                 FilePutString(game.Characters[i].ScriptName, writer);
-                FilePutString(TextProperty(game.Characters[i].RealName), writer);
+                FilePutString(TextProperty(game.Characters[i].DisplayName), writer);
             }
             // Inventory items
             writer.Write((int)game.InventoryItems.Count + 1); // +1 for a dummy item at id 0
             writer.Write((int)0); // inventory slot 0 is unused, so its name is just a single 0-length
             for (int i = 0; i < game.InventoryItems.Count; ++i)
             {
-                FilePutString(TextProperty(game.InventoryItems[i].Description), writer);
+                FilePutString(TextProperty(game.InventoryItems[i].DisplayName), writer);
             }
             // Mouse cursors
             writer.Write((int)game.Cursors.Count);
@@ -2135,7 +2135,7 @@ namespace AGS.Editor
             foreach (Dialog dialog in game.Dialogs)
             {
                 // Dialog topic settings
-                FilePutString(dialog.Name, writer);
+                FilePutString(dialog.ScriptName, writer);
                 int topic_flags = 0;
                 if (dialog.ShowTextParser) topic_flags |= NativeConstants.DTFLG_SHOWPARSER;
                 writer.Write(topic_flags);

--- a/Editor/AGS.Editor/GUI/AutoNumberSpeechWizardPage2.cs
+++ b/Editor/AGS.Editor/GUI/AutoNumberSpeechWizardPage2.cs
@@ -19,7 +19,7 @@ namespace AGS.Editor
             cmbWhichCharacter.Items.Add("Only re-number the narrator");
             foreach (Character character in characters)
             {
-                cmbWhichCharacter.Items.Add("Only re-number " + character.RealName);
+                cmbWhichCharacter.Items.Add("Only re-number " + character.DisplayName);
             }
             cmbWhichCharacter.SelectedIndex = 0;
         }

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1561,7 +1561,7 @@ namespace AGS.Editor
 			if (character != null)
 			{
 				sw.WriteLine();
-				sw.WriteLine("*** Lines for character " + character.RealName + " (ID " + charID + ") ***");
+				sw.WriteLine("*** Lines for character " + character.DisplayName + " (ID " + charID + ") ***");
 				sw.WriteLine();
 			}
 			else

--- a/Editor/AGS.Editor/ImportExport.cs
+++ b/Editor/AGS.Editor/ImportExport.cs
@@ -765,7 +765,7 @@ namespace AGS.Editor
         {
             View newView = ReadOldStyleView(reader, game, folder, palette);
             newView.ID = game.FindAndAllocateAvailableViewID();
-            newView.Name = viewName;
+            newView.ScriptName = viewName;
             game.RootViewFolder.Views.Add(newView);
             return newView.ID;
         }
@@ -783,12 +783,12 @@ namespace AGS.Editor
 
         private static void EnsureViewNameIsUnique(View view, Game game)
         {
-            string scriptNameBase = view.Name; 
+            string scriptNameBase = view.ScriptName; 
             int suffix = 0;
-            while (game.IsScriptNameAlreadyUsed(view.Name.ToUpperInvariant(), view))
+            while (game.IsScriptNameAlreadyUsed(view.ScriptName.ToUpperInvariant(), view))
             {
                 suffix++;
-                view.Name = scriptNameBase + suffix;
+                view.ScriptName = scriptNameBase + suffix;
             }
         }
 
@@ -1005,9 +1005,9 @@ namespace AGS.Editor
             }
             foreach (GUIControl control in gui.Controls)
             {
-                while (game.IsScriptNameAlreadyUsed(control.Name, control))
+                while (game.IsScriptNameAlreadyUsed(control.ScriptName, control))
                 {
-                    control.Name += "2";
+                    control.ScriptName += "2";
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -156,7 +156,7 @@ namespace AGS.Editor
                     if (_selected.Count > 1)
                         return;
                     objectBeingChanged = _selectedControl;
-                    newName = _selectedControl.Name;
+                    newName = _selectedControl.ScriptName;
                 }
                 Game game = Factory.AGSEditor.CurrentGame;
                 bool nameInUse = game.IsScriptNameAlreadyUsed(newName, objectBeingChanged);
@@ -174,7 +174,7 @@ namespace AGS.Editor
                     Factory.GUIController.ShowMessage("This script name is already used by another item.", MessageBoxIcon.Warning);
                     if (_selectedControl != null)
                     {
-                        _selectedControl.Name = (string)oldValue;
+                        _selectedControl.ScriptName = (string)oldValue;
                     }
                     else
                     {
@@ -732,7 +732,7 @@ namespace AGS.Editor
             {
                 Type controlType = _selectedControl.GetType();
                 var textProperty = controlType.GetProperty("Text");
-                string title = "Edit " + _selectedControl.Name + " text...";
+                string title = "Edit " + _selectedControl.ScriptName + " text...";
 
                 String currentText = (String)textProperty.GetValue(_selectedControl);
                 String newText = MultilineStringEditorDialog.ShowEditor(title, currentText);
@@ -923,7 +923,7 @@ namespace AGS.Editor
             int refControlX = 0, refControlY = 0;
             foreach (var newControl in newControls)
             {
-                newControl.Name = Factory.AGSEditor.GetFirstAvailableScriptName(newControl.ControlType);
+                newControl.ScriptName = Factory.AGSEditor.GetFirstAvailableScriptName(newControl.ControlType);
                 newControl.ZOrder = _gui.Controls.Count;
                 newControl.ID = _gui.Controls.Count;
                 newControl.MemberOf = null;
@@ -1235,7 +1235,7 @@ namespace AGS.Editor
                     throw new AGSEditorException("Unknown control type added: " + _controlAddMode.ToString());
             }
 
-            newControl.Name = Factory.AGSEditor.GetFirstAvailableScriptName(newControl.ControlType);
+            newControl.ScriptName = Factory.AGSEditor.GetFirstAvailableScriptName(newControl.ControlType);
             newControl.ZOrder = _gui.Controls.Count;
             newControl.Parent = _gui;
             newControl.ID = _gui.Controls.Count;
@@ -1419,7 +1419,7 @@ namespace AGS.Editor
 			if (objectToCheck is GUI)
 				itemName = ((GUI)objectToCheck).Name;
 			else
-				itemName = ((GUIControl)objectToCheck).Name;
+				itemName = ((GUIControl)objectToCheck).ScriptName;
 
 			if (string.IsNullOrEmpty(itemName))
 			{

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -305,7 +305,7 @@ namespace AGS.Editor
         /// </summary>
         protected override string GetNavbarItemTitle(Character obj)
         {
-            return MakeLayerItemName("Character", obj.ScriptName, obj.RealName, obj.ID);
+            return MakeLayerItemName("Character", obj.ScriptName, obj.DisplayName, obj.ID);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -51,7 +51,7 @@ namespace AGS.Editor
 
         protected override string GetItemName(int id)
         {
-            return MakeLayerItemName("Hotspot", _room.Hotspots[id].Name, _room.Hotspots[id].Description, id);
+            return MakeLayerItemName("Hotspot", _room.Hotspots[id].ScriptName, _room.Hotspots[id].DisplayName, id);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace AGS.Editor
         public override bool TrySelectItemByName(string name)
         {
             int id = -1;
-            var hotspot = _room.Hotspots.FirstOrDefault((h) => h.Name == name);
+            var hotspot = _room.Hotspots.FirstOrDefault((h) => h.ScriptName == name);
             if (hotspot == null)
             {
                 if (name.StartsWith("Hotspot") && int.TryParse(name.Substring(6), out id)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -168,7 +168,7 @@ namespace AGS.Editor
                 }
                 RoomObject newObj = new RoomObject(_room);
                 newObj.ID = _room.Objects.Count;
-                newObj.Name = Factory.AGSEditor.GetFirstAvailableScriptName("oObject", 0, _room);
+                newObj.ScriptName = Factory.AGSEditor.GetFirstAvailableScriptName("oObject", 0, _room);
                 newObj.StartX = MenuClickPos.X;
                 newObj.StartY = MenuClickPos.Y;
                 _room.Objects.Add(newObj);
@@ -252,7 +252,7 @@ namespace AGS.Editor
         /// </summary>
         protected override string GetItemScriptName(RoomObject obj)
         {
-            return obj.Name;
+            return obj.ScriptName;
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace AGS.Editor
         /// </summary>
         protected override string GetNavbarItemTitle(RoomObject obj)
         {
-            return MakeLayerItemName("Object", obj.Name, obj.Description, obj.ID);
+            return MakeLayerItemName("Object", obj.ScriptName, obj.DisplayName, obj.ID);
         }
 
         public override bool AllowClicksInterception()
@@ -337,7 +337,7 @@ namespace AGS.Editor
         /// </summary>
         public override bool TrySelectItemByName(string name)
         {
-            var obj = _room.Objects.FirstOrDefault((o) => o.Name == name);
+            var obj = _room.Objects.FirstOrDefault((o) => o.ScriptName == name);
             if (obj == null)
             {
                 int id;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1330,8 +1330,14 @@ builtin managed struct InventoryItem {
   import attribute int  Graphic;
   /// Gets the ID number of the inventory item.
   readonly import attribute int ID;
+#ifdef SCRIPT_COMPAT_v400
   /// Gets/sets the human-readable name of the inventory item.
   import attribute String Name;
+#endif // SCRIPT_COMPAT_v400_30
+#ifdef SCRIPT_API_v400_30
+  /// Gets/sets the human-readable name of the inventory item.
+  import attribute String DisplayName;
+#endif // SCRIPT_API_v400_30
   /// Sets an integer custom property for this item.
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this item.
@@ -2175,8 +2181,14 @@ builtin managed struct Hotspot {
   import attribute bool Enabled;
   /// Gets the ID of the hotspot.
   readonly import attribute int ID;
+#ifdef SCRIPT_COMPAT_v400
   /// Gets/sets the human-readable name of the hotspot.
   import attribute String Name;
+#endif // SCRIPT_COMPAT_v400_30
+#ifdef SCRIPT_API_v400_30
+  /// Gets/sets the human-readable name of the hotspot.
+  import attribute String DisplayName;
+#endif // SCRIPT_API_v400_30
   /// Gets the X co-ordinate of the walk-to point for this hotspot.
   readonly import attribute int WalkToX;
   /// Gets the Y co-ordinate of the walk-to point for this hotspot.
@@ -2759,8 +2771,14 @@ builtin managed struct Object {
   readonly import attribute int  Loop;
   /// Gets whether the object is currently moving.
   readonly import attribute bool Moving;
+#ifdef SCRIPT_COMPAT_v400
   /// Gets/sets the human-readable name of the object.
   import attribute String Name;
+#endif // SCRIPT_COMPAT_v400_30
+#ifdef SCRIPT_API_v400_30
+  /// Gets/sets the human-readable name of the object.
+  import attribute String DisplayName;
+#endif // SCRIPT_API_v400_30
   /// Gets/sets whether other objects and characters can move through this object.
   import attribute bool Solid;
   /// Gets/sets the object's transparency.
@@ -3023,8 +3041,14 @@ builtin managed struct Character {
   import attribute bool MovementLinkedToAnimation;
   /// Gets whether the character is currently moving.
   readonly import attribute bool Moving;
+#ifdef SCRIPT_COMPAT_v400
   /// Gets/sets the human-readable character's name.
   import attribute String Name;
+#endif // SCRIPT_COMPAT_v400_30
+#ifdef SCRIPT_API_v400_30
+  /// Gets/sets the human-readable character's name.
+  import attribute String DisplayName;
+#endif // SCRIPT_API_v400_30
   /// Gets the character's normal walking view.
   readonly import attribute int NormalView;
   /// Gets the room number that the character was in before this one.
@@ -3219,8 +3243,12 @@ builtin struct Game {
   import static int    GetColorFromRGB(int red, int green, int blue);
   /// Gets the number of frames in the specified view loop.
   import static int    GetFrameCountForLoop(int view, int loop);
+#ifdef SCRIPT_COMPAT_v400
   /// Gets the name of whatever is on the screen at (x,y)
   import static String GetLocationName(int x, int y);
+#endif // SCRIPT_COMPAT_v400_30
+  /// Gets the human-readable name of whatever is on the screen at (x,y)
+  import static String GetDisplayNameAt(int x, int y);
   /// Gets the number of loops in the specified view.
   import static int    GetLoopCountForView(int view);
   /// Gets whether the "Run next loop after this" setting is checked for the specified loop.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1313,9 +1313,15 @@ builtin managed struct InventoryItem {
   /// Returns the inventory item at the specified location.
   import static InventoryItem* GetAtScreenXY(int x, int y, HitTestOptions guiHitOptions = eHit_Interactable, HitTestOptions invHitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the inventory item by its script name
   import static InventoryItem* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the inventory item by its script name
+  import static InventoryItem* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Gets an integer custom property for this item.
   import int  GetProperty(const string property);
   /// Gets a text custom property for this item.
@@ -1711,9 +1717,15 @@ builtin managed struct GUIControl {
   /// Gets the GUI Control that is visible at the specified location on the screen, or null.
   import static GUIControl* GetAtScreenXY(int x, int y, HitTestOptions guiHitOptions = eHit_Interactable, HitTestOptions controlHitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$  $AUTOCOMPLETENOINHERIT$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the GUI Control by its script name
   import static GUIControl* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the GUI Control by its script name
+  import static GUIControl* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Sends this control to the back of the z-order, behind all other controls.
   import void SendToBack();
   /// Moves the control to the specified position within the GUI.
@@ -2040,9 +2052,15 @@ builtin managed struct GUI {
   /// Gets the topmost GUI visible on the screen at the specified co-ordinates.
   import static GUI* GetAtScreenXY(int x, int y, HitTestOptions hitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the GUI by its script name
   import static GUI* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the GUI by its script name
+  import static GUI* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
 #ifdef SCRIPT_API_v363
   /// Returns the first found active TextBox control; which is the one that receives key and text input right now.
   import static TextBox* GetActiveTextInputControl(); // $AUTOCOMPLETESTATICONLY$
@@ -2168,9 +2186,15 @@ builtin managed struct Hotspot {
   /// Gets the hotspot that is at the specified position on the screen.
   import static Hotspot* GetAtScreenXY(int x, int y, HitTestOptions hitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the hotspot by its script name
   import static Hotspot* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the hotspot by its script name
+  import static Hotspot* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Gets an integer Custom Property for this hotspot.
   import int  GetProperty(const string property);
   /// Gets a text Custom Property for this hotspot.
@@ -2310,9 +2334,15 @@ builtin managed struct Walkbehind {
 
 builtin managed struct Dialog {
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the dialog by its script name
   import static Dialog* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the dialog by its script name
+  import static Dialog* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Displays the options for this dialog and returns which one the player selected.
   import int DisplayOptions(DialogOptionSayStyle = eSayUseOptionSetting);
   /// Gets the enabled state for the specified option in this dialog.
@@ -2569,9 +2599,15 @@ builtin managed struct AudioChannel {
 
 builtin managed struct AudioClip {
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the audio clip by its script name
   import static AudioClip* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the audio clip by its script name
+  import static AudioClip* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Plays this audio clip.
   import AudioChannel* Play(AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);
   /// Plays this audio clip, starting from the specified offset.
@@ -2724,9 +2760,15 @@ builtin managed struct Object {
   /// Gets the object that is on the screen at the specified co-ordinates.
   import static Object* GetAtScreenXY(int x, int y, HitTestOptions hitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the object by its script name
   import static Object* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the object by its script name
+  import static Object* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Gets an integer Custom Property for this object.
   import int GetProperty(const string property);
   /// Gets a text Custom Property for this object.
@@ -2935,9 +2977,15 @@ builtin managed struct Character {
   /// Returns the character that is at the specified position on the screen.
   import static Character* GetAtScreenXY(int x, int y, HitTestOptions hitOptions = eHit_Interactable); // $AUTOCOMPLETESTATICONLY$
 #ifdef SCRIPT_API_v361
+  #ifdef SCRIPT_COMPAT_v400
   /// Gets the character by its script name
   import static Character* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+  #endif // SCRIPT_COMPAT_v400
 #endif // SCRIPT_API_v361
+#ifdef SCRIPT_API_v400_30
+  /// Gets the character by its script name
+  import static Character* GetByScriptName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif // SCRIPT_API_v400_30
   /// Gets a numeric custom property for this character.
   import int GetProperty(const string property);
   /// Gets a text custom property for this character.

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -706,17 +706,17 @@ namespace AGS.Editor
         {
             foreach (RoomObject obj in room.Objects)
             {
-                if (obj.Name.Length > 0)
+                if (obj.ScriptName.Length > 0)
                 {
-                    sb.AppendLine("import readonly Object *" + obj.Name + ";");
+                    sb.AppendLine("import readonly Object *" + obj.ScriptName + ";");
                 }
             }
 
             foreach (RoomHotspot hotspot in room.Hotspots)
             {
-                if (hotspot.Name.Length > 0)
+                if (hotspot.ScriptName.Length > 0)
                 {
-                    sb.AppendLine("import readonly Hotspot *" + hotspot.Name + ";");
+                    sb.AppendLine("import readonly Hotspot *" + hotspot.ScriptName + ";");
                 }
             }
         }
@@ -730,9 +730,9 @@ namespace AGS.Editor
 
                 foreach (InventoryItem item in items)
                 {
-                    if (item.Name.Length > 0)
+                    if (item.ScriptName.Length > 0)
                     {
-                        sb.AppendLine("import readonly InventoryItem *" + item.Name + ";");
+                        sb.AppendLine("import readonly InventoryItem *" + item.ScriptName + ";");
                     }
                 }
             }
@@ -751,9 +751,9 @@ namespace AGS.Editor
 
                 foreach (Dialog item in dialogs)
                 {
-                    if (item.Name.Length > 0)
+                    if (item.ScriptName.Length > 0)
                     {
-                        sb.AppendLine("import readonly Dialog *" + item.Name + ";");
+                        sb.AppendLine("import readonly Dialog *" + item.ScriptName + ";");
                     }
                 }
             }
@@ -768,9 +768,9 @@ namespace AGS.Editor
         {
             foreach (AGS.Types.View view in viewFolder.Views)
             {
-                if (view.Name.Length > 0)
+                if (view.ScriptName.Length > 0)
                 {
-                    sb.AppendLine("#define " + view.Name.ToUpperInvariant() + " " + view.ID);
+                    sb.AppendLine("#define " + view.ScriptName.ToUpperInvariant() + " " + view.ID);
                 }
             }
 
@@ -803,9 +803,9 @@ namespace AGS.Editor
 
                     foreach (GUIControl control in gui.Controls)
                     {
-                        if (control.Name.Length > 0)
+                        if (control.ScriptName.Length > 0)
                         {
-                            sb.AppendLine("import readonly " + control.ScriptClassType + " *" + control.Name + ";");
+                            sb.AppendLine("import readonly " + control.ScriptClassType + " *" + control.ScriptName + ";");
                         }
                     }
                 }

--- a/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
+++ b/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
@@ -59,7 +59,7 @@ namespace AGS.Editor
                     }
                 }
 
-                dialog.Script = processor.ProcessText(GameTextLine.MakeScript(dialog.Script, dialog.FileName, dialog.Name), GameTextType.DialogScript);
+                dialog.Script = processor.ProcessText(GameTextLine.MakeScript(dialog.Script, dialog.FileName, dialog.ScriptName), GameTextType.DialogScript);
             }
 
             foreach (ScriptAndHeader script in game.RootScriptFolder.AllItemsFlat)

--- a/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
+++ b/Editor/AGS.Editor/TextProcessing/TextProcessingHelper.cs
@@ -19,15 +19,15 @@ namespace AGS.Editor
 
             foreach (Dialog dialog in game.RootDialogFolder.AllItemsFlat)
             {
-                string sourceRef = string.IsNullOrEmpty(dialog.Name) ? $"Dialog {dialog.ID}" : $"Dialog {dialog.ID}; {dialog.Name}";
+                string sourceRef = string.IsNullOrEmpty(dialog.ScriptName) ? $"Dialog {dialog.ID}" : $"Dialog {dialog.ID}; {dialog.ScriptName}";
                 foreach (DialogOption option in dialog.Options)
                 {
                     option.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(game.PlayerCharacter.ID, option.Text, sourceRef), GameTextType.DialogOption);
-                    option.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(game.PlayerCharacter.ID, option.Text, dialog.Name), GameTextType.DialogOption);
+                    option.Text = processor.ProcessText(GameTextLine.MakeSpeechLine(game.PlayerCharacter.ID, option.Text, dialog.ScriptName), GameTextType.DialogOption);
                 }
 
                 dialog.Script = processor.ProcessText(dialog.Script, sourceRef, GameTextType.DialogScript);
-                dialog.Script = processor.ProcessText(GameTextLine.MakeScript(dialog.Script, dialog.FileName, dialog.Name), GameTextType.DialogScript);
+                dialog.Script = processor.ProcessText(GameTextLine.MakeScript(dialog.Script, dialog.FileName, dialog.ScriptName), GameTextType.DialogScript);
             }
 
             foreach (ScriptAndHeader script in game.RootScriptFolder.AllItemsFlat)
@@ -64,13 +64,13 @@ namespace AGS.Editor
 
             foreach (Character character in game.RootCharacterFolder.AllItemsFlat)
             {
-                character.RealName = processor.ProcessText(character.RealName, "Characters", GameTextType.ItemDescription);
+                character.DisplayName = processor.ProcessText(character.DisplayName, "Characters", GameTextType.ItemDescription);
                 ProcessProperties(processor, game.PropertySchema, character.Properties, "Characters", errors);
             }
 
             foreach (InventoryItem item in game.RootInventoryItemFolder.AllItemsFlat)
             {
-                item.Description = processor.ProcessText(item.Description, "Inventory items", GameTextType.ItemDescription);
+                item.DisplayName = processor.ProcessText(item.DisplayName, "Inventory items", GameTextType.ItemDescription);
                 ProcessProperties(processor, game.PropertySchema, item.Properties, "Inventory items", errors);
             }
 

--- a/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
+++ b/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
@@ -245,7 +245,7 @@ namespace AGS.Editor
 
             foreach (Dialog otherDialog in _game.RootDialogFolder.AllItemsFlat)
             {
-                if (string.Compare(otherDialog.Name, newDialogName, true) == 0)
+                if (string.Compare(otherDialog.ScriptName, newDialogName, true) == 0)
                 {
                     return string.Format("return {0};", otherDialog.ID) + "}";
                 }

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -219,7 +219,7 @@ namespace AGS.Editor.Utils
             {
                 if (item.Image == spriteNumber)
                 {
-                    usageReport.AppendLine("Inventory item " + item.ID + " (" + item.Name + ")");
+                    usageReport.AppendLine("Inventory item " + item.ID + " (" + item.ScriptName + ")");
                 }
             }
 
@@ -250,7 +250,7 @@ namespace AGS.Editor.Utils
                             (button.MouseoverImage == spriteNumber) ||
                             (button.PushedImage == spriteNumber))
                         {
-                            usageReport.AppendLine("GUI button " + control.Name + " on GUI " + gui.Name);
+                            usageReport.AppendLine("GUI button " + control.ScriptName + " on GUI " + gui.Name);
                         }
                     }
                     GUISlider slider = control as GUISlider;
@@ -259,13 +259,13 @@ namespace AGS.Editor.Utils
                         if ((slider.HandleImage == spriteNumber) ||
                             (slider.BackgroundImage == spriteNumber))
                         {
-                            usageReport.AppendLine("GUI slider " + control.Name + " on GUI " + gui.Name);
+                            usageReport.AppendLine("GUI slider " + control.ScriptName + " on GUI " + gui.Name);
                         }
                     }
                     GUITextWindowEdge edge = control as GUITextWindowEdge;
                     if ((edge != null) && (edge.Image == spriteNumber))
                     {
-                        usageReport.AppendLine("Text window edge " + control.Name + " on GUI " + gui.Name);
+                        usageReport.AppendLine("Text window edge " + control.ScriptName + " on GUI " + gui.Name);
                     }
                 }
             }

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -13,13 +13,13 @@ namespace AGS.Types
     public class Character : ICustomTypeDescriptor, IToXml, IComparable<Character>, ICloneable
     {
         public const string PROPERTY_NAME_SCRIPTNAME = "ScriptName";
-        public const string PROPERTY_NAME_DESCRIPTION = "RealName";
+        public const string PROPERTY_NAME_DESCRIPTION = "Description";
         public const string PROPERTY_NAME_STARTINGROOM = "StartingRoom";
         public const int NARRATOR_CHARACTER_ID = 999;
 
         private int _id;
         private string _scriptName = string.Empty;
-        private string _fullName = string.Empty;
+        private string _displayName = string.Empty;
         private int _view = 1;
         private int _speechView;
         private int _idleView;
@@ -86,10 +86,18 @@ namespace AGS.Types
         [Description("The full name of the character")]
         [Category("Design")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string DisplayName
+        {
+            get { return _displayName; }
+            set { _displayName = value; }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string RealName
         {
-            get { return _fullName; }
-            set { _fullName = value; }
+            get { return DisplayName; }
+            set { DisplayName = value; }
         }
 
         [Description("The normal walking view for the character")]
@@ -514,7 +522,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle("Character", _scriptName, _fullName, _id); }
+            get { return TypesHelper.MakePropertyGridTitle("Character", _scriptName, _displayName, _id); }
         }
 
         #region Serialization

--- a/Editor/AGS.Types/Dialog.cs
+++ b/Editor/AGS.Types/Dialog.cs
@@ -12,7 +12,7 @@ namespace AGS.Types
     public class Dialog : IScript, IToXml, IComparable<Dialog>, ICloneable
     {
         private int _id;
-        private string _name;
+        private string _scriptName;
         private bool _showTextParser;
         private string _script;
         [NonSerialized]
@@ -44,10 +44,18 @@ namespace AGS.Types
         [Description("The script name of the dialog")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Name
         {
-            get { return _name; }
-            set { _name = Utilities.ValidateScriptName(value); }
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Browsable(false)]
@@ -105,7 +113,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string WindowTitle
         {
-            get { return string.IsNullOrEmpty(this.Name) ? ("Dialog " + this.ID) : ("Dialog: " + this.Name); }
+            get { return string.IsNullOrEmpty(this.ScriptName) ? ("Dialog " + this.ID) : ("Dialog: " + this.ScriptName); }
         }
 
         [AGSSerializeClass()]
@@ -125,14 +133,15 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle("Dialog", _name, _id); }
+            get { return TypesHelper.MakePropertyGridTitle("Dialog", _scriptName, _id); }
         }
 
         public Dialog(XmlNode node)
         {
             _scriptChangedSinceLastCompile = true;
             _id = Convert.ToInt32(SerializeUtils.GetElementString(node, "ID"));
-            _name = SerializeUtils.GetElementString(node, "Name");
+            _scriptName = SerializeUtils.GetElementStringOrDefault(node, "Name", _scriptName); // old-style script name
+            _scriptName = SerializeUtils.GetElementStringOrDefault(node, "ScriptName", _scriptName);
             _showTextParser = Boolean.Parse(SerializeUtils.GetElementString(node, "ShowTextParser"));
             XmlNode scriptNode = node.SelectSingleNode("Script");
             // Luckily the CDATA section is easy to read back
@@ -148,7 +157,7 @@ namespace AGS.Types
         {
             writer.WriteStartElement("Dialog");
             writer.WriteElementString("ID", ID.ToString());
-            writer.WriteElementString("Name", _name);
+            writer.WriteElementString("ScriptName", _scriptName);
             writer.WriteElementString("ShowTextParser", _showTextParser.ToString());
             writer.WriteStartElement("Script");
             writer.WriteCData(_script);

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -57,6 +57,8 @@ namespace AGS.Types
         v400_18 = 4000018,
         [Description("4.0.0 Alpha 28")]
         v400_24 = 4000024,
+        [Description("4.0.0 Alpha 34")]
+        v400_30 = 4000030,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -12,9 +12,9 @@ namespace AGS.Types
     [DefaultProperty("BackgroundImage")]
     public abstract class GUI : IToXml, IComparable<GUI>, ICloneable
     {
-        protected string _name;
+        protected string _scriptName = string.Empty;
         protected int _id;
-        protected int _bgcol;
+        protected int _bgcol = 8;
         protected int _bgimage;
         protected List<GUIControl> _controls = new List<GUIControl>();
         private CustomProperties _properties = new CustomProperties(CustomPropertyAppliesTo.GUIs);
@@ -22,8 +22,6 @@ namespace AGS.Types
 
         public GUI()
         {
-            _name = string.Empty;
-            _bgcol = 8;
         }
 
         /// <summary>
@@ -89,13 +87,19 @@ namespace AGS.Types
         [Description("The script name of the GUI")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
-        public string Name
+        public string ScriptName
         {
-            get { return _name; }
+            get { return _scriptName; }
             set
             {
-                _name = Utilities.ValidateScriptName(value);
+                _scriptName = Utilities.ValidateScriptName(value);
             }
+        }
+
+        public string Name
+        {
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Description("Script module which contains this GUI's event functions")]
@@ -118,7 +122,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle(GetType().Name, _name, _id); }
+            get { return TypesHelper.MakePropertyGridTitle(GetType().Name, _scriptName, _id); }
         }
 
         [Browsable(false)]

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -12,7 +12,7 @@ namespace AGS.Types
     {
         protected GUIControl(int x, int y, int width, int height)
         {
-            _name = string.Empty;
+            _scriptName = string.Empty;
             _width = width;
             _height = height;
             _x = x;
@@ -28,7 +28,7 @@ namespace AGS.Types
 
         protected GUIControl() { }
 
-        protected string _name;
+        protected string _scriptName;
         protected int _id;
         protected int _zorder;
         private int _width;
@@ -146,13 +146,21 @@ namespace AGS.Types
         [Description("The script name of the control")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
-        public string Name
+        public string ScriptName
         {
-            get { return _name; }
+            get { return _scriptName; }
             set
             {
-                _name = Utilities.ValidateScriptName(value);
+                _scriptName = Utilities.ValidateScriptName(value);
             }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
+        public string Name
+        {
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Description("Determines whether the Control can be clicked on, or whether mouse clicks pass straight through it")]
@@ -296,7 +304,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle(ControlType, _name, _id); }
+            get { return TypesHelper.MakePropertyGridTitle(ControlType, _scriptName, _id); }
         }
 
         /// <summary>

--- a/Editor/AGS.Types/GUITextWindowEdge.cs
+++ b/Editor/AGS.Types/GUITextWindowEdge.cs
@@ -26,7 +26,7 @@ namespace AGS.Types
             _image = 1;
             _id = id;
             _zorder = id;
-            _name = string.Empty;
+            _scriptName = string.Empty;
         }
 
         public GUITextWindowEdge(XmlNode node)

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -496,7 +496,7 @@ namespace AGS.Types
 			}
 			View newView = new View();
 			newView.ID = FindAndAllocateAvailableViewID();
-			newView.Name = "View" + newView.ID;
+			newView.ScriptName = "View" + newView.ID;
 			createInFolder.Views.Add(newView);
 			NotifyClientsViewsUpdated();
 			return newView;
@@ -920,14 +920,14 @@ namespace AGS.Types
             {
                 if (gui != ignoreObject)
                 {
-                    if (gui.Name == tryName)
+                    if (gui.ScriptName == tryName)
                     {
                         return true;
                     }
 
-                    if (gui.Name.StartsWith("g") &&
-                        (gui.Name.Length > 1) &&
-                        (gui.Name.Substring(1).ToUpperInvariant() == tryName))
+                    if (gui.ScriptName.StartsWith("g") &&
+                        (gui.ScriptName.Length > 1) &&
+                        (gui.ScriptName.Substring(1).ToUpperInvariant() == tryName))
                     {
                         return true;
                     }
@@ -935,7 +935,7 @@ namespace AGS.Types
 
                 foreach (GUIControl control in gui.Controls)
                 {
-                    if ((control.Name == tryName) && (control != ignoreObject))
+                    if ((control.ScriptName == tryName) && (control != ignoreObject))
                     {
                         return true;
                     }
@@ -944,7 +944,7 @@ namespace AGS.Types
 
             foreach (InventoryItem item in this.RootInventoryItemFolder.AllItemsFlat)
             {
-                if ((item.Name == tryName) && (item != ignoreObject))
+                if ((item.ScriptName == tryName) && (item != ignoreObject))
                 {
                     return true;
                 }
@@ -970,7 +970,7 @@ namespace AGS.Types
 
             foreach (Dialog dialog in this.RootDialogFolder.AllItemsFlat)
             {
-                if ((dialog.Name == tryName) && (dialog != ignoreObject))
+                if ((dialog.ScriptName == tryName) && (dialog != ignoreObject))
                 {
                     return true;
                 }
@@ -1020,7 +1020,7 @@ namespace AGS.Types
         {
             foreach (View view in folderToCheck.Views)
             {
-                if ((view.Name.ToUpperInvariant() == name) && (view != ignoreObject))
+                if ((view.ScriptName.ToUpperInvariant() == name) && (view != ignoreObject))
                 {
                     return true;
                 }

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -9,8 +9,8 @@ namespace AGS.Types
     [DefaultProperty("Image")]
     public class InventoryItem : IToXml, IComparable<InventoryItem>, ICloneable
     {
-        private string _name;
-        private string _description;
+        private string _scriptName;
+        private string _displayName;
         private int _image;
         private int _cursorImage;
         private bool _startWithItem;
@@ -28,8 +28,8 @@ namespace AGS.Types
         public InventoryItem()
         {
             _startWithItem = false;
-            _name = string.Empty;
-            _description = string.Empty;
+            _scriptName = string.Empty;
+            _displayName = string.Empty;
             _image = 0;
             _cursorImage = 0;
             _hotspotX = 0;
@@ -102,31 +102,47 @@ namespace AGS.Types
         [Description("Description of the item")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string DisplayName
+        {
+            get { return _displayName; }
+            set { _displayName = value; }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Description
         {
-            get { return _description; }
-            set { _description = value; }
+            get { return DisplayName; }
+            set { DisplayName = value; }
         }
 
         [Description("The script name of the item")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Name
         {
-            get { return _name; }
-            set { _name = Utilities.ValidateScriptName(value); }
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Browsable(false)]
         public string WindowTitle
         {
-            get { return "Inventory: " + this.Name; }
+            get { return "Inventory: " + this.ScriptName; }
         }
 
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle("Inventory item", _name, _description, _id); }
+            get { return TypesHelper.MakePropertyGridTitle("Inventory item", _scriptName, _displayName, _id); }
         }
 
         [AGSSerializeClass()]

--- a/Editor/AGS.Types/InventoryItemFolder.cs
+++ b/Editor/AGS.Types/InventoryItemFolder.cs
@@ -69,7 +69,7 @@ namespace AGS.Types
 
         private bool IsItemByName(InventoryItem inventoryItem, string inventoryItemName)
         {
-            return inventoryItem.Name == inventoryItemName;
+            return inventoryItem.ScriptName == inventoryItemName;
         }
     }
 }

--- a/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/MultilineStringUIEditor.cs
@@ -26,7 +26,7 @@ namespace AGS.Types
             GUIControl ctrl = context.Instance as GUIControl;
             if (ctrl != null)
             {
-                title = "Edit " + ctrl.Name + " text...";
+                title = "Edit " + ctrl.ScriptName + " text...";
             }
 
             GUIControl[] ctrls = context.Instance as GUIControl[];

--- a/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ScriptFunctionUIEditor.cs
@@ -37,14 +37,14 @@ namespace AGS.Types
             }
             else if (context.Instance is GUIControl)
             {
-                itemName = ((GUIControl)context.Instance).Name;
+                itemName = ((GUIControl)context.Instance).ScriptName;
                 GUI gui = ((GUIControl)context.Instance).Parent;
                 if (gui != null)
                     scriptModule = gui.ScriptModule;
             }
             else if (context.Instance is InventoryItem)
             {
-                itemName = ((InventoryItem)context.Instance).Name;
+                itemName = ((InventoryItem)context.Instance).ScriptName;
                 scriptModule = ((InventoryItem)context.Instance).ScriptModule;
             }
             else if (context.Instance is Character)
@@ -59,12 +59,12 @@ namespace AGS.Types
             }
             else if (context.Instance is RoomHotspot)
             {
-                itemName = ((RoomHotspot)context.Instance).Name;
+                itemName = ((RoomHotspot)context.Instance).ScriptName;
                 scriptModule = ((RoomHotspot)context.Instance).Room.ScriptFileName;
             }
             else if (context.Instance is RoomObject)
             {
-                itemName = ((RoomObject)context.Instance).Name;
+                itemName = ((RoomObject)context.Instance).ScriptName;
                 scriptModule = ((RoomObject)context.Instance).Room.ScriptFileName;
             }
             else if (context.Instance is RoomRegion)

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -564,14 +564,14 @@ namespace AGS.Types
 
             foreach (RoomHotspot hotspot in Hotspots)
             {
-                if ((hotspot.Name == tryName) && (hotspot != ignoreObject))
+                if ((hotspot.ScriptName == tryName) && (hotspot != ignoreObject))
                 {
                     return true;
                 }
             }
             foreach (RoomObject obj in Objects)
             {
-                if ((obj.Name == tryName) && (obj != ignoreObject))
+                if ((obj.ScriptName == tryName) && (obj != ignoreObject))
                 {
                     return true;
                 }

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -11,12 +11,12 @@ namespace AGS.Types
     [DefaultProperty("Description")]
     public class RoomHotspot : IChangeNotification, IToXml
 	{
-		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
+		public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
         public const string PROPERTY_NAME_DESCRIPTION = "Description";
 
         private int _id;
-        private string _name = string.Empty;
-        private string _description = string.Empty;
+        private string _scriptName = string.Empty;
+        private string _displayName = string.Empty;
         private Point _walkToPoint;
         private CustomProperties _properties = new CustomProperties(CustomPropertyAppliesTo.Hotspots);
         // Game Events
@@ -53,20 +53,36 @@ namespace AGS.Types
         [Description("Description of the hotspot")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
-        public string Description
+        public string DisplayName
         {
-            get { return _description; }
-            set { _description = value; }
+            get { return _displayName; }
+            set { _displayName = value; }
         }
 
-		[DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
+        [Obsolete]
+        [Browsable(false)]
+        public string Description
+        {
+            get { return DisplayName; }
+            set { DisplayName = value; }
+        }
+
+        [DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
 		[Description("The script name of the hotspot")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Name
         {
-            get { return _name; }
-            set { _name = Utilities.ValidateScriptName(value); }
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Description("The player will walk to this spot when the hotspot is activated")]
@@ -80,7 +96,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle("Hotspot", _name, _description, _id); }
+            get { return TypesHelper.MakePropertyGridTitle("Hotspot", _scriptName, _displayName, _id); }
         }
 
         [AGSSerializeClass()]

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -11,7 +11,7 @@ namespace AGS.Types
     [DefaultProperty("Image")]
 	public class RoomObject : IComparable<RoomObject>, IChangeNotification, ICustomTypeDescriptor, IToXml
     {
-		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
+		public const string PROPERTY_NAME_SCRIPT_NAME = "ScriptName";
         public const string PROPERTY_NAME_DESCRIPTION = "Description";
 
         private int _id;
@@ -27,8 +27,8 @@ namespace AGS.Types
         private int _baseline = 0;
         private bool _solid = false;
         private Rectangle _blockingRect = Rectangle.Empty;
-        private string _name = string.Empty;
-        private string _description = string.Empty;
+        private string _scriptName = string.Empty;
+        private string _displayName = string.Empty;
         private bool _useRoomAreaScaling;
         private bool _useRoomAreaLighting;
         private CustomProperties _properties = new CustomProperties(CustomPropertyAppliesTo.Objects);
@@ -213,20 +213,36 @@ namespace AGS.Types
         [Description("Description of the object")]
         [Category("Appearance")]
         [EditorAttribute(typeof(MultiLineStringUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
-        public string Description
+        public string DisplayName
         {
-            get { return _description; }
-            set { _description = value; }
+            get { return _displayName; }
+            set { _displayName = value; }
         }
 
-		[DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
+        [Obsolete]
+        [Browsable(false)]
+        public string Description
+        {
+            get { return DisplayName; }
+            set { DisplayName = value; }
+        }
+
+        [DisplayName(PROPERTY_NAME_SCRIPT_NAME)]
         [Description("The script name of the object")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Name
         {
-            get { return _name; }
-            set { _name = Utilities.ValidateScriptName(value); }
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Description("Whether the object should be affected by walkable area scaling")]
@@ -250,7 +266,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string PropertyGridTitle
         {
-            get { return TypesHelper.MakePropertyGridTitle("Object", _name, _description, _id); }
+            get { return TypesHelper.MakePropertyGridTitle("Object", _scriptName, _displayName, _id); }
         }
 
         [AGSSerializeClass()]

--- a/Editor/AGS.Types/View.cs
+++ b/Editor/AGS.Types/View.cs
@@ -13,7 +13,7 @@ namespace AGS.Types
         public delegate void ViewUpdatedHandler(View view);
         public event ViewUpdatedHandler ViewUpdated;
 
-        private string _name;
+        private string _scriptName;
         private int _id;
         private List<ViewLoop> _loops = new List<ViewLoop>();
 
@@ -34,10 +34,18 @@ namespace AGS.Types
         [Description("The script name of the view")]
         [Category("Design")]
         [BrowsableMultiedit(false)]
+        public string ScriptName
+        {
+            get { return _scriptName; }
+            set { _scriptName = Utilities.ValidateScriptName(value); }
+        }
+
+        [Obsolete]
+        [Browsable(false)]
         public string Name
         {
-            get { return _name; }
-            set { _name = Utilities.ValidateScriptName(value); }
+            get { return ScriptName; }
+            set { ScriptName = value; }
         }
 
         [Browsable(false)]
@@ -51,7 +59,7 @@ namespace AGS.Types
         [AGSNoSerialize()]
         public string WindowTitle
         {
-            get { return "View: " + Name; }
+            get { return "View: " + ScriptName; }
         }
 
         // TODO: remove this; should not be a part of the basic type,
@@ -60,7 +68,7 @@ namespace AGS.Types
         [AGSNoSerialize()]
         public string NameAndID
         {
-            get { return _id.ToString() + ": " + _name; }
+            get { return _id.ToString() + ": " + _scriptName; }
         }
 
         /// <summary>
@@ -86,8 +94,9 @@ namespace AGS.Types
 
         public View(XmlNode node)
         {
-            ID = Convert.ToInt32(SerializeUtils.GetElementString(node, "ID"));
-            Name = SerializeUtils.GetElementString(node, "Name");
+            _id = Convert.ToInt32(SerializeUtils.GetElementString(node, "ID"));
+            _scriptName = SerializeUtils.GetElementStringOrDefault(node, "Name", _scriptName);
+            _scriptName = SerializeUtils.GetElementStringOrDefault(node, "ScriptName", _scriptName);
             foreach (XmlNode loopNode in SerializeUtils.GetChildNodes(node, "Loops"))
             {
                 _loops.Add(new ViewLoop(loopNode));
@@ -98,7 +107,7 @@ namespace AGS.Types
         {
             writer.WriteStartElement("View");
             writer.WriteElementString("ID", ID.ToString());
-            writer.WriteElementString("Name", _name);
+            writer.WriteElementString("ScriptName", _scriptName);
 
             writer.WriteStartElement("Loops");
             foreach (ViewLoop loop in _loops)

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -270,7 +270,9 @@ RuntimeScriptValue Sc_AudioClip_SetTextProperty(void *self, const RuntimeScriptV
 void RegisterAudioClipAPI()
 {
     ScFnRegister audioclip_api[] = {
+        // [OBSOLETE] GetByName => GetByScriptName
         { "AudioClip::GetByName",         API_FN_PAIR(AudioClip_GetByName) },
+        { "AudioClip::GetByScriptName",   API_FN_PAIR(AudioClip_GetByName) },
         { "AudioClip::Play^2",            API_FN_PAIR(AudioClip_Play) },
         { "AudioClip::PlayFrom^3",        API_FN_PAIR(AudioClip_PlayFrom) },
         { "AudioClip::PlayQueued^2",      API_FN_PAIR(AudioClip_PlayQueued) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -4884,6 +4884,8 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::get_DestinationY",          API_FN_PAIR(Character_GetDestinationY) },
         { "Character::get_DiagonalLoops",         API_FN_PAIR(Character_GetDiagonalWalking) },
         { "Character::set_DiagonalLoops",         API_FN_PAIR(Character_SetDiagonalWalking) },
+        { "Character::get_DisplayName",           API_FN_PAIR(Character_GetName) },
+        { "Character::set_DisplayName",           API_FN_PAIR(Character_SetName) },
         { "Character::get_Enabled",               API_FN_PAIR(Character_GetEnabled) },
         { "Character::set_Enabled",               API_FN_PAIR(Character_SetEnabled) },
         { "Character::get_Following",             API_FN_PAIR(Character_GetFollowing) },
@@ -4908,6 +4910,7 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::get_MovementLinkedToAnimation",API_FN_PAIR(Character_GetMovementLinkedToAnimation) },
         { "Character::set_MovementLinkedToAnimation",API_FN_PAIR(Character_SetMovementLinkedToAnimation) },
         { "Character::get_Moving",                API_FN_PAIR(Character_GetMoving) },
+        // [OBSOLETE] Name => DisplayName
         { "Character::get_Name",                  API_FN_PAIR(Character_GetName) },
         { "Character::set_Name",                  API_FN_PAIR(Character_SetName) },
         { "Character::get_NormalView",            API_FN_PAIR(Character_GetNormalView) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -4788,7 +4788,9 @@ void RegisterCharacterAPI(ScriptAPIVersion /*base_api*/, ScriptAPIVersion /*comp
         { "Character::GetAtScreenXY^2",           API_FN_PAIR(Character_GetAtScreenXY2) },
         { "Character::GetAtRoomXY^3",             API_FN_PAIR(Character_GetAtRoomXY) },
         { "Character::GetAtScreenXY^3",           API_FN_PAIR(Character_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "Character::GetByName",                 API_FN_PAIR(Character_GetByName) },
+        { "Character::GetByScriptName",           API_FN_PAIR(Character_GetByName) },
 
         { "Character::AddInventory^2",            API_FN_PAIR(Character_AddInventory) },
         { "Character::AddWaypoint^2",             API_FN_PAIR(Character_AddWaypoint) },

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -2371,7 +2371,9 @@ void RegisterDialogAPI()
 {
     ScFnRegister dialog_api[] = {
         // Dialog
+        // [OBSOLETE] GetByName => GetByScriptName
         { "Dialog::GetByName",            API_FN_PAIR(Dialog_GetByName) },
+        { "Dialog::GetByScriptName",      API_FN_PAIR(Dialog_GetByName) },
         { "Dialog::Stop",                 API_FN_PAIR(Dialog_Stop) },
         { "Dialog::get_CurrentDialog",    API_FN_PAIR(Dialog_GetCurrentDialog) },
         { "Dialog::get_ExecutedOption",   API_FN_PAIR(Dialog_GetExecutedOption) },

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2582,7 +2582,9 @@ void RegisterGameAPI()
         { "Game::DoOnceOnly^1",                           API_FN_PAIR(Game_DoOnceOnly) },
         { "Game::GetColorFromRGB^3",                      API_FN_PAIR(Game_GetColorFromRGB) },
         { "Game::GetColorFromRGBA^4",                     API_FN_PAIR(Game_GetColorFromRGBA) },
+        { "Game::GetDisplayNameAt^2",                     API_FN_PAIR(Game_GetLocationName) },
         { "Game::GetFrameCountForLoop^2",                 API_FN_PAIR(Game_GetFrameCountForLoop) },
+        // [OBSOLETE] GetLocationName => GetDisplayNameAt
         { "Game::GetLocationName^2",                      API_FN_PAIR(Game_GetLocationName) },
         { "Game::GetLoopCountForView^1",                  API_FN_PAIR(Game_GetLoopCountForView) },
         { "Game::GetRunNextSettingForLoop^2",             API_FN_PAIR(Game_GetRunNextSettingForLoop) },

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -1581,7 +1581,9 @@ void RegisterGUIAPI()
     ScFnRegister gui_api[] = {
         { "GUI::GetAtScreenXY^2",         API_FN_PAIR(GUI_GetAtScreenXY2) },
         { "GUI::GetAtScreenXY^3",         API_FN_PAIR(GUI_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "GUI::GetByName^1",             API_FN_PAIR(GUI_GetByName) },
+        { "GUI::GetByScriptName^1",       API_FN_PAIR(GUI_GetByName) },
         { "GUI::GetActiveTextInputControl^0", API_FN_PAIR(GUI_GetActiveTextInputControl) },
         { "GUI::ProcessClick^3",          API_FN_PAIR(GUI_ProcessClick) },
         { "GUI::ScreenToGUIPoint",        API_FN_PAIR(GUI_ScreenToGUIPoint) },

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -796,7 +796,9 @@ void RegisterGUIControlAPI()
     ScFnRegister guicontrol_api[] = {
         { "GUIControl::GetAtScreenXY^2",  API_FN_PAIR(GUIControl_GetAtScreenXY2) },
         { "GUIControl::GetAtScreenXY^4",  API_FN_PAIR(GUIControl_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "GUIControl::GetByName",        API_FN_PAIR(GUIControl_GetByName) },
+        { "GUIControl::GetByScriptName",  API_FN_PAIR(GUIControl_GetByName) },
 
         { "GUIControl::BringToFront^0",   API_FN_PAIR(GUIControl_BringToFront) },
         { "GUIControl::SendToBack^0",     API_FN_PAIR(GUIControl_SendToBack) },

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -375,9 +375,12 @@ void RegisterHotspotAPI()
         { "Hotspot::SetTextProperty^2",   API_FN_PAIR(Hotspot_SetTextProperty) },
         { "Hotspot::IsInteractionAvailable^1", API_FN_PAIR(Hotspot_IsInteractionAvailable) },
         { "Hotspot::RunInteraction^1",    API_FN_PAIR(Hotspot_RunInteraction) },
+        { "Hotspot::get_DisplayName",     API_FN_PAIR(Hotspot_GetName_New) },
+        { "Hotspot::set_DisplayName",     API_FN_PAIR(Hotspot_SetName) },
         { "Hotspot::get_Enabled",         API_FN_PAIR(Hotspot_GetEnabled) },
         { "Hotspot::set_Enabled",         API_FN_PAIR(Hotspot_SetEnabled) },
         { "Hotspot::get_ID",              API_FN_PAIR(Hotspot_GetID) },
+        // [OBSOLETE] Name => DisplayName
         { "Hotspot::get_Name",            API_FN_PAIR(Hotspot_GetName_New) },
         { "Hotspot::set_Name",            API_FN_PAIR(Hotspot_SetName) },
         { "Hotspot::get_ScriptName",      API_FN_PAIR(Hotspot_GetScriptName) },

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -365,7 +365,9 @@ void RegisterHotspotAPI()
         { "Hotspot::GetAtScreenXY^2",     API_FN_PAIR(Hotspot_GetAtScreenXY2) },
         { "Hotspot::GetAtRoomXY^3",       API_FN_PAIR(Hotspot_GetAtRoomXY) },
         { "Hotspot::GetAtScreenXY^3",     API_FN_PAIR(Hotspot_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "Hotspot::GetByName",           API_FN_PAIR(Hotspot_GetByName) },
+        { "Hotspot::GetByScriptName",     API_FN_PAIR(Hotspot_GetByName) },
         { "Hotspot::GetDrawingSurface",   API_FN_PAIR(Hotspot_GetDrawingSurface) },
 
         { "Hotspot::GetProperty^1",       API_FN_PAIR(Hotspot_GetProperty) },

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -433,9 +433,12 @@ void RegisterInventoryItemAPI()
         { "InventoryItem::set_CursorHotspotX",        API_FN_PAIR(InventoryItem_SetCursorHotspotX) },
         { "InventoryItem::get_CursorHotspotY",        API_FN_PAIR(InventoryItem_GetCursorHotspotY) },
         { "InventoryItem::set_CursorHotspotY",        API_FN_PAIR(InventoryItem_SetCursorHotspotY) },
+        { "InventoryItem::get_DisplayName",           API_FN_PAIR(InventoryItem_GetName_New) },
+        { "InventoryItem::set_DisplayName",           API_FN_PAIR(InventoryItem_SetName) },
         { "InventoryItem::get_Graphic",               API_FN_PAIR(InventoryItem_GetGraphic) },
         { "InventoryItem::set_Graphic",               API_FN_PAIR(InventoryItem_SetGraphic) },
         { "InventoryItem::get_ID",                    API_FN_PAIR(InventoryItem_GetID) },
+        // [OBSOLETE] Name => DisplayName
         { "InventoryItem::get_Name",                  API_FN_PAIR(InventoryItem_GetName_New) },
         { "InventoryItem::set_Name",                  API_FN_PAIR(InventoryItem_SetName) },
         { "InventoryItem::get_ScriptName",            API_FN_PAIR(InventoryItem_GetScriptName) },

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -417,7 +417,9 @@ void RegisterInventoryItemAPI()
     ScFnRegister invitem_api[] = {
         { "InventoryItem::GetAtScreenXY^2",           API_FN_PAIR(InventoryItem_GetAtScreenXY2) },
         { "InventoryItem::GetAtScreenXY^4",           API_FN_PAIR(InventoryItem_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "InventoryItem::GetByName",                 API_FN_PAIR(InventoryItem_GetByName) },
+        { "InventoryItem::GetByScriptName",           API_FN_PAIR(InventoryItem_GetByName) },
 
         { "InventoryItem::IsInteractionAvailable^1",  API_FN_PAIR(InventoryItem_CheckInteractionAvailable) },
         { "InventoryItem::GetProperty^1",             API_FN_PAIR(InventoryItem_GetProperty) },

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -2127,7 +2127,9 @@ void RegisterObjectAPI()
         { "Object::GetAtScreenXY^2",          API_FN_PAIR(Object_GetAtScreenXY2) },
         { "Object::GetAtRoomXY^3",            API_FN_PAIR(Object_GetAtRoomXY) },
         { "Object::GetAtScreenXY^3",          API_FN_PAIR(Object_GetAtScreenXY) },
+        // [OBSOLETE] GetByName => GetByScriptName
         { "Object::GetByName",                API_FN_PAIR(Object_GetByName) },
+        { "Object::GetByScriptName",          API_FN_PAIR(Object_GetByName) },
 
         { "Object::Animate^5",                API_FN_PAIR(Object_Animate5) },
         { "Object::Animate^6",                API_FN_PAIR(Object_Animate6) },

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -2175,6 +2175,8 @@ void RegisterObjectAPI()
         { "Object::set_Clickable",            API_FN_PAIR(Object_SetClickable) },
         { "Object::get_DestinationX",         API_FN_PAIR(Object_GetDestinationX) },
         { "Object::get_DestinationY",         API_FN_PAIR(Object_GetDestinationY) },
+        { "Object::get_DisplayName",          API_FN_PAIR(Object_GetName_New) },
+        { "Object::set_DisplayName",          API_FN_PAIR(Object_SetName) },
         { "Object::get_Enabled",              API_FN_PAIR(Object_GetEnabled) },
         { "Object::set_Enabled",              API_FN_PAIR(Object_SetEnabled) },
         { "Object::get_Frame",                API_FN_PAIR(Object_GetFrame) },
@@ -2185,6 +2187,7 @@ void RegisterObjectAPI()
         { "Object::get_ManualScaling",        API_FN_PAIR(Object_GetManualScaling) },
         { "Object::set_ManualScaling",        API_FN_PAIR(Object_SetManualScaling) },
         { "Object::get_Moving",               API_FN_PAIR(Object_GetMoving) },
+        // [OBSOLETE] Name => DisplayName
         { "Object::get_Name",                 API_FN_PAIR(Object_GetName_New) },
         { "Object::set_Name",                 API_FN_PAIR(Object_SetName) },
         { "Object::get_Scaling",              API_FN_PAIR(Object_GetScaling) },


### PR DESCRIPTION
**Problem**

There's a historical issue with naming of the two kinds of properties, one is for "script name" (unique string identifier), and another for a human-readable "name/description". It started somewhere around early 3.x versions, and is periodically causing confusion among beginner users. The closest issues which were opened in the past are #2823 and #2824 (both are closed atm).

In short, the problem is this:
Back in 2.x editor these fields were called more consistently: the "Name" was used for "human readable name", and it was Name in script properties too. Also, there was function [Game.GetLocationName](https://adventuregamestudio.github.io/ags-manual/Game.html#gamegetlocationname) that returns a description of the object under coordinates.
At the same time the scripting name field was labelled "Script O-Name" (probably short for "Script Object Name"), although it did not have an equivalent in scripting api at the time.

Then when 3.x editor came, Chris Jones decided to change the naming in the Editor, and suddenly "Script O-Name" became just "Name", while "Name" was called "Description" (and "Real Name" in Character type). However, the scripting API did not change.

As a result, there's this discrepancy, summarized by the following table:
v2 Editor | v3 Editor | Script API | meaning
-- | -- | -- | --
Name | Description | Name | human-readable text, description
Script O-Name | Name | ScriptName | unique identifier, variable name

As an additional mistake, around version 3.6 I introduced new functions called `Type.GetByName` which finds the object by its *script name*.

**Suggestion**

For AGS 4.0 I thought that it makes sense to not getting constrained by the existing words and find a good combination of terms to distinguish these two values.
After some thinking, and also [reading opinions of other users](https://www.adventuregamestudio.co.uk/forums/editor-development/asking-for-advice-about-namescriptnamedescription-term-discrepancy/), I decided to choose a variant supported by the couple of users:

* **ScriptName** - unique string identifier
* **DisplayName** - human-readable name/description.

So what's done in this PR:
1. The properties are renamed accordingly in the Editor and project file (old properties still exist but declared obsolete, in order to be able to read old games).
2. In script API all `Name` properties are renamed to `DisplayName` (there were 4 of them).
3. In script API the function `Game.GetLocationName` is renamed to `Game.GetDisplayNameAt`, per user's suggestion.
4. In script API the functions `Type.GetByName` are renamed to `Type.GetByScriptName`.