### PR TITLE
4.0: Anything - universal implicit parent for managed structs

### DIFF
--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -149,6 +149,7 @@ const char *GetScriptAPIName(ScriptAPIVersion v)
     case kScriptAPI_v400_16: return "4.0.0-alpha20";
     case kScriptAPI_v400_18: return "4.0.0-alpha22";
     case kScriptAPI_v400_24: return "4.0.0-alpha28";
+    case kScriptAPI_v400_30: return "4.0.0-alpha34";
     default: return "unknown";
     }
 }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -208,7 +208,8 @@ enum ScriptAPIVersion
     kScriptAPI_v400_16 = 4000016,
     kScriptAPI_v400_18 = 4000018,
     kScriptAPI_v400_24 = 4000024,
-    kScriptAPI_Current = kScriptAPI_v400_24
+    kScriptAPI_v400_30 = 4000030,
+    kScriptAPI_Current = kScriptAPI_v400_30
 };
 
 const char *GetScriptAPIName(ScriptAPIVersion v);

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -49,6 +49,7 @@ AGS::SymbolTableEntry::~SymbolTableEntry()
 
 AGS::SymbolTableEntry &AGS::SymbolTableEntry::operator=(const SymbolTableEntry &orig)
 {
+    this->Sym = orig.Sym;
     this->Name = orig.Name;
     this->Declared = orig.Declared;
     this->Scope = orig.Scope;
@@ -78,6 +79,7 @@ std::map<AGS::TypeQualifier, AGS::Symbol> const &AGS::TypeQualifierSet::TQToSymb
         { TQ::kBuiltin,         kKW_Builtin, },
         { TQ::kImport,          kKW_ImportStd, },
         { TQ::kManaged,         kKW_Managed,  },
+        { TQ::kManagedBase,     kKW_ManagedBase,  },
         { TQ::kProtected,       kKW_Protected,  },
         { TQ::kReadonly,        kKW_Readonly, },
         { TQ::kStatic,          kKW_Static, },
@@ -94,7 +96,9 @@ AGS::TypeQualifierSet AGS::TypeQualifierSet::WithoutTypedefQualifiers()
     ret[TQ::kAutoptr] =
         ret[TQ::kBuiltin] =
         ret[TQ::kInternalstring] =
-        ret[TQ::kManaged] = false;
+        ret[TQ::kManaged] =
+        ret[TQ::kManagedBase] =
+        false;
     return ret;
 }
 
@@ -137,13 +141,20 @@ void AGS::SymbolTableEntry::Clear()
     VartypeD = nullptr;
 }
 
+AGS::SymbolTableEntry::SymbolTableEntry(Symbol const sym, const std::string &name)
+    : Sym(sym)
+    , Name(name)
+{
+}
+
 AGS::SymbolTableEntry::SymbolTableEntry(SymbolTableEntry const &orig)
 {
     *this = orig;
 }
 
 AGS::SymbolTable::SymbolTable()
-    : _stringStructSym (kKW_NoSymbol)
+    : _managedBaseSym(kKW_NoSymbol)
+    , _stringStructSym(kKW_NoSymbol)
     , _stringStructPtrSym(kKW_NoSymbol)
 {
     _findCache.clear();
@@ -341,6 +352,7 @@ AGS::SymbolTable::SymbolTable()
     AddKeyword(kKW_ImportTry, "_tryimport");
     AddKeyword(kKW_Internalstring, "internalstring");
     AddKeyword(kKW_Managed, "managed");
+    AddKeyword(kKW_ManagedBase, "managedbase");
     AddKeyword(kKW_Noloopcheck, "noloopcheck");
     AddKeyword(kKW_Null, "null");
     MakeEntryLiteral(kKW_Null);
@@ -424,6 +436,11 @@ bool AGS::SymbolTable::IsVTF(Symbol s, VartypeFlag flag) const
         return false;
 
     return entries.at(s).VartypeD->Flags[flag];
+}
+
+void AGS::SymbolTable::SetManagedBaseSym(Symbol const s)
+{
+    _managedBaseSym = s;
 }
 
 void AGS::SymbolTable::SetStringStructSym(Symbol const s)
@@ -854,8 +871,7 @@ AGS::Symbol AGS::SymbolTable::Add(std::string const &name)
         entries.reserve((new_size1 < new_size2) ? new_size1 : new_size2);
     }
     int const idx_of_new_entry = entries.size();
-    entries.emplace_back();
-    entries.at(idx_of_new_entry).Name = name;
+    entries.emplace_back(idx_of_new_entry, name);
     _findCache[name] = idx_of_new_entry;
     return idx_of_new_entry;
 }
@@ -875,7 +891,8 @@ AGS::Symbol AGS::SymbolTable::FindOrMakeLiteral(std::string const &name, Vartype
 
 AGS::Symbol AGS::SymbolTable::AddNoSymbol(Predefined kw, std::string const &name)
 {
-    SymbolTableEntry &entry = entries[kw];
+    SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
 
     _findCache[name] = kw;
@@ -885,6 +902,7 @@ AGS::Symbol AGS::SymbolTable::AddNoSymbol(Predefined kw, std::string const &name
 AGS::Symbol AGS::SymbolTable::AddAssign(Predefined kw, std::string const &name, size_t prio, CodeCell int_opcode, CodeCell float_opcode, CodeCell dyn_opcode, CodeCell string_opcode)
 {
     SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
     entry.OperatorD = new SymbolTableEntry::OperatorDesc;
     entry.OperatorD->BinaryPrio = prio;
@@ -900,6 +918,7 @@ AGS::Symbol AGS::SymbolTable::AddAssign(Predefined kw, std::string const &name, 
 AGS::Symbol AGS::SymbolTable::AddDelimeter(Predefined kw, std::string const &name, bool is_opener, Symbol partner, bool can_be_expression)
 {
     SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
     entry.DelimeterD = new SymbolTableEntry::DelimeterDesc;
     entry.DelimeterD->Opening = is_opener;
@@ -913,6 +932,7 @@ AGS::Symbol AGS::SymbolTable::AddDelimeter(Predefined kw, std::string const &nam
 AGS::Symbol AGS::SymbolTable::AddKeyword(Predefined kw, std::string const &name)
 {
     SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
     
     _findCache[name] = kw;
@@ -922,6 +942,7 @@ AGS::Symbol AGS::SymbolTable::AddKeyword(Predefined kw, std::string const &name)
 AGS::Symbol AGS::SymbolTable::AddOperator(Predefined kw, std::string const &name, size_t binary_prio, size_t unary_prio, bool boolean, CodeCell int_opcode, CodeCell float_opcode, CodeCell dyn_opcode, CodeCell string_opcode)
 {
     SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
     entry.OperatorD = new SymbolTableEntry::OperatorDesc;
     entry.OperatorD->BinaryPrio = binary_prio;
@@ -947,6 +968,7 @@ void AGS::SymbolTable::OperatorCtFunctions(Predefined kw, CompileTimeFunc * int_
 AGS::Symbol AGS::SymbolTable::AddVartype(Predefined kw, std::string const &name, size_t size, bool is_integer_vartype)
 {
     SymbolTableEntry &entry = entries.at(kw);
+    entry.Sym = kw;
     entry.Name = name;
     entry.VartypeD = new SymbolTableEntry::VartypeDesc;
     entry.VartypeD->Size = size;

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -81,6 +81,7 @@ enum class TQ : size_t // Type qualifier
     kImport,
     kInternalstring,
     kManaged,
+    kManagedBase,
 
     kProtected,
     kReadonly,
@@ -220,8 +221,9 @@ enum Predefined : Symbol
     kKW_Switch,         // "switch"
     kKW_While,          // "while"
     kKW_Writeprotected,  // "writeprotected"
+    kKW_ManagedBase,    // "managedbase"
 };
-constexpr Predefined kKW_LastPredefined = kKW_Writeprotected;
+constexpr Predefined kKW_LastPredefined = kKW_ManagedBase;
 constexpr Predefined kKW_Dynpointer = kKW_Multiply;
 
 // For function parameters, used in functions of the symbol table
@@ -250,6 +252,7 @@ public:
 
 struct SymbolTableEntry : public SymbolTableConstant
 {
+    Symbol Sym = kKW_NoSymbol;
     std::string Name = "";
     size_t Declared = kNoSrcLocation;    // where this was declared, pertains to _src
     size_t Scope = 0u;
@@ -356,6 +359,7 @@ struct SymbolTableEntry : public SymbolTableConstant
     } *VartypeD = nullptr;
 
     SymbolTableEntry() = default;
+    SymbolTableEntry(Symbol const sym, const std::string &name);
     // Deep copy semantics for the pointers
     SymbolTableEntry(SymbolTableEntry const &orig);
     ~SymbolTableEntry();
@@ -376,6 +380,7 @@ private:
         size_t operator() (std::pair<Vartype, VartypeType> pair) const { return hash(pair.first ^ (1021 * static_cast<int>(pair.second))); };
     };
 
+    Symbol _managedBaseSym; // the symbol that corresponds to the implicit managed struct parent
     Symbol _stringStructSym; // the symbol that corresponds to "String" or whatever the stringstruct is
     AGS::Vartype _stringStructPtrSym;
     Symbol _lastAllocated; // the last symbol that has been allocated at initialization; don't confuse with LastPredefined
@@ -425,6 +430,9 @@ public:
 
     // Don't reset _findCache: It isn't rebuilt automatically; Find() and FindOrAdd() will no longer work.
     inline void ResetCaches() const { _vartypesCache.clear(); };
+
+    void SetManagedBaseSym(Symbol s);
+    inline Symbol GetManagedBaseSym() const { return _managedBaseSym; }
 
     void SetStringStructSym(Symbol s);
     inline Symbol GetStringStructSym() const { return _stringStructSym; }

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -38,6 +38,8 @@ void ccGetExtensions2(std::vector<std::string> &exts)
     exts.push_back("DYNARRAY_LENGTH");
     // Compile-time check of the string formatting
     exts.push_back("FORMATCHECK");
+    // Implicit parent type for all the managed types
+    exts.push_back("MANAGEDBASE");
 }
 
 // Convert VartypeFlags to RTTI::TypeFlags

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -5433,6 +5433,10 @@ void AGS::Parser::ParseStruct_SetTypeInSymboltable(Symbol stname, TypeQualifierS
     if (tqs[TQ::kAutoptr])
         flags[VTF::kAutoptr] = true;
 
+    // Default managed types to have 'managedbase' as a parent (if one is identified)
+    if (flags[VTF::kManaged] && (_sym.GetManagedBaseSym() != stname))
+        entry.VartypeD->Parent = _sym.GetManagedBaseSym();
+
     _sym.SetDeclared(stname, _src.GetCursor());
 }
 
@@ -5448,6 +5452,8 @@ void AGS::Parser::ParseStruct_ExtendsClause(Symbol stname)
         UserError(
 			ReferenceMsgSym("Expected a struct type, found '%s' instead", parent).c_str(), 
 			_sym.GetName(parent).c_str());
+    if (_sym.GetManagedBaseSym() == stname)
+        UserError("A type declared as 'managedbase' cannot have a parent type itself");
     if (!_sym.IsManagedVartype(parent) && _sym.IsManagedVartype(stname))
         UserError("Managed struct cannot extend the unmanaged struct '%s'", _sym.GetName(parent).c_str());
     if (_sym.IsManagedVartype(parent) && !_sym.IsManagedVartype(stname))
@@ -5487,6 +5493,7 @@ void AGS::Parser::Parse_CheckTQ(TypeQualifierSet tqs, bool in_func_body, bool in
             tqs[(error_tq = TQ::kImport)] ||
             tqs[(error_tq = TQ::kInternalstring)] ||
             tqs[(error_tq = TQ::kManaged)] ||
+            tqs[(error_tq = TQ::kManagedBase)] ||
             tqs[(error_tq = TQ::kStatic)])
         {
             UserError("Cannot use '%s' within a function body", _sym.GetName(tqs.TQ2Symbol(error_tq)).c_str());
@@ -5500,6 +5507,12 @@ void AGS::Parser::Parse_CheckTQ(TypeQualifierSet tqs, bool in_func_body, bool in
     {
         if (!tqs[TQ::kManaged])
             UserError("'autoptr' must be combined with 'managed'");
+    }
+
+    if (tqs[TQ::kManagedBase])
+    {
+        if (!tqs[TQ::kManaged])
+            UserError("'managedbase' must be combined with 'managed'");
     }
 
     // Note: 'builtin' does not always presuppose 'managed'
@@ -5536,6 +5549,10 @@ void AGS::Parser::ParseQualifiers(TypeQualifierSet &tqs)
         case kKW_ImportTry:      tqs[TQ::kImport] = true; itry_found = true;  break;
         case kKW_Internalstring: tqs[TQ::kInternalstring] = true; break;
         case kKW_Managed:        tqs[TQ::kManaged] = true; break;
+        case kKW_ManagedBase:
+            tqs[TQ::kManaged] = true; // auto treat 'managedbase' as 'managed'
+            tqs[TQ::kManagedBase] = true;
+            break;
         case kKW_Protected:      tqs[TQ::kProtected] = true; break;
         case kKW_Readonly:       tqs[TQ::kReadonly] = true; break;
         case kKW_Static:         tqs[TQ::kStatic] = true; break;
@@ -6047,6 +6064,26 @@ void AGS::Parser::ParseStruct(TypeQualifierSet tqs, Symbol &struct_of_current_fu
             UserError("The stringstruct type is already defined to be %s", _sym.GetName(_sym.GetStringStructSym()).c_str());
         _sym.SetStringStructSym(stname);
     }
+    // Declare the struct type that is a implicit managed struct base
+    if (tqs[TQ::kManagedBase])
+    {
+        if (_sym.GetManagedBaseSym() > 0 && stname != _sym.GetManagedBaseSym())
+        {
+            UserError("The 'managedbase' type is already defined to be %s", _sym.GetName(_sym.GetManagedBaseSym()).c_str());
+        }
+        else
+        {
+            // Find if there's any managed struct fully-declared prior (forward declarations are marked by VTF::kUndefined)
+            if (std::find_if(_sym.entries.begin(), _sym.entries.end(), [stname](SymbolTableEntry &e)
+                { return e.Sym != stname && e.VartypeD && !e.VartypeD->Flags[VTF::kUndefined] && e.VartypeD->Flags[VTF::kManaged]; })
+                != _sym.entries.end())
+            {
+                UserError("The 'managedbase' type must be declared prior to any other managed type, including built-in types");
+            }
+
+            _sym.SetManagedBaseSym(stname);
+        }
+    }
 
     if (kKW_Extends == _src.PeekNext())
 		ParseStruct_ExtendsClause(stname);
@@ -6145,6 +6182,7 @@ void AGS::Parser::ParseStruct(TypeQualifierSet tqs, Symbol &struct_of_current_fu
     vardecl_tqs[TQ::kAutoptr] = false;
     vardecl_tqs[TQ::kBuiltin] = false;
     vardecl_tqs[TQ::kManaged] = false;
+    vardecl_tqs[TQ::kManagedBase] = false;
     vardecl_tqs[TQ::kInternalstring] = false;
 
     Vartype vartype = stname;
@@ -6331,6 +6369,7 @@ void AGS::Parser::ParseAttribute(TypeQualifierSet tqs, Symbol const name_of_curr
         tqs[error_tq = TQ::kBuiltin] ||
         tqs[error_tq = TQ::kInternalstring] ||
         tqs[error_tq = TQ::kManaged] ||
+        tqs[error_tq = TQ::kManagedBase] ||
         tqs[error_tq = TQ::kProtected] ||
         tqs[error_tq = TQ::kWriteprotected])
         UserError("Cannot use '%s' in front of 'attribute'", _sym.GetName(tqs.TQ2Symbol(error_tq)).c_str());

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -230,6 +230,8 @@ namespace AGS.Editor
                         state.InsideStructDefinition = new ScriptStruct(state.LastWord, string.Empty, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex);
                         functions = state.InsideStructDefinition.Functions;
                         variables = state.InsideStructDefinition.Variables;
+                        if (state.FindWordInList("managedbase") >= 0)
+                            state.InsideStructDefinition.IsManagedBase = true;
                     }
                     else
                     {
@@ -348,10 +350,27 @@ namespace AGS.Editor
 				}
             }
 
+            ApplyManagedBase(newCache, structsLookup);
             GenerateDynamicArrayStructs(newCache, structsLookup);
 
             scriptToCache.AutoCompleteData.CopyFrom(newCache);
 			scriptToCache.AutoCompleteData.Populated = true;
+        }
+
+        private static void ApplyManagedBase(ScriptAutoCompleteData data, List<ScriptStruct> structsLookup)
+        {
+            ScriptStruct managedBase = structsLookup.Find((s) => { return s.IsManagedBase; });
+            if (managedBase != null)
+            {
+                foreach (var s in data.Structs)
+                {
+                    if (!s.IsManagedBase && string.IsNullOrEmpty(s.ParentType))
+                    {
+                        s.ParentType = managedBase.Name;
+                        ApplyInheritedMembers(s, managedBase);
+                    }
+                }
+            }
         }
 
         private static void GenerateDynamicArrayStructs(ScriptAutoCompleteData data, List<ScriptStruct> structsLookup)
@@ -439,21 +458,26 @@ namespace AGS.Editor
         private static ScriptStruct CreateInheritedStruct(ScriptStruct baseStruct, AutoCompleteParserState state)
         {
             ScriptStruct newStruct = new ScriptStruct(state.PreviousWord2, baseStruct.Name, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex);
+            ApplyInheritedMembers(newStruct, baseStruct);
+            return newStruct;
+        }
+
+        private static void ApplyInheritedMembers(ScriptStruct childStruct, ScriptStruct baseStruct)
+        {
             foreach (ScriptFunction func in baseStruct.Functions)
             {
                 if (!func.NoInherit)
                 {
-                    newStruct.Functions.Add(func);
+                    childStruct.Functions.Add(func);
                 }
             }
             foreach (ScriptVariable var in baseStruct.Variables)
             {
                 if (!var.NoInherit)
                 {
-                    newStruct.Variables.Add(var);
+                    childStruct.Variables.Add(var);
                 }
             }
-            return newStruct;
         }
 
         private static void ProcessPreProcessorDirective(List<ScriptDefine> defines, ref FastString script, AutoCompleteParserState state)

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -21,6 +21,12 @@
 #define __format
 #endif
 
+// Redefine 'managedbase' as simply 'managed' in case the script
+// compiler does not support the former.
+#ifndef SCRIPT_EXT_MANAGEDBASE
+#define managedbase managed
+#endif
+
 // CursorMode isn't actually defined yet, but int will do
 #define CursorMode int
 #define FontType int
@@ -429,6 +435,17 @@ enum eKeyMod
   eKeyModMask       = 0x00FF0000
 };
 #endif // SCRIPT_API_v360
+
+#ifdef SCRIPT_API_v400_30
+// Remember: managedbase class must be the first fully-declared managed type,
+// but forward-declarations are still allowed (and we need them).
+internalstring autoptr builtin managed struct String;
+
+/// The implicit base class for all the managed types.
+managedbase struct Anything {
+    import readonly attribute String TypeName;
+};
+#endif
 
 #ifdef SCRIPT_API_v3507
 managed struct Point {

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptStruct.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptStruct.cs
@@ -65,6 +65,9 @@ namespace AGS.Types.AutoComplete
         public string BaseType;
         /// Tells if this is a fully defined struct, or a temporary struct draft
         public bool FullDefinition;
+        /// Tells if this is a universal implicit parent type for all the managed structs.
+        public bool IsManagedBase;
+
         public List<ScriptVariable> Variables = new List<ScriptVariable>();
         public List<ScriptFunction> Functions = new List<ScriptFunction>();
 

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -57,6 +57,8 @@ namespace AGS.Types
         v400_18 = 4000018,
         [Description("4.0.0 Alpha 28")]
         v400_24 = 4000024,
+        [Description("4.0.0 Alpha 34")]
+        v400_30 = 4000030,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -15,7 +15,6 @@
 // Script API Functions
 //
 //=============================================================================
-
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
@@ -47,10 +46,43 @@
 #include "ac/string.h"
 #include "ac/room.h"
 #include "ac/dynobj/cc_dynamicarray.h"
+#include "ac/dynobj/dynobj_manager.h"
 #include "ac/dynobj/scriptstring.h"
 #include "media/video/video.h"
 #include "media/audio/audio_system.h"
+#include "script/runtimescript.h"
 #include "util/string_compat.h"
+
+using namespace AGS::Engine;
+
+const char *Anything_GetTypeName(void *obj)
+{
+    auto *mgr = ccGetObjectManager(obj);
+    if (!mgr)
+        return CreateNewScriptString("");
+
+    const char *name = nullptr;
+    uint32_t obj_tid = mgr->GetTypeID(obj);
+    if (obj_tid != UINT32_MAX)
+    {
+        const auto &types = RuntimeScript::GetJointRTTI()->GetTypes();
+        if (obj_tid < types.size())
+            name = types[obj_tid].name;
+    }
+    if (!name)
+    {
+        name = mgr->GetType();
+    }
+    return CreateNewScriptString(name);
+}
+
+//=============================================================================
+
+RuntimeScriptValue Sc_Anything_GetTypeName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_SELF(Anything_GetTypeName);
+    return RuntimeScriptValue().SetScriptObject((void*)Anything_GetTypeName(self), &myScriptStringImpl);
+}
 
 // void (char*texx, ...)
 RuntimeScriptValue Sc_sc_AbortGame(const RuntimeScriptValue *params, int32_t param_count)
@@ -868,4 +900,13 @@ void RegisterGlobalAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*
         };
         ccAddExternalFunctions(global_api_dlgs);
     }
+
+    // Ultimate base managed class
+    // NOTE: put it here so that i wont have to make a separate cpp just for
+    // this small section. Move it elsewhere later if a better place is found.
+    ScFnRegister anything_api[] = {
+        { "Anything::get_TypeName",     API_FN_PAIR(Anything_GetTypeName) },
+    };
+
+    ccAddExternalFunctions(anything_api);
 }


### PR DESCRIPTION
Resolves #2992

This introduces `Anything`, a simple managed struct which can be used as a parent by any managed type, both built-in and declared by user:
```
managedbase struct Anything {
    import readonly attribute String TypeName;
};
```

The keyword `managedbase` must be supported by the script compiler in order for this feature take full effect. If it does, then ALL managed structs that do not have a direct parent class (via `extends` keyword) will automatically inherit the type declared as `managedbase`.

This provides 2 effects:
1. Minor: each managed struct will have TypeName attribute, allowing to check its type name.
2. Major: we can now have a managed pointer type that can refer to virtually any managed object, hence allowing a fully generic storage. Given we support `as` downcast keyword, one can store anything in a `Anything*` variable, and later cast it down to the actual type.

On implementation:
1. New script compiler supports `managedbase` keyword. The rules of using this keyword are:
    1.1. Must be the first fully declared managed struct in script. Preceding forward declarations of managed structs are allowed.
    1.2. There can be only one 'managedbase' type.
    1.3. Cannot inherit (extend) anything else itself, must not have a parent.
    1.4 `managedbase` automatically makes the struct `managed`, so you may omit `managed` keyword.
    1.5 It is not forbidden to directly inherit `managedbase` struct, this will have exact same effect as if it was automatically inherited.
    1.6. Cannot be inherited by non-managed struct.
2. Old script compiler: TODO, not done yet.
3. Compilers must declare "MANAGEDBASE" extension, indicating that they support this keyword. `SCRIPT_EXT_MANAGEDBASE` macro may be used to test if it's supported. For the case if it's not supported i added a redefinition of `managedbase` to `managed` into the script header.
4. Engine: TypeName attribute returns Type string for all the built-in, and plugin's classes (where it should be provided by the author). For user-declared structs it retrieves the actual name from RTTI, if it's available. If it's not available, then will return empty string (never returns null pointer).
5. AutoComplete: properly supports `managedbase` keyword. After all structs are gathered, finds if there's a "managedbase", and applies as a parent to all structs that don't have a parent.
