### PR TITLE
Editor: fix Room Editor's navbar hiding drop menus when hot-tracking

### DIFF
--- a/Editor/AGS.Controls/AGS.Controls.csproj
+++ b/Editor/AGS.Controls/AGS.Controls.csproj
@@ -144,6 +144,9 @@
     <Compile Include="AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Controls\ToolStripDropDownButtonEx.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\ContextMenuTriggerEventArgs.cs" />
     <Compile Include="Controls\LineInBetween.cs">
       <SubType>Component</SubType>

--- a/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
+++ b/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
@@ -153,6 +153,12 @@ namespace AddressBarExt.Controls
             set { InitializeRoot(value); }
         }
 
+        public ToolStripDropDownMenuEx ActiveDropDownMenu
+        {
+            get;
+            private set;
+        }
+
         #endregion
 
         #region Constructor/s
@@ -236,11 +242,26 @@ namespace AddressBarExt.Controls
         }
 
         /// <summary>
+        /// Method to handle when a node has mouse entering its bounds.
+        /// </summary>
+        /// <param name="sender">Sender of this event</param>
+        /// <param name="e">Event arguments</param>
+        private void Node_MouseEnter(object sender, EventArgs e)
+        {
+            // If entering a bar's top-level item, focus the toolstrip bar,
+            // this prevents a need to click twice on item when a dropdown menu is open
+            if (ActiveDropDownMenu != null && sender is ToolStripItem && (sender as ToolStripItem).Owner == ts_bar)
+            {
+                ts_bar.Focus();
+            }
+        }
+
+        /// <summary>
         /// Method to handle when a node is double clicked
         /// </summary>
         /// <param name="sender">Sender of this event</param>
         /// <param name="e">Event arguments</param>
-        private void NodeDoubleClickHandler(Object sender, EventArgs e)
+        private void Node_DoubleClick(Object sender, EventArgs e)
         {
             //check we are handlign the double click event
             if (NodeDoubleClick != null && sender.GetType() == typeof(ToolStripButton))
@@ -286,17 +307,44 @@ namespace AddressBarExt.Controls
             }
         }
 
+        private void TsDropDown_Closed(object sender, ToolStripDropDownClosedEventArgs e)
+        {
+            ActiveDropDownMenu = null;
+        }
+
+        private void TsDropDown_Opened(object sender, EventArgs e)
+        {
+            ActiveDropDownMenu = sender as ToolStripDropDownMenuEx;
+        }
+
         /// <summary>
         /// Method that puts focus onto a given ToolStripDropDownMenuEx
         /// </summary>
         /// <param name="sender">Sender of this event</param>
         /// <param name="e">Event Arguments</param>
-        private void GiveToolStripDropDownMenuFocus(Object sender, EventArgs e)
+        private void TsDropDown_MouseEnter(Object sender, EventArgs e)
         {
             if (sender.GetType() == typeof(ToolStripDropDownMenuEx))
             {
                 //focus on the item
                 ((ToolStripDropDownMenuEx)sender).Focus();
+            }
+        }
+
+        /// <summary>
+        /// Method is called whenever a tool strip's dropdown menu is about to get closed.
+        /// </summary>
+        /// <param name="sender">Sender of this event</param>
+        /// <param name="e">Event Arguments</param>
+        private void TsDropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
+        {
+            // The AddressBar has a hot-tracking feature, which highlights the bar items
+            // as the mouse cursor hovers them. This acts as a "item selection", causing other
+            // items to be deselected, in which case their dropdown menus are also closed.
+            // Because this is incovenient for users, we keep the menu opened in this exact case.
+            if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
+            {
+                e.Cancel = true;
             }
         }
 
@@ -337,7 +385,8 @@ namespace AddressBarExt.Controls
             tsButton.DoubleClickEnabled = true;
 
             //add the double click handler
-            tsButton.DoubleClick += new EventHandler(NodeDoubleClickHandler);
+            tsButton.DoubleClick += Node_DoubleClick;
+            tsButton.MouseEnter += Node_MouseEnter;
 
             if (position < 0)
                 ts_bar.Items.Add(tsButton);
@@ -351,11 +400,11 @@ namespace AddressBarExt.Controls
                 if (node.Children.Length > 0)
                 {
                     //create the drop down button
-                    //tsddButton = new ToolStripDropDownButton("");
+                    //tsddButton = new ToolStripDropDownButtonEx("");
 
                     //AGS: use some text to pickup text layout styling
                     //and provide a bigger target to click on
-                    tsddButton = new ToolStripDropDownButton("···");
+                    tsddButton = new ToolStripDropDownButtonEx("···");
                     tsddButton.ShowDropDownArrow = false;
 
                     //check if we have any tag data (we cache already built drop down items in the node TAG data.
@@ -413,8 +462,10 @@ namespace AddressBarExt.Controls
                         //assign the parent
                         tsDropDown.Tag = tsddButton;
 
-                        //handle the mouse entering/leaving the control
-                        tsDropDown.MouseEnter += new EventHandler(GiveToolStripDropDownMenuFocus);
+                        tsDropDown.Opened += TsDropDown_Opened;
+                        tsDropDown.MouseEnter += TsDropDown_MouseEnter;
+                        tsDropDown.Closing += TsDropDown_Closing;
+                        tsDropDown.Closed += TsDropDown_Closed;
                     }
                     else
                     {
@@ -449,6 +500,8 @@ namespace AddressBarExt.Controls
                     //AGS: prefer padding over margin to get a bigger click target
                     //and reduce the amount of unclickable gaps
                     tsddButton.Padding = new Padding(1, 0, 1, 0);
+
+                    tsddButton.MouseEnter += Node_MouseEnter;
 
                     //add it to the bar
                     if (position < 0)
@@ -635,7 +688,7 @@ namespace AddressBarExt.Controls
                 else
                 {
                     //create the overflow button
-                    ToolStripDropDownButton tsd = new ToolStripDropDownButton("..");
+                    ToolStripDropDownButton tsd = new ToolStripDropDownButtonEx("..");
 
                     //add the drop down
                     tsd.DropDown = tsddOverflow;

--- a/Editor/AGS.Controls/Controls/ToolStripDropDownButtonEx.cs
+++ b/Editor/AGS.Controls/Controls/ToolStripDropDownButtonEx.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AGS.Controls
+{
+    /// <summary>
+    /// ToolStripDropDownButtonEx is a customized variant of ToolStripDropDownButton.
+    /// 
+    /// References:
+    /// 1. ToolStripDropDownButton (and friends) source code:
+    /// https://github.com/dotnet/winforms/tree/main/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownButton.cs
+    /// </summary>
+    public class ToolStripDropDownButtonEx : ToolStripDropDownButton
+    {
+        public ToolStripDropDownButtonEx()
+        {
+        }
+
+        public ToolStripDropDownButtonEx(string text)
+            : base(text)
+        {
+        }
+
+        public ToolStripDropDownButtonEx(Image image)
+            : base(image)
+        {
+        }
+
+        public ToolStripDropDownButtonEx(string text, Image image)
+            : base(text, image)
+        {
+        }
+
+        public ToolStripDropDownButtonEx(string text, Image image, EventHandler onClick)
+            : base(text, image, onClick)
+        {
+        }
+
+        public ToolStripDropDownButtonEx(string text, Image image, EventHandler onClick, string name)
+            : base(text, image, onClick, name)
+        {
+        }
+
+        public ToolStripDropDownButtonEx(string text, Image image, params ToolStripItem[] dropDownItems)
+            : base(text, image, dropDownItems)
+        {
+        }
+
+        /// <summary>
+        /// OnDropDownHide is called whenever the ToolStripDropDownButton
+        /// is auto-hiding its own dropdown menu.
+        /// -------------------------------------------------------------------
+        /// Explanation:
+        /// 
+        /// When the ToolStripDropDownMenu is closing, it fires a Closing event,
+        /// and passes the ToolStripDropDownCloseReason there. Idea is that the external
+        /// code can check that reason and decide what to do in each exact case.
+        /// The problem is, that for some reason, it does not work. Either our setup breaks
+        /// it, or there's a mistake in the version of the .NET Framework we are using.
+        /// In any case, the event receives only AppFocusChange reason all the time,
+        /// regardless of what have happened.
+        /// See:
+        /// https://github.com/dotnet/winforms/tree/main/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+        /// 
+        /// Here we hack the system by presetting ItemClicked reason whenever the Button
+        /// is told to auto-hide its menu. Judging by the internal code, this only happens
+        /// when another item was "selected", which occurs during the hot-tracking.
+        /// </summary>
+        protected override void OnDropDownHide(EventArgs e)
+        {
+            var dropDownMenu = DropDown as ToolStripDropDownMenuEx;
+            if (dropDownMenu != null)
+            {
+                // Double check that some other item was selected on the parent toolstrip.
+                foreach (ToolStripItem item in Parent.Items)
+                {
+                    if (item != null && item != this && item.Selected)
+                    {
+                        dropDownMenu.SetCloseReason(ToolStripDropDownCloseReason.ItemClicked);
+                        break;
+                    }
+                }
+            }
+            base.OnDropDownHide(e);
+        }
+    }
+}

--- a/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
+++ b/Editor/AGS.Controls/Controls/ToolStripDropDownMenuEx.cs
@@ -15,7 +15,7 @@ namespace AGS.Controls
     /// 
     /// References:
     /// 1. ToolStrip (and friends) source code:
-    /// https://referencesource.microsoft.com/#system.windows.forms/winforms/Managed/System/WinForms/ToolStripDropDownMenu.cs
+    /// https://github.com/dotnet/winforms/tree/main/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownMenu.cs
     /// 2. Ideas on coding ToolStrip scroll with a mousewheel:
     /// https://stackoverflow.com/questions/13139074/mouse-wheel-scrolling-toolstrip-menu-items
     /// </summary>
@@ -70,6 +70,12 @@ namespace AGS.Controls
         private static Action<ToolStrip, int> ScrollInternal
             = (Action<ToolStrip, int>)Delegate.CreateDelegate(typeof(Action<ToolStrip, int>),
                 typeof(ToolStrip).GetMethod("ScrollInternal",
+                  System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance));
+
+        private static Action<ToolStripDropDown, ToolStripDropDownCloseReason> SetCloseReasonInternal
+            = (Action<ToolStripDropDown, ToolStripDropDownCloseReason>)Delegate.CreateDelegate(typeof(Action<ToolStripDropDown, ToolStripDropDownCloseReason>),
+                typeof(ToolStripDropDown).GetMethod("SetCloseReason",
                   System.Reflection.BindingFlags.NonPublic
                 | System.Reflection.BindingFlags.Instance));
 
@@ -218,6 +224,16 @@ namespace AGS.Controls
                 UpScrollButton(this).Control.Enabled = firstItem.Bounds.Top < topPosition;
                 DownScrollButton(this).Control.Enabled = lastItem.Bounds.Bottom > bottomPosition;
             }
+        }
+
+        /// <summary>
+        /// Lets to set the closing reason for this dropdown menu.
+        /// This will be used next time the menu is closing, and then reset.
+        /// </summary>
+        /// <param name="reason"></param>
+        internal void SetCloseReason(ToolStripDropDownCloseReason reason)
+        {
+            SetCloseReasonInternal(this, reason);
         }
     }
 }


### PR DESCRIPTION
This is an attempt to fix the navigation bar in the Room Editor to NOT automatically hide dropdown menus when user hovers the mouse cursor over the other items in the bar (without clicking). This issue was annoying users for a very long time.

I had an attempt couple of years back, but it was not successful, leading to other glitches, so I abandoned it:
https://github.com/adventuregamestudio/ags/issues/2415#issuecomment-2102486304

In a nutshell, it turned out that simply handling Closing event is not enough, as something is not working right in the version of .NET Framework we are using, and it's reporting the incorrect CloseReason all the time. So I had to add few hacks (getting into the .NET internals through reflection) to make it work properly. Details are in comments to the code.

This must be tested a bit, to see if the drop-down menu CLOSES when it should close.

Also, there's a chance that the above issue was fixed in the later versions of framework, in which case we just need to remove these hacks whenever we move to those.