### PR TITLE
Common: interactions report deserialization errors

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -122,7 +122,7 @@ HGameFileError GameSetupStruct::read_cursors(Common::Stream *in)
     return HGameFileError::None();
 }
 
-void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver)
+HError GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver)
 {
     numIntrVars = 0;
 
@@ -131,23 +131,48 @@ void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersi
         charScripts.resize(numcharacters);
         invScripts.resize(numinvitems);
         for (size_t i = 0; i < (size_t)numcharacters; ++i)
-            charScripts[i] = InteractionEvents::CreateFromStream_v361(in);
+        {
+            HError err;
+            auto inter = InteractionEvents::CreateFromStream_v361(err, in);
+            if (!err)
+                return err;
+            charScripts[i] = std::move(inter);
+        }
         // NOTE: new inventory items' events are loaded starting from 1 for some reason
         for (size_t i = 1; i < (size_t)numinvitems; ++i)
-            invScripts[i] = InteractionEvents::CreateFromStream_v361(in);
+        {
+            HError err;
+            auto inter = InteractionEvents::CreateFromStream_v361(err, in);
+            if (!err)
+                return err;
+            invScripts[i] = std::move(inter);
+        }
     }
     else // 2.x
     {
         intrChar.resize(numcharacters);
         for (size_t i = 0; i < (size_t)numcharacters; ++i)
-            intrChar[i] = Interaction::CreateFromStream(in);
+        {
+            HError err;
+            auto inter = Interaction::CreateFromStream(err, in);
+            if (!err)
+                return err;
+            intrChar[i] = std::move(inter);
+        }
         for (size_t i = 0; i < (size_t)numinvitems; ++i)
-            intrInv[i] = Interaction::CreateFromStream(in);
+        {
+            HError err;
+            auto inter = Interaction::CreateFromStream(err, in);
+            if (!err)
+                return err;
+            intrInv[i] = std::move(inter);
+        }
 
         numIntrVars = in->ReadInt32();
         for (size_t i = 0; i < (size_t)numIntrVars; ++i)
             intrVars[i].Read(in);
     }
+    return HError::None();
 }
 
 void GameSetupStruct::read_words_dictionary(Common::Stream *in)

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -34,6 +34,7 @@ using Common::UInteraction;
 using Common::UInteractionEvents;
 using Common::InteractionVariable;
 using Common::HGameFileError;
+using Common::HError;
 
 
 // TODO: split GameSetupStruct into struct used to hold loaded game data, and actual runtime object
@@ -128,7 +129,7 @@ struct GameSetupStruct : public GameSetupStructBase
     void read_savegame_info(Common::Stream *in, GameDataVersion data_ver);
     void read_font_infos(Common::Stream *in, GameDataVersion data_ver);
     HGameFileError read_cursors(Common::Stream *in);
-    void read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);
+    HError read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);
     void read_words_dictionary(Common::Stream *in);
 
     void ReadInvInfo(Common::Stream *in);

--- a/Common/game/interactions.cpp
+++ b/Common/game/interactions.cpp
@@ -14,7 +14,6 @@
 #include "game/interactions.h"
 #include <algorithm>
 #include <string.h>
-#include "ac/common.h" // quit
 #include "util/stream.h"
 #include "util/string_utils.h"
 
@@ -29,17 +28,21 @@ namespace Common
 //
 //-----------------------------------------------------------------------------
 
-std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v361(Stream *in)
+std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v361(HError &error, Stream *in)
 {
+    error = HError::None();
     std::unique_ptr<InteractionEvents> inter(new InteractionEvents());
     inter->Read_v361(in);
     return inter;
 }
 
-std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v362(Stream *in)
+std::unique_ptr<InteractionEvents> InteractionEvents::CreateFromStream_v362(HError &error, Stream *in)
 {
     std::unique_ptr<InteractionEvents> inter(new InteractionEvents());
-    inter->Read_v362(in);
+    error = inter->Read_v362(in);
+    if (!error)
+        return nullptr;
+
     return inter;
 }
 
@@ -328,21 +331,30 @@ void Interaction::Reset()
     Events.clear();
 }
 
-std::unique_ptr<Interaction> Interaction::CreateFromStream(Stream *in)
+std::unique_ptr<Interaction> Interaction::CreateFromStream(HError &error, Stream *in)
 {
-    if (in->ReadInt32() != kInteractionVersion_Initial)
-        return nullptr; // unsupported format
+    error = HError::None();
+    std::unique_ptr<Interaction> inter(new Interaction());
+    const int version = in->ReadInt32();
+    if (version != kInteractionVersion_Initial)
+    {
+        error = new Error(String::FromFormat("Interaction version not supported: %d", version));
+        return nullptr;
+    }
 
     const size_t evt_count = in->ReadInt32();
     if (evt_count > MAX_NEWINTERACTION_EVENTS)
-        quit("Can't deserialize interaction: too many events"); // FIXME: dont quit, report HError
+    {
+        error = new Error(String::FromFormat("Too many interaction events (in data: %zu, max: %d)",
+            evt_count, MAX_NEWINTERACTION_EVENTS));
+        return nullptr;
+    }
 
     int types[MAX_NEWINTERACTION_EVENTS];
     int load_response[MAX_NEWINTERACTION_EVENTS];
     in->ReadArrayOfInt32(types, evt_count);
     in->ReadArrayOfInt32(load_response, evt_count);
 
-    std::unique_ptr<Interaction> inter(new Interaction());
     inter->Events.resize(evt_count);
     for (size_t i = 0; i < evt_count; ++i)
     {

--- a/Common/game/interactions.h
+++ b/Common/game/interactions.h
@@ -99,9 +99,9 @@ struct InteractionEvents
     std::vector<EventHandler> Events;
 
     // Read and create pre-3.6.2 version of the InteractionEvents
-    static std::unique_ptr<InteractionEvents> CreateFromStream_v361(Stream *in);
+    static std::unique_ptr<InteractionEvents> CreateFromStream_v361(HError &error, Stream *in);
     // Read and create 3.6.2+ version of the InteractionEvents
-    static std::unique_ptr<InteractionEvents> CreateFromStream_v362(Stream *in);
+    static std::unique_ptr<InteractionEvents> CreateFromStream_v362(HError &error, Stream *in);
     void Read_v361(Stream *in);
     HError Read_v362(Stream *in);
     void Write_v361(Stream *out) const;
@@ -228,7 +228,7 @@ struct Interaction
     void Reset();
 
     // Game static data (de)serialization
-    static std::unique_ptr<Interaction> CreateFromStream(Stream *in);
+    static std::unique_ptr<Interaction> CreateFromStream(HError &error, Stream *in);
     void Write(Stream *out) const;
 
     Interaction &operator =(const Interaction &inter);

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -863,11 +863,21 @@ static HError ReadInteractionScriptModules(Stream *in, LoadedGameEntities &ents)
     if (!ReadAndAssertCount(in, "characters", static_cast<uint32_t>(ents.Game.chars.size()), err))
         return err;
     for (size_t i = 0; i < (size_t)ents.Game.numcharacters; ++i)
-        ents.Game.charScripts[i] = InteractionEvents::CreateFromStream_v362(in);
+    {
+        auto inter = InteractionEvents::CreateFromStream_v362(err, in);
+        if (!err)
+            return err;
+        ents.Game.charScripts[i] = std::move(inter);
+    }
     if (!ReadAndAssertCount(in, "inventory items", static_cast<uint32_t>(ents.Game.numinvitems), err))
         return err;
     for (uint32_t i = 0; i < (uint32_t)ents.Game.numinvitems; ++i)
-        ents.Game.invScripts[i] = InteractionEvents::CreateFromStream_v362(in);
+    {
+        auto inter = InteractionEvents::CreateFromStream_v362(err, in);
+        if (!err)
+            return err;
+        ents.Game.invScripts[i] = std::move(inter);
+    }
 
     // Script module specification for GUI events
     if (!ReadAndAssertCount(in, "GUI", static_cast<uint32_t>(ents.Game.numgui), err))
@@ -1119,7 +1129,9 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, std::unique_ptr<Stream> &&
     err = game.read_cursors(in);
     if (!err)
         return err;
-    game.read_interaction_scripts(in, data_ver);
+    HError inter_err = game.read_interaction_scripts(in, data_ver);
+    if (!inter_err)
+        return new MainGameFileError(kMGFErr_GameEntityFailed, inter_err);
     if (sinfo.HasWordsDict)
         game.read_words_dictionary(in);
 

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -176,10 +176,26 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
     if (data_ver >= kRoomVersion_241 && data_ver < kRoomVersion_300a)
     {
         for (uint32_t i = 0; i < room->HotspotCount; ++i)
-            room->Hotspots[i].Interaction = Interaction::CreateFromStream(in);
+        {
+            HError err;
+            auto inter = Interaction::CreateFromStream(err, in);
+            if (!err)
+                return err;
+            room->Hotspots[i].Interaction = std::move(inter);
+        }
         for (auto &obj : room->Objects)
-            obj.Interaction = Interaction::CreateFromStream(in);
-        room->Interaction = Interaction::CreateFromStream(in);
+        {
+            HError err;
+            auto inter = Interaction::CreateFromStream(err, in);
+            if (!err)
+                return err;
+            obj.Interaction = std::move(inter);
+        }
+        HError err;
+        auto inter = Interaction::CreateFromStream(err, in);
+        if (!err)
+            return err;
+        room->Interaction = std::move(inter);
     }
 
     if (data_ver >= kRoomVersion_255b)
@@ -191,7 +207,13 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
         if (data_ver < kRoomVersion_300a)
         {
             for (uint32_t i = 0; i < room->RegionCount; ++i)
-                room->Regions[i].Interaction = Interaction::CreateFromStream(in);
+            {
+                HError err;
+                auto inter = Interaction::CreateFromStream(err, in);
+                if (!err)
+                    return err;
+                room->Regions[i].Interaction = std::move(inter);
+            }
         }
     }
 
@@ -199,13 +221,32 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
     // NOTE: we keep pre-3.6.2 interaction format for now, room interactions don't need module selection
     if (data_ver >= kRoomVersion_300a)
     {
-        room->EventHandlers = InteractionEvents::CreateFromStream_v361(in);
+        HError err;
+        auto inter = InteractionEvents::CreateFromStream_v361(err, in);
+        if (!err)
+            return err;
+        room->EventHandlers = std::move(inter);
         for (uint32_t i = 0; i < room->HotspotCount; ++i)
-            room->Hotspots[i].EventHandlers = InteractionEvents::CreateFromStream_v361(in);
+        {
+            inter = InteractionEvents::CreateFromStream_v361(err, in);
+            if (!err)
+                return err;
+            room->Hotspots[i].EventHandlers = std::move(inter);
+        }
         for (auto &obj : room->Objects)
-            obj.EventHandlers = InteractionEvents::CreateFromStream_v361(in);
+        {
+            inter = InteractionEvents::CreateFromStream_v361(err, in);
+            if (!err)
+                return err;
+            obj.EventHandlers = std::move(inter);
+        }
         for (uint32_t i = 0; i < room->RegionCount; ++i)
-            room->Regions[i].EventHandlers = InteractionEvents::CreateFromStream_v361(in);
+        {
+            inter = InteractionEvents::CreateFromStream_v361(err, in);
+            if (!err)
+                return err;
+            room->Regions[i].EventHandlers = std::move(inter);
+        }
     }
 
     if (data_ver >= kRoomVersion_200_alpha)


### PR DESCRIPTION
Refactor out the quit call, fix silently ignored error and readjust factory functions to return HError.

When I was trying to make the tests for the data_file_writer.cpp (in #3016), I noticed this approach would make things easier to test, but since it impacts a few things I decided to move it to its own PR - and also because there was a FIX-ME comment in interactions.cpp that gave me this idea in the first place. If this is alright, then I will rebase my other PR on top of this to get on with the tests.

**AI Disclosure:** I used Codex in JetBrains CLion to automate this refactor, I did in part of the other branch and then went back to master branch to apply it.