### PR TITLE
AgfExport: commands for exporting lists of fonts, translations, and default config

### DIFF
--- a/Solutions/Tools.App/agfexport.vcxproj
+++ b/Solutions/Tools.App/agfexport.vcxproj
@@ -24,6 +24,8 @@
     <ClCompile Include="..\..\Common\util\cmdlineopts.cpp" />
     <ClCompile Include="..\..\Common\util\file.cpp" />
     <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\inifile.cpp" />
+    <ClCompile Include="..\..\Common\util\ini_util.cpp" />
     <ClCompile Include="..\..\Common\util\path.cpp" />
     <ClCompile Include="..\..\Common\util\stdio_compat.c" />
     <ClCompile Include="..\..\Common\util\stream.cpp" />
@@ -31,9 +33,11 @@
     <ClCompile Include="..\..\Common\util\string_compat.c" />
     <ClCompile Include="..\..\Common\util\string_utils.cpp" />
     <ClCompile Include="..\..\Common\util\textstreamreader.cpp" />
+    <ClCompile Include="..\..\Common\util\textstreamwriter.cpp" />
     <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp" />
     <ClCompile Include="..\..\Tools\agfexport\main.cpp" />
     <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
+    <ClCompile Include="..\..\Tools\data\game_utils.cpp" />
     <ClCompile Include="..\..\Tools\data\scriptgen.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Tools.App/agfexport.vcxproj.filters
+++ b/Solutions/Tools.App/agfexport.vcxproj.filters
@@ -67,6 +67,18 @@
     <ClCompile Include="..\..\Common\util\string_compat.c">
       <Filter>Common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\ini_util.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\inifile.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\textstreamwriter.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\game_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -50,6 +50,10 @@ set(TOOLS_COMMON_SOURCES
         ../Common/util/file.h
         ../Common/util/filestream.cpp
         ../Common/util/filestream.h
+        ../Common/util/ini_util.cpp
+        ../Common/util/ini_util.h
+        ../Common/util/inifile.cpp
+        ../Common/util/inifile.h
         ../Common/util/lzw.cpp
         ../Common/util/lzw.h
         ../Common/util/memorystream.cpp
@@ -109,6 +113,7 @@ target_sources(libtools
         data/dialogscriptconv.cpp
         data/dialogscriptconv.h
         data/game_utils.h
+        data/game_utils.cpp
         data/include_utils.cpp
         data/include_utils.h
         data/mfl_utils.cpp

--- a/Tools/agfexport/Makefile
+++ b/Tools/agfexport/Makefile
@@ -28,16 +28,20 @@ COMMON_OBJS = \
 	../../Common/util/cmdlineopts.cpp \
 	../../Common/util/file.cpp \
 	../../Common/util/filestream.cpp \
+	../../Common/util/ini_util.cpp \
+	../../Common/util/inifile.cpp \
 	../../Common/util/path.cpp \
 	../../Common/util/stdio_compat.c \
 	../../Common/util/stream.cpp \
 	../../Common/util/string.cpp \
 	../../Common/util/string_compat.c \
 	../../Common/util/string_utils.cpp \
-	../../Common/util/textstreamreader.cpp
+	../../Common/util/textstreamreader.cpp \
+	../../Common/util/textstreamwriter.cpp
 
 TOOL_OBJS = \
 	../../Tools/data/agfreader.cpp \
+	../../Tools/data/game_utils.cpp \
 	../../Tools/data/scriptgen.cpp
 
 TINYXML2 = \

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -25,8 +25,9 @@ const char *HELP_STRING = ""
     "  game-cfg               Generate default game config\n"
     "  glvar                  Generate global variables scripts\n"
     "  header-list            Exports ordered list of headers from script modules\n"
-    "  script-list            Exports ordered list of scripts from script modules\n"
+    "  plugin-list            Exports list of game plugins\n"
     "  room-list              Exports list of active rooms\n"
+    "  script-list            Exports ordered list of scripts from script modules\n"
     "  tra-list               Exports list of translations\n"
     "  -h, --help             Show help message for command\n";
 
@@ -65,12 +66,12 @@ const char *HELP_HEADER_LIST = ""
     "  -h, --help             Show this help message\n"
     "  -t, --to-stdout        Instead write the list of scripts to stdout";
 
-const char *HELP_SCRIPT_LIST = ""
-    "Usage: agfexport script-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-    "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules."
+const char *HELP_PLUGIN_LIST = ""
+    "Usage: agfexport plugin-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+     "Writes <OUT-FILE>, a file with a list of game plugins."
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of scripts to stdout";
+    "  -t, --to-stdout        Instead write the list of rooms to stdout";
 
 const char *HELP_ROOM_LIST = ""
     "Usage: agfexport room-list <INPUT-GAME.AGF> <OUT-FILE>\n"
@@ -78,6 +79,13 @@ const char *HELP_ROOM_LIST = ""
     "Commands:\n"
     "  -h, --help             Show this help message\n"
     "  -t, --to-stdout        Instead write the list of rooms to stdout";
+
+const char *HELP_SCRIPT_LIST = ""
+    "Usage: agfexport script-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+    "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules."
+    "Commands:\n"
+    "  -h, --help             Show this help message\n"
+    "  -t, --to-stdout        Instead write the list of scripts to stdout";
 
 const char *HELP_TRA_LIST = ""
     "Usage: agfexport tra-list <INPUT-GAME.AGF> <OUT-FILE>\n"
@@ -93,8 +101,9 @@ enum CommandType
     kCmdGameCfg,
     kCmdGlVar,
     kCmdHeaderList,
-    kCmdScriptList,
+    kCmdPluginList,
     kCmdRoomList,
+    kCmdScriptList,
     kCmdTraList,
     kCmdMAX,
     kCmdNone = kCmdMAX
@@ -112,8 +121,9 @@ struct Command
         {"game-cfg",    kCmdGameCfg,    2, HELP_GAMECFG},
         {"glvar",       kCmdGlVar,      3, HELP_GLVAR},
         {"header-list", kCmdHeaderList, 2, HELP_HEADER_LIST},
-        {"script-list", kCmdScriptList, 2, HELP_SCRIPT_LIST},
+        {"plugin-list", kCmdPluginList, 2, HELP_PLUGIN_LIST},
         {"room-list",   kCmdRoomList,   2, HELP_ROOM_LIST},
+        {"script-list", kCmdScriptList, 2, HELP_SCRIPT_LIST},
         {"tra-list",    kCmdTraList,    2, HELP_TRA_LIST},
         {nullptr,       kCmdNone,       0, nullptr}
 };
@@ -133,12 +143,17 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
 {
     String exp_data;
 
-    if (cmd == kCmdScriptList)
+    if (cmd == kCmdFontList)
     {
-        std::vector<String> scripts;
-        AGF::ReadScriptList(scripts, reader.GetGameRoot());
-        for (const auto &s: scripts)
-            exp_data.AppendFmt("%s\n", s.GetCStr());
+        std::vector<int> font_index;
+        AGF::ReadFontList(font_index, reader.GetGameRoot());
+        // Unfortunately, in AGS 3.x project there's no explicit indication of a filename,
+        // only font ID. The actual file is chosen at runtime among all variants, by certain priority rule.
+        for (const auto &f : font_index)
+        {
+            exp_data.AppendFmt("agsfnt%d.ttf\n", f);
+            exp_data.AppendFmt("agsfnt%d.wfn\n", f);
+        }
     }
 
     if (cmd == kCmdHeaderList)
@@ -146,6 +161,15 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
         std::vector<String> scripts;
         AGF::ReadScriptHeaderList(scripts, reader.GetGameRoot());
         for (const auto &s: scripts)
+            exp_data.AppendFmt("%s\n", s.GetCStr());
+    }
+
+    if (cmd == kCmdPluginList)
+    {
+        std::vector<String> plugins;
+        AGF::ReadPluginList(plugins, reader.GetGameRoot());
+        // We expect the plugin's filename to contain .dll extension
+        for (const auto &s: plugins)
             exp_data.AppendFmt("%s\n", s.GetCStr());
     }
 
@@ -163,17 +187,12 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
             exp_data.AppendFmt("room%d.crm\n", r);
     }
 
-    if (cmd == kCmdFontList)
+    if (cmd == kCmdScriptList)
     {
-        std::vector<int> font_index;
-        AGF::ReadFontList(font_index, reader.GetGameRoot());
-        // Unfortunately, in AGS 3.x project there's no explicit indication of a filename,
-        // only font ID. The actual file is chosen at runtime among all variants, by certain priority rule.
-        for (const auto &f : font_index)
-        {
-            exp_data.AppendFmt("agsfnt%d.ttf\n", f);
-            exp_data.AppendFmt("agsfnt%d.wfn\n", f);
-        }
+        std::vector<String> scripts;
+        AGF::ReadScriptList(scripts, reader.GetGameRoot());
+        for (const auto &s: scripts)
+            exp_data.AppendFmt("%s\n", s.GetCStr());
     }
 
     if (cmd == kCmdTraList)
@@ -333,9 +352,10 @@ int main(int argc, char *argv[])
     switch (command)
     {
         case kCmdHeaderList:
-        case kCmdScriptList:
         case kCmdFontList:
+        case kCmdPluginList:
         case kCmdRoomList:
+        case kCmdScriptList:
         case kCmdTraList:
             err = list_command(reader, command, out_file, stdout_list_print);
             break;

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -8,6 +8,7 @@
 #include "data/agfreader.h"
 #include "data/scriptgen.h"
 #include "util/file.h"
+#include "util/ini_util.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
@@ -21,6 +22,7 @@ const char *HELP_STRING = ""
     "Commands:\n"
     "  autoash                Generate auto script header\n"
     "  font-list              Exports list of font files\n"
+    "  game-cfg               Generate default game config\n"
     "  glvar                  Generate global variables scripts\n"
     "  header-list            Exports ordered list of headers from script modules\n"
     "  script-list            Exports ordered list of scripts from script modules\n"
@@ -41,6 +43,13 @@ const char *HELP_FONT_LIST = ""
     "Commands:\n"
     "  -h, --help             Show this help message\n"
     "  -t, --to-stdout        Instead write the list of font files to stdout";
+
+const char *HELP_GAMECFG = ""
+    "Usage: agfexport gamecfg <INPUT-GAME.AGF> <OUT-FILE.CFG>\n"
+    "Writes <OUT-FILE.CFG>, default game config.\n"
+    "Config's contents are based on DefaultSetup node of the AGF file.\n"
+    "Commands:\n"
+    "  -h, --help             Show this help message\n";
 
 const char *HELP_GLVAR = ""
     "Usage: agfexport glvar <INPUT-GAME.AGF> <HEAD.ASH> <BODY.ASC>\n"
@@ -81,6 +90,7 @@ enum CommandType
 {
     kCmdAutoAsh = 0,
     kCmdFontList,
+    kCmdGameCfg,
     kCmdGlVar,
     kCmdHeaderList,
     kCmdScriptList,
@@ -99,6 +109,7 @@ struct Command
 } Command[] = {
         {"autoash",     kCmdAutoAsh,    2, HELP_AUTOASH},
         {"font-list",   kCmdFontList,   2, HELP_FONT_LIST},
+        {"game-cfg",    kCmdGameCfg,    2, HELP_GAMECFG},
         {"glvar",       kCmdGlVar,      3, HELP_GLVAR},
         {"header-list", kCmdHeaderList, 2, HELP_HEADER_LIST},
         {"script-list", kCmdScriptList, 2, HELP_SCRIPT_LIST},
@@ -112,7 +123,6 @@ HError write_to_file(const String &content, const String &file)
     std::unique_ptr<Stream> out(File::CreateFile(file));
     if (!out)
     {
-
         return new Error(String::FromFormat("Failed to open output file '%s' for writing.", file.GetCStr()));
     }
     out->Write(content.GetCStr(), content.GetLength());
@@ -219,6 +229,24 @@ HError glvar_command(AGF::AGFReader &reader, const String &header_file, const St
     return HError::None();
 }
 
+HError gamecfg_command(AGF::AGFReader &reader, const String &dst)
+{
+    printf("Output config file: %s\n", dst.GetCStr());
+
+    GameSettings settings;
+    RuntimeSetup setup;
+    AGF::ReadGameSettings(settings, reader.GetGameRoot());
+    AGF::ReadRuntimeSetup(setup, reader.GetGameRoot());
+
+    // Copy runtime setup to config tree
+    ConfigTree cfg;
+    WriteConfig(setup, &settings, cfg);
+
+    // Write config tree as ini
+    String str;
+    IniUtil::WriteToString(str, cfg);
+    return write_to_file(str, dst);
+}
 
 int main(int argc, char *argv[])
 {
@@ -316,6 +344,9 @@ int main(int argc, char *argv[])
             break;
         case kCmdGlVar:
             err = glvar_command(reader, out_file, result.PosArgs[3]);
+            break;
+        case kCmdGameCfg:
+            err = gamecfg_command(reader, out_file);
             break;
         case kCmdMAX:
         default:

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -20,6 +20,7 @@ const char *HELP_STRING = ""
     "Usage: agfexport <COMMAND> [<OPTIONS>] <input-game.agf> <out-file>\n"
     "Commands:\n"
     "  autoash                Generate auto script header\n"
+    "  font-list              Exports list of font files\n"
     "  glvar                  Generate global variables scripts\n"
     "  header-list            Exports ordered list of headers from script modules\n"
     "  script-list            Exports ordered list of scripts from script modules\n"
@@ -33,6 +34,13 @@ const char *HELP_AUTOASH = ""
     "This header has global elements from the game necessary for building scripts.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n";
+
+const char *HELP_FONT_LIST = ""
+    "Usage: agfexport font-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+     "Writes <OUT-FILE>, a file with a list of font files used by the game."
+    "Commands:\n"
+    "  -h, --help             Show this help message\n"
+    "  -t, --to-stdout        Instead write the list of font files to stdout";
 
 const char *HELP_GLVAR = ""
     "Usage: agfexport glvar <INPUT-GAME.AGF> <HEAD.ASH> <BODY.ASC>\n"
@@ -72,6 +80,7 @@ const char *HELP_TRA_LIST = ""
 enum CommandType
 {
     kCmdAutoAsh = 0,
+    kCmdFontList,
     kCmdGlVar,
     kCmdHeaderList,
     kCmdScriptList,
@@ -89,6 +98,7 @@ struct Command
     const char *Help;
 } Command[] = {
         {"autoash",     kCmdAutoAsh,    2, HELP_AUTOASH},
+        {"font-list",   kCmdFontList,   2, HELP_FONT_LIST},
         {"glvar",       kCmdGlVar,      3, HELP_GLVAR},
         {"header-list", kCmdHeaderList, 2, HELP_HEADER_LIST},
         {"script-list", kCmdScriptList, 2, HELP_SCRIPT_LIST},
@@ -141,6 +151,19 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
         std::sort(rooms.begin(), rooms.end());
         for (const auto &r: rooms)
             exp_data.AppendFmt("room%d.crm\n", r);
+    }
+
+    if (cmd == kCmdFontList)
+    {
+        std::vector<int> font_index;
+        AGF::ReadFontList(font_index, reader.GetGameRoot());
+        // Unfortunately, in AGS 3.x project there's no explicit indication of a filename,
+        // only font ID. The actual file is chosen at runtime among all variants, by certain priority rule.
+        for (const auto &f : font_index)
+        {
+            exp_data.AppendFmt("agsfnt%d.ttf\n", f);
+            exp_data.AppendFmt("agsfnt%d.wfn\n", f);
+        }
     }
 
     if (cmd == kCmdTraList)
@@ -283,6 +306,7 @@ int main(int argc, char *argv[])
     {
         case kCmdHeaderList:
         case kCmdScriptList:
+        case kCmdFontList:
         case kCmdRoomList:
         case kCmdTraList:
             err = list_command(reader, command, out_file, stdout_list_print);

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -15,8 +15,8 @@ using namespace AGS::DataUtil;
 namespace AGF = AGS::AGF;
 
 const char *HELP_STRING = ""
-    "agfexport v0.2.0 - AGS game project miscellaneous export tool\n"
-    "Copyright (c) 2024 AGS Team and contributors\n"
+    "agfexport v0.3.0 - AGS game project miscellaneous export tool\n"
+    "Copyright (c) 2026 AGS Team and contributors\n"
     "Usage: agfexport <COMMAND> [<OPTIONS>] <input-game.agf> <out-file>\n"
     "Commands:\n"
     "  autoash                Generate auto script header\n"
@@ -24,6 +24,7 @@ const char *HELP_STRING = ""
     "  header-list            Exports ordered list of headers from script modules\n"
     "  script-list            Exports ordered list of scripts from script modules\n"
     "  room-list              Exports list of active rooms\n"
+    "  tra-list               Exports list of translations\n"
     "  -h, --help             Show help message for command\n";
 
 const char *HELP_AUTOASH = ""
@@ -61,6 +62,13 @@ const char *HELP_ROOM_LIST = ""
     "  -h, --help             Show this help message\n"
     "  -t, --to-stdout        Instead write the list of rooms to stdout";
 
+const char *HELP_TRA_LIST = ""
+    "Usage: agfexport tra-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+     "Writes <OUT-FILE>, a file with a list of translations."
+    "Commands:\n"
+    "  -h, --help             Show this help message\n"
+    "  -t, --to-stdout        Instead write the list of translations to stdout";
+
 enum CommandType
 {
     kCmdAutoAsh = 0,
@@ -68,6 +76,7 @@ enum CommandType
     kCmdHeaderList,
     kCmdScriptList,
     kCmdRoomList,
+    kCmdTraList,
     kCmdMAX,
     kCmdNone = kCmdMAX
 };
@@ -84,6 +93,7 @@ struct Command
         {"header-list", kCmdHeaderList, 2, HELP_HEADER_LIST},
         {"script-list", kCmdScriptList, 2, HELP_SCRIPT_LIST},
         {"room-list",   kCmdRoomList,   2, HELP_ROOM_LIST},
+        {"tra-list",    kCmdTraList,    2, HELP_TRA_LIST},
         {nullptr,       kCmdNone,       0, nullptr}
 };
 
@@ -126,11 +136,19 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
         AGF::ReadRoomList(rooms_dsc, reader.GetGameRoot());
         rooms.reserve(rooms_dsc.size());
         for (const auto &rd: rooms_dsc)
-                    rooms.push_back(rd.first);
+            rooms.push_back(rd.first);
 
         std::sort(rooms.begin(), rooms.end());
         for (const auto &r: rooms)
             exp_data.AppendFmt("room%d.crm\n", r);
+    }
+
+    if (cmd == kCmdTraList)
+    {
+        std::vector<String> translations;
+        AGF::ReadTranslationList(translations, reader.GetGameRoot());
+        for (const auto &s: translations)
+            exp_data.AppendFmt("%s.trs\n", s.GetCStr());
     }
 
     if (to_stdout)
@@ -266,6 +284,7 @@ int main(int argc, char *argv[])
         case kCmdHeaderList:
         case kCmdScriptList:
         case kCmdRoomList:
+        case kCmdTraList:
             err = list_command(reader, command, out_file, stdout_list_print);
             break;
         case kCmdAutoAsh:

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -21,6 +21,7 @@ const char *HELP_STRING = ""
     "Usage: agfexport <COMMAND> [<OPTIONS>] <input-game.agf> <out-file>\n"
     "Commands:\n"
     "  autoash                Generate auto script header\n"
+    "  custom-data-dir        Exports list of custom data directories\n"
     "  font-list              Exports list of font files\n"
     "  game-cfg               Generate default game config\n"
     "  glvar                  Generate global variables scripts\n"
@@ -38,12 +39,19 @@ const char *HELP_AUTOASH = ""
     "Commands:\n"
     "  -h, --help             Show this help message\n";
 
-const char *HELP_FONT_LIST = ""
-    "Usage: agfexport font-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-     "Writes <OUT-FILE>, a file with a list of font files used by the game."
+const char *HELP_CUSTOMDATADIR_LIST = ""
+    "Usage: agfexport custom-data-dir <INPUT-GAME.AGF> <OUT-FILE>\n"
+    "Writes <OUT-FILE>, a file with a list of custom game data directories.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of font files to stdout";
+    "  -t, --to-stdout        Instead write the list of font files to stdout\n";
+
+const char *HELP_FONT_LIST = ""
+    "Usage: agfexport font-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+    "Writes <OUT-FILE>, a file with a list of font files used by the game\n."
+    "Commands:\n"
+    "  -h, --help             Show this help message\n"
+    "  -t, --to-stdout        Instead write the list of font files to stdout\n";
 
 const char *HELP_GAMECFG = ""
     "Usage: agfexport gamecfg <INPUT-GAME.AGF> <OUT-FILE.CFG>\n"
@@ -61,42 +69,43 @@ const char *HELP_GLVAR = ""
 
 const char *HELP_HEADER_LIST = ""
     "Usage: agfexport header-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-    "Writes <OUT-FILE>, a file with a list of headers from script modules."
+    "Writes <OUT-FILE>, a file with a list of headers from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of scripts to stdout";
+    "  -t, --to-stdout        Instead write the list of scripts to stdout\n";
 
 const char *HELP_PLUGIN_LIST = ""
     "Usage: agfexport plugin-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-     "Writes <OUT-FILE>, a file with a list of game plugins."
+    "Writes <OUT-FILE>, a file with a list of game plugins.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of rooms to stdout";
+    "  -t, --to-stdout        Instead write the list of rooms to stdout\n";
 
 const char *HELP_ROOM_LIST = ""
     "Usage: agfexport room-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-     "Writes <OUT-FILE>, a file with a list of rooms."
+    "Writes <OUT-FILE>, a file with a list of rooms.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of rooms to stdout";
+    "  -t, --to-stdout        Instead write the list of rooms to stdout\n";
 
 const char *HELP_SCRIPT_LIST = ""
     "Usage: agfexport script-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-    "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules."
+    "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of scripts to stdout";
+    "  -t, --to-stdout        Instead write the list of scripts to stdout\n";
 
 const char *HELP_TRA_LIST = ""
     "Usage: agfexport tra-list <INPUT-GAME.AGF> <OUT-FILE>\n"
-     "Writes <OUT-FILE>, a file with a list of translations."
+    "Writes <OUT-FILE>, a file with a list of translations.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of translations to stdout";
+    "  -t, --to-stdout        Instead write the list of translations to stdout\n";
 
 enum CommandType
 {
     kCmdAutoAsh = 0,
+    kCmdCustomDataDir,
     kCmdFontList,
     kCmdGameCfg,
     kCmdGlVar,
@@ -117,6 +126,7 @@ struct Command
     const char *Help;
 } Command[] = {
         {"autoash",     kCmdAutoAsh,    2, HELP_AUTOASH},
+        {"custom-data-dir", kCmdCustomDataDir, 2, HELP_CUSTOMDATADIR_LIST},
         {"font-list",   kCmdFontList,   2, HELP_FONT_LIST},
         {"game-cfg",    kCmdGameCfg,    2, HELP_GAMECFG},
         {"glvar",       kCmdGlVar,      3, HELP_GLVAR},
@@ -142,6 +152,18 @@ HError write_to_file(const String &content, const String &file)
 HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String &file, bool to_stdout)
 {
     String exp_data;
+
+    if (cmd == kCmdCustomDataDir)
+    {
+        std::vector<String> dirs;
+        AGF::ReadCustomDataDirectories(dirs, reader.GetGameRoot());
+        // Unfortunately, in AGS 3.x project there's no explicit indication of a filename,
+        // only font ID. The actual file is chosen at runtime among all variants, by certain priority rule.
+        for (const auto &dir : dirs)
+        {
+            exp_data.AppendFmt("%s\n", dir.GetCStr());
+        }
+    }
 
     if (cmd == kCmdFontList)
     {
@@ -351,8 +373,9 @@ int main(int argc, char *argv[])
     String exp_data;
     switch (command)
     {
-        case kCmdHeaderList:
+        case kCmdCustomDataDir:
         case kCmdFontList:
+        case kCmdHeaderList:
         case kCmdPluginList:
         case kCmdRoomList:
         case kCmdScriptList:

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -49,7 +49,7 @@ const char *HELP_AUDIOCLIP_LIST = ""
 #endif
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_AUTOASH = ""
     "Usage: agfexport autoash <INPUT-GAME.AGF> <OUT-FILE.ASH>\n"
@@ -63,17 +63,17 @@ const char *HELP_CUSTOMDATADIR_LIST = ""
     "Writes <OUT-FILE>, a file with a list of custom game data directories.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_FONT_LIST = ""
     "Usage: agfexport font-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of font files used by the game\n."
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_GAMECFG = ""
-    "Usage: agfexport gamecfg <INPUT-GAME.AGF> <OUT-FILE.CFG>\n"
+    "Usage: agfexport game-cfg <INPUT-GAME.AGF> <OUT-FILE.CFG>\n"
     "Writes <OUT-FILE.CFG>, default game config.\n"
     "Config's contents are based on DefaultSetup node of the AGF file.\n"
     "Commands:\n"
@@ -91,35 +91,35 @@ const char *HELP_HEADER_LIST = ""
     "Writes <OUT-FILE>, a file with a list of headers from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_PLUGIN_LIST = ""
     "Usage: agfexport plugin-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of game plugins.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_ROOM_LIST = ""
     "Usage: agfexport room-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of rooms.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_SCRIPT_LIST = ""
     "Usage: agfexport script-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 const char *HELP_TRA_LIST = ""
     "Usage: agfexport tra-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of translations.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -s, --stdout           Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead print the list to stdout\n";
 
 enum CommandType
 {
@@ -145,7 +145,7 @@ struct Command
     const size_t NumArgs;
     const char *Help;
 } Command[] = {
-        {"audio-list",  kCmdAudioClipList, 2, HELP_AUDIOCLIP_LIST},
+        {"audioclip-list", kCmdAudioClipList, 2, HELP_AUDIOCLIP_LIST},
         {"autoash",     kCmdAutoAsh,    2, HELP_AUTOASH},
         {"custom-data-dir", kCmdCustomDataDir, 2, HELP_CUSTOMDATADIR_LIST},
         {"font-list",   kCmdFontList,   2, HELP_FONT_LIST},
@@ -196,8 +196,6 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
     {
         std::vector<String> dirs;
         AGF::ReadCustomDataDirectories(dirs, reader.GetGameRoot());
-        // Unfortunately, in AGS 3.x project there's no explicit indication of a filename,
-        // only font ID. The actual file is chosen at runtime among all variants, by certain priority rule.
         for (const auto &dir : dirs)
         {
             exp_data.AppendFmt("%s\n", dir.GetCStr());
@@ -448,6 +446,6 @@ int main(int argc, char *argv[])
     else if (!stdout_list_print)
     {
         fprintf(StdFile, "Data exported successfully.\n");
-        return 0;
     }
+    return 0;
 }

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -44,14 +44,14 @@ const char *HELP_CUSTOMDATADIR_LIST = ""
     "Writes <OUT-FILE>, a file with a list of custom game data directories.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_FONT_LIST = ""
     "Usage: agfexport font-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of font files used by the game\n."
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of font files to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_GAMECFG = ""
     "Usage: agfexport gamecfg <INPUT-GAME.AGF> <OUT-FILE.CFG>\n"
@@ -72,35 +72,35 @@ const char *HELP_HEADER_LIST = ""
     "Writes <OUT-FILE>, a file with a list of headers from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of scripts to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_PLUGIN_LIST = ""
     "Usage: agfexport plugin-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of game plugins.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of rooms to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_ROOM_LIST = ""
     "Usage: agfexport room-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of rooms.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of rooms to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_SCRIPT_LIST = ""
     "Usage: agfexport script-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with an ordered list of scripts from script modules.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of scripts to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_TRA_LIST = ""
     "Usage: agfexport tra-list <INPUT-GAME.AGF> <OUT-FILE>\n"
     "Writes <OUT-FILE>, a file with a list of translations.\n"
     "Commands:\n"
     "  -h, --help             Show this help message\n"
-    "  -t, --to-stdout        Instead write the list of translations to stdout\n";
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 enum CommandType
 {
@@ -138,6 +138,10 @@ struct Command
         {nullptr,       kCmdNone,       0, nullptr}
 };
 
+// A file target to print program log to (info, warnings and errors)
+// TODO: replace this with a proper log system for tools.
+FILE *StdFile = stdout;
+
 HError write_to_file(const String &content, const String &file)
 {
     std::unique_ptr<Stream> out(File::CreateFile(file));
@@ -151,6 +155,9 @@ HError write_to_file(const String &content, const String &file)
 
 HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String &file, bool to_stdout)
 {
+    if (!to_stdout)
+        fprintf(StdFile, "Output list file: %s\n", file.GetCStr());
+
     String exp_data;
 
     if (cmd == kCmdCustomDataDir)
@@ -230,14 +237,16 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
         printf("%s", exp_data.GetCStr());
         return HError::None();
     }
-
-    return write_to_file(exp_data, file);
+    else
+    {
+        return write_to_file(exp_data, file);
+    }
 }
 
 HError autoash_command(AGF::AGFReader &reader, const String &dst)
 {
     const char *dst_autoash = dst.GetCStr();
-    printf("Output script header: %s\n", dst_autoash);
+    fprintf(StdFile, "Output script header: %s\n", dst_autoash);
 
     GameRef game_ref;
     AGF::ReadGameRef(game_ref, reader);
@@ -247,8 +256,8 @@ HError autoash_command(AGF::AGFReader &reader, const String &dst)
 
 HError glvar_command(AGF::AGFReader &reader, const String &header_file, const String &body_file)
 {
-    printf("Output script header: %s\n", header_file.GetCStr());
-    printf("Output script body: %s\n", body_file.GetCStr());
+    fprintf(StdFile, "Output script header: %s\n", header_file.GetCStr());
+    fprintf(StdFile, "Output script body: %s\n", body_file.GetCStr());
 
     std::vector<Variable> vars;
     AGF::ReadGlobalVariables(vars, reader.GetGameRoot());
@@ -259,20 +268,20 @@ HError glvar_command(AGF::AGFReader &reader, const String &header_file, const St
     if (!err)
         return err;
 
-    printf("Script header written successfully.\n");
+    fprintf(StdFile, "Script header written successfully.\n");
 
     err = write_to_file(body, body_file);
     if (!err)
         return err;
 
-    printf("Script body written successfully.\n");
+    fprintf(StdFile, "Script body written successfully.\n");
 
     return HError::None();
 }
 
 HError gamecfg_command(AGF::AGFReader &reader, const String &dst)
 {
-    printf("Output config file: %s\n", dst.GetCStr());
+    fprintf(StdFile, "Output config file: %s\n", dst.GetCStr());
 
     GameSettings settings;
     RuntimeSetup setup;
@@ -301,12 +310,11 @@ int main(int argc, char *argv[])
         return result.HelpRequested ? 0 : -1;
     }
 
-    const bool stdout_list_print = result.Opt.count("-t") || result.Opt.count("--to-stdout");
-    // for (auto &owv: result.OptWithValue)
-    // {
-    //    const String &opt = owv.first;
-    //    const String &value = owv.second;
-    // }
+    const bool stdout_list_print = result.Opt.count("-s") || result.Opt.count("--stdout");
+    if (stdout_list_print)
+    {
+        StdFile = stderr;
+    }
 
     //-----------------------------------------------------------------------//
     // Parse command specific arguments
@@ -327,14 +335,14 @@ int main(int argc, char *argv[])
             const char *cmd_help = Command[cmd].Help;
             if (result.HelpRequested)
             {
-                printf("%s\n", cmd_help);
+                fprintf(StdFile, "%s\n", cmd_help);
                 return 0;
             }
             if (asked_command_argc != required_cmd_argc)
             {
-                printf("Error: required positional arguments don't match\n");
-                printf("Requires %zu arguments, passed %zu\n", required_cmd_argc, asked_command_argc);
-                printf("%s\n", cmd_help);
+                fprintf(StdFile, "Error: required positional arguments don't match\n");
+                fprintf(StdFile, "Requires %zu arguments, passed %zu\n", required_cmd_argc, asked_command_argc);
+                fprintf(StdFile, "%s\n", cmd_help);
                 return -1;
             }
 
@@ -348,8 +356,8 @@ int main(int argc, char *argv[])
 
     if (command == kCmdNone)
     {
-        printf("Error: unknown command '%s'\n", asked_command.GetCStr());
-        printf("%s\n", HELP_STRING);
+        fprintf(StdFile, "Error: unknown command '%s'\n", asked_command.GetCStr());
+        fprintf(StdFile, "%s\n", HELP_STRING);
         return -1;
     }
 
@@ -362,8 +370,8 @@ int main(int argc, char *argv[])
     HError err = reader.Open(game_agf.GetCStr());
     if (!err)
     {
-        printf("Error: failed to open source AGF '%s':\n", game_agf.GetCStr());
-        printf("%s\n", err->FullMessage().GetCStr());
+        fprintf(StdFile, "Error: failed to open source AGF '%s':\n", game_agf.GetCStr());
+        fprintf(StdFile, "%s\n", err->FullMessage().GetCStr());
         return -1;
     }
 
@@ -400,11 +408,13 @@ int main(int argc, char *argv[])
 
     if (!err)
     {
-        printf("Error: failed to execute command\n");
-        printf("%s\n", err->FullMessage().GetCStr());
+        fprintf(StdFile, "Error: failed to execute command\n");
+        fprintf(StdFile, "%s\n", err->FullMessage().GetCStr());
         return -1;
-    } else if(!stdout_list_print) {
-        printf("Data exported successfully.\n");
     }
-    return 0;
+    else if (!stdout_list_print)
+    {
+        fprintf(StdFile, "Data exported successfully.\n");
+        return 0;
+    }
 }

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -16,10 +16,12 @@ using namespace AGS::DataUtil;
 namespace AGF = AGS::AGF;
 
 const char *HELP_STRING = ""
+   //--------------------------------------------------------------------------------|
     "agfexport v0.3.0 - AGS game project miscellaneous export tool\n"
     "Copyright (c) 2026 AGS Team and contributors\n"
     "Usage: agfexport <COMMAND> [<OPTIONS>] <input-game.agf> <out-file>\n"
     "Commands:\n"
+    "  audioclip-list         Exports list of audio clips and their sources\n"
     "  autoash                Generate auto script header\n"
     "  custom-data-dir        Exports list of custom data directories\n"
     "  font-list              Exports list of font files\n"
@@ -31,6 +33,23 @@ const char *HELP_STRING = ""
     "  script-list            Exports ordered list of scripts from script modules\n"
     "  tra-list               Exports list of translations\n"
     "  -h, --help             Show help message for command\n";
+
+const char *HELP_AUDIOCLIP_LIST = ""
+    "Usage: agfexport audioclip-list <INPUT-GAME.AGF> <OUT-FILE>\n"
+    "Writes <OUT-FILE>, a file with a list of audio files used by the game\n."
+    "Each entry in the list consists of 3 comma-separated items:\n"
+    "  * audio clip's import filename\n"
+    "  * audio clip's source absolute filepath\n"
+    "  * packing location, which is either 'ags' for the main game pack\n"
+    "    or 'vox' for the separate 'audio.vox'\n"
+#if (AGS_PLATFORM_OS_WINDOWS)
+    "Entry example: au000001.ogg,C:\\Projects\\Audio\\OriginalMusic.ogg,vox\n"
+#else
+    "Entry example: au000001.ogg,~/Projects/Audio/OriginalMusic.ogg,vox\n"
+#endif
+    "Commands:\n"
+    "  -h, --help             Show this help message\n"
+    "  -s, --stdout           Instead write the list of font files to stdout\n";
 
 const char *HELP_AUTOASH = ""
     "Usage: agfexport autoash <INPUT-GAME.AGF> <OUT-FILE.ASH>\n"
@@ -104,7 +123,8 @@ const char *HELP_TRA_LIST = ""
 
 enum CommandType
 {
-    kCmdAutoAsh = 0,
+    kCmdAudioClipList,
+    kCmdAutoAsh,
     kCmdCustomDataDir,
     kCmdFontList,
     kCmdGameCfg,
@@ -125,6 +145,7 @@ struct Command
     const size_t NumArgs;
     const char *Help;
 } Command[] = {
+        {"audio-list",  kCmdAudioClipList, 2, HELP_AUDIOCLIP_LIST},
         {"autoash",     kCmdAutoAsh,    2, HELP_AUTOASH},
         {"custom-data-dir", kCmdCustomDataDir, 2, HELP_CUSTOMDATADIR_LIST},
         {"font-list",   kCmdFontList,   2, HELP_FONT_LIST},
@@ -159,6 +180,17 @@ HError list_command(const AGF::AGFReader &reader, CommandType cmd, const String 
         fprintf(StdFile, "Output list file: %s\n", file.GetCStr());
 
     String exp_data;
+
+    if (cmd == kCmdAudioClipList)
+    {
+        std::vector<AudioClipData> clips;
+        AGF::ReadAudioClips(clips, reader.GetGameRoot());
+        for (const auto &clip : clips)
+        {
+            exp_data.AppendFmt("%s,%s,%s\n", clip.CacheFileName.GetCStr(), clip.SourceFileName.GetCStr(),
+                clip.BundlingType == kAudioBundling_InMainData ? "ags" : "vox");
+        }
+    }
 
     if (cmd == kCmdCustomDataDir)
     {
@@ -381,6 +413,7 @@ int main(int argc, char *argv[])
     String exp_data;
     switch (command)
     {
+        case kCmdAudioClipList:
         case kCmdCustomDataDir:
         case kCmdFontList:
         case kCmdHeaderList:

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1699,6 +1699,19 @@ void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem elem)
     p_set.ReadAllData(set_elem, setup);
 }
 
+void ReadCustomDataDirectories(std::vector<String> &dirs, DocElem root)
+{
+    AGF::Game p_game;
+    AGF::GameSettings p_set;
+    DataUtil::GameSettings set;
+    p_set.ReadAllData(p_game.GetSettings(root), set);
+    const auto game_dirs = set.CustomDataDir.Split(',');
+    dirs.clear();
+    for (const auto &dir : game_dirs)
+        if (!dir.IsEmpty())
+            dirs.push_back(dir);
+}
+
 void ReadFontList(std::vector<int> &font_list, DocElem root)
 {
     AGF::Fonts fonts;

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1688,6 +1688,18 @@ void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root)
     }
 }
 
+void ReadFontList(std::vector<int> &font_list, DocElem root)
+{
+    AGF::Fonts fonts;
+    AGF::Font font;
+    std::vector<DocElem> font_els;
+    fonts.GetAll(root, font_els);
+    for (const auto &t : font_els)
+    {
+        font_list.push_back(font.ReadID(t));
+    }
+}
+
 void ReadTranslationList(std::vector<String> &trs_list, DocElem root)
 {
     AGF::Translations translations;

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1699,6 +1699,42 @@ void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem elem)
     p_set.ReadAllData(set_elem, setup);
 }
 
+void ReadFontList(std::vector<int> &font_list, DocElem root)
+{
+    AGF::Fonts fonts;
+    AGF::Font font;
+    std::vector<DocElem> font_els;
+    fonts.GetAll(root, font_els);
+    for (const auto &t : font_els)
+    {
+        font_list.push_back(font.ReadID(t));
+    }
+}
+
+void ReadPluginList(std::vector<String> &plugin_list, DocElem root)
+{
+    AGF::Plugins plugins;
+    AGF::Plugin plugin;
+    std::vector<DocElem> pl_els;
+    plugins.GetAll(root, pl_els);
+    for (const auto &pl : pl_els)
+    {
+        plugin_list.push_back(plugin.ReadFileName(pl));
+    }
+}
+
+void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root)
+{
+    AGF::Rooms rooms;
+    AGF::Room room;
+    std::vector<DocElem> room_els;
+    rooms.GetAll(root, room_els);
+    for (const auto &r : room_els)
+    {
+        room_list.push_back(std::make_pair(room.ReadNumber(r), room.ReadDescription(r)));
+    }
+}
+
 void ReadScriptList(std::vector<String> &script_list, DocElem root)
 {
     AGF::ScriptModules scmodules;
@@ -1726,30 +1762,6 @@ void ReadScriptHeaderList(std::vector<String> &headers_list, DocElem root)
         DocElem header = scmodule.GetHeader(m);
         if (!header) continue;
         headers_list.push_back(scelem.ReadFilename(header));
-    }
-}
-
-void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root)
-{
-    AGF::Rooms rooms;
-    AGF::Room room;
-    std::vector<DocElem> room_els;
-    rooms.GetAll(root, room_els);
-    for (const auto &r : room_els)
-    {
-        room_list.push_back(std::make_pair(room.ReadNumber(r), room.ReadDescription(r)));
-    }
-}
-
-void ReadFontList(std::vector<int> &font_list, DocElem root)
-{
-    AGF::Fonts fonts;
-    AGF::Font font;
-    std::vector<DocElem> font_els;
-    fonts.GetAll(root, font_els);
-    for (const auto &t : font_els)
-    {
-        font_list.push_back(font.ReadID(t));
     }
 }
 

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1688,5 +1688,17 @@ void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root)
     }
 }
 
+void ReadTranslationList(std::vector<String> &trs_list, DocElem root)
+{
+    AGF::Translations translations;
+    AGF::Translation translation;
+    std::vector<DocElem> trs_els;
+    translations.GetAll(root, trs_els);
+    for (const auto &t : trs_els)
+    {
+        trs_list.push_back(translation.ReadName(t));
+    }
+}
+
 } // namespace AGF
 } // namespace AGS

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -309,6 +309,14 @@ int ValueParser::ReadInt(DocElem elem, const char *field, int def_value)
     return def_value;
 }
 
+float ValueParser::ReadFloat(DocElem elem, const char *field, float def_value)
+{
+    DocElem name_f = elem->FirstChildElement(field);
+    if (name_f)
+        return StrUtil::StringToFloat(name_f->GetText(), def_value);
+    return def_value;
+}
+
 bool ValueParser::ReadBool(DocElem elem, const char *field, bool def_value)
 {
     if (!elem)
@@ -865,9 +873,46 @@ void CustomPropertySchema::GetAll(DocElem root, std::vector<DocElem> &elems)
     }
 }
 
+void RuntimeSetup::ReadAllData(DocElem elem, DataUtil::RuntimeSetup &setup)
+{
+    setup.AAScaledSprites = ReadBool(elem, "AAScaledSprites");
+    setup.AutoLockMouse = ReadBool(elem, "AutoLockMouse");
+    setup.CompressSaves = ReadBool(elem, "CompressSaves");
+    setup.CustomAppDataPath = ReadString(elem, "CustomAppDataPath");
+    setup.CustomSavePath = ReadString(elem, "CustomSavePath");
+    setup.AudioDriver = ReadString(elem, "DigitalSound");
+    setup.FullscreenDesktop = ReadBool(elem, "FullscreenDesktop");
+    setup.FullscreenGameScaling = ReadString(elem, "FullscreenGameScaling");
+    setup.WindowGameScaling = ReadString(elem, "GameScaling");
+    setup.GameScalingMultiplier = ReadInt(elem, "GameScalingMultiplier");
+    setup.GraphicsDriver = ReadString(elem, "GraphicsDriver");
+    setup.GraphicsFilter = ReadString(elem, "GraphicsFilter");
+    setup.MouseSpeed = ReadFloat(elem, "MouseSpeed");
+    setup.RenderAtScreenResolution = ReadBool(elem, "RenderAtScreenResolution");
+    setup.Rotation = ReadString(elem, "Rotation");
+    setup.ShowFPS = ReadBool(elem, "ShowFPS");
+    setup.SoundCacheSize = ReadInt(elem, "SoundCacheSize");
+    setup.SpriteCacheSize = ReadInt(elem, "SpriteCacheSize");
+    setup.TextureCacheSize = ReadInt(elem, "TextureCacheSize");
+    setup.TitleText = ReadString(elem, "TitleText");
+    setup.TouchToMouseEmulation = ReadString(elem, "TouchToMouseEmulation");
+    setup.TouchToMouseMotionMode = ReadString(elem, "TouchToMouseMotionMode");
+    setup.Translation = ReadString(elem, "Translation");
+    setup.UseCustomAppDataPath = ReadBool(elem, "UseCustomAppDataPath");
+    setup.UseCustomSavePath = ReadBool(elem, "UseCustomSavePath");
+    setup.UseVoicePack = ReadBool(elem, "UseVoicePack");
+    setup.VSync = ReadBool(elem, "VSync");
+    setup.Windowed = ReadBool(elem, "Windowed");
+}
+
 DocElem Game::GetSettings(DocElem elem)
 {
     return elem->FirstChildElement("Settings");
+}
+
+DocElem Game::GetDefaultSetup(DocElem elem)
+{
+    return elem->FirstChildElement("RuntimeSetup");
 }
 
 DocElem ScriptWithHeader::GetHeader(DocElem elem)
@@ -1644,6 +1689,14 @@ void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader)
         for (const auto &view : views)
             if (view.ID > 0) game.Views[view.ID - 1] = view;
     }
+}
+
+void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem elem)
+{
+    AGF::Game p_game;
+    AGF::RuntimeSetup p_set;
+    DocElem set_elem = p_game.GetDefaultSetup(elem);
+    p_set.ReadAllData(set_elem, setup);
 }
 
 void ReadScriptList(std::vector<String> &script_list, DocElem root)

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1116,7 +1116,7 @@ static DataUtil::SpriteImportResolution ReadSpriteImportResolution(const String 
 static DataUtil::AudioFileBundlingType ReadAudioBundlingType(const String &value)
 {
     return StrUtil::ParseEnumWithBase(value, kAudioBundlingTypeNames,
-        DataUtil::kAudioBundling_InGameEXE, DataUtil::kAudioBundling_InGameEXE);
+        DataUtil::kAudioBundling_InMainData, DataUtil::kAudioBundling_InMainData);
 }
 
 static DataUtil::AudioClipFileType ReadAudioFileType(const String &value)
@@ -1697,6 +1697,20 @@ void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem elem)
     AGF::RuntimeSetup p_set;
     DocElem set_elem = p_game.GetDefaultSetup(elem);
     p_set.ReadAllData(set_elem, setup);
+}
+
+void ReadAudioClips(std::vector<DataUtil::AudioClipData> &clips, DocElem root)
+{
+    AGF::AudioClips aclips;
+    AGF::AudioClip aclip;
+    std::vector<DocElem> aclip_els;
+    aclips.GetAll(root, aclip_els);
+    for (const auto &a_el : aclip_els)
+    {
+        DataUtil::AudioClipData adata;
+        aclip.ReadAllData(a_el, adata);
+        clips.push_back(adata);
+    }
 }
 
 void ReadCustomDataDirectories(std::vector<String> &dirs, DocElem root)

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -80,6 +80,7 @@ public:
     // all of them return default value if the field cannot be read
     static const char *ReadString(DocElem elem, const char *field, const char *def_value = "");
     static int ReadInt(DocElem elem, const char *field, int def_value = 0);
+    static float ReadFloat(DocElem elem, const char *field, float def_value = 0.f);
     static bool ReadBool(DocElem elem, const char *field, bool def_value = false);
 
     // Read values stored as XML attributes rather than child elements.
@@ -387,6 +388,7 @@ public:
     String ReadScriptName(DocElem elem) override { return ""; }
 
     DocElem GetSettings(DocElem elem);
+    DocElem GetDefaultSetup(DocElem elem);
 };
 
 class GameSettings : public EntityParser
@@ -395,7 +397,16 @@ public:
     String ReadType(DocElem elem) override { return "GameSettings"; }
     int    ReadID(DocElem elem) override { return -1; }
     String ReadScriptName(DocElem elem) override { return ""; }
-    void ReadAllData(DocElem elem, DataUtil::GameSettings& s);
+    void   ReadAllData(DocElem elem, DataUtil::GameSettings& s);
+};
+
+class RuntimeSetup : public EntityParser
+{
+public:
+    String ReadType(DocElem elem) override { return "RuntimeSetup"; }
+    int    ReadID(DocElem elem) override { return -1; }
+    String ReadScriptName(DocElem elem) override { return ""; }
+    void   ReadAllData(DocElem elem, DataUtil::RuntimeSetup &setup);
 };
 
 // Parses a description of an individual script file (header or body)
@@ -485,6 +496,8 @@ void ReadGameSettings(DataUtil::GameSettings &opt, DocElem root);
 void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader);
 // Reads full game data required for serializing a compiled game.
 void ReadGameData(DataUtil::GameData &game, AGFReader &reader);
+// Reads default runtime game setup data
+void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem root);
 // Reads an ordered list of script module names (their order determines dependency).
 void ReadScriptList(std::vector<String> &script_list, DocElem root);
 // Reads an ordered list of script header module names (their order determines dependency).

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -491,6 +491,9 @@ void ReadScriptList(std::vector<String> &script_list, DocElem root);
 void ReadScriptHeaderList(std::vector<String> &script_list, DocElem root);
 // Reads a list of room ID and descriptions found in the game document.
 void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
+// Reads a list of font IDs.
+// In 3.x AGS project the font items do not provide explicit filenames, so one has to rely on IDs.
+void ReadFontList(std::vector<int> &font_list, DocElem root);
 // Reads a list of translation names.
 void ReadTranslationList(std::vector<String> &trs_list, DocElem root);
 

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -435,6 +435,23 @@ public:
     }
 };
 
+// Parses a description of a game plugin
+class Plugin : public ValueParser
+{
+public:
+    String ReadFileName(DocElem elem) { return ReadString(elem, "FileName"); }
+};
+
+// Parses a list of game plugins
+class Plugins : public EntityListParser
+{
+public:
+    void GetAll(DocElem root, std::vector<DocElem> &elems) override
+    {
+        GetAllElems(root, elems, nullptr, "Plugins", "Plugin");
+    }
+};
+
 // Parses a description of a room
 class Room : public ValueParser
 {
@@ -498,15 +515,17 @@ void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader);
 void ReadGameData(DataUtil::GameData &game, AGFReader &reader);
 // Reads default runtime game setup data
 void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem root);
+// Reads a list of font IDs.
+// In 3.x AGS project the font items do not provide explicit filenames, so one has to rely on IDs.
+void ReadFontList(std::vector<int> &font_list, DocElem root);
+// Reads a list of plugins registered for this game project.
+void ReadPluginList(std::vector<String> &plugin_list, DocElem root);
+// Reads a list of room ID and descriptions found in the game document.
+void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
 // Reads an ordered list of script module names (their order determines dependency).
 void ReadScriptList(std::vector<String> &script_list, DocElem root);
 // Reads an ordered list of script header module names (their order determines dependency).
 void ReadScriptHeaderList(std::vector<String> &script_list, DocElem root);
-// Reads a list of room ID and descriptions found in the game document.
-void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
-// Reads a list of font IDs.
-// In 3.x AGS project the font items do not provide explicit filenames, so one has to rely on IDs.
-void ReadFontList(std::vector<int> &font_list, DocElem root);
 // Reads a list of translation names.
 void ReadTranslationList(std::vector<String> &trs_list, DocElem root);
 

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -442,6 +442,23 @@ public:
     }
 };
 
+// Parses a description of a translation
+class Translation : public ValueParser
+{
+public:
+    String ReadName(DocElem elem) { return ReadString(elem, "Name"); }
+};
+
+// Parses a list of translations
+class Translations : public EntityListParser
+{
+public:
+    void GetAll(DocElem root, std::vector<DocElem> &elems) override
+    {
+        GetAllElems(root, elems, nullptr, "Translations", "Translation");
+    }
+};
+
 
 //
 // Helper functions
@@ -474,6 +491,8 @@ void ReadScriptList(std::vector<String> &script_list, DocElem root);
 void ReadScriptHeaderList(std::vector<String> &script_list, DocElem root);
 // Reads a list of room ID and descriptions found in the game document.
 void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
+// Reads a list of translation names.
+void ReadTranslationList(std::vector<String> &trs_list, DocElem root);
 
 } // namespace AGF
 } // namespace AGS

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -515,6 +515,8 @@ void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader);
 void ReadGameData(DataUtil::GameData &game, AGFReader &reader);
 // Reads default runtime game setup data
 void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem root);
+// Reads a list of custom asset directories for this project
+void ReadCustomDataDirectories(std::vector<String> &dirs, DocElem root);
 // Reads a list of font IDs.
 // In 3.x AGS project the font items do not provide explicit filenames, so one has to rely on IDs.
 void ReadFontList(std::vector<int> &font_list, DocElem root);

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -515,6 +515,8 @@ void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader);
 void ReadGameData(DataUtil::GameData &game, AGFReader &reader);
 // Reads default runtime game setup data
 void ReadRuntimeSetup(DataUtil::RuntimeSetup &setup, DocElem root);
+// Reads a list of audio clips for this project
+void ReadAudioClips(std::vector<DataUtil::AudioClipData> &clips, DocElem root);
 // Reads a list of custom asset directories for this project
 void ReadCustomDataDirectories(std::vector<String> &dirs, DocElem root);
 // Reads a list of font IDs.

--- a/Tools/data/game_utils.cpp
+++ b/Tools/data/game_utils.cpp
@@ -1,0 +1,125 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "data/game_utils.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+// TODO: consider a generic String-to-String conversion based on a array of string pairs?
+
+String MakeGameScalingConfig(const String &scaling)
+{
+    if (scaling == "MaxInteger" || scaling == "Integer")
+        return "round";
+    if (scaling == "StretchToFit")
+        return "stretch";
+    if (scaling == "ProportionalStretch")
+        return "proportional";
+    return "";
+}
+
+String MakeRotationConfig(const String &rotation)
+{
+    if (rotation == "Unlocked")
+        return "unlocked";
+    else if (rotation == "Portrait")
+        return "portrait";
+    else if (rotation == "Landscape")
+        return "landscape";
+    return "";
+}
+
+String MakeTouchMouseEmulModeConfig(const String &mode)
+{
+    if (mode == "OneFinger")
+        return "one_finger";
+    if (mode == "TwoFingers")
+        return "two_fingers";
+    return "off";
+}
+
+String CustomPathForConfig(bool use_custom_path, const String &custom_path)
+{
+    String path_value = ""; // no value
+    if (use_custom_path)
+    {
+        if (custom_path.IsEmpty())
+            path_value = "."; // same directory
+        else
+            path_value = custom_path;
+    }
+    return path_value;
+}
+
+void WriteConfig(const RuntimeSetup &setup, const GameSettings *settings, ConfigTree &cfg)
+{
+    cfg["graphics"]["driver"] = setup.GraphicsDriver;
+    cfg["graphics"]["windowed"] = setup.Windowed ? "1" : "0";
+    cfg["graphics"]["fullscreen"] = setup.FullscreenDesktop ? "full_window" : "desktop";
+    if (setup.WindowGameScaling == "Integer")
+        cfg["graphics"]["window"] = String::FromFormat("x%d", setup.GameScalingMultiplier);
+    else
+        cfg["graphics"]["window"] = "desktop";
+
+    cfg["graphics"]["game_scale_fs"] = MakeGameScalingConfig(setup.FullscreenGameScaling);
+    cfg["graphics"]["game_scale_win"] = MakeGameScalingConfig(setup.WindowGameScaling);
+
+    cfg["graphics"]["filter"] = setup.GraphicsFilter;
+    cfg["graphics"]["vsync"] = setup.VSync ? "1" : "0";
+    cfg["graphics"]["antialias"] = setup.AAScaledSprites ? "1" : "0";
+    bool render_at_screenres = setup.RenderAtScreenResolution;
+    if (settings)
+        render_at_screenres = render_at_screenres
+            && (settings->RenderAtScreenResolution != ::kRenderAtScreenRes_Disabled)
+            || (settings->RenderAtScreenResolution == ::kRenderAtScreenRes_Enabled);
+    cfg["graphics"]["render_at_screenres"] = render_at_screenres ? "1" : "0";
+    
+    cfg["graphics"]["rotation"] = MakeRotationConfig(setup.Rotation);
+
+    bool audio_enabled = setup.AudioDriver != "Disabled";
+    cfg["sound"]["enabled"] = audio_enabled ? "1" : "0";
+    cfg["sound"]["driver"] = ""; // always default
+    cfg["sound"]["usespeech"] = setup.UseVoicePack ? "1" : "0";
+
+    cfg["language"]["translation"] = setup.Translation;
+    cfg["mouse"]["auto_lock"] = setup.AutoLockMouse ? "1" : "0";
+    cfg["mouse"]["speed"] = String::FromFormat("%.f", setup.MouseSpeed);
+
+    // Touch input
+    cfg["touch"]["emul_mouse_mode"] = MakeTouchMouseEmulModeConfig(setup.TouchToMouseEmulation);
+    cfg["touch"]["emul_mouse_relative"] = setup.TouchToMouseMotionMode == "Relative" ? "1" : "0";
+
+    // Note: the cache sizes are written in KB (while we have it in MB on the editor pane)
+    cfg["graphics"]["sprite_cache_size"] = String::FromFormat("%d", setup.SpriteCacheSize * 1024);
+    cfg["graphics"]["texture_cache_size"] = String::FromFormat("%d", setup.TextureCacheSize * 1024);
+    cfg["sound"]["cache_size"] = String::FromFormat("%d", setup.SoundCacheSize * 1024);
+    cfg["misc"]["compress_saves"] = setup.CompressSaves ? "1" : "0";
+
+    cfg["misc"]["user_data_dir"] = CustomPathForConfig(setup.UseCustomSavePath, setup.CustomSavePath);
+    cfg["misc"]["shared_data_dir"] = CustomPathForConfig(setup.UseCustomAppDataPath, setup.CustomAppDataPath);
+    cfg["misc"]["titletext"] = setup.TitleText;
+
+    // Do not write show_fps in a release build, this is only intended for the developer
+    if (!settings || !settings->DebugMode)
+    {
+        cfg["misc"]["show_fps"] = setup.ShowFPS ? "1" : "0";
+    }
+}
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -22,7 +22,7 @@
 #include "game/customproperties.h"
 #include "gui/guidefines.h"
 #include "util/geometry.h"
-#include "util/string.h"
+#include "util/ini_util.h"
 
 namespace AGS
 {
@@ -579,6 +579,39 @@ struct GameSettings
     GuiDisableStyle WhenInterfaceDisabled = AGS::Common::kGuiDis_Greyout;
 };
 
+struct RuntimeSetup
+{
+    // TODO: consider turning enum-like string fields into actual enum fields? see notes below
+    String GraphicsDriver;
+    bool Windowed = false;
+    bool FullscreenDesktop = false;
+    String FullscreenGameScaling; // enum-like field
+    String WindowGameScaling; // enum-like field
+    int GameScalingMultiplier = 0;
+    String GraphicsFilter;
+    bool VSync = false;
+    bool AAScaledSprites = false;
+    bool RenderAtScreenResolution = false;
+    String Rotation; // enum-like field
+    String AudioDriver; // enum-like field
+    bool UseVoicePack = false;
+    String Translation;
+    bool AutoLockMouse = false;
+    float MouseSpeed = 0.f;
+    String TouchToMouseEmulation; // enum-like field
+    String TouchToMouseMotionMode; // enum-like field
+    bool ShowFPS = false;
+    int SpriteCacheSize = 0;
+    int TextureCacheSize = 0;
+    int SoundCacheSize = 0;
+    bool CompressSaves = false;
+    bool UseCustomSavePath = false;
+    String CustomSavePath;
+    bool UseCustomAppDataPath = false;
+    String CustomAppDataPath;
+    String TitleText;
+};
+
 struct CustomPropertySchemaItem
 {
     String Name;
@@ -665,6 +698,10 @@ struct GameData : GameRef
     std::vector<PluginData> Plugins;
     String EditorVersion;
 };
+
+// Fills ConfigTree with contents of RuntimeSetup, in accordance to the AGS config format.
+// Optionally uses GameSettings to adjust certain config options.
+void WriteConfig(const RuntimeSetup &setup, const GameSettings *settings, AGS::Common::ConfigTree &cfg);
 
 } // namespace DataUtil
 } // namespace AGS

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -153,7 +153,7 @@ enum SpriteImportResolution
 
 enum AudioFileBundlingType
 {
-    kAudioBundling_InGameEXE = 1,
+    kAudioBundling_InMainData = 1,
     kAudioBundling_InSeparateVOX = 2
 };
 
@@ -319,7 +319,7 @@ struct AudioClipData : EntityRef
     int Index{};
     String SourceFileName;
     String CacheFileName;
-    AudioFileBundlingType BundlingType = kAudioBundling_InGameEXE;
+    AudioFileBundlingType BundlingType = kAudioBundling_InMainData;
     int Type{};
     AudioClipFileType FileType = kAudioFile_Undefined;
     bool Repeat{};


### PR DESCRIPTION
Adds following commands to the agfexport tool:

* `audioclip-list` - exports list of audio clip files, their sources, and packing location, as comma-separated entries, e.g.:
    `au000001.ogg,C:\\Projects\\Audio\\OriginalMusic.ogg,vox`
* `custom-data-dir` - exports list of custom game data directories to include into final package.
* `game-cfg` - writes default game config.
* `font-list` - exports list of font files. Note that since in 3.x we cannot tell exact file names for fonts, this list is a *suggestion* containing all possible variants (wfn and ttf); a build tool should expect some of these files missing which is not a error case.
* `plugin-list` - exports list of game plugins.
* `tra-list` - exports list of translation sources (`.trs` in 3.x). This list may be used to know which translations to compile and include into game package.

