### PR TITLE
agspak: support multiple input dirs

### DIFF
--- a/Tools/agspak/commands.cpp
+++ b/Tools/agspak/commands.cpp
@@ -110,15 +110,12 @@ static HError CutAssetLibrary(const String &pak_file, bool verbose)
     return HError::None();
 }
 
-static HError PrepareAssetLibrary(AssetLibInfo &lib,
-    const String &src_dir, const String &dst_pak,
-    const std::vector<String> &pattern_list, const String &pattern_file,
-    bool do_subdirs, size_t part_size_mb, bool verbose)
+// Makes the list of assets from a single input directory, applying pattern list and/or rules from pattern file.
+// Fills a map of asset-name -> filepath pairs.
+static HError MakeAssetMapFromADir(const String &asset_dir, StringIMap &asset_map,
+    const std::vector<String> &pattern_list, const String &pattern_file, bool do_subdirs, bool verbose)
 {
-    const String &asset_dir = src_dir;
-    const String &lib_basefile = dst_pak;
     const bool has_pattern_file = !pattern_file.IsEmpty();
-
     std::vector<String> files;
     HError err = MakeListOfFiles(files, asset_dir, do_subdirs);
     if (!err)
@@ -157,28 +154,70 @@ static HError PrepareAssetLibrary(AssetLibInfo &lib,
         files = std::move(output_files);
     }
 
+    MakeAssetMapFromFileList(asset_map, files, asset_dir);
+    return HError::None();
+}
+
+// Configure the full asset library table of contents, by searching in all
+// the provided input directories, and picking files according to the pattern
+// list and/or pattern file.
+// Fills a map of asset-name -> filepath pairs.
+static HError PrepareAssetLibrary(AssetLibInfo &lib,
+    const std::vector<std::pair<String, bool>> &src_dirs, const String &dst_pak,
+    StringIMap &asset_map,
+    const std::vector<String> &pattern_list, const String &pattern_file,
+    DuplicateAssetAction dup_action,
+    size_t part_size_mb, bool verbose)
+{
+    const String &lib_basefile = dst_pak;
     std::vector<AssetInfo> assets;
-    err = MakeAssetListFromFileList(files, assets, asset_dir);
-    if (!err)
+    HError err;
+    for (const auto &src_dir : src_dirs)
     {
-        printf("Error: failed to prepare list of assets:\n");
-        printf("%s\n", err->FullMessage().GetCStr());
-        return err;
+        StringIMap local_asset_map;
+        err = MakeAssetMapFromADir(src_dir.first, local_asset_map, pattern_list, pattern_file, src_dir.second, verbose);
+        if (!err)
+            return err;
+
+        // Handle asset duplicates
+        std::vector<String> remove_keys;
+        for (const auto &asset_entry : local_asset_map)
+        {
+            const auto it_exist = asset_map.find(asset_entry.first);
+            if (it_exist != asset_map.end())
+            {
+                switch (dup_action)
+                {
+                case kAssetDup_Replace:
+                    printf("Warning: duplicate asset '%s' [replace]: first found: '%s', new found: '%s'\n", asset_entry.first.GetCStr(),
+                        it_exist->second.GetCStr(), asset_entry.second.GetCStr());
+                    break;
+                case kAssetDup_Skip:
+                    printf("Warning: duplicate asset '%s' [skip]: first found: '%s', new found: '%s'\n", asset_entry.first.GetCStr(),
+                        it_exist->second.GetCStr(), asset_entry.second.GetCStr());
+                    remove_keys.push_back(asset_entry.first);
+                    break;
+                default:
+                    return new Error(String::FromFormat("Duplicate asset '%s': first found: '%s', new found: '%s'\n", asset_entry.first.GetCStr(),
+                        it_exist->second.GetCStr(), asset_entry.second.GetCStr()));
+                }
+            }
+        }
+        for (const auto &rem_key : remove_keys)
+            local_asset_map.erase(rem_key);
+
+        asset_map.insert(local_asset_map.begin(), local_asset_map.end());
     }
-    if (assets.size() == 0)
+
+    if (asset_map.size() == 0)
     {
-        printf("No valid assets found in the provided directory.\nDone.\n");
-        return HError::None();
+        return new Error("No valid assets found in any of the provided input location(s)");
     }
 
     soff_t part_size_b = part_size_mb * 1024 * 1024; // MB to bytes
-    err = MakeAssetLib(lib, lib_basefile, assets, part_size_b);
+    err = MakeAssetLib(lib, lib_basefile, asset_map, part_size_b);
     if (!err)
-    {
-        printf("Error: failed to configure asset library:\n");
-        printf("%s\n", err->FullMessage().GetCStr());
         return err;
-    }
 
     return HError::None();
 }
@@ -227,31 +266,55 @@ int Command_Cut(const String &src_pak, bool verbose)
     return 0;
 }
 
-int Command_Create(const String &src_dir, const String &dst_pak, bool append,
-                   const std::vector<String> &pattern_list, const String &pattern_file,
-                   bool do_subdirs, size_t part_size_mb, bool verbose)
+int Command_Create(std::vector<std::pair<String, bool>> &src_dirs, const String &dst_pak, bool append,
+                   const std::vector<String> &pattern_list, const String &pattern_file, DuplicateAssetAction dup_action,
+                   size_t part_size_mb, bool verbose)
 {
-    printf("Input directory: %s\n", src_dir.GetCStr());
+    if (src_dirs.size() == 1)
+    {
+        printf("Input directory: %s", src_dirs[0].first.GetCStr());
+    }
+    else if (src_dirs.size() > 1)
+    {
+        printf("Input directories: %s%s\n", src_dirs[0].first.GetCStr(), src_dirs[0].second ? " [recursive]" : "");
+        for (size_t i = 1; i < src_dirs.size(); ++i)
+            printf("                   %s%s\n", src_dirs[i].first.GetCStr(), src_dirs[i].second ? " [recursive]" : "");
+    }
     printf("Output pack file: %s\n", dst_pak.GetCStr());
     const bool has_pattern_file = !pattern_file.IsEmpty();
     if (has_pattern_file)
         printf("Pattern file name: %s\n", pattern_file.GetCStr());
 
-    if (!File::IsDirectory(src_dir))
+    size_t valid_src_dirs = src_dirs.size();
+    for (const auto &dir : src_dirs)
     {
-        printf("Error: not a valid input directory.\n");
+        if (!File::IsDirectory(dir.first))
+        {
+            printf("Warning: not a valid input directory: %s.\n", dir.first.GetCStr());
+            valid_src_dirs--;
+        }
+    }
+
+    if (valid_src_dirs == 0)
+    {
+        printf("Error: no valid input directories provided");
         return -1;
     }
 
     //-----------------------------------------------------------------------//
     // Gather list of files and set up library info
     //-----------------------------------------------------------------------//
-    const String &asset_dir = src_dir;
+    // This will be the list of input file -> asset entry pairs
     const String &lib_basefile = dst_pak;
+    StringIMap asset_map;
     AssetLibInfo lib;
-    HError err = PrepareAssetLibrary(lib, asset_dir, lib_basefile, pattern_list, pattern_file, do_subdirs, part_size_mb, verbose);
+    HError err = PrepareAssetLibrary(lib, src_dirs, lib_basefile, asset_map, pattern_list, pattern_file, dup_action, part_size_mb, verbose);
     if (!err)
+    {
+        printf("Error: failed to prepare asset library:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
         return -1;
+    }
 
     //-----------------------------------------------------------------------//
     // If we are appending, then check for the existing library in the
@@ -272,7 +335,7 @@ int Command_Create(const String &src_dir, const String &dst_pak, bool append,
     // Write pack file
     //-----------------------------------------------------------------------//
     String lib_dir = Path::GetParent(lib_basefile);
-    err = WriteLibrary(lib, asset_dir, lib_dir, MFLUtil::kMFLVersion_MultiV30, append, verbose);
+    err = WriteLibrary(lib, asset_map, lib_dir, MFLUtil::kMFLVersion_MultiV30, append, verbose);
     if (!err)
     {
         printf("Error: failed to write pack file:\n");

--- a/Tools/agspak/commands.cpp
+++ b/Tools/agspak/commands.cpp
@@ -461,7 +461,7 @@ int Command_List(const String &src_pak)
     // TODO: print more info, but perhaps require cmd arguments for that? (because it's not always useful)
     for (const auto &asset : lib.AssetInfos)
     {
-        printf("* %s\n", asset.FileName.GetCStr());
+        printf("* %-40s[%10lld]\n", asset.FileName.GetCStr(), asset.Size);
     }
     printf("Done.\n");
     return 0;

--- a/Tools/agspak/commands.cpp
+++ b/Tools/agspak/commands.cpp
@@ -203,10 +203,12 @@ static HError PrepareAssetLibrary(AssetLibInfo &lib,
                 }
             }
         }
+
         for (const auto &rem_key : remove_keys)
             local_asset_map.erase(rem_key);
 
-        asset_map.insert(local_asset_map.begin(), local_asset_map.end());
+        for (const auto &new_item : local_asset_map)
+            asset_map[new_item.first] = new_item.second;
     }
 
     if (asset_map.size() == 0)
@@ -272,7 +274,7 @@ int Command_Create(std::vector<std::pair<String, bool>> &src_dirs, const String 
 {
     if (src_dirs.size() == 1)
     {
-        printf("Input directory: %s", src_dirs[0].first.GetCStr());
+        printf("Input directory: %s\n", src_dirs[0].first.GetCStr());
     }
     else if (src_dirs.size() > 1)
     {
@@ -297,7 +299,7 @@ int Command_Create(std::vector<std::pair<String, bool>> &src_dirs, const String 
 
     if (valid_src_dirs == 0)
     {
-        printf("Error: no valid input directories provided");
+        printf("Error: no valid input directories provided\n");
         return -1;
     }
 

--- a/Tools/agspak/commands.cpp
+++ b/Tools/agspak/commands.cpp
@@ -251,7 +251,7 @@ int Command_Attach(const String &src_pak, const String &dst_file, bool verbose)
     return 0;
 }
 
-int Command_Cut(const String &src_pak, bool verbose)
+int Command_CutAttachment(const String &src_pak, bool verbose)
 {
     printf("Input pack file: %s\n", src_pak.GetCStr());
 

--- a/Tools/agspak/commands.h
+++ b/Tools/agspak/commands.h
@@ -21,10 +21,17 @@ namespace AGSPak
 {
     using String = AGS::Common::String;
 
+    enum DuplicateAssetAction
+    {
+        kAssetDup_Error,
+        kAssetDup_Replace,
+        kAssetDup_Skip,
+    };
+
     int Command_Attach(const String &src_pak, const String &dst_file, bool verbose);
-    int Command_Create(const String &src_dir, const String &dst_pak, bool append,
-        const std::vector<String> &pattern_list,
-        const String &pattern_file, bool do_subdirs, size_t part_size_mb, bool verbose);
+    int Command_Create(std::vector<std::pair<String, bool>> &src_dirs, const String &dst_pak, bool append,
+        const std::vector<String> &pattern_list, const String &pattern_file, DuplicateAssetAction dup_action,
+        size_t part_size_mb, bool verbose);
     int Command_Cut(const String &src_file, bool verbose);
     int Command_Detach(const String &src_file, const String &dst_pak, bool verbose);
     int Command_Export(const String &src_pak, const String &dst_dir, const std::vector<String> &pattern_list);

--- a/Tools/agspak/commands.h
+++ b/Tools/agspak/commands.h
@@ -32,7 +32,7 @@ namespace AGSPak
     int Command_Create(std::vector<std::pair<String, bool>> &src_dirs, const String &dst_pak, bool append,
         const std::vector<String> &pattern_list, const String &pattern_file, DuplicateAssetAction dup_action,
         size_t part_size_mb, bool verbose);
-    int Command_Cut(const String &src_file, bool verbose);
+    int Command_CutAttachment(const String &src_file, bool verbose);
     int Command_Detach(const String &src_file, const String &dst_pak, bool verbose);
     int Command_Export(const String &src_pak, const String &dst_dir, const std::vector<String> &pattern_list);
     int Command_List(const String &src_pak);

--- a/Tools/agspak/main.cpp
+++ b/Tools/agspak/main.cpp
@@ -67,6 +67,9 @@ const char *HELP_STRING = "Usage:\n"
     "                         If no asset data is found, then nothing will be done.\n"
     "\n"
     "Command options:\n"
+    "  -D, --dir <directory>  when creating a pack file, additionally include files\n"
+    "                         from this input directory. These files will be put into\n"
+    "                         the root level of the asset pack's virtual filesystem.\n"
     "  -f, --pattern-file <file>\n"
     "                         when creating a pack file, use pattern file with the\n"
     "                         include/exclude patterns\n"
@@ -76,6 +79,16 @@ const char *HELP_STRING = "Usage:\n"
     "                         partition\n"
     "  -r, --recursive        when creating a pack file, include all subdirectories\n"
     "                         of a working directory too\n"
+    "  -R, --recursive-dir <directory>\n"
+    "                         when creating a pack file, additionally include files\n"
+    "                         from this directory and all of its subdirectories.\n"
+    "                         These files will be put into respective subdirs\n"
+    "                         relative to the asset pack's root.\n"
+    "  --replace-dup          when creating a pack file from multiple input dirs\n"
+    "                         replace any assets with duplicate names with the last\n"
+    "                         asset file found.\n"
+    "  --skip-dup             when creating a pack file from multiple input dirs\n"
+    "                         skip any assets with duplicate names.\n"
     "\n"
     "Other options:\n"
     "  -v, --verbose          print operation details"
@@ -131,14 +144,18 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
     const String dst_file = cmdargs.PosArgs.size() > 1 ? cmdargs.PosArgs[1] : String();
     const String file_list_str = cmdargs.PosArgs.size() > 2 ? cmdargs.PosArgs[2] : String();
     // Common options
+    const bool do_subdirs = cmdargs.Opt.count("-r") || cmdargs.Opt.count("--recursive");
+    const bool verbose = cmdargs.Opt.count("-v") || cmdargs.Opt.count("--verbose");
+    size_t part_size_mb = 0;
+
     // a include pattern file that should be inside the input-dir
     // TO-DO: support nested include pattern files in input-dir
     String pattern_file;
-
+    std::vector<std::pair<String, bool>> work_dirs;
+    work_dirs.push_back(std::make_pair(work_dir, do_subdirs));
     // TODO: easier way to:
     //  - get either short or long named option;
     //  - get option's value without the search loop in the code
-    size_t part_size_mb = 0;
     for (const auto &opt_with_value : cmdargs.OptWithValue)
     {
         if (opt_with_value.first == "-f" || opt_with_value.first == "--pattern-file")
@@ -149,9 +166,15 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
         {
             part_size_mb = StrUtil::StringToInt(opt_with_value.second);
         }
+        else if (opt_with_value.first == "-D" || opt_with_value.first == "--dir")
+        {
+            work_dirs.push_back(std::make_pair(opt_with_value.second, false));
+        }
+        else if (opt_with_value.first == "-R" || opt_with_value.first == "--recursive-dir")
+        {
+            work_dirs.push_back(std::make_pair(opt_with_value.second, true));
+        }
     }
-    const bool do_subdirs = cmdargs.Opt.count("-r") || cmdargs.Opt.count("--recursive");
-    const bool verbose = cmdargs.Opt.count("-v") || cmdargs.Opt.count("--verbose");
 
     std::vector<String> pattern_list;
     if (!file_list_str.IsEmpty())
@@ -171,7 +194,14 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
         {
             if (cmdargs.PosArgs.size() < 2)
                 break; // not enough args
-            return AGSPak::Command_Create(work_dir, pak_file, command == 'A', pattern_list, pattern_file, do_subdirs, part_size_mb, verbose);
+
+            AGSPak::DuplicateAssetAction dup_action = AGSPak::kAssetDup_Error;
+            if (cmdargs.Opt.count("--replace-dup") != 0)
+                dup_action = AGSPak::kAssetDup_Replace;
+            else if (cmdargs.Opt.count("--skip-dup") != 0)
+                dup_action = AGSPak::kAssetDup_Skip;
+
+            return AGSPak::Command_Create(work_dirs, pak_file, command == 'A', pattern_list, pattern_file, dup_action, part_size_mb, verbose);
         }
     case 'd': // detach
         {
@@ -212,7 +242,7 @@ int main(int argc, char *argv[])
 {
     printf("%s\n", BIN_STRING);
 
-    CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv, {"-p", "-f", "--pattern-file"});
+    CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv, {"-p", "-f", "--pattern-file", "-D", "--dir", "-R", "-recursive-dir"});
     if (cmdargs.HelpRequested)
     {
         printf("%s\n", HELP_STRING);

--- a/Tools/agspak/main.cpp
+++ b/Tools/agspak/main.cpp
@@ -32,8 +32,8 @@
 using namespace AGS::Common;
 using namespace AGS::DataUtil;
 
-const char *BIN_STRING = "agspak v0.4.0 - AGS game packaging tool\n"
-    "Copyright (c) 2025 AGS Team and contributors\n";
+const char *BIN_STRING = "agspak v0.5.0 - AGS game packaging tool\n"
+    "Copyright (c) 2026 AGS Team and contributors\n";
 
 const char *HELP_STRING = "Usage:\n"
    //--------------------------------------------------------------------------------|
@@ -62,8 +62,10 @@ const char *HELP_STRING = "Usage:\n"
     "                         If no asset data is found, then nothing will be done.\n"
     "  -e, --export           export (extract) files from the existing pack file\n"
     "                         into the output directory.\n"
+    // -i, --import           RESERVED: import (add, overwrite) asset(s) to the pack
     "  -l, --list             print pack file's contents.\n"
-    "  -x, --cut              cut (deletes) appended asset data from a file.\n"
+    // -x, --cut              RESERVED: cut (delete) selected asset(s) from the pack
+    "  -X, --cut-attachment   cut (delete) all appended asset data from a file.\n"
     "                         If no asset data is found, then nothing will be done.\n"
     "\n"
     "Command options:\n"
@@ -121,9 +123,9 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
             command = 'a';
             break;
         }
-        if (opt == "-x" || opt == "--cut")
+        if (opt == "-X" || opt == "--cut-attachment")
         {
-            command = 'x';
+            command = 'X';
             break;
         }
         if (opt == "-d" || opt == "--detach")
@@ -221,11 +223,11 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
                 break; // not enough args
             return AGSPak::Command_List(pak_file);
         }
-    case 'x': // cut
+    case 'X': // cut-attachment
         {
             if (cmdargs.PosArgs.size() < 1)
                 break; // not enough args
-            return AGSPak::Command_Cut(pak_file, verbose);
+            return AGSPak::Command_CutAttachment(pak_file, verbose);
         }
     default:
         printf("Error: no valid command is specified\n");

--- a/Tools/agspak/main.cpp
+++ b/Tools/agspak/main.cpp
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 {
     printf("%s\n", BIN_STRING);
 
-    CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv, {"-p", "-f", "--pattern-file", "-D", "--dir", "-R", "-recursive-dir"});
+    CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv, {"-p", "-f", "--pattern-file", "-D", "--dir", "-R", "--recursive-dir"});
     if (cmdargs.HelpRequested)
     {
         printf("%s\n", HELP_STRING);

--- a/Tools/data/mfl_utils.cpp
+++ b/Tools/data/mfl_utils.cpp
@@ -27,7 +27,7 @@ namespace DataUtil
 
 // TODO: might replace "printf" with the logging functions,
 // but then we'd also need to make sure they are initialized in tools
-
+// FIXME: actually return HError from this function!
 static void ExportAsset(Stream *lib_in, const AssetInfo &asset, const String &dst_dir)
 {
     String dst_f = Path::ConcatPaths(dst_dir, asset.FileName);
@@ -110,44 +110,33 @@ HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, bool
     return HError::None();
 }
 
-HError MakeAssetListFromFileList(const std::vector<String> &files, std::vector<AssetInfo> &assets, const String &asset_dir)
+void MakeAssetMapFromFileList(StringIMap &asset_map, const std::vector<String> &files, const String &asset_dir)
 {
-    String fpath;
-    const String &parent = asset_dir;
     for (const auto &file : files)
     {
-        AssetInfo asset;
-        asset.FileName = file;
-        Path::ConcatPaths(fpath, parent, asset.FileName);
-        asset.Size = File::GetFileSize(fpath);
-        assets.push_back(asset);
+        asset_map.insert(std::make_pair(file, Path::ConcatPaths(asset_dir, file)));
     }
-    return HError::None();
-}
-
-HError MakeAssetList(std::vector<AssetInfo> &assets, const String &asset_dir,
-    bool do_subdirs, const String &lib_basefile)
-{
-    String dpath;
-    String fpath;
-    const String &base = asset_dir;
-    const String &parent = asset_dir;
-
-    for (FindFile ff = FindFile::Open(parent, "*", true, false, do_subdirs ? -1 : 0);
-        !ff.AtEnd(); ff.Next())
-    {
-        AssetInfo asset;
-        asset.FileName = ff.Current();
-        Path::ConcatPaths(fpath, parent, asset.FileName);
-        asset.Size = File::GetFileSize(fpath);
-        assets.push_back(asset);
-    }
-    return HError::None();
 }
 
 HError MakeAssetLib(AssetLibInfo &lib, const String &lib_basefile,
-    std::vector<AssetInfo> &assets, soff_t part_size, bool append_first)
+    const StringIMap &asset_map, soff_t part_size, bool append_first)
 {
+    // Generate the list of AssetInfos, as we must precalculate file sizes
+    // before arranging them among the library partitions.
+    std::vector<AssetInfo> assets;
+    for (const auto &asset_entry : asset_map)
+    {
+        soff_t filesz = File::GetFileSize(asset_entry.second);
+        if (filesz < 0)
+            return new Error("Failed to retrieve asset file's size: %s", asset_entry.second);
+        AssetInfo asset;
+        asset.FileName = asset_entry.first;
+        asset.Size = filesz;
+        assets.push_back(asset);
+    }
+    // TODO: sort so that the subdirectories come last?
+    std::sort(assets.begin(), assets.end(), [](const AssetInfo &a1, const AssetInfo &a2) { return a1.FileName.CompareNoCase(a2.FileName) < 0; });
+
     int lib_id = 0;
     if (part_size > 0)
     {
@@ -199,17 +188,17 @@ HError MakeAssetLib(AssetLibInfo &lib, const String &lib_basefile,
     return HError::None();
 }
 
-HError WriteLibraryFile(AssetLibInfo &lib, const String &asset_dir, const String &lib_filename,
-                        MFLUtil::MFLVersion lib_version, int lib_index, bool append, bool verbose)
+HError WriteLibraryFile(AssetLibInfo &lib, const StringIMap &asset_map,
+    const String &lib_filename, MFLUtil::MFLVersion lib_version, int lib_index, bool append, bool verbose)
 {
     append &= File::IsFile(lib_filename); // append only if this file exists, otherwise create
     std::unique_ptr<Stream> out(append ? File::CreateTempFile() : File::CreateFile(lib_filename));
     if (!out)
     {
         if (append)
-            return new Error("Error: failed to open a temporary file for writing pack data.");
+            return new Error("Failed to open a temporary file for writing pack data.");
         else
-            return new Error("Error: failed to open pack file for writing.");
+            return new Error("Failed to open pack file for writing.");
     }
 
     soff_t s_offset = out->GetPosition();
@@ -219,7 +208,10 @@ HError WriteLibraryFile(AssetLibInfo &lib, const String &asset_dir, const String
         if (asset.LibUid == lib_index)
         {
             asset.Offset = out->GetPosition() - s_offset;
-            String path = Path::ConcatPaths(asset_dir, asset.FileName);
+            auto it_file = asset_map.find(asset.FileName);
+            if (it_file == asset_map.end())
+                return new Error(String::FromFormat("Internal error: no file path for asset: %s", asset.FileName.GetCStr()));
+            const String path = it_file->second;
             std::unique_ptr<Stream> in(File::OpenFileRead(path));
             if (!in)
                 return new Error(String::FromFormat("Failed to open the asset file for reading: %s", path.GetCStr()));
@@ -241,7 +233,7 @@ HError WriteLibraryFile(AssetLibInfo &lib, const String &asset_dir, const String
     {
         std::unique_ptr<Stream> final(File::OpenFileWrite(lib_filename));
         if (!final)
-            return new Error("Error: failed to open destination file for writing.");
+            return new Error("Failed to open destination file for writing.");
         final->Seek(0, kSeekEnd);
         lib.BaseFileOffset = final->GetPosition();
         out->Seek(0, kSeekBegin);
@@ -251,8 +243,9 @@ HError WriteLibraryFile(AssetLibInfo &lib, const String &asset_dir, const String
     return HError::None();
 }
 
-HError WriteLibrary(AssetLibInfo &lib, const String &asset_dir, const String &dst_dir, MFLUtil::MFLVersion lib_version,
-                    bool append_first, bool verbose)
+HError WriteLibrary(AssetLibInfo &lib, const StringIMap &asset_map,
+    const String &dst_dir, MFLUtil::MFLVersion lib_version,
+    bool append_first, bool verbose)
 {
     for (size_t id = 0; id < lib.LibFileNames.size(); ++id)
     {
@@ -260,7 +253,7 @@ HError WriteLibrary(AssetLibInfo &lib, const String &asset_dir, const String &ds
         if (verbose)
             printf("Info: writing pack file '%s' ...\n", dst_file.GetCStr());
 
-        HError err = WriteLibraryFile(lib, asset_dir, dst_file, lib_version, id, append_first && (id == 0), verbose);
+        HError err = WriteLibraryFile(lib, asset_map, dst_file, lib_version, id, append_first && (id == 0), verbose);
         if (!err)
         {
             if (verbose)
@@ -284,7 +277,7 @@ HError TestLibraryFile(const String &lib_file, const AssetLibInfo *compare_lib)
 {
     std::unique_ptr<Stream> in(File::OpenFileRead(lib_file));
     if (!in)
-        return new Error("Error: failed to open pack file for reading.");
+        return new Error("Failed to open pack file for reading.");
 
     AssetLibInfo lib;
     MFLUtil::MFLError mfl_err = MFLUtil::ReadHeader(lib, in.get());

--- a/Tools/data/mfl_utils.cpp
+++ b/Tools/data/mfl_utils.cpp
@@ -128,7 +128,7 @@ HError MakeAssetLib(AssetLibInfo &lib, const String &lib_basefile,
     {
         soff_t filesz = File::GetFileSize(asset_entry.second);
         if (filesz < 0)
-            return new Error("Failed to retrieve asset file's size: %s", asset_entry.second);
+            return new Error(String::FromFormat("Failed to retrieve asset file's size: %s", asset_entry.second.GetCStr()));
         AssetInfo asset;
         asset.FileName = asset_entry.first;
         asset.Size = filesz;

--- a/Tools/data/mfl_utils.h
+++ b/Tools/data/mfl_utils.h
@@ -15,10 +15,12 @@
 #define __AGS_TOOL_DATA__MFLUTIL_H
 
 #include <functional>
+#include <vector>
 #include "data/asset.h"
 #include "data/multifilelib.h"
 #include "util/error.h"
 #include "util/stream.h"
+#include "util/string_types.h"
 
 namespace AGS
 {
@@ -29,6 +31,7 @@ namespace DataUtil
     using AGS::Common::HError;
     using AGS::Common::Stream;
     using AGS::Common::String;
+    using AGS::Common::StringIMap;
 
     // Exports assets from the library by reading its parts and writing assets into files.
     // lib_dir - tells the directory where the library parts are located.
@@ -39,27 +42,25 @@ namespace DataUtil
     // Same as above, but allows to pass a functor used to filter assets.
     HError ExportFromLibrary(const AssetLibInfo &lib, const String &lib_dir, const String &dst_dir,
         const std::function<bool(const String&)> &asset_filter);
-    // Gather a list of files from a given directory as a vector of strings
+    // Gather a list of files from a given directory as a vector of relative filepaths
     HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, bool do_subdirs);
-    // Prepare list of assets from a list of filenames
-    HError MakeAssetListFromFileList(const std::vector<String> &files, std::vector<AssetInfo> &assets, const String &asset_dir);
-    // Gather a list of files from a given directory
-    HError MakeAssetList(std::vector<AssetInfo> &assets, const String &asset_dir,
-        bool do_subdirs, const String &lib_basefile);
-    // Generate AssetLibInfo based on a list of assets, optionally limiting each
+    // Create a map of asset-name -> file-path pairs from the list of filepaths based in the root directory.
+    // The asset-names will only contain directories if their input files are located in the nested subdirs inside the root dir.
+    void MakeAssetMapFromFileList(StringIMap &asset_map, const std::vector<String> &files, const String &asset_dir);
+    // Generate AssetLibInfo based on a map of assets, optionally limiting each
     // library partition by part_size bytes.
     // append_first param tells that the very first lib file is going to be
     // appended to a existing file (makes a difference if part_size != 0).
     HError MakeAssetLib(AssetLibInfo &lib, const String &lib_basefile,
-        std::vector<AssetInfo> &assets, soff_t part_size = 0, bool append_first = false);
+        const StringIMap &asset_map, soff_t part_size = 0, bool append_first = false);
     // Writes the library partition into the file lib_filename;
     // recalculates asset offsets and stores in lib as it goes.
     HError WriteLibraryFile(AssetLibInfo &lib, const String &src_dir, const String &lib_filename,
                             Common::MFLUtil::MFLVersion lib_version, int lib_index, bool append, bool verbose);
     // Writes the potentially multi-file library into the dst_dir directory;
     // recalculates asset offsets and stores in lib as it goes.
-    HError WriteLibrary(AssetLibInfo &lib, const String &asset_dir, const String &dst_dir,
-                        Common::MFLUtil::MFLVersion lib_version,
+    HError WriteLibrary(AssetLibInfo &lib, const StringIMap &asset_map,
+                        const String &dst_dir, Common::MFLUtil::MFLVersion lib_version,
                         bool append_first, bool verbose);
     // Tests that the given file is recognized as a asset library.
     // Optionally compares read table of contents with the provided lib info.

--- a/Tools/data/mfl_utils.h
+++ b/Tools/data/mfl_utils.h
@@ -55,8 +55,8 @@ namespace DataUtil
         const StringIMap &asset_map, soff_t part_size = 0, bool append_first = false);
     // Writes the library partition into the file lib_filename;
     // recalculates asset offsets and stores in lib as it goes.
-    HError WriteLibraryFile(AssetLibInfo &lib, const String &src_dir, const String &lib_filename,
-                            Common::MFLUtil::MFLVersion lib_version, int lib_index, bool append, bool verbose);
+    HError WriteLibraryFile(AssetLibInfo &lib, const StringIMap &asset_map,
+        const String &lib_filename, Common::MFLUtil::MFLVersion lib_version, int lib_index, bool append, bool verbose);
     // Writes the potentially multi-file library into the dst_dir directory;
     // recalculates asset offsets and stores in lib as it goes.
     HError WriteLibrary(AssetLibInfo &lib, const StringIMap &asset_map,


### PR DESCRIPTION
Resolve #3022

Add `-D dir` and `-R dir` options for "create" command, that add more separate input directories, where `-D` instructs to read only this exact dir's contents and `-R` instructs to read this dir and all the nested dirs recursively.
The files found in these directories will be put relative to the asset pack's virtual filesystem's root. So assets generated from the input dir itself will have no parent path, and assets generated from nested dirs will have relative parent paths.

For handling asset duplicates added two more options:
- `--replace-dup` - every next found duplicate overrides the previous one. As the dirs are checked in the same order as they were in the command line, this allows to accurately override one dir contents with another.
- `--skip-dup` - skip duplicates (the first found asset of this name will be used).

If neither of the above two options is provided, then any found duplicate will cause error.