### PR TITLE
Tool: spriteimport

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -251,6 +251,7 @@ if(AGS_TESTS)
         test/inifile_test.cpp
         test/math_test.cpp
         test/memory_test.cpp
+        test/paletteop_test.cpp
         test/path_test.cpp
         test/splitline_test.cpp
 		test/spritecache_test.cpp

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -417,17 +417,23 @@ Bitmap *SpriteCache::LoadSprite(sprkey_t index, bool lock)
 
 void SpriteCache::RemapSpriteToPlaceholder(sprkey_t index)
 {
-    assert((index > 0) && ((size_t)index < _spriteData.size()));
-    _sprInfos[index] = SpriteInfo(_placeholder->GetWidth(), _placeholder->GetHeight(), 0);
-    _spriteData[index].Flags |= SPRCACHEFLAG_ERROR;
-    SprCacheLog("RemapSpriteToPlaceholder: %d", index);
+    assert((index >= 0) && ((size_t)index < _spriteData.size()));
+    if ((index >= 0) && ((size_t)index < _spriteData.size()))
+    {
+        _sprInfos[index] = SpriteInfo(_placeholder->GetWidth(), _placeholder->GetHeight(), 0);
+        _spriteData[index].Flags |= SPRCACHEFLAG_ERROR;
+        SprCacheLog("RemapSpriteToPlaceholder: %d", index);
+    }
 }
 
 void SpriteCache::InitNullSprite(sprkey_t index)
 {
-    assert(index >= 0);
-    _sprInfos[index] = SpriteInfo();
-    _spriteData[index] = SpriteData();
+    assert((index >= 0) && ((size_t)index < _spriteData.size()));
+    if ((index >= 0) && ((size_t)index < _spriteData.size()))
+    {
+        _sprInfos[index] = SpriteInfo();
+        _spriteData[index] = SpriteData();
+    }
 }
 
 std::vector<std::pair<bool, BitmapData>> SpriteCache::PrepareSpriteData()

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -901,10 +901,15 @@ void SpriteFileWriter::WriteRawData(const SpriteDatHeader &hdr, const uint8_t *d
 
 void SpriteFileWriter::Finalize()
 {
-    if (!_out || _lastSlotPos < 0) return;
-    _out->Seek(_lastSlotPos, kSeekBegin);
-    _out->WriteInt32(_index.GetLastSlot());
-    _out.reset();
+    if (_out)
+    {
+        if (_lastSlotPos >= 0)
+        {
+            _out->Seek(_lastSlotPos, kSeekBegin);
+            _out->WriteInt32(_index.GetLastSlot());
+        }
+        _out.reset();
+    }
 }
 
 } // namespace Common

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -209,6 +209,7 @@ public:
         : _out(std::move(out)) {}
     ~SpriteFileWriter() = default;
 
+    sprkey_t GetLastWrittenSlot() const { return _index.Offsets.size() > 0 ? static_cast<sprkey_t>(_index.Offsets.size() - 1) : -1; }
     // Get the sprite index, accumulated after write
     const SpriteFileIndex &GetIndex() const { return _index; }
 
@@ -223,6 +224,8 @@ public:
     void WriteEmptySlot();
     // Writes a raw sprite data without any additional processing
     void WriteRawData(const SpriteDatHeader &hdr, const uint8_t *data, size_t data_sz);
+    inline void WriteRawData(const SpriteDatHeader &hdr, const std::vector<uint8_t> &data)
+        { WriteRawData(hdr, data.data(), data.size()); }
     // Finalizes current format; no further writing is possible after this
     void Finalize();
 

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -152,46 +152,20 @@ void AllocateBitmapAndSubBitmap(Bitmap *parent, Bitmap *child, int sub_width, in
 
 void MakeOpaque(Bitmap *bmp)
 {
-    if (bmp->GetColorDepth() < 32)
-        return; // no alpha channel
-
-    for (int i = 0; i < bmp->GetHeight(); ++i)
-    {
-        uint32_t *line = reinterpret_cast<uint32_t*>(bmp->GetScanLineForWriting(i));
-        uint32_t *line_end = line + bmp->GetWidth();
-        for (uint32_t *px = line; px != line_end; ++px)
-            *px = makeacol32(getr32(*px), getg32(*px), getb32(*px), 255);
-    }
+    auto bm_data = bmp->GetBitmapData();
+    PixelOp::MakeOpaque(bm_data);
 }
 
 void MakeOpaqueSkipMask(Bitmap *bmp)
 {
-    if (bmp->GetColorDepth() < 32)
-        return; // no alpha channel
-
-    for (int i = 0; i < bmp->GetHeight(); ++i)
-    {
-        uint32_t *line = reinterpret_cast<uint32_t*>(bmp->GetScanLineForWriting(i));
-        uint32_t *line_end = line + bmp->GetWidth();
-        for (uint32_t *px = line; px != line_end; ++px)
-            if (*px != MASK_COLOR_32)
-                *px = makeacol32(getr32(*px), getg32(*px), getb32(*px), 255);
-    }
+    auto bm_data = bmp->GetBitmapData();
+    PixelOp::MakeOpaqueSkipMask(bm_data);
 }
 
 void ReplaceAlphaWithRGBMask(Bitmap *bmp, int alpha_threshold)
 {
-    if (bmp->GetColorDepth() < 32)
-        return; // no alpha channel
-
-    for (int i = 0; i < bmp->GetHeight(); ++i)
-    {
-        uint32_t *line = reinterpret_cast<uint32_t*>(bmp->GetScanLineForWriting(i));
-        uint32_t *line_end = line + bmp->GetWidth();
-        for (uint32_t *px = line; px != line_end; ++px)
-            if (geta32(*px) <= alpha_threshold)
-                *px = MASK_COLOR_32;
-    }
+    auto bm_data = bmp->GetBitmapData();
+    PixelOp::ReplaceAlphaWithRGBMask(bm_data);
 }
 
 // Functor that copies the "mask color" pixels from source to dest

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -112,13 +112,17 @@ namespace BitmapHelper
     // This function does not make an effort to retain the original image.
     void    AllocateBitmapAndSubBitmap(Bitmap *parent, Bitmap *child, int sub_width, int sub_height, int color_depth);
 
+    // TODO: all the following functions may be actually reimplemented in PixelOp
+    // namespace, where they will work with raw pixel buffers instead of Bitmaps.
+    // Then these Bitmap helpers will simply delegate the work to them.
+    // 
     // Makes the given bitmap opaque (full alpha), while keeping pixel RGB unchanged.
-    void    MakeOpaque(Bitmap *bmp);
+    void MakeOpaque(Bitmap *bmp);
     // Makes the given bitmap opaque (full alpha), while keeping pixel RGB unchanged.
     // Skips mask color (leaves it with zero alpha).
-    void    MakeOpaqueSkipMask(Bitmap *bmp);
+    void MakeOpaqueSkipMask(Bitmap *bmp);
     // Replaces pixels with alpha <= threshold with standard mask color.
-    void    ReplaceAlphaWithRGBMask(Bitmap *bmp, int alpha_threshold);
+    void ReplaceAlphaWithRGBMask(Bitmap *bmp, int alpha_threshold);
     // Replaces fully transparent (alpha = 0) pixels with standard mask color.
     inline void ReplaceZeroAlphaWithRGBMask(Bitmap *bmp) { ReplaceAlphaWithRGBMask(bmp, 0); }
     // Replaces less than 50% transparent (alpha < 128) pixels with standard mask color.

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -46,18 +46,34 @@ namespace PixelOp
 void CopyPixels(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
     const int width, const int height, uint8_t *dst_buffer, const size_t dst_pitch)
 {
-    CopyPixelsRegion(src_buffer, bpp, src_pitch, 0u, width, height, dst_buffer, dst_pitch, 0u);
+    CopyPixelsRegion(src_buffer, bpp, src_pitch, 0, 0, width, height, dst_buffer, dst_pitch, 0, 0);
 }
 
 void CopyPixelsRegion(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
-    const size_t src_px_off, const int width_px, const int height_px,
-    uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off)
+    const int src_px_off, const int src_py_off, const int width_px, const int height_px,
+    uint8_t *dst_buffer, const size_t dst_pitch, const int dst_px_off, const int dst_py_off)
 {
-    const size_t src_boff = src_px_off * bpp;
-    const size_t dst_boff = dst_px_off * bpp;
+    const size_t src_boff = (src_py_off * src_pitch) + (src_px_off * bpp);
+    const size_t dst_boff = (dst_py_off * dst_pitch) + (dst_px_off * bpp);
     const size_t width_b = width_px * bpp;
     // NOTE: all assertions are done further in Memory::BlockCopy
     Memory::BlockCopy(src_buffer, src_pitch, src_boff, width_b, height_px, dst_buffer, dst_pitch, dst_boff);
+}
+
+PixelBuffer CopyPixelsRegion(const BitmapData &bm_data, const int src_x, const int src_y, const int width, const int height)
+{
+    const int src_bpp = bm_data.GetBytesPerPixel();
+    const size_t src_pitch = bm_data.GetStride();
+    int do_src_x = src_x, do_src_y = src_y;
+    int do_width = width, do_height = height;
+    Math::ClampLength(do_src_x, do_width, 0, bm_data.GetWidth() - 1);
+    Math::ClampLength(do_src_y, do_height, 0, bm_data.GetHeight() - 1);
+    if (do_width == 0 || do_height == 0)
+        return {};
+
+    PixelBuffer out_buf(do_width, do_height, bm_data.GetFormat());
+    CopyPixelsRegion(bm_data.GetData(), src_bpp, src_pitch, do_src_x, do_src_y, do_width, do_height, out_buf.GetData(), out_buf.GetStride(), 0, 0);
+    return out_buf;
 }
 
 bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -39,6 +39,38 @@ uint32_t BitmapData::GetPixel(int x, int y) const
     }
 }
 
+void BitmapData::SetPixel(int x, int y, uint32_t value)
+{
+    uint8_t *line = GetLine(y);
+    switch (_bitsPerPixel)
+    {
+    // for 1-bit and 4-bit: clear the bit(s) position to zero and then write new value
+    case 1: line[x / 8] = line[x / 8] & ~(1 << (7 - x % 8)) | ((value & 1) << (7 - x % 8)); break;
+    case 4: line[x / 2] = line[x / 2] & ~(4 << (1 - x % 2)) | ((value & 4) << (1 - x % 2)); break;
+    case 8: line[x] = static_cast<uint8_t>(value & 0xFF); break;
+    case 15: /* same as 16 */
+    case 16: *reinterpret_cast<uint16_t*>(&line[x * 2]) = value; break;
+    case 24: Memory::WriteInt24(&line[x * 3], value); break;
+    case 32: *reinterpret_cast<uint32_t*>(&line[x * 4]) = value; break;
+    default: assert(false); break;
+    }
+}
+
+String PixelFormatName(PixelFormat fmt)
+{
+    switch (fmt)
+    {
+    case kPxFmt_Indexed1:   return "1-bit indexed";
+    case kPxFmt_Indexed4:   return "4-bit indexed";
+    case kPxFmt_Indexed8:   return "8-bit indexed";
+    case kPxFmt_R5G5B5:     return "15-bit R5G5B5";
+    case kPxFmt_R5G6B5:     return "16-bit R5G6B5";
+    case kPxFmt_R8G8B8:     return "24-bit R8G8B8";
+    case kPxFmt_A8R8G8B8:   return "32-bit A8R8G8B8";
+    default:                return "unknown";
+    }
+}
+
 
 namespace PixelOp
 {
@@ -76,6 +108,8 @@ PixelBuffer CopyPixelsRegion(const BitmapData &bm_data, const int src_x, const i
     return out_buf;
 }
 
+// TODO: quite possibly may be *at least partially* reimplemented as a template function,
+// with parameters defining pixel sizes and rgb shifts.
 bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,
     const int width, const int height, uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch)
 {
@@ -200,6 +234,14 @@ bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const siz
     return false;
 }
 
+bool CopyConvert(const BitmapData &src, PixelBuffer &dst, const PixelFormat dst_fmt)
+{
+    if (dst.GetDataSize() != GetDataSizeForPixelFormat(dst_fmt, src.GetWidth(), src.GetHeight()))
+        dst = PixelBuffer(src.GetWidth(), src.GetHeight(), dst_fmt);
+    return CopyConvert(src.GetData(), src.GetFormat(), src.GetStride(), src.GetWidth(), src.GetHeight(),
+        dst.GetData(), dst_fmt, dst.GetStride());
+}
+
 void CopySwapRGBA(const uint8_t *src_buffer, const size_t src_pitch, int src_r_shift, int src_g_shift, int src_b_shift, int src_a_shift,
     uint8_t *dst_buffer, const size_t dst_pitch, int dst_r_shift, int dst_g_shift, int dst_b_shift, int dst_a_shift,
     const int width, const int height, const PixelFormat px_fmt)
@@ -276,6 +318,50 @@ void CopySwapRGBA(const uint8_t *src_buffer, int src_r_shift, int src_g_shift, i
     const size_t pitch = GetStrideForPixelFormat(px_fmt, width);
     CopySwapRGBA(src_buffer, pitch, src_r_shift, src_g_shift, src_b_shift, src_a_shift,
         dst_buffer, pitch, dst_r_shift, dst_g_shift, dst_b_shift, dst_a_shift, width, height, px_fmt);
+}
+
+void MakeOpaque(BitmapData &bm_data)
+{
+    if (bm_data.GetColorDepth() < 32)
+        return; // no alpha channel
+
+    for (int i = 0; i < bm_data.GetHeight(); ++i)
+    {
+        uint32_t *line = reinterpret_cast<uint32_t*>(bm_data.GetLine(i));
+        uint32_t *line_end = line + bm_data.GetWidth();
+        for (uint32_t *px = line; px != line_end; ++px)
+            *px = makeacol32(getr32(*px), getg32(*px), getb32(*px), 255);
+    }
+}
+
+void MakeOpaqueSkipMask(BitmapData &bm_data)
+{
+    if (bm_data.GetColorDepth() < 32)
+        return; // no alpha channel
+
+    for (int i = 0; i < bm_data.GetHeight(); ++i)
+    {
+        uint32_t *line = reinterpret_cast<uint32_t*>(bm_data.GetLine(i));
+        uint32_t *line_end = line + bm_data.GetWidth();
+        for (uint32_t *px = line; px != line_end; ++px)
+            if (*px != MASK_COLOR_32)
+                *px = makeacol32(getr32(*px), getg32(*px), getb32(*px), 255);
+    }
+}
+
+void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold)
+{
+    if (bm_data.GetColorDepth() < 32)
+        return; // no alpha channel
+
+    for (int i = 0; i < bm_data.GetHeight(); ++i)
+    {
+        uint32_t *line = reinterpret_cast<uint32_t*>(bm_data.GetLine(i));
+        uint32_t *line_end = line + bm_data.GetWidth();
+        for (uint32_t *px = line; px != line_end; ++px)
+            if (geta32(*px) <= alpha_threshold)
+                *px = MASK_COLOR_32;
+    }
 }
 
 } // namespace PixelOperations

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -98,8 +98,8 @@ PixelBuffer CopyPixelsRegion(const BitmapData &bm_data, const int src_x, const i
     const size_t src_pitch = bm_data.GetStride();
     int do_src_x = src_x, do_src_y = src_y;
     int do_width = width, do_height = height;
-    Math::ClampLength(do_src_x, do_width, 0, bm_data.GetWidth() - 1);
-    Math::ClampLength(do_src_y, do_height, 0, bm_data.GetHeight() - 1);
+    Math::ClampLength(do_src_x, do_width, 0, bm_data.GetWidth());
+    Math::ClampLength(do_src_y, do_height, 0, bm_data.GetHeight());
     if (do_width == 0 || do_height == 0)
         return {};
 

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -366,5 +366,54 @@ void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold)
 
 } // namespace PixelOperations
 
+namespace PaletteOp
+{
+    void Rotate(PALETTE pal, uint8_t first, uint8_t last, bool forward)
+    {
+        int dir = forward ? 1 : -1;
+        if (!forward)
+            std::swap(first, last);
+
+        RGB temp = pal[first];
+        for (int i = first; i < last; i += dir)
+            pal[i] = pal[i + dir];
+        pal[last] = temp;
+    }
+
+    void Remap(BitmapData &bm_data, const PALETTE src_pal, const PALETTE dst_pal, bool keep_transparent)
+    {
+        uint8_t color_mapped_table[256];
+        for (int i = 0; i < 256; ++i)
+        {
+            if ((src_pal[i].r == 0) && (src_pal[i].g == 0) && (src_pal[i].b == 0))
+            {
+                color_mapped_table[i] = 0;
+            }
+            else
+            {
+                color_mapped_table[i] = bestfit_color(dst_pal, src_pal[i].r, src_pal[i].g, src_pal[i].b);
+            }
+        }
+
+        if (keep_transparent)
+        {
+            // keep transparency
+            color_mapped_table[0] = 0;
+            // any other pixels which are being mapped to 0, map to 16 instead
+            for (int i = 0; i < 256; ++i)
+            {
+                if (color_mapped_table[i] == 0)
+                    color_mapped_table[i] = 16;
+            }
+        }
+
+        // Remap pixels to the new palette
+        for (uint8_t *ptr = bm_data.GetData(); ptr < bm_data.GetData() + bm_data.GetDataSize(); ++ptr)
+        {
+            *ptr = color_mapped_table[*ptr];
+        }
+    }
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/gfx/bitmapdata.cpp
+++ b/Common/gfx/bitmapdata.cpp
@@ -366,5 +366,62 @@ void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold)
 
 } // namespace PixelOperations
 
+namespace PaletteOp
+{
+    void Rotate(PALETTE pal, uint8_t first, uint8_t last, bool to_left)
+    {
+        assert(first < last);
+        if (last <= first)
+            return; // nothing to do
+
+        RGB wrap = pal[to_left ? first : last];
+        if (to_left)
+        {
+            for (int i = first; i < last; ++i)
+                pal[i] = pal[i + 1];
+        }
+        else
+        {
+            for (int i = last; i > first; --i)
+                pal[i] = pal[i - 1];
+        }
+        pal[to_left ? last : first] = wrap;
+    }
+
+    void Remap(BitmapData &bm_data, const PALETTE src_pal, const PALETTE dst_pal, bool keep_transparent)
+    {
+        uint8_t color_mapped_table[256];
+        for (int i = 0; i < 256; ++i)
+        {
+            if ((src_pal[i].r == 0) && (src_pal[i].g == 0) && (src_pal[i].b == 0))
+            {
+                color_mapped_table[i] = 0;
+            }
+            else
+            {
+                color_mapped_table[i] = bestfit_color(dst_pal, src_pal[i].r, src_pal[i].g, src_pal[i].b);
+            }
+        }
+
+        if (keep_transparent)
+        {
+            // keep transparency
+            color_mapped_table[0] = 0;
+            // any other pixels which are being mapped to 0, map to 16 instead
+            for (int i = 1; i < 256; ++i)
+            {
+                if (color_mapped_table[i] == 0)
+                    color_mapped_table[i] = 16;
+            }
+        }
+
+        // Remap pixels to the new palette
+        for (uint8_t *ptr = bm_data.GetData(); ptr < bm_data.GetData() + bm_data.GetDataSize(); ++ptr)
+        {
+            *ptr = color_mapped_table[*ptr];
+        }
+    }
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -18,7 +18,9 @@
 #ifndef __AGS_CN_GFX__BITMAPDATA_H
 #define __AGS_CN_GFX__BITMAPDATA_H
 
+#include <array>
 #include <memory>
+#include <allegro.h> // RGB and PALETTE types, MASK_COLOR constants
 #include "debug/assert.h"
 #include "platform/types.h"
 #include "util/string.h"
@@ -137,13 +139,16 @@ inline int GetDefaultMaskColor(PixelFormat fmt)
         // All the indexed formats use 0 index as the default mask color
         return 0;
     // Following correspond to magenta (aka "magic pink")
-    case kPxFmt_R5G5B5:     return 0x7C1F;
-    case kPxFmt_R5G6B5:     return 0xF81F;
-    case kPxFmt_R8G8B8:     return 0xFF00FF;
-    case kPxFmt_A8R8G8B8:   return 0xFF00FF; // NOTE: it's a value without alpha
+    case kPxFmt_R5G5B5:     return MASK_COLOR_15;
+    case kPxFmt_R5G6B5:     return MASK_COLOR_16;
+    case kPxFmt_R8G8B8:     return MASK_COLOR_24;
+    case kPxFmt_A8R8G8B8:   return MASK_COLOR_32; // NOTE: it's a value without alpha
     default: assert(false); return 0;
     }
 }
+
+
+typedef std::array<RGB, PAL_SIZE> Palette;
 
 
 // BitmapData is a non-owning wrapper over a pixel buffer,
@@ -301,6 +306,7 @@ private:
 };
 
 
+// Various operations with the pixel buffers: copying, converting, etc.
 namespace PixelOp
 {
     // Copy pixel data from one memory buffer to another. It is required that the
@@ -375,6 +381,37 @@ namespace PixelOp
     void MakeOpaqueSkipMask(BitmapData &bm_data);
     // Replaces pixels with alpha <= threshold with standard mask color.
     void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold = 0);
+}
+
+// Various operations with palette
+namespace PaletteOp
+{
+    inline void SetRGB(Palette &pal, int index, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF)
+    {
+        pal[index] = { r, g, b, a };
+    }
+
+    // FIXME: this is a temporary unsafe variant, use ref to PALETTE (RGB[256]), not pointer to array of unknown size
+    // (will require fixes around the code in AGS.Native)
+    inline void SetRGB(PALETTE pal, int index, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF)
+    {
+        pal[index] = { r, g, b, a };
+    }
+
+    // Rotates palette colors in the range [first, last], in the given direction
+    void Rotate(PALETTE pal, uint8_t first, uint8_t last, bool forward);
+    inline void Rotate(Palette pal, uint8_t first, uint8_t last, bool forward)
+    {
+        Rotate(pal.data(), first, last, forward);
+    }
+    // Remaps bitmap's colors between source and destination palettes, trying to
+    // find the closest match to source palette colors. If told to keep transparency,
+    // the mask color will be translated exclusively, preventing any occasional matches.
+    void Remap(BitmapData &bm_data, const PALETTE src_pal, const PALETTE dst_pal, bool keep_transparent = true);
+    inline void Remap(BitmapData &bm_data, const Palette &src_pal, const Palette &dst_pal, bool keep_transparent = true)
+    {
+        Remap(bm_data, src_pal.data(), dst_pal.data(), keep_transparent);
+    }
 }
 
 } // namespace Common

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include "debug/assert.h"
 #include "platform/types.h"
+#include "util/string.h"
 
 namespace AGS
 {
@@ -90,6 +91,18 @@ inline bool PixelFormatHasAlpha(PixelFormat fmt)
     }
 }
 
+inline bool PixelFormatIndexed(PixelFormat fmt)
+{
+    switch (fmt)
+    {
+    case kPxFmt_Indexed1:
+    case kPxFmt_Indexed4:
+    case kPxFmt_Indexed8:
+        return true;
+    default: return false;
+    }
+}
+
 inline size_t GetStrideForPixelFormat(PixelFormat fmt, int width)
 {
     switch (fmt)
@@ -108,11 +121,37 @@ inline size_t GetDataSizeForPixelFormat(PixelFormat fmt, int width, int height)
     return GetStrideForPixelFormat(fmt, width) * height;
 }
 
+String PixelFormatName(PixelFormat fmt);
+
+// Returns default mask color (transparent color) for the given pixel format.
+// Note that this refers to the special color that may be optionally used as
+// a transparent, but disregards alpha channel. Images with alpha channel
+// should normally use alpha values for transparency.
+inline int GetDefaultMaskColor(PixelFormat fmt)
+{
+    switch (fmt)
+    {
+    case kPxFmt_Indexed1:
+    case kPxFmt_Indexed4:
+    case kPxFmt_Indexed8:
+        // All the indexed formats use 0 index as the default mask color
+        return 0;
+    // Following correspond to magenta (aka "magic pink")
+    case kPxFmt_R5G5B5:     return 0x7C1F;
+    case kPxFmt_R5G6B5:     return 0xF81F;
+    case kPxFmt_R8G8B8:     return 0xFF00FF;
+    case kPxFmt_A8R8G8B8:   return 0xFF00FF; // NOTE: it's a value without alpha
+    default: assert(false); return 0;
+    }
+}
+
 
 // BitmapData is a non-owning wrapper over a pixel buffer,
 // combined with the description of its format.
 // Its purpose is to pass the buffer pointer without bringing
 // dependency on full Bitmap class.
+// TODO: consider adding optional palette field (unique_ptr with RGB array?),
+// may be useful to combine them when loading indexed images.
 class BitmapData
 {
 public:
@@ -139,6 +178,8 @@ public:
     inline size_t GetDataSize() const { return _dataSize; }
     // Gets the length of a single bitmap line, in bytes;
     // this line may have extra padding beyond the bitmap's width
+    // TODO: bring the Stride/Pitch term to a consistency among all the AGS classes and functions
+    // (BitmapData, PixelBuffer, Bitmap, and parameters in pixel & bitmap related operations).
     inline size_t GetStride() const { return _stride; }
     inline const uint8_t *GetData() const { return _cbuf; }
     inline uint8_t *GetData() { return _buf; }
@@ -155,6 +196,7 @@ public:
     }
 
     uint32_t GetPixel(int x, int y) const;
+    void SetPixel(int x, int y, uint32_t value);
 
 protected:
     BitmapData(int width, int height, PixelFormat fmt)
@@ -301,9 +343,17 @@ namespace PixelOp
     //          * 16-bit    => 24-bit
     //          * 16-bit    => 32-bit
     //          add more common conversions later!
+    // FIXME: this might require a mask color parameter when converting from non-32bit
+    // to 32-bit ARGB, because otherwise the non-32bit mask color might end up opaque
+    // color which is not recognized as mask color in 32bit image.
     // FIXME: this would require a palette if conversion goes from indexed to non-indexed!
+    // Consider adding more function variants that accept mask colors and palettes.
     bool CopyConvert(const uint8_t *src_buffer, const PixelFormat src_fmt, const size_t src_pitch,
         const int width, const int height, uint8_t *dst_buffer, const PixelFormat dst_fmt, const size_t dst_pitch);
+    // Copies pixels from source to dest buffer, possibly converting between source
+    // and dest pixel format. The resulting dest buffer may be possibly reallocated if it's
+    // not large enough to accomodate the converted data.
+    bool CopyConvert(const BitmapData &src, PixelBuffer &dst, const PixelFormat dst_fmt);
     // Copies pixels from source to dest buffer, swapping the RGB components, according
     // to the provided RGB shifts. This operation requires that pixel format is kept the same.
     // It is actually possible to swap in-place (where src and dst are the same buffers).
@@ -317,6 +367,14 @@ namespace PixelOp
     void CopySwapRGBA(const uint8_t *src_buffer, int src_r_shift, int src_g_shift, int src_b_shift, int src_a_shift,
         uint8_t *dst_buffer, int dst_r_shift, int dst_g_shift, int dst_b_shift, int dst_a_shift,
         const int width, const int height, const PixelFormat px_fmt);
+
+    // Makes the given image opaque (full alpha), while keeping RGB unchanged.
+    void MakeOpaque(BitmapData &bm_data);
+    // Makes the given image opaque (full alpha), while keeping RGB values unchanged.
+    // Skips mask color (leaves it with zero alpha).
+    void MakeOpaqueSkipMask(BitmapData &bm_data);
+    // Replaces pixels with alpha <= threshold with standard mask color.
+    void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold = 0);
 }
 
 } // namespace Common

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -18,7 +18,9 @@
 #ifndef __AGS_CN_GFX__BITMAPDATA_H
 #define __AGS_CN_GFX__BITMAPDATA_H
 
+#include <array>
 #include <memory>
+#include <allegro.h> // RGB and PALETTE types, MASK_COLOR constants
 #include "debug/assert.h"
 #include "platform/types.h"
 #include "util/string.h"
@@ -137,13 +139,16 @@ inline int GetDefaultMaskColor(PixelFormat fmt)
         // All the indexed formats use 0 index as the default mask color
         return 0;
     // Following correspond to magenta (aka "magic pink")
-    case kPxFmt_R5G5B5:     return 0x7C1F;
-    case kPxFmt_R5G6B5:     return 0xF81F;
-    case kPxFmt_R8G8B8:     return 0xFF00FF;
-    case kPxFmt_A8R8G8B8:   return 0xFF00FF; // NOTE: it's a value without alpha
+    case kPxFmt_R5G5B5:     return MASK_COLOR_15;
+    case kPxFmt_R5G6B5:     return MASK_COLOR_16;
+    case kPxFmt_R8G8B8:     return MASK_COLOR_24;
+    case kPxFmt_A8R8G8B8:   return MASK_COLOR_32; // NOTE: it's a value without alpha
     default: assert(false); return 0;
     }
 }
+
+
+typedef std::array<RGB, PAL_SIZE> Palette;
 
 
 // BitmapData is a non-owning wrapper over a pixel buffer,
@@ -301,6 +306,7 @@ private:
 };
 
 
+// Various operations with the pixel buffers: copying, converting, etc.
 namespace PixelOp
 {
     // Copy pixel data from one memory buffer to another. It is required that the
@@ -375,6 +381,37 @@ namespace PixelOp
     void MakeOpaqueSkipMask(BitmapData &bm_data);
     // Replaces pixels with alpha <= threshold with standard mask color.
     void ReplaceAlphaWithRGBMask(BitmapData &bm_data, int alpha_threshold = 0);
+}
+
+// Various operations with palette
+namespace PaletteOp
+{
+    inline void SetRGB(Palette &pal, int index, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF)
+    {
+        pal[index] = { r, g, b, a };
+    }
+
+    // FIXME: this is a temporary unsafe variant, use ref to PALETTE (RGB[256]), not pointer to array of unknown size
+    // (will require fixes around the code in AGS.Native)
+    inline void SetRGB(PALETTE pal, int index, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF)
+    {
+        pal[index] = { r, g, b, a };
+    }
+
+    // Rotates palette colors in the range [first, last], in the given direction
+    void Rotate(PALETTE pal, uint8_t first, uint8_t last, bool to_left);
+    inline void Rotate(Palette &pal, uint8_t first, uint8_t last, bool to_left)
+    {
+        Rotate(pal.data(), first, last, to_left);
+    }
+    // Remaps bitmap's colors between source and destination palettes, trying to
+    // find the closest match to source palette colors. If told to keep transparency,
+    // the mask color will be translated exclusively, preventing any occasional matches.
+    void Remap(BitmapData &bm_data, const PALETTE src_pal, const PALETTE dst_pal, bool keep_transparent = true);
+    inline void Remap(BitmapData &bm_data, const Palette &src_pal, const Palette &dst_pal, bool keep_transparent = true)
+    {
+        Remap(bm_data, src_pal.data(), dst_pal.data(), keep_transparent);
+    }
 }
 
 } // namespace Common

--- a/Common/gfx/bitmapdata.h
+++ b/Common/gfx/bitmapdata.h
@@ -277,15 +277,19 @@ namespace PixelOp
     // Pitches are given in bytes and define the length of the source and dest scan lines.
     // Width and height of the rectangle, as well as source and destination offsets are *in pixels*.
     void CopyPixelsRegion(const uint8_t *src_buffer, const int bpp, const size_t src_pitch,
-        const size_t src_px_off, const int width_px, const int height_px,
-        uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off);
+        const int src_px_off, const int src_py_off, const int width_px, const int height_px,
+        uint8_t *dst_buffer, const size_t dst_pitch, const int dst_px_off, const int dst_py_off);
     inline void CopyPixelsRegion(const uint8_t *src_buffer, const PixelFormat fmt, const size_t src_pitch,
-        const size_t src_px_off, const int width_px, const int height_px,
-        uint8_t *dst_buffer, const size_t dst_pitch, const size_t dst_px_off)
+        const int src_px_off, const int width_px, const int height_px,
+        uint8_t *dst_buffer, const size_t dst_pitch, const int dst_px_off)
     {
         CopyPixelsRegion(src_buffer, PixelFormatToPixelBytes(fmt), src_pitch,
-            src_px_off, width_px, height_px, dst_buffer, dst_pitch, dst_px_off);
+            src_px_off, 0, width_px, height_px, dst_buffer, dst_pitch, dst_px_off, 0);
     }
+
+    // Copy a portion of pixel data and return as a new PixelBuffer.
+    // Position and size of the region is in pixels.
+    PixelBuffer CopyPixelsRegion(const BitmapData &bm_data, const int src_x, const int src_y, const int width, const int height);
 
     // Copies pixels from source to dest buffer, possibly converting between source
     // and dest pixel format. The destination buffer must be properly allocated

--- a/Common/gfx/image_file.h
+++ b/Common/gfx/image_file.h
@@ -33,23 +33,29 @@ namespace ImageFile
     // Reads PixelBuffer object from the stream, optionally filling in palette (if available).
     // "ext" parameter tells which image format to expect.
     // Optionally assigns a source pixel format, for informational purposes.
+    // TODO: pass HError& as an argument
     PixelBuffer LoadImage(Stream *in, const String &ext, PixelFormat *src_fmt = nullptr, RGB *pal = nullptr);
     // Reads PixelBuffer object from the file, optionally filling in palette (if available).
     // Filename's extension will hint which image format to expect.
     // Optionally assigns a source pixel format, for informational purposes.
+    // TODO: pass HError& as an argument
     PixelBuffer LoadImage(const String &filename, PixelFormat *src_fmt = nullptr, RGB *pal = nullptr);
     // Writes BitmapData object to the stream, optionally using a palette.
     // FIXME: skip_alpha parameter is added as a hotfix, to be able to reduce
     // image file size when writing 32-bit sprites without alpha. Normally this
     // should be replaced with a "destination pixel format" parameter.
+    // TODO: replace bool with HError
     bool SaveImage(const BitmapData &bmdata, bool skip_alpha, const RGB *pal, Stream *out, const String &ext);
     // Writes BitmapData object to the stream;
     // "ext" parameter tells which image format to use.
+    // TODO: replace bool with HError
     inline bool SaveImage(const BitmapData& bmdata, Stream* out, const String& ext)
         { return SaveImage(bmdata, false, nullptr, out, ext); }
     // Writes BitmapData object to the file, optionally using a palette.
+    // TODO: replace bool with HError
     bool SaveImage(const BitmapData &bmdata, bool skip_alpha, const RGB *pal, const String &filename);
     // Writes BitmapData object to the file
+    // TODO: replace bool with HError
     inline bool SaveImage(const BitmapData& bmdata, const String &filename)
         { return SaveImage(bmdata, false, nullptr, filename); }
 

--- a/Common/test/paletteop_test.cpp
+++ b/Common/test/paletteop_test.cpp
@@ -1,0 +1,62 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "gtest/gtest.h"
+#include "gfx/bitmapdata.h"
+
+using namespace AGS::Common;
+
+TEST(PixelOp, SetRGB) {
+    Palette pal;
+    std::fill(pal.begin(), pal.end(), RGB{0,0,0,0});
+    PaletteOp::SetRGB(pal, 4, 255, 128, 64, 32);
+    EXPECT_EQ(pal[4].r, 255);
+    EXPECT_EQ(pal[4].g, 128);
+    EXPECT_EQ(pal[4].b, 64);
+    EXPECT_EQ(pal[4].a, 32);
+}
+
+TEST(PixelOp, Rotate) {
+    Palette pal;
+    std::fill(pal.begin(), pal.end(), RGB{0,0,0,0});
+    PaletteOp::SetRGB(pal, 10, 1, 1, 1);
+    PaletteOp::SetRGB(pal, 11, 2, 2, 2);
+    PaletteOp::SetRGB(pal, 12, 3, 3, 3);
+    PaletteOp::SetRGB(pal, 13, 4, 4, 4);
+    PaletteOp::SetRGB(pal, 14, 5, 5, 5);
+
+    PaletteOp::Rotate(pal, 10, 14, true /* left */);
+    EXPECT_EQ(pal[10].r, 2);
+    EXPECT_EQ(pal[11].r, 3);
+    EXPECT_EQ(pal[12].r, 4);
+    EXPECT_EQ(pal[13].r, 5);
+    EXPECT_EQ(pal[14].r, 1);
+    PaletteOp::Rotate(pal, 10, 14, true /* left */);
+    EXPECT_EQ(pal[10].r, 3);
+    EXPECT_EQ(pal[11].r, 4);
+    EXPECT_EQ(pal[12].r, 5);
+    EXPECT_EQ(pal[13].r, 1);
+    EXPECT_EQ(pal[14].r, 2);
+    PaletteOp::Rotate(pal, 10, 14, false /* right */);
+    EXPECT_EQ(pal[10].r, 2);
+    EXPECT_EQ(pal[11].r, 3);
+    EXPECT_EQ(pal[12].r, 4);
+    EXPECT_EQ(pal[13].r, 5);
+    EXPECT_EQ(pal[14].r, 1);
+    PaletteOp::Rotate(pal, 10, 14, false /* right */);
+    EXPECT_EQ(pal[10].r, 1);
+    EXPECT_EQ(pal[11].r, 2);
+    EXPECT_EQ(pal[12].r, 3);
+    EXPECT_EQ(pal[13].r, 4);
+    EXPECT_EQ(pal[14].r, 5);
+}

--- a/Common/util/bufferedstream.cpp
+++ b/Common/util/bufferedstream.cpp
@@ -62,7 +62,7 @@ BufferedStream::~BufferedStream()
 
 std::unique_ptr<IStreamBase> BufferedStream::ReleaseStreamBase()
 {
-    if (_base && CanWrite())
+    if (_base && (_bufferMode == kStream_Write))
         FlushBuffer(_position);
     return std::move(_base);
 }
@@ -80,17 +80,19 @@ void BufferedStream::FillBufferFromPosition(soff_t position)
     _buffer.resize(fill_size);
     auto sz = _base->Read(_buffer.data(), fill_size);
     _buffer.resize(sz);
+    _bufferMode = kStream_Read;
     _bufferPosition = position;
 }
 
 void BufferedStream::FlushBuffer(soff_t position)
 {
-    assert(_base);
-    if (!_base)
+    assert(_base && (_bufferMode == kStream_Write));
+    if (!_base || (_bufferMode != kStream_Write))
         return;
 
     size_t sz = _buffer.size() > 0 ? _base->Write(_buffer.data(), _buffer.size()) : 0u;
     _buffer.clear(); // will start from the clean buffer next time
+    _bufferMode = kStream_None;
     _bufferPosition += sz;
     if (position != _bufferPosition)
     {
@@ -118,17 +120,19 @@ void BufferedStream::Close()
 {
     if (_base)
     {
-        if (CanWrite())
+        if (_bufferMode == kStream_Write)
             FlushBuffer(_position);
         _base->Close();
     }
+
+    _base = nullptr;
 }
 
 bool BufferedStream::Flush()
 {
     if (_base)
     {
-        if (CanWrite())
+        if (_bufferMode == kStream_Write)
             FlushBuffer(_position);
         return _base->Flush();
     }
@@ -155,8 +159,15 @@ size_t BufferedStream::Read(void *buffer, size_t size)
     }
 
     auto *to = static_cast<uint8_t*>(buffer);
-    while(size > 0)
+    while (size > 0)
     {
+        // If the buffer filled with bytes to write, then flush it into the stream
+        if (_bufferMode == kStream_Write)
+        {
+            FlushBuffer(_position);
+        }
+
+        // Fill the buffer for reading, if necessary
         if (_position < _bufferPosition ||
             static_cast<uint64_t>(_position) >= static_cast<uint64_t>(_bufferPosition + _buffer.size()))
         {
@@ -193,9 +204,19 @@ size_t BufferedStream::Write(const void *buffer, size_t size)
     const uint8_t *from = static_cast<const uint8_t*>(buffer);
     while (size > 0)
     {
-        if (_position < _bufferPosition || // seeked before buffer pos
+        // If the buffer is not holding written bytes, then clear it and reposition the stream
+        if (_bufferMode != kStream_Write)
+        {
+            _buffer.clear();
+            _base->Seek(_position, kSeekBegin);
+            _bufferPosition = _position;
+        }
+
+        // Flush the written buffer into the stream, if necessary
+        if ((_bufferMode == kStream_Write) &&
+           (_position < _bufferPosition || // seeked before buffer pos
             _position > _bufferPosition + static_cast<soff_t>(_buffer.size()) || // seeked beyond buffer pos
-            _position >= _bufferPosition + static_cast<soff_t>(BufferSize)) // seeked, or exceeded buffer limit
+            _position >= _bufferPosition + static_cast<soff_t>(BufferSize))) // seeked, or exceeded buffer limit
         {
             FlushBuffer(_position);
         }
@@ -204,6 +225,7 @@ size_t BufferedStream::Write(const void *buffer, size_t size)
         if (_buffer.size() < pos_in_buff + chunk_sz)
             _buffer.resize(pos_in_buff + chunk_sz);
         memcpy(_buffer.data() + pos_in_buff, from, chunk_sz);
+        _bufferMode = kStream_Write;
         _position += chunk_sz;
         from += chunk_sz;
         size -= chunk_sz;

--- a/Common/util/bufferedstream.h
+++ b/Common/util/bufferedstream.h
@@ -82,7 +82,8 @@ private:
     soff_t _end = 0; // valid section ending offset
     soff_t _position = 0; // absolute read/write offset
     soff_t _bufferPosition = 0; // buffer's location relative to base stream
-    std::vector<uint8_t> _buffer;
+    std::vector<uint8_t> _buffer; // buffer, accumulating data in read or write mode
+    StreamMode _bufferMode = kStream_None; // current buffer mode (can be *only* read OR write)
 };
 
 } // namespace Common

--- a/Common/util/memory.h
+++ b/Common/util/memory.h
@@ -256,7 +256,7 @@ namespace Memory
     //-------------------------------------------------------------------------
     // Copies a block of 2D data from source buffer into destination buffer.
     // Pitches, offsets and width are in bytes, height is a number of lines.
-    // FIXME: a safer version that requires to assert buffer size
+    // FIXME: a safer version that requires to pass and assert buffer size
     inline void BlockCopy( const uint8_t *src, const size_t src_pitch, const size_t src_offset,
         const size_t width, const size_t height,
         uint8_t *dst, const size_t dst_pitch, const size_t dst_offset)

--- a/Common/util/stream.cpp
+++ b/Common/util/stream.cpp
@@ -187,6 +187,7 @@ size_t Stream::WriteByteCount(uint8_t b, size_t count)
 //-----------------------------------------------------------------------------
 
 StreamSection::StreamSection(std::unique_ptr<IStreamBase> &&base, soff_t start, soff_t end)
+    : StreamBase(base->GetPath())
 {
     OpenSection(base.get(), start, end);
     _ownBase = std::move(base);
@@ -194,9 +195,15 @@ StreamSection::StreamSection(std::unique_ptr<IStreamBase> &&base, soff_t start, 
 }
 
 StreamSection::StreamSection(IStreamBase *base, soff_t start, soff_t end)
+    : StreamBase(base->GetPath())
 {
     OpenSection(base, start, end);
     _base = base;
+}
+
+StreamSection::~StreamSection()
+{
+    Close();
 }
 
 void StreamSection::Open(IStreamBase *base)
@@ -231,6 +238,11 @@ void StreamSection::Close()
     // Only close the base stream if owning one
     if (_ownBase)
         _ownBase->Close();
+    else if (_base && CanWrite())
+        _base->Flush();
+
+    _ownBase = nullptr;
+    _base = nullptr;
 }
 
 size_t StreamSection::Read(void *buffer, size_t len)

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -512,6 +512,7 @@ public:
     // Constructs a non-owning StreamSection over a base stream.
     // TODO: allow end < 0 in which case the end of base stream is used
     StreamSection(IStreamBase *base, soff_t start, soff_t end);
+    ~StreamSection();
 
     StreamMode  GetMode() const override { return _base->GetMode(); }
     const char *GetPath() const override { return _base->GetPath(); }

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -183,7 +183,7 @@ public:
     ~Stream() = default;
 
     IStreamBase *GetStreamBase() { return _base.get(); }
-    // TODO: consider using shader ptr instead
+    // TODO: consider using shared ptr instead
     void AttachStreamBase(std::unique_ptr<IStreamBase> &&base) { _base = std::move(base); }
     std::unique_ptr<IStreamBase> ReleaseStreamBase() { return std::move(_base); }
 
@@ -507,8 +507,10 @@ public:
     // Constructs a owning StreamSection over a base stream,
     // restricting working range to [start, end), i.e. end offset is
     // +1 past allowed position.
+    // TODO: allow end < 0 in which case the end of base stream is used
     StreamSection(std::unique_ptr<IStreamBase> &&base, soff_t start, soff_t end);
     // Constructs a non-owning StreamSection over a base stream.
+    // TODO: allow end < 0 in which case the end of base stream is used
     StreamSection(IStreamBase *base, soff_t start, soff_t end);
 
     StreamMode  GetMode() const override { return _base->GetMode(); }

--- a/Common/util/wgt2allg.cpp
+++ b/Common/util/wgt2allg.cpp
@@ -16,6 +16,14 @@
 
 using namespace AGS::Common;
 
+const int col_lookups[32] = {
+    0x000000, 0x0000A0, 0x00A000, 0x00A0A0, 0xA00000,   // 4
+    0xA000A0, 0xA05000, 0xA0A0A0, 0x505050, 0x5050FF, 0x50FF50, 0x50FFFF,       // 11
+    0xFF5050, 0xFF50FF, 0xFFFF50, 0xFFFFFF, 0x000000, 0x101010, 0x202020,       // 18
+    0x303030, 0x404040, 0x505050, 0x606060, 0x707070, 0x808080, 0x909090,       // 25
+    0xA0A0A0, 0xB0B0B0, 0xC0C0C0, 0xD0D0D0, 0xE0E0E0, 0xF0F0F0
+};
+
 int my_setcolor(const int color, int color_depth, bool fix_alpha)
 {
     if (color_depth == 8)
@@ -53,35 +61,7 @@ int my_setcolor(const int color, int color_depth, bool fix_alpha)
     }
 }
 
-  void wsetrgb(int coll, int r, int g, int b, RGB * pall)
-  {
-    pall[coll].r = r;
-    pall[coll].g = g;
-    pall[coll].b = b;
-  }
-
-  void wcolrotate(unsigned char start, unsigned char finish, int dir, RGB * pall)
-  {
-    int jj;
-    if (dir == 0) {
-      // rotate left
-        RGB tempp = pall[start];
-
-      for (jj = start; jj < finish; jj++)
-        pall[jj] = pall[jj + 1];
-
-      pall[finish] = tempp;
-    }
-    else {
-      // rotate right
-        RGB tempp = pall[finish];
-
-      for (jj = finish - 1; jj >= start; jj--)
-        pall[jj + 1] = pall[jj];
-
-      pall[start] = tempp;
-    }
-  }
+  
 
   Bitmap *wnewblock(Bitmap *src, int x1, int y1, int x2, int y2)
   {
@@ -119,51 +99,4 @@ int my_setcolor(const int color, int color_depth, bool fix_alpha)
       ds->Blit(&wputblock_wrapper, xx, yy, kBitmap_Transparency);
     else
       ds->Blit(&wputblock_wrapper, 0, 0, xx, yy, wputblock_wrapper.GetWidth(), wputblock_wrapper.GetHeight());
-  }
-
-  const int col_lookups[32] = {
-    0x000000, 0x0000A0, 0x00A000, 0x00A0A0, 0xA00000,   // 4
-    0xA000A0, 0xA05000, 0xA0A0A0, 0x505050, 0x5050FF, 0x50FF50, 0x50FFFF,       // 11
-    0xFF5050, 0xFF50FF, 0xFFFF50, 0xFFFFFF, 0x000000, 0x101010, 0x202020,       // 18
-    0x303030, 0x404040, 0x505050, 0x606060, 0x707070, 0x808080, 0x909090,       // 25
-    0xA0A0A0, 0xB0B0B0, 0xC0C0C0, 0xD0D0D0, 0xE0E0E0, 0xF0F0F0
-  };
-
-  void wremap(const RGB * pal1, Bitmap *picc, const RGB * pal2, bool keep_transparent)
-  {
-    unsigned char color_mapped_table[256];
-
-    for (int jj = 0; jj < 256; jj++)
-    {
-      if ((pal1[jj].r == 0) && (pal1[jj].g == 0) && (pal1[jj].b == 0))
-      {
-        color_mapped_table[jj] = 0;
-      }
-      else
-      {
-        color_mapped_table[jj] = bestfit_color(pal2, pal1[jj].r, pal1[jj].g, pal1[jj].b);
-      }
-    }
-
-    if (keep_transparent) {
-      // keep transparency
-      color_mapped_table[0] = 0;
-      // any other pixels which are being mapped to 0, map to 16 instead
-      for (int jj = 1; jj < 256; jj++) {
-        if (color_mapped_table[jj] == 0)
-          color_mapped_table[jj] = 16;
-      }
-    }
-
-    int pic_size = picc->GetWidth() * picc->GetHeight();
-    for (int jj = 0; jj < pic_size; jj++) {
-      int xxl = jj % (picc->GetWidth()), yyl = jj / (picc->GetWidth());
-      int rr = picc->GetPixel(xxl, yyl);
-      picc->PutPixel(xxl, yyl, color_mapped_table[rr]);
-    }
-  }
-
-  void wremapall(const RGB * pal1, Bitmap *picc, const RGB * pal2)
-  {
-    wremap(pal1, picc, pal2, false);
   }

--- a/Common/util/wgt2allg.h
+++ b/Common/util/wgt2allg.h
@@ -13,6 +13,7 @@
 //=============================================================================
 //
 // Few graphic utility functions, remains of a bigger deprecated api.
+// FIXME: either get rid of these or tidy and reorganize them.
 //
 //=============================================================================
 #ifndef __WGT4_H
@@ -27,19 +28,11 @@ using namespace AGS; // FIXME later
 
     extern int my_setcolor(int color, int color_depth, bool fix_alpha);
     
-    extern void wsetrgb(int coll, int r, int g, int b, RGB * pall);
-    extern void wcolrotate(unsigned char start, unsigned char finish, int dir, RGB * pall);
-
     extern Common::Bitmap *wnewblock(Common::Bitmap *src, int x1, int y1, int x2, int y2);
 
     extern void wputblock(Common::Bitmap *ds, int xx, int yy, Common::Bitmap *bll, int xray);
 	// CHECKME: temporary solution for plugin system
 	extern void wputblock_raw(Common::Bitmap *ds, int xx, int yy, BITMAP *bll, int xray);
-    extern const int col_lookups[32];
-
-    // TODO: these are used only in the Editor's agsnative.cpp
-    extern void wremap(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2, bool keep_transparent = true);
-    extern void wremapall(const RGB * pal1, Common::Bitmap *picc, const RGB * pal2);
 
 
 #endif // __WGT4_H

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2775,26 +2775,28 @@ AGSBitmap *CreateNativeBitmap(System::Drawing::Bitmap^ bmp, int spriteImportMeth
     AGSBitmap *tempsprite = CreateBlockFromBitmap(bmp, imgPalBuf, nullptr, true,
         alphaChannel, keep_trans, fix_palette, &importedColourDepth);
 
+    // Prior to transparency conversion, deal with 32-bit alpha channel:
+    // either convert zero-alpha pixels to standard mask color, or to opaque color
+    int flags = 0;
+    if (tempsprite->GetColorDepth() == 32)
+    {
+        if (alphaChannel)
+        {
+            flags |= SPF_ALPHACHANNEL;
+            BitmapHelper::ReplaceZeroAlphaWithRGBMask(tempsprite);
+        }
+        else
+        {
+            BitmapHelper::MakeOpaqueSkipMask(tempsprite);
+        }
+    }
+
     int transcol = 0;
     sort_out_transparency(tempsprite, spriteImportMethod, transColour, imgPalBuf, importedColourDepth, transcol);
     if (thisgame.color_depth == 1)
     {
         if (remapColours)
             sort_out_palette(tempsprite, imgPalBuf, useRoomBackgroundColours, transcol);
-    }
-
-    int flags = 0;
-    if (alphaChannel)
-    {
-        flags |= SPF_ALPHACHANNEL;
-        if (tempsprite->GetColorDepth() == 32)
-        {
-            BitmapHelper::ReplaceZeroAlphaWithRGBMask(tempsprite);
-        }
-    }
-    else if (tempsprite->GetColorDepth() == 32)
-    {
-        BitmapHelper::MakeOpaqueSkipMask(tempsprite);
     }
 
     if (out_flags)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1522,7 +1522,7 @@ void sort_out_palette(Common::Bitmap *toimp, RGB*itspal, bool useBgSlots, int tr
       itspal[transcol] = itspal[0];
     PaletteOp::SetRGB(itspal, 0,0,0,0); // set index 0 to black
     RGB oldpale[256];
-    for (int uu=0;uu<255;uu++) {
+    for (int uu=0;uu<PAL_SIZE;uu++) {
       if (useBgSlots)  //  use background scene palette
         oldpale[uu]=palette[uu];
       else if (thisgame.paluses[uu]==PAL_BACKGROUND)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -61,6 +61,7 @@ using AGS::Common::AssetLibInfo;
 using AGS::Common::AssetManager;
 namespace AGSProps = AGS::Common::Properties;
 namespace BitmapHelper = AGS::Common::BitmapHelper;
+namespace PaletteOp = AGS::Common::PaletteOp;
 using AGS::Common::GUIMain;
 using AGS::Common::GUIButton;
 using AGS::Common::GUIInvWindow;
@@ -1519,17 +1520,18 @@ void sort_out_palette(Common::Bitmap *toimp, RGB*itspal, bool useBgSlots, int tr
     // 256-colour mode only
     if (transcol!=0)
       itspal[transcol] = itspal[0];
-    wsetrgb(0,0,0,0,itspal); // set index 0 to black
+    PaletteOp::SetRGB(itspal, 0,0,0,0); // set index 0 to black
     RGB oldpale[256];
     for (int uu=0;uu<255;uu++) {
       if (useBgSlots)  //  use background scene palette
         oldpale[uu]=palette[uu];
       else if (thisgame.paluses[uu]==PAL_BACKGROUND)
-        wsetrgb(uu,0,0,0,oldpale);
+          PaletteOp::SetRGB(oldpale, uu,0,0,0);
       else 
         oldpale[uu]=palette[uu];
     }
-    wremap(itspal,toimp,oldpale); 
+    AGS::Common::BitmapData bm_data = toimp->GetBitmapData();
+    PaletteOp::Remap(bm_data, itspal, oldpale);
     set_palette_range(palette, 0, 255, 0);
   }
   else if (toimp->GetColorDepth() == 8) {  // hi-colour game
@@ -1667,7 +1669,7 @@ void free_old_game_data()
 }
 
 // remap the scene, from its current palette oldpale to palette
-void remap_background (Common::Bitmap *scene, const RGB *oldpale, RGB*palette, int exactPal) {
+void remap_background(Common::Bitmap *scene, const PALETTE oldpale, PALETTE palette, int exactPal) {
 
   if (exactPal) {
     // exact palette import (for doing palette effects, don't change)
@@ -1701,7 +1703,7 @@ void remap_background (Common::Bitmap *scene, const RGB *oldpale, RGB*palette, i
   RGB tpal[256];
   for (int a=0;a<256;a++) {
     if (thisgame.paluses[a]==PAL_BACKGROUND)
-      wsetrgb(a,0,0,0,palette);  // black out the bg slots before starting
+      PaletteOp::SetRGB(palette, a,0,0,0); // black out the bg slots before starting
     if ((oldpale[a].r==0) & (oldpale[a].g==0) & (oldpale[a].b==0)) {
       imgpalcnt[a]=0;
       continue;
@@ -1744,7 +1746,8 @@ void remap_background (Common::Bitmap *scene, const RGB *oldpale, RGB*palette, i
     }
     else tpal[a]=palette[a];
   }
-  wremapall(oldpale,scene,tpal); //palette);
+  AGS::Common::BitmapData bm_data = scene->GetBitmapData();
+  PaletteOp::Remap(bm_data, oldpale, tpal, false);
 }
 
 void validate_mask(Common::Bitmap *toValidate, const char *name, int maxColour) {
@@ -2669,7 +2672,10 @@ void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap 
 		  	theRoom->BgFrames[0].IsPaletteShared = 1;
 
 		  if (!useExactPalette)
-			wremapall(oldpale, newbg, palette);
+          {
+            AGS::Common::BitmapData bm_data = newbg->GetBitmapData();
+			AGS::Common::PaletteOp::Remap(bm_data, oldpale, palette, false);
+          }
 		}
 		else {
 		  theRoom->BgFrames[backgroundNumber].IsPaletteShared = 0;

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -511,8 +511,8 @@ void *DrawingSurface_GetPixelsCopyImpl(ScriptDrawingSurface *sds, int x, int y, 
     {
         const int src_pitch = ds->GetWidth() * ds->GetBPP();
         const int dst_pitch = width * ds->GetBPP();
-        PixelOp::CopyPixelsRegion(ds->GetData() + y * src_pitch, ds->GetBPP(), src_pitch,
-            x, width, height, static_cast<uint8_t*>(arr.Obj()), dst_pitch, 0u);
+        PixelOp::CopyPixelsRegion(ds->GetData(), ds->GetBPP(), src_pitch,
+            x, y, width, height, static_cast<uint8_t*>(arr.Obj()), dst_pitch, 0, 0);
     }
     return arr.Obj();
 }
@@ -561,8 +561,8 @@ void DrawingSurface_SetPixelsImpl(ScriptDrawingSurface *sds, void *arrobj, int x
     const int dst_pitch = ds->GetWidth() * ds->GetBPP();
     const int copy_width = std::min(width, ds->GetWidth() - x);
     const int copy_height = std::min(height, std::min<int>(arr_header.TotalSize / (src_pitch), ds->GetHeight()));
-    PixelOp::CopyPixelsRegion(arr_ptr, ds->GetBPP(), src_pitch, 0u, copy_width, copy_height,
-        ds->GetDataForWriting() + y * dst_pitch, dst_pitch, x);
+    PixelOp::CopyPixelsRegion(arr_ptr, ds->GetBPP(), src_pitch, 0, 0, copy_width, copy_height,
+        ds->GetDataForWriting(), dst_pitch, x, y);
     sds->FinishedDrawing();
 }
 

--- a/Engine/ac/global_palette.cpp
+++ b/Engine/ac/global_palette.cpp
@@ -34,12 +34,12 @@ void CyclePalette(int strt,int eend) {
 
     if (eend > strt) {
         // forwards
-        wcolrotate(strt, eend, 0, palette);
+        PaletteOp::Rotate(palette, strt, eend, true);
         set_palette_range(palette, strt, eend, 0);
     }
     else {
         // backwards
-        wcolrotate(eend, strt, 1, palette);
+        PaletteOp::Rotate(palette, eend, strt, false);
         set_palette_range(palette, eend, strt, 0);
     }
 
@@ -48,15 +48,9 @@ void SetPalRGB(int inndx,int rr,int gg,int bb) {
     if (game.color_depth > 1)
         invalidate_screen();
 
-    wsetrgb(inndx,rr,gg,bb,palette);
+    PaletteOp::SetRGB(palette, inndx, rr, gg, bb);
     set_palette_range(palette, inndx, inndx, 0);
 }
-/*void scSetPal(color*pptr) {
-wsetpalette(0,255,pptr);
-}
-void scGetPal(color*pptr) {
-get_palette(pptr);
-}*/
 
 void UpdatePalette() {
     if (game.color_depth > 1)

--- a/Solutions/Tests.App/Common.Lib.Test.vcxproj
+++ b/Solutions/Tests.App/Common.Lib.Test.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="..\..\Common\test\math_test.cpp" />
     <ClCompile Include="..\..\Common\test\memory_test.cpp" />
     <ClCompile Include="..\..\Common\test\path_test.cpp" />
+    <ClCompile Include="..\..\Common\test\paletteop_test.cpp" />
     <ClCompile Include="..\..\Common\test\splitline_test.cpp" />
     <ClCompile Include="..\..\Common\test\spritecache_test.cpp" />
     <ClCompile Include="..\..\Common\test\spritefile_test.cpp" />

--- a/Solutions/Tests.App/Common.Lib.Test.vcxproj.filters
+++ b/Solutions/Tests.App/Common.Lib.Test.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="..\..\Common\test\datahelpers_test.cpp">
       <Filter>Test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\test\paletteop_test.cpp">
+      <Filter>Test</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Test">

--- a/Solutions/Tests.App/Tools.Test.vcxproj
+++ b/Solutions/Tests.App/Tools.Test.vcxproj
@@ -185,7 +185,6 @@
     <ClCompile Include="..\..\Common\game\customproperties.cpp" />
     <ClCompile Include="..\..\Common\game\interactions.cpp" />
     <ClCompile Include="..\..\Common\libsrc\googletest\googletest\src\gtest-all.cc" />
-    <ClCompile Include="..\..\Common\libsrc\googletest\googletest\src\gtest_main.cc" />
     <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
     <ClCompile Include="..\..\Common\util\file.cpp" />
     <ClCompile Include="..\..\Common\util\filestream.cpp" />
@@ -205,10 +204,13 @@
     <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
     <ClCompile Include="..\..\Tools\data\data_file_writer.cpp" />
     <ClCompile Include="..\..\Tools\data\include_utils.cpp" />
+    <ClCompile Include="..\..\Tools\data\sprite_utils.cpp" />
     <ClCompile Include="..\..\Tools\test\agfreader_test.cpp" />
     <ClCompile Include="..\..\Tools\test\data_file_writer_test.cpp" />
     <ClCompile Include="..\..\Tools\test\data_helpers_test.cpp" />
+    <ClCompile Include="..\..\Tools\test\gtest_main.cc" />
     <ClCompile Include="..\..\Tools\test\include_utils_test.cpp" />
+    <ClCompile Include="..\..\Tools\test\spriteimport_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common.Lib\Common.Lib.vcxproj">
@@ -246,6 +248,8 @@
     <ClInclude Include="..\..\Tools\data\data_file_writer.h" />
     <ClInclude Include="..\..\Tools\data\game_utils.h" />
     <ClInclude Include="..\..\Tools\data\include_utils.h" />
+    <ClInclude Include="..\..\Tools\data\sprite_utils.h" />
+    <ClInclude Include="..\..\Tools\test\spriteimport_env.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solutions/Tests.App/Tools.Test.vcxproj.filters
+++ b/Solutions/Tests.App/Tools.Test.vcxproj.filters
@@ -60,9 +60,6 @@
     <ClCompile Include="..\..\Tools\test\include_utils_test.cpp">
       <Filter>Test</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Common\libsrc\googletest\googletest\src\gtest_main.cc">
-      <Filter>Test</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Common\libsrc\googletest\googletest\src\gtest-all.cc">
       <Filter>Test</Filter>
     </ClCompile>
@@ -140,6 +137,15 @@
     </ClCompile>
     <ClCompile Include="..\..\libsrc\allegro\src\win\wfile.c">
       <Filter>libsrc\allegro</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\test\spriteimport_test.cpp">
+      <Filter>Test</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\sprite_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\test\gtest_main.cc">
+      <Filter>Test</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -221,14 +227,20 @@
     <ClInclude Include="..\..\Tools\data\data_file_writer.h">
       <Filter>data</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Tools\data\game_utils.h">
-      <Filter>data</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">
       <Filter>libsrc\tinyxml2</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\util\memorystream.h">
       <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\game_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\sprite_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\test\spriteimport_env.h">
+      <Filter>Test</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Tools.App/spriteimport.vcxproj
+++ b/Solutions/Tools.App/spriteimport.vcxproj
@@ -20,12 +20,20 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\ac\spritefile.cpp" />
+    <ClCompile Include="..\..\Common\data\data_ext.cpp" />
+    <ClCompile Include="..\..\Common\data\data_helpers.cpp" />
     <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
+    <ClCompile Include="..\..\Common\game\customproperties.cpp" />
+    <ClCompile Include="..\..\Common\game\interactions.cpp" />
+    <ClCompile Include="..\..\Common\game\roomdata.cpp" />
+    <ClCompile Include="..\..\Common\game\room_file.cpp" />
     <ClCompile Include="..\..\Common\gfx\bitmapdata.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_bmp.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_file.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_pcx.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_png.cpp" />
+    <ClCompile Include="..\..\Common\script\cc_common.cpp" />
+    <ClCompile Include="..\..\Common\script\cc_script.cpp" />
     <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
     <ClCompile Include="..\..\Common\util\cmdlineopts.cpp" />
     <ClCompile Include="..\..\Common\util\compress.cpp" />
@@ -54,14 +62,23 @@
     <ClCompile Include="..\..\libsrc\stb\stb_image.c" />
     <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp" />
     <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
+    <ClCompile Include="..\..\Tools\data\cc_script_stubs.cpp" />
     <ClCompile Include="..\..\Tools\data\sprite_utils.cpp" />
     <ClCompile Include="..\..\Tools\spriteimport\commands.cpp" />
     <ClCompile Include="..\..\Tools\spriteimport\main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\spritefile.h" />
+    <ClInclude Include="..\..\Common\data\data_ext.h" />
+    <ClInclude Include="..\..\Common\data\data_helpers.h" />
+    <ClInclude Include="..\..\Common\game\customproperties.h" />
+    <ClInclude Include="..\..\Common\game\interactions.h" />
+    <ClInclude Include="..\..\Common\game\roomdata.h" />
+    <ClInclude Include="..\..\Common\game\room_file.h" />
     <ClInclude Include="..\..\Common\gfx\bitmapdata.h" />
     <ClInclude Include="..\..\Common\gfx\image_file.h" />
+    <ClInclude Include="..\..\Common\script\cc_common.h" />
+    <ClInclude Include="..\..\Common\script\cc_script.h" />
     <ClInclude Include="..\..\Common\util\bufferedstream.h" />
     <ClInclude Include="..\..\Common\util\cmdlineopts.h" />
     <ClInclude Include="..\..\Common\util\compress.h" />

--- a/Solutions/Tools.App/spriteimport.vcxproj
+++ b/Solutions/Tools.App/spriteimport.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\ac\spritefile.cpp" />
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
     <ClCompile Include="..\..\Common\gfx\bitmapdata.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_bmp.cpp" />
     <ClCompile Include="..\..\Common\gfx\image_file.cpp" />
@@ -42,18 +43,20 @@
     <ClCompile Include="..\..\libsrc\allegro\src\allegro.c" />
     <ClCompile Include="..\..\libsrc\allegro\src\color.c" />
     <ClCompile Include="..\..\libsrc\allegro\src\file.c">
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)al_file.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)al_file.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)al_file.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)al_file.obj</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)al_file</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)al_file</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)al_file</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)al_file</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\..\libsrc\allegro\src\unicode.c" />
     <ClCompile Include="..\..\libsrc\allegro\src\win\wfile.c" />
     <ClCompile Include="..\..\libsrc\miniz\miniz.c" />
     <ClCompile Include="..\..\libsrc\stb\stb_image.c" />
+    <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp" />
+    <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
     <ClCompile Include="..\..\Tools\data\sprite_utils.cpp" />
-    <ClCompile Include="..\..\Tools\spritepak\main.cpp" />
-    <ClCompile Include="..\..\Tools\spritepak\commands.cpp" />
+    <ClCompile Include="..\..\Tools\spriteimport\commands.cpp" />
+    <ClCompile Include="..\..\Tools\spriteimport\main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\spritefile.h" />
@@ -75,14 +78,16 @@
     <ClInclude Include="..\..\Common\util\string_utils.h" />
     <ClInclude Include="..\..\libsrc\miniz\miniz.h" />
     <ClInclude Include="..\..\libsrc\stb\stb_image.h" />
+    <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h" />
+    <ClInclude Include="..\..\Tools\data\agfreader.h" />
     <ClInclude Include="..\..\Tools\data\sprite_utils.h" />
-    <ClInclude Include="..\..\Tools\spritepak\commands.h" />
+    <ClInclude Include="..\..\Tools\spriteimport\commands.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{1D3E1B95-BD32-4A33-84FE-C995D9015657}</ProjectGuid>
+    <ProjectGuid>{747CA29B-219C-424A-A7A3-33A8B6BE027B}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>spritepak</ProjectName>
+    <ProjectName>spriteimport</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -143,7 +148,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -158,7 +163,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -174,7 +179,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -193,7 +198,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;..\..\libsrc\allegro\include;..\..\libsrc\miniz;..\..\libsrc\stb;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/Solutions/Tools.App/spriteimport.vcxproj.filters
+++ b/Solutions/Tools.App/spriteimport.vcxproj.filters
@@ -8,9 +8,6 @@
     <Filter Include="Common">
       <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
     </Filter>
-    <Filter Include="spritepak">
-      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
-    </Filter>
     <Filter Include="miniz">
       <UniqueIdentifier>{3c265ae8-b584-444e-af07-9c70a00f4543}</UniqueIdentifier>
     </Filter>
@@ -20,17 +17,17 @@
     <Filter Include="stb">
       <UniqueIdentifier>{a82a002f-a4f4-4bca-84e0-19b83412b412}</UniqueIdentifier>
     </Filter>
+    <Filter Include="spriteimport">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
     <Filter Include="data">
-      <UniqueIdentifier>{9f7942ab-5b85-4cc8-ac20-5325364c9474}</UniqueIdentifier>
+      <UniqueIdentifier>{da53c193-4ae0-441d-96b3-8d1ecc5a5d25}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tinyxml">
+      <UniqueIdentifier>{1d881862-6fc0-43f5-a907-206932f12a23}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\Tools\spritepak\main.cpp">
-      <Filter>spritepak</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\Tools\spritepak\commands.cpp">
-      <Filter>spritepak</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Common\ac\spritefile.cpp">
       <Filter>Common</Filter>
     </ClCompile>
@@ -100,26 +97,38 @@
     <ClCompile Include="..\..\libsrc\stb\stb_image.c">
       <Filter>stb</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Tools\data\sprite_utils.cpp">
-      <Filter>data</Filter>
+    <ClCompile Include="..\..\Tools\spriteimport\commands.cpp">
+      <Filter>spriteimport</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libsrc\allegro\src\file.c">
+    <ClCompile Include="..\..\Tools\spriteimport\main.cpp">
+      <Filter>spriteimport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\allegro\src\allegro.c">
       <Filter>allegro</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libsrc\allegro\src\unicode.c">
       <Filter>allegro</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libsrc\allegro\src\allegro.c">
-      <Filter>allegro</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libsrc\allegro\src\win\wfile.c">
       <Filter>allegro</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libsrc\allegro\src\file.c">
+      <Filter>allegro</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\sprite_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\agfreader.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp">
+      <Filter>tinyxml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\Tools\spritepak\commands.h">
-      <Filter>spritepak</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\Common\ac\spritefile.h">
       <Filter>Common</Filter>
     </ClInclude>
@@ -177,8 +186,17 @@
     <ClInclude Include="..\..\libsrc\stb\stb_image.h">
       <Filter>stb</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Tools\spriteimport\commands.h">
+      <Filter>spriteimport</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\Tools\data\sprite_utils.h">
       <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\agfreader.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">
+      <Filter>tinyxml</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Tools.App/spriteimport.vcxproj.filters
+++ b/Solutions/Tools.App/spriteimport.vcxproj.filters
@@ -127,6 +127,33 @@
     <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
       <Filter>Common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\game\room_file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\data\data_ext.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\data\data_helpers.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\customproperties.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\interactions.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\roomdata.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\script\cc_common.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\script\cc_script.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\cc_script_stubs.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\spritefile.h">
@@ -197,6 +224,30 @@
     </ClInclude>
     <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">
       <Filter>tinyxml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\game\room_file.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\data\data_ext.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\data\data_helpers.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\game\customproperties.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\game\interactions.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\game\roomdata.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\script\cc_common.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\script\cc_script.h">
+      <Filter>Common</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -17,6 +17,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spritepak", "Tools.App\spri
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2dta", "Tools.App\agf2dta.vcxproj", "{864B9942-C183-4985-AA65-877DA02725F0}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spriteimport", "Tools.App\spriteimport.vcxproj", "{747CA29B-219C-424A-A7A3-33A8B6BE027B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -81,6 +83,14 @@ Global
 		{864B9942-C183-4985-AA65-877DA02725F0}.Release|x64.Build.0 = Release|x64
 		{864B9942-C183-4985-AA65-877DA02725F0}.Release|x86.ActiveCfg = Release|Win32
 		{864B9942-C183-4985-AA65-877DA02725F0}.Release|x86.Build.0 = Release|Win32
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Debug|x64.ActiveCfg = Debug|x64
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Debug|x64.Build.0 = Debug|x64
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Debug|x86.ActiveCfg = Debug|Win32
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Debug|x86.Build.0 = Debug|Win32
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Release|x64.ActiveCfg = Release|x64
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Release|x64.Build.0 = Release|x64
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Release|x86.ActiveCfg = Release|Win32
+		{747CA29B-219C-424A-A7A3-33A8B6BE027B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -142,6 +142,8 @@ target_sources(libtools
         data/script_utils.h
         data/scriptgen.cpp
         data/scriptgen.h
+        data/sprite_utils.cpp
+        data/sprite_utils.h
         data/tra_utils.cpp
         data/tra_utils.h
         ${TOOLS_COMMON_SOURCES}
@@ -199,6 +201,17 @@ set_target_properties(crmpak PROPERTIES
         CXX_EXTENSIONS NO
         )
 target_link_libraries(crmpak PUBLIC libtools)
+
+#----- spritepak -------------------------------------------------
+add_executable(spriteimport spriteimport/main.cpp
+        spriteimport/commands.h
+        spriteimport/commands.cpp
+        )
+set_target_properties(spriteimport PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(spriteimport PUBLIC libtools)
 
 #----- spritepak -------------------------------------------------
 add_executable(spritepak spritepak/main.cpp

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -287,6 +287,8 @@ if(AGS_TESTS)
       test/data_file_writer_test.cpp
       test/data_helpers_test.cpp
       test/include_utils_test.cpp
+      test/spriteimport_test.cpp
+      test/gtest_main.cc # need to use our own, cannot link one from gtest
    )
    set_target_properties(tools_test PROPERTIES
       CXX_STANDARD 11
@@ -300,7 +302,7 @@ if(AGS_TESTS)
       libtools
       AlFont::AlFont
       AAStr::AAStr
-      gtest_main
+      gtest
    )
 
    include(GoogleTest)

--- a/Tools/agf2dlgasc/Makefile
+++ b/Tools/agf2dlgasc/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/Tools/agf2dta/Makefile
+++ b/Tools/agf2dta/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/Tools/agfexport/Makefile
+++ b/Tools/agfexport/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/Tools/agspak/Makefile
+++ b/Tools/agspak/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -1389,6 +1389,24 @@ static void ReadGameCommon(DataUtil::GameRef &game, DocElem root)
     ReadGameSettings(game.Settings, root);
 }
 
+void ReadGamePalette(std::vector<DataUtil::PaletteEntryData> &pal_data, DocElem root)
+{
+    DocElem palette = root->FirstChildElement("Palette");
+    for (DocElem entry = palette ? palette->FirstChildElement("PaletteEntry") : nullptr;
+        entry; entry = entry->NextSiblingElement("PaletteEntry"))
+    {
+        const int index = ValueParser::ReadAttributeInt(entry, "Index", -1);
+        if (index < 0 || index >= 256) continue;
+        if (pal_data.size() <= static_cast<uint8_t>(index))
+            pal_data.resize(index + 1);
+        auto &data = pal_data[index];
+        data.ColourType = ReadColourType(ValueParser::ReadAttributeString(entry, "Type", "Gamewide"));
+        data.Red = ValueParser::ReadAttributeInt(entry, "Red");
+        data.Green = ValueParser::ReadAttributeInt(entry, "Green");
+        data.Blue = ValueParser::ReadAttributeInt(entry, "Blue");
+    }
+}
+
 static void GetAllSprites(std::vector<DataUtil::SpriteData> &sprites, DocElem root)
 {
     std::vector<DocElem> elems;
@@ -1599,18 +1617,7 @@ void ReadGameData(DataUtil::GameData &game, AGFReader &reader)
     }
 
     game.Palette.resize(256);
-    DocElem palette = root->FirstChildElement("Palette");
-    for (DocElem entry = palette ? palette->FirstChildElement("PaletteEntry") : nullptr;
-         entry; entry = entry->NextSiblingElement("PaletteEntry"))
-    {
-        const int index = ValueParser::ReadAttributeInt(entry, "Index", -1);
-        if (index < 0 || index >= 256) continue;
-        auto &data = game.Palette[index];
-        data.ColourType = ReadColourType(ValueParser::ReadAttributeString(entry, "Type", "Gamewide"));
-        data.Red = ValueParser::ReadAttributeInt(entry, "Red");
-        data.Green = ValueParser::ReadAttributeInt(entry, "Green");
-        data.Blue = ValueParser::ReadAttributeInt(entry, "Blue");
-    }
+    ReadGamePalette(game.Palette, root);
 
     GetAllSprites(game.Sprites, root);
 

--- a/Tools/data/agfreader.cpp
+++ b/Tools/data/agfreader.cpp
@@ -119,6 +119,10 @@ static const CstrArr<3> kSpriteImportResolutionNames = {{
     "Real", "LowRes", "HighRes"
 }};
 
+static const CstrArr<8> kSpriteImportTransparencyNames = {{
+    "PaletteIndex0", "TopLeft", "BottomLeft", "TopRight", "BottomRight", "LeaveAsIs", "NoTransparency", "PaletteIndex"
+}};
+
 static const CstrArr<2> kAudioBundlingTypeNames = {{
     "InGameEXE", "InSeparateVOX"
 }};
@@ -1113,6 +1117,12 @@ static DataUtil::SpriteImportResolution ReadSpriteImportResolution(const String 
         DataUtil::kSpriteImport_Real, DataUtil::kSpriteImport_Real);
 }
 
+static DataUtil::SpriteImportTransparency ReadSpriteImportTransparency(const String &value)
+{
+    return StrUtil::ParseEnumWithBase(value, kSpriteImportTransparencyNames,
+        DataUtil::kSpriteImport_PaletteIndex0, DataUtil::kSpriteImport_LeaveAsIs);
+}
+
 static DataUtil::AudioFileBundlingType ReadAudioBundlingType(const String &value)
 {
     return StrUtil::ParseEnumWithBase(value, kAudioBundlingTypeNames,
@@ -1379,6 +1389,40 @@ static void ReadGameCommon(DataUtil::GameRef &game, DocElem root)
     ReadGameSettings(game.Settings, root);
 }
 
+static void GetAllSprites(std::vector<DataUtil::SpriteData> &sprites, DocElem root)
+{
+    std::vector<DocElem> elems;
+    CollectElements(root->FirstChildElement("Sprites"), "Sprite", elems);
+    for (DocElem sprite : elems)
+    {
+        DataUtil::SpriteData data;
+        data.Slot = ValueParser::ReadAttributeInt(sprite, "Slot", -1);
+        data.Width = ValueParser::ReadAttributeInt(sprite, "Width", 0);
+        data.Height = ValueParser::ReadAttributeInt(sprite, "Height", 0);
+        data.ColorDepth = ValueParser::ReadAttributeInt(sprite, "ColorDepth", 0);
+        data.Resolution = ReadSpriteImportResolution(ValueParser::ReadAttributeString(sprite, "Resolution", "Real"));
+        data.AlphaChannel = ValueParser::ReadAttributeBool(sprite, "AlphaChannel");
+        data.ColoursLockedToRoom = ValueParser::ReadAttributeInt(sprite, "ColoursLockedToRoom", 0);
+        DocElem source = sprite->FirstChildElement("Source");
+        if (source)
+        {
+            data.SourceFile = ValueParser::ReadString(source, "FileName");
+            data.ImportOffsetX = ValueParser::ReadInt(source, "OffsetX");
+            data.ImportOffsetY = ValueParser::ReadInt(source, "OffsetY");
+            data.ImportFrame = ValueParser::ReadInt(source, "Frame");
+            data.RemapToGamePalette = ValueParser::ReadBool(source, "RemapToGamePalette");
+            data.RemapToRoomPalette = ValueParser::ReadBool(source, "RemapToRoomPalette");
+            data.TransparentColour = ReadSpriteImportTransparency(ValueParser::ReadString(sprite, "ImportMethod", "LeaveAsIs"));
+            data.ImportAlphaChannel = ValueParser::ReadBool(source, "ImportAlphaChannel");
+            data.ImportWidth = ValueParser::ReadInt(source, "ImportWidth");
+            data.ImportHeight = ValueParser::ReadInt(source, "ImportHeight");
+            data.ImportAsTile = ValueParser::ReadBool(source, "ImportAsTile");
+            data.TransparentColourIndex = ValueParser::ReadInt(source, "TransparentColorIndex");
+        }
+        sprites.push_back(data);
+    }
+}
+
 void ReadGameData(DataUtil::GameData &game, AGFReader &reader)
 {
     game = DataUtil::GameData{};
@@ -1568,17 +1612,7 @@ void ReadGameData(DataUtil::GameData &game, AGFReader &reader)
         data.Blue = ValueParser::ReadAttributeInt(entry, "Blue");
     }
 
-    elems.clear();
-    CollectElements(root->FirstChildElement("Sprites"), "Sprite", elems);
-    for (DocElem sprite : elems)
-    {
-        DataUtil::SpriteData data;
-        data.Slot = ValueParser::ReadAttributeInt(sprite, "Slot", -1);
-        const String resolution = ValueParser::ReadAttributeString(sprite, "Resolution", "Real");
-        data.Resolution = ReadSpriteImportResolution(resolution);
-        data.AlphaChannel = ValueParser::ReadAttributeBool(sprite, "AlphaChannel");
-        game.Sprites.push_back(data);
-    }
+    GetAllSprites(game.Sprites, root);
 
     DocElem plugins = root->FirstChildElement("Plugins");
     for (DocElem plugin = plugins ? plugins->FirstChildElement("Plugin") : nullptr;
@@ -1790,6 +1824,11 @@ void ReadScriptHeaderList(std::vector<String> &headers_list, DocElem root)
         if (!header) continue;
         headers_list.push_back(scelem.ReadFilename(header));
     }
+}
+
+void ReadSpriteList(std::vector<DataUtil::SpriteData> &sprites, DocElem root)
+{
+    GetAllSprites(sprites, root);
 }
 
 void ReadTranslationList(std::vector<String> &trs_list, DocElem root)

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -530,6 +530,8 @@ void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
 void ReadScriptList(std::vector<String> &script_list, DocElem root);
 // Reads an ordered list of script header module names (their order determines dependency).
 void ReadScriptHeaderList(std::vector<String> &script_list, DocElem root);
+// Reads game palette settings
+void ReadGamePalette(std::vector<DataUtil::PaletteEntryData> &pal_data, DocElem root);
 // Reads a list of all the sprite import specs from the game data
 void ReadSpriteList(std::vector<DataUtil::SpriteData> &sprites, DocElem root);
 // Reads a list of translation names.

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -530,6 +530,8 @@ void ReadRoomList(std::vector<std::pair<int, String>> &room_list, DocElem root);
 void ReadScriptList(std::vector<String> &script_list, DocElem root);
 // Reads an ordered list of script header module names (their order determines dependency).
 void ReadScriptHeaderList(std::vector<String> &script_list, DocElem root);
+// Reads a list of all the sprite import specs from the game data
+void ReadSpriteList(std::vector<DataUtil::SpriteData> &sprites, DocElem root);
 // Reads a list of translation names.
 void ReadTranslationList(std::vector<String> &trs_list, DocElem root);
 

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -41,6 +41,7 @@ using ::ScreenTransitionStyle;
 
 enum GameColorDepth
 {
+    kGameColorDepth_Undefined = 0,
     kGameColorDepth_Palette = 1,
     kGameColorDepth_HighColor = 2,
     kGameColorDepth_TrueColor = 4
@@ -77,6 +78,7 @@ enum GUIPopupStyle
 enum PaletteColourType
 {
     kPaletteColourType_Gamewide = 0,
+    kPaletteColourType_Locked = 1, // commonly unused
     kPaletteColourType_Background = 2
 };
 

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -151,6 +151,26 @@ enum SpriteImportResolution
     kSpriteImport_HighRes = 1
 };
 
+enum SpriteImportTransparency
+{
+    // Pixels of palette index 0 will be transparent (256-colour games only)
+    kSpriteImport_PaletteIndex0 = 0,
+    // The top-left pixel will be the transparent colour for this sprite
+    kSpriteImport_TopLeft,
+    // The bottom-left pixel will be the transparent colour for this sprite
+    kSpriteImport_BottomLeft,
+    // The top-right pixel will be the transparent colour for this sprite
+    kSpriteImport_TopRight,
+    // The bottom-right pixel will be the transparent colour for this sprite
+    kSpriteImport_BottomRight,
+    // AGS will leave the sprite's pixels as they are. Any pixels that match the AGS Transparent Colour will be invisible.
+    kSpriteImport_LeaveAsIs,
+    // AGS will remove all transparent pixels by changing them to a very similar non-transparent colour
+    kSpriteImport_NoTransparency,
+    // Pixels of chosen palette index will be transparent (256-colour games only)
+    kSpriteImport_PaletteIndex
+};
+
 enum AudioFileBundlingType
 {
     kAudioBundling_InMainData = 1,
@@ -286,9 +306,29 @@ struct FontData : EntityRef
 
 struct SpriteData
 {
-    int Slot{};
+    int Slot = -1;
+    // CHECKME: these are duplicating ImportWidth/Height, and seem to be
+    // just for a quick reference in Game.agf? need to double check their use.
+    int Width = 0;
+    int Height = 0;
+    int ColorDepth = 0;
     SpriteImportResolution Resolution = kSpriteImport_Real;
+    // This is a reference to where it actually has one, but ImportAlphaChannel
+    // is one that controls sprite import.
     bool AlphaChannel = false;
+    String SourceFile;
+    bool ImportAlphaChannel = false;
+    int ColoursLockedToRoom = -1;
+    int ImportOffsetX = 0;
+    int ImportOffsetY = 0;
+    int ImportWidth = 0;
+    int ImportHeight = 0;
+    bool ImportAsTile = false;
+    int ImportFrame = 0;
+    SpriteImportTransparency TransparentColour = kSpriteImport_LeaveAsIs;
+    int TransparentColourIndex = 0;
+    bool RemapToGamePalette = false;
+    bool RemapToRoomPalette = false;
 };
 
 struct PaletteEntryData

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -311,11 +311,12 @@ struct SpriteData
     // just for a quick reference in Game.agf? need to double check their use.
     int Width = 0;
     int Height = 0;
-    int ColorDepth = 0;
+    int ColorDepth = 0; // bits per pixel
     SpriteImportResolution Resolution = kSpriteImport_Real;
     // This is a reference to where it actually has one, but ImportAlphaChannel
     // is one that controls sprite import.
     bool AlphaChannel = false;
+    // Import settings
     String SourceFile;
     bool ImportAlphaChannel = false;
     int ColoursLockedToRoom = -1;

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -313,11 +313,12 @@ struct SpriteData
     // just for a quick reference in Game.agf? need to double check their use.
     int Width = 0;
     int Height = 0;
-    int ColorDepth = 0;
+    int ColorDepth = 0; // bits per pixel
     SpriteImportResolution Resolution = kSpriteImport_Real;
     // This is a reference to where it actually has one, but ImportAlphaChannel
     // is one that controls sprite import.
     bool AlphaChannel = false;
+    // Import settings
     String SourceFile;
     bool ImportAlphaChannel = false;
     int ColoursLockedToRoom = -1;

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -492,11 +492,13 @@ static HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const 
 }
 
 // Removes all transparency pixels (change them to a close non-trnasparent colour)
-// FIXME: this operation is kind of non-sensical for arbitrary image; by the looks of its code
-// is purposed for 8-bit paletted image, not any image.
 // TODO: should be a part of PixelOp namespace
 static void RemoveTransparency(BitmapData &bm_data, const int transcol)
 {
+    // FIXME: this replacement is kind of non-sensical for arbitrary image; by the looks of its code
+    // is purposed for 8-bit paletted image, where color 0 is replaced with color 16 which is also "black".
+    // Then, for hi-res color depth, IIRC there was a function in Allegro called something like
+    // "best_color_match" or similar, which may be of better use here, instead of "transcol - 1".
     int r_color;
     if (transcol == 0)
         r_color = 16;
@@ -648,6 +650,20 @@ HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
     if (!err)
         return err;
 
+    // Prior to transparency conversion, deal with 32-bit alpha channel:
+    // either convert zero-alpha pixels to standard mask color, or to opaque color
+    if (final_buf.GetColorDepth() == 32)
+    {
+        if (alpha_channel)
+        {
+            PixelOp::ReplaceAlphaWithRGBMask(final_buf);
+        }
+        else
+        {
+            PixelOp::MakeOpaqueSkipMask(final_buf);
+        }
+    }
+
     int transcol = 0;
     SortOutTransparency(final_buf, sprite_trans, trans_color, img_pal_buf, src_color_depth, transcol);
     if (game_color_depth == 8)
@@ -674,18 +690,6 @@ HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
                 SortOutPalette(final_buf, img_pal_buf, game_color_opt.Palette, game_color_opt.PalUses, use_room_pal, transcol);
             }
         }
-    }
-
-    if (alpha_channel)
-    {
-        if (final_buf.GetColorDepth() == 32)
-        {
-            PixelOp::ReplaceAlphaWithRGBMask(final_buf);
-        }
-    }
-    else if (final_buf.GetColorDepth() == 32)
-    {
-        PixelOp::MakeOpaqueSkipMask(final_buf);
     }
 
     dst_image = std::move(final_buf);

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -109,5 +109,573 @@ HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, cons
     return HError::None();
 }
 
+static bool DoesPaletteHaveAlpha(const std::array<RGB, 256> &pal)
+{
+    for (const auto &rgb : pal)
+        if ((rgb.a != 0) && (rgb.a != 255))
+            return true;
+    return false;
+}
+
+static bool DoesBitmapHaveAlpha(const PixelBuffer &image, const std::array<RGB, 256> *pal)
+{
+    if (PixelFormatHasAlpha(image.GetFormat()))
+        return true;
+
+    if (PixelFormatIndexed(image.GetFormat()) && pal)
+        return DoesPaletteHaveAlpha(*pal);
+
+    return false;
+}
+
+// Forces transparency color to the palette index 0
+// This must be done, because AGS (or rather Allegro 4) hardcodes transparent color index as 0.
+static void NormalizePaletteTransparency(BitmapData &bm_data, std::array<RGB, 256> &dst_pal, const int pal_len = 256)
+{
+    assert(PixelFormatIndexed(bm_data.GetFormat()));
+    // Determine actual transparency index in the palette
+    int transparency_index = -1;
+    for (int i = 0; i < pal_len; ++i)
+    {
+        if (dst_pal[i].a == 0)
+        {
+            transparency_index = i;
+            break;
+        }
+    }
+
+    // If there's no transparent color available in the palette,
+    // then try to make a dummy transparent slot, so that we could
+    // swap it with the color at original index 0.
+    if (transparency_index < 0)
+    {
+        // If there's still free slots left in palette, then simply add a dummy slot in the end.
+        if (pal_len < 256)
+        {
+            transparency_index = pal_len;
+        }
+        // If palette has all 256 slots, then look up for any slot
+        // which is not used within the image, and turn it into "transparency".
+        else
+        {
+            bool used[256] = { 0 };
+            const uint8_t *px_ptr = bm_data.GetData();
+            const uint8_t *px_end = px_ptr + bm_data.GetDataSize();
+            for (; px_ptr != px_end; ++px_ptr)
+            {
+                used[*px_ptr] = true;
+            }
+            const bool *unused_at = std::find(used, used + 256, false);
+            if (unused_at < used + 256)
+                transparency_index = unused_at - used;
+        }
+
+        if (transparency_index >= 0)
+        {
+            dst_pal[transparency_index] = { 0,0,0,0 };
+        }
+    }
+
+    // If transparent color is not 0, then swap found transparent index
+    // with color at index 0
+    if (transparency_index > 0)
+    {
+        RGB toswap = dst_pal[0];
+        dst_pal[0] = dst_pal[transparency_index];
+        dst_pal[transparency_index] = toswap;
+
+        uint8_t *px_ptr = bm_data.GetData();
+        uint8_t *px_end = px_ptr + bm_data.GetDataSize();
+        for (; px_ptr != px_end; ++px_ptr)
+        {
+            if (*px_ptr == 0)
+                *px_ptr = static_cast<uint8_t>(transparency_index);
+            else if (*px_ptr == static_cast<uint8_t>(transparency_index))
+                *px_ptr = 0;
+        }
+    }
+}
+
+// Converts imported image's palette to the native AGS format
+static void ConvertPaletteToGameFormat(BitmapData &bm_data, const int game_color_depth,
+    const std::array<RGB, 256> &src_pal, std::array<RGB, 256> &dst_pal, bool normalize_trans)
+{
+    assert(PixelFormatIndexed(bm_data.GetFormat()));
+    // FIXME: currently we do not have means to get used palette slots here.
+    // for that we'd need to pass palette as a struct with "slot count" field,
+    // and also be able to read that in Image::LoadImage().
+    const int pal_len = 256;
+    // Copy palette, fixing colors if necessary
+    for (int i = 0; i < 256; ++i)
+    {
+        if (i >= pal_len)
+        {
+            // BMP files can have an arbitrary palette size, fill any
+            // missing colours with transparent black
+            dst_pal[i].r = 0;
+            dst_pal[i].g = 0;
+            dst_pal[i].b = 0;
+            dst_pal[i].a = 0;
+        }
+        else if (game_color_depth == 1)
+        {
+            // allegro palette is 0-63
+            dst_pal[i].r = src_pal[i].r / 4;
+            dst_pal[i].g = src_pal[i].g / 4;
+            dst_pal[i].b = src_pal[i].b / 4;
+            dst_pal[i].a = 255; // opaque
+        }
+        else
+        {
+            dst_pal[i].r = src_pal[i].r;
+            dst_pal[i].g = src_pal[i].g;
+            dst_pal[i].b = src_pal[i].b;
+            dst_pal[i].a = src_pal[i].a;
+        }
+    }
+
+    if (normalize_trans)
+    {
+        NormalizePaletteTransparency(bm_data, dst_pal, pal_len);
+    }
+}
+
+template <typename T> T makecol_frompal_opaque(const RGB &c);
+template <> uint16_t makecol_frompal_opaque(const RGB &c) { return makecol16(c.r, c.g, c.b); }
+template <> uint32_t makecol_frompal_opaque(const RGB &c) { return makeacol32(c.r, c.g, c.b, 255); }
+
+template <typename PxType>
+static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const std::array<RGB, 256> &src_pal,
+    uint8_t *dst_buf, uint32_t src_width, size_t src_stride, size_t dst_stride)
+{
+    for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
+    {
+        PxType *dst_ptr = reinterpret_cast<PxType*>(dst_buf);
+        for (const uint8_t *src_ptr = src_buf; src_ptr < src_buf + src_width; ++src_ptr, ++dst_ptr)
+        {
+            *dst_ptr = makecol_frompal_opaque<PxType>(src_pal[*src_ptr]);
+        }
+    }
+}
+
+template <typename PxType>
+static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const std::array<RGB, 256> &src_pal,
+    uint8_t *dst_buf, uint32_t src_width, size_t src_stride, size_t dst_stride, const uint32_t maskcolor, const uint32_t safe_magenta)
+{
+    for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
+    {
+        PxType *dst_ptr = reinterpret_cast<PxType*>(dst_buf);
+        for (const uint8_t *src_ptr = src_buf; src_ptr < src_buf + src_width; ++src_ptr, ++dst_ptr)
+        {
+            const int px = *src_ptr;
+            const PxType color = makecol_frompal_opaque<PxType>(src_pal[px]);
+            if (px == 0)
+                *dst_ptr = maskcolor;
+            else if (color == maskcolor) // replace magenta with close match
+                *dst_ptr = safe_magenta;
+            else
+                *dst_ptr = color;
+        }
+    }
+}
+
+// Converts 8-bit pixel data with RGB palette to either 16-bit or 32-bit buffer.
+// TODO: this should be a part of PixelOp::CopyConvert
+// TODO: rewrite as a template function, having respective integer type as pixel size.
+static void Convert8BitToHiColor(const BitmapData &src, const std::array<RGB, 256> &src_pal, PixelBuffer &dst, const bool keep_transparency)
+{
+    assert(dst.GetBytesPerPixel() == 16 || dst.GetBytesPerPixel() == 32);
+    const int dst_depth = PixelFormatToPixelBits(dst.GetFormat());
+
+    if (keep_transparency)
+    {
+        const uint32_t maskcolor = GetDefaultMaskColor(dst.GetFormat());
+        // define a safe magenta color to use to preserve opacity in colors that match maskcolor
+        // manually compose to use the full palette instead of allegro 0-63 restricted one (???)
+        const uint32_t safe_magenta = (dst_depth == 16)
+            ? makecol_depth(dst_depth, 255, 4, 255)  // 16 bit
+            : makecol_depth(dst_depth, 255, 1, 255); // 24-32 bit
+
+        if (dst_depth == 16)
+        {
+            Convert8BitToHiColorImpl<uint16_t>(src.GetData(), src.GetData() + src.GetStride() * src.GetHeight(), src_pal,
+                dst.GetData(), src.GetWidth(), src.GetStride(), dst.GetStride(),
+                maskcolor, safe_magenta);
+        }
+        else 
+        {
+            Convert8BitToHiColorImpl<uint32_t>(src.GetData(), src.GetData() + src.GetStride() * src.GetHeight(), src_pal,
+                dst.GetData(), src.GetWidth(), src.GetStride(), dst.GetStride(),
+                maskcolor, safe_magenta);
+        }
+    }
+    else
+    {
+        if (dst_depth == 16)
+        {
+            Convert8BitToHiColorImpl<uint16_t>(src.GetData(), src.GetData() + src.GetStride() * src.GetHeight(), src_pal,
+                dst.GetData(), src.GetWidth(), src.GetStride(), dst.GetStride());
+        }
+        else
+        {
+            Convert8BitToHiColorImpl<uint32_t>(src.GetData(), src.GetData() + src.GetStride() * src.GetHeight(), src_pal,
+                dst.GetData(), src.GetWidth(), src.GetStride(), dst.GetStride());
+        }
+    }
+}
+
+// Converts 8-bit pixel data with ARGB palette to 32-bit buffer.
+// TODO: this should be a part of PixelOp::CopyConvert
+static void Convert8BitARGBTo32(const BitmapData &src, const std::array<RGB, 256> &src_pal, PixelBuffer &dst)
+{
+    assert(dst.GetBytesPerPixel() == 32);
+    const uint8_t *src_buf = src.GetData();
+    const uint8_t *src_end = src.GetData() + src.GetStride() * src.GetHeight();
+    uint32_t *dst_buf = reinterpret_cast<uint32_t*>(dst.GetData());
+    const uint32_t src_width = src.GetWidth();
+    const size_t src_stride = src.GetStride();
+    const size_t dst_stride = dst.GetStride();
+    for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
+    {
+        uint32_t *dst_ptr = dst_buf;
+        for (const uint8_t *src_ptr = src_buf; src_ptr < src_buf + src_width; ++src_ptr, ++dst_ptr)
+        {
+            const RGB &pal_color = src_pal[*src_ptr];
+            *dst_ptr = makeacol32(pal_color.r, pal_color.g, pal_color.b, pal_color.a);
+        }
+    }
+}
+
+template <typename SrcPxType, typename DstPxType>
+static void FixMaskColorImpl(const uint8_t *src_buf, const uint8_t *src_end,
+    uint8_t *dst_buf, uint32_t src_width, size_t src_stride, size_t dst_stride,
+    const uint32_t src_maskcolor, const uint32_t dst_maskcolor, const uint32_t safe_color)
+{
+    for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
+    {
+        DstPxType *dst_ptr = reinterpret_cast<DstPxType*>(dst_buf);
+        for (const SrcPxType *src_line = reinterpret_cast<const SrcPxType*>(src_buf), *src_ptr = src_line;
+            src_ptr < src_line + src_width; ++src_ptr, ++dst_ptr)
+        {
+            const SrcPxType src_color = *src_ptr;
+            const DstPxType dst_color = *dst_ptr;
+            if (src_color == src_maskcolor)
+                *dst_ptr = dst_maskcolor;
+            else if (dst_color == dst_maskcolor) // replace mask color with close match
+                *dst_ptr = safe_color;
+            // don't change other colors here
+        }
+    }
+}
+
+// Converts between two standard non-indexed formats (16 <-> 32 bit),
+// optionally convert mask color from src to dest format, otherwise mask color *may* become normal color.
+// TODO: this should be a part of PixelOp::CopyConvert
+static void ConvertAndFixMaskColor(const BitmapData &src, PixelBuffer &dst, const bool keep_transparency)
+{
+    // FIXME: we do this two-step now, but ideally all of this should be done by PixelOp::CopyConvert.
+    PixelOp::CopyConvert(src, dst, dst.GetFormat());
+
+    // Idea is this: if we were asked to keep transparency, this means
+    // that we need to keep all mask pixels from src to become mask pixels in dst,
+    // but *also* any non-mask src pixel that ended up equal to the dst mask color
+    // must be fixed to be the nearest non-mask color.
+    if (keep_transparency)
+    {
+        const int src_depth = src.GetColorDepth();
+        const int dst_depth = src.GetColorDepth();
+        if (src_depth == 16 && dst_depth == 32)
+        {
+            FixMaskColorImpl<uint16_t, uint32_t>(src.GetData(), src.GetData() + src.GetHeight() * src.GetStride(), dst.GetData(),
+                src.GetWidth(), src.GetStride(), dst.GetStride(),
+                GetDefaultMaskColor(src.GetFormat()), GetDefaultMaskColor(dst.GetFormat()), replacement_mask_color(dst.GetColorDepth(), GetDefaultMaskColor(dst.GetFormat())));
+        }
+        else if (src_depth == 32 && dst_depth == 16)
+        {
+            FixMaskColorImpl<uint32_t, uint16_t>(src.GetData(), src.GetData() + src.GetHeight() * src.GetStride(), dst.GetData(),
+                src.GetWidth(), src.GetStride(), dst.GetStride(),
+                GetDefaultMaskColor(src.GetFormat()), GetDefaultMaskColor(dst.GetFormat()), replacement_mask_color(dst.GetColorDepth(), GetDefaultMaskColor(dst.GetFormat())));
+        }
+        else
+        {
+            assert(false);
+        }
+    }
+}
+
+// Takes source buffer and returns dst buffer with either:
+// - a moved source buffer, when no changes whatsoever were necessary.
+// - a moved and modified source buffer with the same pixel format, when only colors need to be replaces.
+// - new pixel data, when full format conversion was necessary.
+HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const std::array<RGB, 256> *src_pal,
+    std::array<RGB, 256> *dst_pal, const int game_color_depth, const bool fix_color_depth,
+    const bool import_alpha, const bool keep_transparency, const bool fix_pal)
+{
+    assert((src.GetColorDepth() > 8) || (src_pal && dst_pal));
+    // First we unpack the pixels from the src pixel buffer to a buffer,
+    // into the one of the standard formats compatible with our bitmap library.
+    const int src_depth = src.GetColorDepth();
+    int dst_depth = 0;
+    switch (src.GetFormat())
+    {
+    case PixelFormat::kPxFmt_Indexed1:
+    case PixelFormat::kPxFmt_Indexed4:    
+    case PixelFormat::kPxFmt_Indexed8:
+        dst_depth = 8; // convert any indexed to 8-bit
+        break;
+    case PixelFormat::kPxFmt_R5G5B5:
+    case PixelFormat::kPxFmt_R5G6B5:
+        dst_depth = 16; // convert to 16-bit
+        break;
+    case PixelFormat::kPxFmt_R8G8B8:
+    case PixelFormat::kPxFmt_A8R8G8B8:
+        dst_depth = 32; // convert to 32-bit
+        break;
+    default:
+        return new Error(String::FromFormat("Unsupported pixel format: %s", PixelFormatName(src.GetFormat())));
+    }
+
+    if ((game_color_depth == 8) && (src_depth > 8))
+    {
+        new Error(String::FromFormat("Cannot import a hi-colour or true-colour image into a 256-colour game."));
+    }
+
+    // Convert pixels to the format, supported by the bitmap library.
+    // This is necessary e.g. in case of 1-bit or 4-bit images that must be
+    // converted to a standard 8-bit image.
+    PixelBuffer compat_buf;
+    if (src_depth != dst_depth)
+    {
+        if (!PixelOp::CopyConvert(src, compat_buf, ColorDepthToPixelFormat(dst_depth)))
+        {
+            new Error(String::FromFormat("Failed to convert an input image into the compatible game format."));
+        }
+    }
+
+    // Which buffer to use as a source further?
+    PixelBuffer *use_buf = compat_buf ? &compat_buf : &src;
+
+    // Second step: prepare the image for the game,
+    // following sprite specs and game's default color depth.
+    // For indexed images: convert loaded palette to the library format.
+    if ((src_depth <= 8) && src_pal && dst_pal)
+    {
+        ConvertPaletteToGameFormat(*use_buf, game_color_depth, *src_pal, *dst_pal, keep_transparency && fix_pal);
+    }
+
+    // Now to upgrade bitmap to the game's color depth, if necessary.
+    const int final_depth = game_color_depth;
+    const bool need_fix_color_depth = (dst_depth != final_depth) && (fix_color_depth);
+    PixelBuffer final_buf;
+    if (need_fix_color_depth)
+    {
+        final_buf = PixelBuffer(src.GetWidth(), src.GetHeight(), ColorDepthToPixelFormat(final_depth));
+
+        if ((dst_depth == 8) && (final_depth > 8))
+        {
+            if (import_alpha && (final_depth == 32))
+                Convert8BitARGBTo32(*use_buf, *dst_pal, final_buf);
+            else
+                Convert8BitToHiColor(*use_buf, *dst_pal, final_buf, keep_transparency);
+        }
+        else
+        {
+            ConvertAndFixMaskColor(*use_buf, final_buf, keep_transparency);
+        }
+
+        use_buf = &final_buf;
+    }
+    
+    // Move output data to the destination buffer (this may be src buffer too!)
+    dst = std::move(*use_buf);
+    return HError::None();
+}
+
+// Removes all transparency pixels (change them to a close non-trnasparent colour)
+// FIXME: this operation is kind of non-sensical for arbitrary image; by the looks of its code
+// is purposed for 8-bit paletted image, not any image.
+// TODO: should be a part of PixelOp namespace
+void RemoveTransparency(BitmapData &bm_data, const int transcol)
+{
+    int r_color;
+    if (transcol == 0)
+        r_color = 16;
+    else
+        r_color = transcol - 1;
+
+    for (int y = 0; y < bm_data.GetHeight(); ++y)
+    {
+        for (int x = 0; x < bm_data.GetWidth(); ++x)
+        {
+            if (bm_data.GetPixel(x, y) == transcol)
+                bm_data.SetPixel(x, y, r_color);
+        }
+    }
+}
+
+// FIXME: this function apparently does about the same as FixMaskColorImpl
+// find a way to reorganize this mess, and reuse code more.
+void MakeColorTransparent(BitmapData &bm_data, const std::array<RGB, 256> &src_pal, int src_color_depth, const int transcol)
+{
+    const int maskcolor = GetDefaultMaskColor(bm_data.GetFormat());
+    int r_color = 16;
+    if (bm_data.GetColorDepth() > 8)
+    {
+        if (src_color_depth == 8)
+            r_color = makecol_depth(bm_data.GetColorDepth(), src_pal[0].r, src_pal[0].g, src_pal[0].b);
+        else
+            r_color = 0;
+    }
+    // swap all transparent pixels with index 0 pixels (???)
+    for (int y = 0; y < bm_data.GetHeight(); ++y)
+    {
+        for (int x = 0; x < bm_data.GetWidth(); ++x)
+        {
+            if (bm_data.GetPixel(x, y) == transcol)
+                bm_data.SetPixel(x, y, maskcolor);
+            else if (bm_data.GetPixel(x, y) == maskcolor)
+                bm_data.SetPixel(x, y, r_color);
+        }
+    }
+}
+
+// Adjusts sprite's transparency using the chosen method
+void SortOutTransparency(BitmapData &bm_data, const SpriteImportTransparency sprite_trans, int trans_index,
+    const std::array<RGB, 256> &src_pal, const int src_color_depth, int &transcol)
+{
+    if (sprite_trans == kSpriteImport_LeaveAsIs)
+    {
+        transcol = GetDefaultMaskColor(bm_data.GetFormat());
+        return;
+    }
+
+    if (sprite_trans == kSpriteImport_NoTransparency)
+    {
+        transcol = GetDefaultMaskColor(bm_data.GetFormat());
+        RemoveTransparency(bm_data, transcol);
+        return;
+    }
+
+    const int dst_depth = bm_data.GetColorDepth();
+    switch (sprite_trans)
+    {
+    case kSpriteImport_TopLeft:
+        transcol = bm_data.GetPixel(0, 0);
+        break;
+    case kSpriteImport_BottomLeft:
+        transcol = bm_data.GetPixel(0, (bm_data.GetHeight()) - 1);
+        break;
+    case kSpriteImport_TopRight:
+        transcol = bm_data.GetPixel((bm_data.GetWidth()) - 1, 0);
+        break;
+    case kSpriteImport_BottomRight:
+        transcol = bm_data.GetPixel((bm_data.GetWidth()) - 1, (bm_data.GetHeight()) - 1);
+        break;
+    case kSpriteImport_PaletteIndex:
+        assert(trans_index >= 0 && trans_index < 256);
+        trans_index = (trans_index >= 0 && trans_index < 256) ? trans_index : 0;
+        if (src_color_depth == 8)
+        {
+            if (dst_depth == 8)
+                transcol = trans_index;
+            else if (trans_index == 0)
+                // on conversion slot 0 was replaced by a standard mask color
+                transcol = GetDefaultMaskColor(bm_data.GetFormat());
+            else
+                transcol = makecol_depth(bm_data.GetColorDepth(), src_pal[trans_index].r, src_pal[trans_index].g, src_pal[trans_index].b);
+        }
+        else
+        {
+            transcol = GetDefaultMaskColor(bm_data.GetFormat());
+        }
+        break;
+    case kSpriteImport_PaletteIndex0:
+    default:
+        transcol = GetDefaultMaskColor(bm_data.GetFormat());
+        break;
+    }
+
+    MakeColorTransparent(bm_data, src_pal, src_color_depth, transcol);
+}
+
+/*
+* FIXME: reimplement this, need to pass palette information from the game data.
+* need to be able to use both game and room bg palette.
+* 
+// Adjusts 8-bit sprite's palette
+void sort_out_palette(Common::Bitmap *toimp, RGB*itspal, bool useBgSlots, int transcol)
+{
+    set_palette_range(palette, 0, 255, 0);
+    if ((thisgame.color_depth == 1) && (itspal != NULL)) { 
+        // 256-colour mode only
+        if (transcol!=0)
+            itspal[transcol] = itspal[0];
+        wsetrgb(0,0,0,0,itspal); // set index 0 to black
+        RGB oldpale[256];
+        for (int uu=0;uu<255;uu++) {
+            if (useBgSlots)  //  use background scene palette
+                oldpale[uu]=palette[uu];
+            else if (thisgame.paluses[uu]==PAL_BACKGROUND)
+                wsetrgb(uu,0,0,0,oldpale);
+            else 
+                oldpale[uu]=palette[uu];
+        }
+        wremap(itspal,toimp,oldpale); 
+        set_palette_range(palette, 0, 255, 0);
+    }
+    else if (toimp->GetColorDepth() == 8) {  // hi-colour game
+        set_palette(itspal);
+    }
+}
+*/
+
+HError ConvertSpriteForGame(PixelBuffer &image, std::array<RGB, 256> *pal,
+    PixelBuffer &dst_image, const int game_color_depth, const SpriteData &sprite)
+{
+    // Safety check: if requested alpha channel, test if bitmap contains one
+    const bool alpha_channel = sprite.ImportAlphaChannel && (game_color_depth == 32) && DoesBitmapHaveAlpha(image, pal);
+    const int src_color_depth = image.GetColorDepth();
+
+    std::array<RGB, 256> img_pal_buf;
+    const SpriteImportTransparency sprite_trans = sprite.TransparentColour;
+    const int trans_color = sprite.TransparentColourIndex;
+    const bool keep_trans = (sprite_trans != kSpriteImport_NoTransparency);
+    const bool fix_palette = (sprite_trans != kSpriteImport_PaletteIndex0) && (sprite_trans != kSpriteImport_PaletteIndex);
+    const bool remap_colors = PixelFormatIndexed(image.GetFormat()) && (sprite.RemapToGamePalette || sprite.RemapToRoomPalette);
+    const bool use_room_pal = sprite.RemapToRoomPalette;
+    PixelBuffer final_buf;
+    HError err = ConvertToGameCompatible(image, final_buf, pal, &img_pal_buf, game_color_depth, true /* fix color depth */,
+            alpha_channel, keep_trans, fix_palette);
+    if (!err)
+        return err;
+
+    int transcol = 0;
+    SortOutTransparency(final_buf, sprite_trans, trans_color, img_pal_buf, src_color_depth, transcol);
+    if (game_color_depth == 8)
+    {
+        /*
+        * FIXME: reimplement this, need to pass palette information from the game data.
+        * need to be able to use both game and room bg palette.
+        if (remap_colors)
+            SortOutPalette(final_buf, img_pal_buf, use_room_pal, transcol);
+            */
+    }
+
+    if (alpha_channel)
+    {
+        if (final_buf.GetColorDepth() == 32)
+        {
+            PixelOp::ReplaceAlphaWithRGBMask(final_buf);
+        }
+    }
+    else if (final_buf.GetColorDepth() == 32)
+    {
+        PixelOp::MakeOpaqueSkipMask(final_buf);
+    }
+
+    dst_image = std::move(final_buf);
+    return HError::None();
+}
+
 } // namespace DataUtil
 } // namespace AGS

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -609,7 +609,7 @@ static void SortOutPalette(BitmapData &bm_data, Palette &pal, const Palette &gam
 
     PaletteOp::SetRGB(pal, 0, 0, 0, 0); // set index 0 to black
     Palette dst_pal;
-    for (int i = 0; i < 255; ++i) // CHECKME: 255th index is ignored?
+    for (int i = 0; i < PAL_SIZE; ++i)
     {
         if (use_bg_slots) // use either slots
             dst_pal[i] = game_pal[i];

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -109,7 +109,7 @@ HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, cons
     return HError::None();
 }
 
-static bool DoesPaletteHaveAlpha(const std::array<RGB, 256> &pal)
+static bool DoesPaletteHaveAlpha(const Palette &pal)
 {
     for (const auto &rgb : pal)
         if ((rgb.a != 0) && (rgb.a != 255))
@@ -117,7 +117,7 @@ static bool DoesPaletteHaveAlpha(const std::array<RGB, 256> &pal)
     return false;
 }
 
-static bool DoesBitmapHaveAlpha(const PixelBuffer &image, const std::array<RGB, 256> *pal)
+static bool DoesBitmapHaveAlpha(const PixelBuffer &image, const Palette *pal)
 {
     if (PixelFormatHasAlpha(image.GetFormat()))
         return true;
@@ -130,7 +130,7 @@ static bool DoesBitmapHaveAlpha(const PixelBuffer &image, const std::array<RGB, 
 
 // Forces transparency color to the palette index 0
 // This must be done, because AGS (or rather Allegro 4) hardcodes transparent color index as 0.
-static void NormalizePaletteTransparency(BitmapData &bm_data, std::array<RGB, 256> &dst_pal, const int pal_len = 256)
+static void NormalizePaletteTransparency(BitmapData &bm_data, Palette &dst_pal, const int pal_len = 256)
 {
     assert(PixelFormatIndexed(bm_data.GetFormat()));
     // Determine actual transparency index in the palette
@@ -198,7 +198,7 @@ static void NormalizePaletteTransparency(BitmapData &bm_data, std::array<RGB, 25
 
 // Converts imported image's palette to the native AGS format
 static void ConvertPaletteToGameFormat(BitmapData &bm_data, const int game_color_depth,
-    const std::array<RGB, 256> &src_pal, std::array<RGB, 256> &dst_pal, bool normalize_trans)
+    const Palette &src_pal, Palette &dst_pal, bool normalize_trans)
 {
     assert(PixelFormatIndexed(bm_data.GetFormat()));
     // FIXME: currently we do not have means to get used palette slots here.
@@ -245,7 +245,7 @@ template <> uint16_t makecol_frompal_opaque(const RGB &c) { return makecol16(c.r
 template <> uint32_t makecol_frompal_opaque(const RGB &c) { return makeacol32(c.r, c.g, c.b, 255); }
 
 template <typename PxType>
-static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const std::array<RGB, 256> &src_pal,
+static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const Palette &src_pal,
     uint8_t *dst_buf, uint32_t src_width, size_t src_stride, size_t dst_stride)
 {
     for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
@@ -259,7 +259,7 @@ static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_
 }
 
 template <typename PxType>
-static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const std::array<RGB, 256> &src_pal,
+static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_end, const Palette &src_pal,
     uint8_t *dst_buf, uint32_t src_width, size_t src_stride, size_t dst_stride, const uint32_t maskcolor, const uint32_t safe_magenta)
 {
     for (; src_buf < src_end; src_buf += src_stride, dst_buf += dst_stride)
@@ -282,7 +282,7 @@ static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_
 // Converts 8-bit pixel data with RGB palette to either 16-bit or 32-bit buffer.
 // TODO: this should be a part of PixelOp::CopyConvert
 // TODO: rewrite as a template function, having respective integer type as pixel size.
-static void Convert8BitToHiColor(const BitmapData &src, const std::array<RGB, 256> &src_pal, PixelBuffer &dst, const bool keep_transparency)
+static void Convert8BitToHiColor(const BitmapData &src, const Palette &src_pal, PixelBuffer &dst, const bool keep_transparency)
 {
     assert(dst.GetBytesPerPixel() == 16 || dst.GetBytesPerPixel() == 32);
     const int dst_depth = PixelFormatToPixelBits(dst.GetFormat());
@@ -326,7 +326,7 @@ static void Convert8BitToHiColor(const BitmapData &src, const std::array<RGB, 25
 
 // Converts 8-bit pixel data with ARGB palette to 32-bit buffer.
 // TODO: this should be a part of PixelOp::CopyConvert
-static void Convert8BitARGBTo32(const BitmapData &src, const std::array<RGB, 256> &src_pal, PixelBuffer &dst)
+static void Convert8BitARGBTo32(const BitmapData &src, const Palette &src_pal, PixelBuffer &dst)
 {
     assert(dst.GetBytesPerPixel() == 32);
     const uint8_t *src_buf = src.GetData();
@@ -407,8 +407,8 @@ static void ConvertAndFixMaskColor(const BitmapData &src, PixelBuffer &dst, cons
 // - a moved source buffer, when no changes whatsoever were necessary.
 // - a moved and modified source buffer with the same pixel format, when only colors need to be replaces.
 // - new pixel data, when full format conversion was necessary.
-HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const std::array<RGB, 256> *src_pal,
-    std::array<RGB, 256> *dst_pal, const int game_color_depth, const bool fix_color_depth,
+static HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const Palette *src_pal,
+    Palette *dst_pal, const int game_color_depth, const bool fix_color_depth,
     const bool import_alpha, const bool keep_transparency, const bool fix_pal)
 {
     assert((src.GetColorDepth() > 8) || (src_pal && dst_pal));
@@ -495,7 +495,7 @@ HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const std::ar
 // FIXME: this operation is kind of non-sensical for arbitrary image; by the looks of its code
 // is purposed for 8-bit paletted image, not any image.
 // TODO: should be a part of PixelOp namespace
-void RemoveTransparency(BitmapData &bm_data, const int transcol)
+static void RemoveTransparency(BitmapData &bm_data, const int transcol)
 {
     int r_color;
     if (transcol == 0)
@@ -515,7 +515,7 @@ void RemoveTransparency(BitmapData &bm_data, const int transcol)
 
 // FIXME: this function apparently does about the same as FixMaskColorImpl
 // find a way to reorganize this mess, and reuse code more.
-void MakeColorTransparent(BitmapData &bm_data, const std::array<RGB, 256> &src_pal, int src_color_depth, const int transcol)
+static void MakeColorTransparent(BitmapData &bm_data, const Palette &src_pal, int src_color_depth, const int transcol)
 {
     const int maskcolor = GetDefaultMaskColor(bm_data.GetFormat());
     int r_color = 16;
@@ -540,8 +540,8 @@ void MakeColorTransparent(BitmapData &bm_data, const std::array<RGB, 256> &src_p
 }
 
 // Adjusts sprite's transparency using the chosen method
-void SortOutTransparency(BitmapData &bm_data, const SpriteImportTransparency sprite_trans, int trans_index,
-    const std::array<RGB, 256> &src_pal, const int src_color_depth, int &transcol)
+static void SortOutTransparency(BitmapData &bm_data, const SpriteImportTransparency sprite_trans, int trans_index,
+    const Palette &src_pal, const int src_color_depth, int &transcol)
 {
     if (sprite_trans == kSpriteImport_LeaveAsIs)
     {
@@ -598,45 +598,44 @@ void SortOutTransparency(BitmapData &bm_data, const SpriteImportTransparency spr
     MakeColorTransparent(bm_data, src_pal, src_color_depth, transcol);
 }
 
-/*
-* FIXME: reimplement this, need to pass palette information from the game data.
-* need to be able to use both game and room bg palette.
-* 
 // Adjusts 8-bit sprite's palette
-void sort_out_palette(Common::Bitmap *toimp, RGB*itspal, bool useBgSlots, int transcol)
+static void SortOutPalette(BitmapData &bm_data, Palette &pal, const Palette &game_pal,
+    const std::array<PaletteColourType, PAL_SIZE> &paluses, bool use_bg_slots, int transcol)
 {
-    set_palette_range(palette, 0, 255, 0);
-    if ((thisgame.color_depth == 1) && (itspal != NULL)) { 
-        // 256-colour mode only
-        if (transcol!=0)
-            itspal[transcol] = itspal[0];
-        wsetrgb(0,0,0,0,itspal); // set index 0 to black
-        RGB oldpale[256];
-        for (int uu=0;uu<255;uu++) {
-            if (useBgSlots)  //  use background scene palette
-                oldpale[uu]=palette[uu];
-            else if (thisgame.paluses[uu]==PAL_BACKGROUND)
-                wsetrgb(uu,0,0,0,oldpale);
-            else 
-                oldpale[uu]=palette[uu];
-        }
-        wremap(itspal,toimp,oldpale); 
-        set_palette_range(palette, 0, 255, 0);
-    }
-    else if (toimp->GetColorDepth() == 8) {  // hi-colour game
-        set_palette(itspal);
-    }
-}
-*/
+    if (transcol != 0)
+        pal[transcol] = pal[0];
 
-HError ConvertSpriteForGame(PixelBuffer &image, std::array<RGB, 256> *pal,
-    PixelBuffer &dst_image, const int game_color_depth, const SpriteData &sprite)
+    PaletteOp::SetRGB(pal, 0, 0, 0, 0); // set index 0 to black
+    Palette dst_pal;
+    for (int i = 0; i < 255; ++i) // CHECKME: 255th index is ignored?
+    {
+        if (use_bg_slots) // use either slots
+            dst_pal[i] = game_pal[i];
+        else if (paluses[i] == kPaletteColourType_Background) // else ignore background slots
+            PaletteOp::SetRGB(dst_pal, i, 0, 0, 0);
+        else
+            dst_pal[i] = game_pal[i];
+    }
+    PaletteOp::Remap(bm_data, pal, dst_pal);
+}
+
+void MergePalettes(Palette &dest_pal, const Palette &game_pal, const Palette &room_pal, const std::array<PaletteColourType, PAL_SIZE> &pal_uses)
 {
+    std::copy(game_pal.begin(), game_pal.end(), dest_pal.begin());
+    for (size_t i = 0; i < PAL_SIZE; ++i)
+        if (pal_uses[i] == kPaletteColourType_Background)
+            dest_pal[i] = room_pal[i];
+}
+
+HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
+    PixelBuffer &dst_image, const GameColorSettings &game_color_opt, const RoomPaletteCache &room_cache, const SpriteData &sprite)
+{
+    const int game_color_depth = static_cast<int>(game_color_opt.ColorDepth) * 8;
     // Safety check: if requested alpha channel, test if bitmap contains one
     const bool alpha_channel = sprite.ImportAlphaChannel && (game_color_depth == 32) && DoesBitmapHaveAlpha(image, pal);
     const int src_color_depth = image.GetColorDepth();
 
-    std::array<RGB, 256> img_pal_buf;
+    Palette img_pal_buf;
     const SpriteImportTransparency sprite_trans = sprite.TransparentColour;
     const int trans_color = sprite.TransparentColourIndex;
     const bool keep_trans = (sprite_trans != kSpriteImport_NoTransparency);
@@ -653,12 +652,28 @@ HError ConvertSpriteForGame(PixelBuffer &image, std::array<RGB, 256> *pal,
     SortOutTransparency(final_buf, sprite_trans, trans_color, img_pal_buf, src_color_depth, transcol);
     if (game_color_depth == 8)
     {
-        /*
-        * FIXME: reimplement this, need to pass palette information from the game data.
-        * need to be able to use both game and room bg palette.
         if (remap_colors)
-            SortOutPalette(final_buf, img_pal_buf, use_room_pal, transcol);
-            */
+        {
+            // Merge game and room palettes
+            Palette *room_pal = nullptr;
+            if (sprite.ColoursLockedToRoom >= 0)
+            {
+                auto it_pal = room_cache.find(sprite.ColoursLockedToRoom);
+                if (it_pal != room_cache.end())
+                    room_pal = it_pal->second.get();
+            }
+
+            if (room_pal)
+            {
+                Palette combined_pal;
+                MergePalettes(combined_pal, game_color_opt.Palette, *room_pal, game_color_opt.PalUses);
+                SortOutPalette(final_buf, img_pal_buf, combined_pal, game_color_opt.PalUses, use_room_pal, transcol);
+            }
+            else
+            {
+                SortOutPalette(final_buf, img_pal_buf, game_color_opt.Palette, game_color_opt.PalUses, use_room_pal, transcol);
+            }
+        }
     }
 
     if (alpha_channel)

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -284,7 +284,7 @@ static void Convert8BitToHiColorImpl(const uint8_t *src_buf, const uint8_t *src_
 // TODO: rewrite as a template function, having respective integer type as pixel size.
 static void Convert8BitToHiColor(const BitmapData &src, const Palette &src_pal, PixelBuffer &dst, const bool keep_transparency)
 {
-    assert(dst.GetBytesPerPixel() == 16 || dst.GetBytesPerPixel() == 32);
+    assert(dst.GetColorDepth() == 16 || dst.GetColorDepth() == 32);
     const int dst_depth = PixelFormatToPixelBits(dst.GetFormat());
 
     if (keep_transparency)
@@ -383,7 +383,7 @@ static void ConvertAndFixMaskColor(const BitmapData &src, PixelBuffer &dst, cons
     if (keep_transparency)
     {
         const int src_depth = src.GetColorDepth();
-        const int dst_depth = src.GetColorDepth();
+        const int dst_depth = dst.GetColorDepth();
         if (src_depth == 16 && dst_depth == 32)
         {
             FixMaskColorImpl<uint16_t, uint32_t>(src.GetData(), src.GetData() + src.GetHeight() * src.GetStride(), dst.GetData(),
@@ -432,7 +432,7 @@ static HError ConvertToGameCompatible(PixelBuffer &src, PixelBuffer &dst, const 
         dst_depth = 32; // convert to 32-bit
         break;
     default:
-        return new Error(String::FromFormat("Unsupported pixel format: %s", PixelFormatName(src.GetFormat())));
+        return new Error(String::FromFormat("Unsupported pixel format: %s", PixelFormatName(src.GetFormat()).GetCStr()));
     }
 
     if ((game_color_depth == 8) && (src_depth > 8))
@@ -499,6 +499,7 @@ static void RemoveTransparency(BitmapData &bm_data, const int transcol)
     // is purposed for 8-bit paletted image, where color 0 is replaced with color 16 which is also "black".
     // Then, for hi-res color depth, IIRC there was a function in Allegro called something like
     // "best_color_match" or similar, which may be of better use here, instead of "transcol - 1".
+    // (unless I am confusing this with something else...)
     int r_color;
     if (transcol == 0)
         r_color = 16;
@@ -528,7 +529,8 @@ static void MakeColorTransparent(BitmapData &bm_data, const Palette &src_pal, in
         else
             r_color = 0;
     }
-    // swap all transparent pixels with index 0 pixels (???)
+    // swap all transparent pixels with standard mask color
+    // swap all existing mask color pixels with replacement color (zero-alpha black)
     for (int y = 0; y < bm_data.GetHeight(); ++y)
     {
         for (int x = 0; x < bm_data.GetWidth(); ++x)
@@ -604,10 +606,13 @@ static void SortOutTransparency(BitmapData &bm_data, const SpriteImportTranspare
 static void SortOutPalette(BitmapData &bm_data, Palette &pal, const Palette &game_pal,
     const std::array<PaletteColourType, PAL_SIZE> &paluses, bool use_bg_slots, int transcol)
 {
+    // Ensure that transparent color is index 0
     if (transcol != 0)
+    {
         pal[transcol] = pal[0];
+        PaletteOp::SetRGB(pal, 0, 0, 0, 0); // set index 0 to black
+    }
 
-    PaletteOp::SetRGB(pal, 0, 0, 0, 0); // set index 0 to black
     Palette dst_pal;
     for (int i = 0; i < PAL_SIZE; ++i)
     {
@@ -629,9 +634,13 @@ void MergePalettes(Palette &dest_pal, const Palette &game_pal, const Palette &ro
             dest_pal[i] = room_pal[i];
 }
 
-HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
-    PixelBuffer &dst_image, const GameColorSettings &game_color_opt, const RoomPaletteCache &room_cache, const SpriteData &sprite)
+HError ConvertSpriteForGame(PixelBuffer &image, const Palette *pal,
+    PixelBuffer &dst_image, const GameColorSettings &game_color_opt, const RoomPaletteCache *room_cache, const SpriteData &sprite)
 {
+    assert(image);
+    if (!image)
+        return new Error("No image data provided");
+
     const int game_color_depth = static_cast<int>(game_color_opt.ColorDepth) * 8;
     // Safety check: if requested alpha channel, test if bitmap contains one
     const bool alpha_channel = sprite.ImportAlphaChannel && (game_color_depth == 32) && DoesBitmapHaveAlpha(image, pal);
@@ -672,10 +681,10 @@ HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
         {
             // Merge game and room palettes
             Palette *room_pal = nullptr;
-            if (sprite.ColoursLockedToRoom >= 0)
+            if ((sprite.ColoursLockedToRoom >= 0) && room_cache)
             {
-                auto it_pal = room_cache.find(sprite.ColoursLockedToRoom);
-                if (it_pal != room_cache.end())
+                auto it_pal = room_cache->find(sprite.ColoursLockedToRoom);
+                if (it_pal != room_cache->end())
                     room_pal = it_pal->second.get();
             }
 

--- a/Tools/data/sprite_utils.cpp
+++ b/Tools/data/sprite_utils.cpp
@@ -1,0 +1,113 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "data/sprite_utils.h"
+#include "util/directory.h"
+#include "util/path.h"
+#include "util/string_types.h"
+#include "util/string_utils.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+static const String DefaultPattern = "spr%06d";
+static const String DefaultRegexPattern = "spr\\d{6}";
+static const String DefaultExtension = "png";
+static const CstrArr<kNumSprCompressTypes> CompressionNames = {{"none", "rle", "lzw", "deflate"}};
+
+String GetCompressionName(SpriteCompression compress)
+{
+    return String::Wrapper(StrUtil::SelectCStr<kNumSprCompressTypes>(
+        CompressionNames, compress, "unknown"));
+}
+
+SpriteCompression CompressionFromName(const String &compress_name)
+{
+    return StrUtil::ParseEnum<SpriteCompression, kNumSprCompressTypes>(
+        compress_name, CompressionNames, kSprCompress_None);
+}
+
+bool ResolveImageFilePattern(const String &pattern, String &res_pattern)
+{
+    String regex_pattern;
+    return ResolveImageFilePattern(pattern, res_pattern, regex_pattern);
+}
+
+bool ResolveImageFilePattern(const String &pattern, String &res_pattern, String &regex_pattern)
+{
+    if (pattern.IsNullOrSpace())
+    {
+        res_pattern = String::FromFormat("%s.%s", DefaultPattern.GetCStr(), DefaultExtension.GetCStr());
+        regex_pattern = String::FromFormat("%s.%s", DefaultRegexPattern.GetCStr(), DefaultExtension.GetCStr());
+        return true;
+    }
+
+    res_pattern = "";
+    regex_pattern = "";
+    bool found_spritenum = false;
+    const auto parts = pattern.Split('%');
+    // Each second part is assumed a placeholder between two '%'
+    for (size_t i = 0; i < parts.size(); ++i)
+    {
+        if (i % 2 == 0)
+        {
+            res_pattern.Append(parts[i]);
+            regex_pattern.Append(parts[i]);
+        }
+        else if (i < parts.size() - 1)
+        {
+            // Resolve placeholder
+            if ((parts[i].GetLast() == 'N' || parts[i].GetLast() == 'n')
+                && (parts[i].GetLength() == 2) && std::isdigit(parts[i][0]))
+            {
+                res_pattern.AppendFmt("%%0%dd", parts[i][0] - '0');
+                regex_pattern.AppendFmt("\\d{%d}", parts[i][0] - '0');
+                found_spritenum = true;
+            }
+            else
+            {
+                res_pattern.Append("_");
+                regex_pattern.Append("_");
+            }
+        }
+    }
+
+    // We cannot export multiple sprites without a sprite number placeholder
+    if (!found_spritenum)
+        return false;
+
+    if (Path::GetFileExtension(res_pattern).IsEmpty())
+    {
+        res_pattern = String::FromFormat("%s.%s", res_pattern.GetCStr(), DefaultExtension.GetCStr());
+        regex_pattern = String::FromFormat("%s.%s", regex_pattern.GetCStr(), DefaultExtension.GetCStr());
+    }
+    return true;
+}
+
+HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex)
+{
+    for (FindFile ff = FindFile::Open(asset_dir, regex, true, false, 0);
+        !ff.AtEnd(); ff.Next())
+    {
+        String filename = ff.Current();
+        files.push_back(filename);
+    }
+    return HError::None();
+}
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/sprite_utils.h
+++ b/Tools/data/sprite_utils.h
@@ -30,7 +30,6 @@ namespace DataUtil
 {
     using HError = AGS::Common::HError;
     using String = AGS::Common::String;
-    using Palette = AGS::Common::Palette;
     using PixelBuffer = AGS::Common::PixelBuffer;
 
     String GetCompressionName(Common::SpriteCompression compress);
@@ -43,9 +42,17 @@ namespace DataUtil
     struct GameColorSettings
     {
         GameColorDepth ColorDepth = kGameColorDepth_Undefined;
-        Palette Palette;
+        AGS::Common::Palette Palette;
         std::array<PaletteColourType, PAL_SIZE> PalUses;
+
+        GameColorSettings()
+        {
+            std::fill(Palette.begin(), Palette.end(), RGB{0,0,0,0});
+            std::fill(PalUses.begin(), PalUses.end(), kPaletteColourType_Gamewide);
+        }
     };
+
+    using Palette = AGS::Common::Palette;
 
     // A cache of room background palettes
     typedef std::map<int, std::unique_ptr<Palette>> RoomPaletteCache;
@@ -53,9 +60,12 @@ namespace DataUtil
     // Merges game and room palettes into the destination paletter, according to the "pal uses" rules
     void MergePalettes(Palette &dest_pal, const Palette &game_pal, const Palette &room_pal, const std::array<PaletteColourType, PAL_SIZE> &pal_uses);
     // Converts image in accordance to the sprite specs.
-    HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
+    // The final image will be located in dst_image.
+    // If no format conversion is necessary, then moves original image to dst_image,
+    // however, the pixel values may still be changed even then (transparency conversion).
+    HError ConvertSpriteForGame(PixelBuffer &image, const Palette *pal,
         PixelBuffer &dst_image, const GameColorSettings &game_color_opts,
-        const RoomPaletteCache &room_cache, const SpriteData &sprite);
+        const RoomPaletteCache *room_cache, const SpriteData &sprite);
 
 } // namespace DataUtil
 } // namespace AGS

--- a/Tools/data/sprite_utils.h
+++ b/Tools/data/sprite_utils.h
@@ -15,6 +15,7 @@
 #define __AGS_TOOL_DATA__SPRITEFILEUTILS_H
 
 #include <regex>
+#include <map>
 #include <vector>
 #include <allegro.h>
 #include "ac/spritefile.h"
@@ -29,6 +30,8 @@ namespace DataUtil
 {
     using HError = AGS::Common::HError;
     using String = AGS::Common::String;
+    using Palette = AGS::Common::Palette;
+    using PixelBuffer = AGS::Common::PixelBuffer;
 
     String GetCompressionName(Common::SpriteCompression compress);
     Common::SpriteCompression CompressionFromName(const String &compress_name);
@@ -37,9 +40,22 @@ namespace DataUtil
     // TODO: move elsewhere, more generic utils?
     HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex);
 
+    struct GameColorSettings
+    {
+        GameColorDepth ColorDepth = kGameColorDepth_Undefined;
+        Palette Palette;
+        std::array<PaletteColourType, PAL_SIZE> PalUses;
+    };
+
+    // A cache of room background palettes
+    typedef std::map<int, std::unique_ptr<Palette>> RoomPaletteCache;
+
+    // Merges game and room palettes into the destination paletter, according to the "pal uses" rules
+    void MergePalettes(Palette &dest_pal, const Palette &game_pal, const Palette &room_pal, const std::array<PaletteColourType, PAL_SIZE> &pal_uses);
     // Converts image in accordance to the sprite specs.
-    HError ConvertSpriteForGame(Common::PixelBuffer &image, std::array<RGB, 256> *pal,
-        Common::PixelBuffer &dst_image, const int game_color_depth, const SpriteData &sprite);
+    HError ConvertSpriteForGame(PixelBuffer &image, Palette *pal,
+        PixelBuffer &dst_image, const GameColorSettings &game_color_opts,
+        const RoomPaletteCache &room_cache, const SpriteData &sprite);
 
 } // namespace DataUtil
 } // namespace AGS

--- a/Tools/data/sprite_utils.h
+++ b/Tools/data/sprite_utils.h
@@ -16,7 +16,10 @@
 
 #include <regex>
 #include <vector>
+#include <allegro.h>
 #include "ac/spritefile.h"
+#include "data/game_utils.h"
+#include "gfx/bitmapdata.h"
 #include "util/error.h"
 #include "util/string.h"
 
@@ -33,6 +36,10 @@ namespace DataUtil
     bool ResolveImageFilePattern(const String &pattern, String &res_pattern, String &regex_pattern);
     // TODO: move elsewhere, more generic utils?
     HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex);
+
+    // Converts image in accordance to the sprite specs.
+    HError ConvertSpriteForGame(Common::PixelBuffer &image, std::array<RGB, 256> *pal,
+        Common::PixelBuffer &dst_image, const int game_color_depth, const SpriteData &sprite);
 
 } // namespace DataUtil
 } // namespace AGS

--- a/Tools/data/sprite_utils.h
+++ b/Tools/data/sprite_utils.h
@@ -1,0 +1,40 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#ifndef __AGS_TOOL_DATA__SPRITEFILEUTILS_H
+#define __AGS_TOOL_DATA__SPRITEFILEUTILS_H
+
+#include <regex>
+#include <vector>
+#include "ac/spritefile.h"
+#include "util/error.h"
+#include "util/string.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+    using HError = AGS::Common::HError;
+    using String = AGS::Common::String;
+
+    String GetCompressionName(Common::SpriteCompression compress);
+    Common::SpriteCompression CompressionFromName(const String &compress_name);
+    bool ResolveImageFilePattern(const String &pattern, String &res_pattern);
+    bool ResolveImageFilePattern(const String &pattern, String &res_pattern, String &regex_pattern);
+    // TODO: move elsewhere, more generic utils?
+    HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex);
+
+} // namespace DataUtil
+} // namespace AGS
+
+#endif // __AGS_TOOL_DATA__SPRITEFILEUTILS_H

--- a/Tools/spriteimport/Makefile
+++ b/Tools/spriteimport/Makefile
@@ -1,0 +1,110 @@
+INCDIR = ../../Common ../../libsrc/miniz ../../libsrc/allegro/include ../../libsrc/stb
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/ac/spritefile.cpp \
+	../../Common/gfx/bitmapdata.cpp \
+	../../Common/gfx/image_bmp.cpp \
+	../../Common/gfx/image_file.cpp \
+	../../Common/gfx/image_pcx.cpp \
+	../../Common/gfx/image_png.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/cmdlineopts.cpp \
+	../../Common/util/compress.cpp \
+	../../Common/util/directory.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/lzw.cpp \
+	../../Common/util/memorystream.cpp \
+	../../Common/util/path.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp
+
+MINIMAL_ALLEGRO_OBJS = \
+	../../libsrc/allegro/src/color.c
+
+MINIZ_OBJS = \
+	../../libsrc/miniz/miniz.c
+
+STB_OBJS = \
+	../../libsrc/stb/stb_image.c
+
+OBJS := main.cpp \
+	commands.cpp \
+	$(COMMON_OBJS) \
+	$(MINIMAL_ALLEGRO_OBJS) \
+	$(MINIZ_OBJS)
+	$(STB_OBJS)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags spritepak
+
+spritepak: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags spritepak
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f spritepak $(OBJS) $(DEPFILES)
+
+install: spritepak
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin spritepak
+
+uninstall:
+	rm -f $(PREFIX)/bin/spritepak

--- a/Tools/spriteimport/Makefile
+++ b/Tools/spriteimport/Makefile
@@ -1,5 +1,7 @@
-INCDIR = ../../Common ../../libsrc/miniz ../../libsrc/allegro/include ../../libsrc/stb
+INCDIR = ../../Common ../../Tools ../../libsrc/miniz ../../libsrc/allegro/include ../../libsrc/stb ../../libsrc/tinyxml2
 LIBDIR =
+
+LD_VERSION := $(shell $(LD) --version 2>/dev/null)
 
 CFLAGS := -O2 -g \
 	-fsigned-char -fno-strict-aliasing -fwrapv \
@@ -20,16 +22,29 @@ AR ?= ar
 CFLAGS   += $(addprefix -I,$(INCDIR))
 CXXFLAGS += $(CFLAGS)
 ASFLAGS  += $(CFLAGS)
-LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
 CFLAGS   += -Werror=implicit-function-declaration
+
+ifneq (,$(findstring GNU ld,$(LD_VERSION)))
+    LDFLAGS += -rdynamic -Wl,--as-needed
+endif
+LDFLAGS  += $(addprefix -L,$(LIBDIR))
 
 COMMON_OBJS = \
 	../../Common/ac/spritefile.cpp \
+	../../Common/data/data_ext.cpp \
+	../../Common/data/data_helpers.cpp \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/game/customproperties.cpp \
+	../../Common/game/interactions.cpp \
+	../../Common/game/room_file.cpp \
+	../../Common/game/roomdata.cpp \
 	../../Common/gfx/bitmapdata.cpp \
 	../../Common/gfx/image_bmp.cpp \
 	../../Common/gfx/image_file.cpp \
 	../../Common/gfx/image_pcx.cpp \
 	../../Common/gfx/image_png.cpp \
+	../../Common/script/cc_common.cpp \
+	../../Common/script/cc_script.cpp \
 	../../Common/util/bufferedstream.cpp \
 	../../Common/util/cmdlineopts.cpp \
 	../../Common/util/compress.cpp \
@@ -45,8 +60,17 @@ COMMON_OBJS = \
 	../../Common/util/string_compat.c \
 	../../Common/util/string_utils.cpp
 
+TOOL_OBJS = \
+	../../Tools/data/agfreader.cpp \
+	../../Tools/data/cc_script_stubs.cpp \
+	../../Tools/data/sprite_utils.cpp
+
 MINIMAL_ALLEGRO_OBJS = \
-	../../libsrc/allegro/src/color.c
+	../../libsrc/allegro/src/allegro.c \
+	../../libsrc/allegro/src/color.c \
+	../../libsrc/allegro/src/file.c \
+	../../libsrc/allegro/src/unicode.c \
+	../../libsrc/allegro/src/unix/ufile.c
 
 MINIZ_OBJS = \
 	../../libsrc/miniz/miniz.c
@@ -54,12 +78,17 @@ MINIZ_OBJS = \
 STB_OBJS = \
 	../../libsrc/stb/stb_image.c
 
+TINYXML2 = \
+	../../libsrc/tinyxml2/tinyxml2.cpp
+
 OBJS := main.cpp \
 	commands.cpp \
 	$(COMMON_OBJS) \
+	$(TOOL_OBJS) \
 	$(MINIMAL_ALLEGRO_OBJS) \
-	$(MINIZ_OBJS)
-	$(STB_OBJS)
+	$(MINIZ_OBJS) \
+	$(STB_OBJS) \
+	$(TINYXML2)
 OBJS := $(OBJS:.cpp=.o)
 OBJS := $(OBJS:.c=.o)
 
@@ -69,16 +98,16 @@ DEPFILES = $(OBJS:.o=.d)
 
 .PHONY: printflags clean install uninstall rebuild
 
-all: printflags spritepak
+all: printflags spriteimport
 
-spritepak: $(OBJS) 
+spriteimport: $(OBJS) 
 	@echo "Linking..."
 	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 
 debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
 debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
 debug: LDFLAGS  += -pg
-debug: printflags spritepak
+debug: printflags spriteimport
 
 -include $(DEPFILES)
 
@@ -100,11 +129,11 @@ rebuild: clean all
 
 clean:
 	@echo "Cleaning..."
-	$(CMD_PREFIX) rm -f spritepak $(OBJS) $(DEPFILES)
+	$(CMD_PREFIX) rm -f spriteimport $(OBJS) $(DEPFILES)
 
 install: spritepak
 	mkdir -p $(PREFIX)/bin
-	cp -t $(PREFIX)/bin spritepak
+	cp -t $(PREFIX)/bin spriteimport
 
 uninstall:
-	rm -f $(PREFIX)/bin/spritepak
+	rm -f $(PREFIX)/bin/spriteimport

--- a/Tools/spriteimport/commands.cpp
+++ b/Tools/spriteimport/commands.cpp
@@ -1,0 +1,333 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "commands.h"
+#include <allegro.h>
+#include <vector>
+#include <map>
+#include "data/agfreader.h"
+#include "data/game_utils.h"
+#include "data/sprite_utils.h"
+#include "gfx/bitmapdata.h"
+#include "gfx/image_file.h"
+#include "util/file.h"
+#include "util/memory_compat.h"
+#include "util/path.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+namespace AGF = AGS::AGF;
+
+namespace SpriteImport
+{
+
+void Init()
+{
+    // Init Allegro RGB shifts; necessary for doing color conversions
+    set_rgb_shifts(10, 5, 0, 11, 5, 0, 16, 8, 0, 16, 8, 0, 24);
+}
+
+// SpriteWriter is a helper class, which either compiles sprites into the
+// spritefile pack (using SpriteFileWriter), or writes sprites as individual
+// image files (provided with a destination directory and filename pattern).
+class SpriteWriter
+{
+public:
+    SpriteWriter(std::unique_ptr<SpriteFileWriter> &&sf_writer, int store_flags, SpriteCompression compress,
+            bool use_sequential_index = false)
+        : _sfWriter(std::move(sf_writer))
+        , _sfStoreFlags(store_flags)
+        , _sfCompress(compress)
+        , _useSequentialIndex(use_sequential_index)
+    {}
+
+    SpriteWriter(const String &out_dir, const String &image_pattern, bool use_sequential_index = false)
+        : _outDir(out_dir)
+        , _imagePattern(image_pattern)
+        , _useSequentialIndex(use_sequential_index)
+    {}
+
+    HError Begin(sprkey_t topmost_sprite)
+    {
+        if (_sfWriter)
+        {
+            _sfWriter->Begin(_sfStoreFlags, _sfCompress, topmost_sprite);
+        }
+        return HError::None();
+    }
+    HError WriteSprite(const BitmapData &image, int slot)
+    {
+        if (_useSequentialIndex)
+            slot = ++_lastSlot;
+        _lastSlot = slot;
+
+        if (_sfWriter)
+        {
+            // Spritefile must have all the gaps filled with "empty slot" entries
+            for (sprkey_t last_slot = _sfWriter->GetLastWrittenSlot() + 1; last_slot < slot; ++last_slot)
+                _sfWriter->WriteEmptySlot();
+
+            if (image)
+                _sfWriter->WriteBitmap(image);
+            else
+                _sfWriter->WriteEmptySlot();
+            return HError::None();
+        }
+        else if (image)
+        {
+            String filename = String::FromFormat(_imagePattern.GetCStr(), slot);
+            if (!ImageFile::SaveImage(image, Path::ConcatPaths(_outDir, filename)))
+            {
+                return new Error(String::FromFormat("Failed to save sprite %d as the image file '%s'", slot, filename.GetCStr()));
+            }
+        }
+        return HError::None();
+    }
+    HError End()
+    {
+        if (_sfWriter)
+        {
+            _sfWriter->Finalize();
+            _sfWriter = nullptr;
+        }
+        return HError::None();
+    }
+
+private:
+    std::unique_ptr<SpriteFileWriter> _sfWriter;
+    int _sfStoreFlags = 0;
+    SpriteCompression _sfCompress = kSprCompress_None;
+    String _outDir;
+    String _imagePattern;
+    bool _useSequentialIndex = false;
+    int _lastSlot = -1;
+};
+
+HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &sprites, bool verbose)
+{
+    AGF::AGFReader reader;
+    HError err = reader.Open(src_agf.GetCStr());
+    if (!err)
+        return new Error(String::FromFormat("Failed to open source AGF '%s':\n", src_agf.GetCStr()), err);
+    AGF::ReadSpriteList(sprites, reader.GetGameRoot());
+    return HError::None();
+}
+
+void MapSpritesToSources(const String &src_dir, const std::vector<SpriteData> &sprites, std::multimap<String, SpriteData> &source_to_sprite)
+{
+    for (const auto &sprite : sprites)
+    {
+        if (!sprite.SourceFile.IsEmpty())
+        {
+            String sprite_path = Path::IsRelativePath(sprite.SourceFile) ?
+                Path::ConcatPaths(src_dir, sprite.SourceFile) : sprite.SourceFile;
+            source_to_sprite.insert(std::make_pair(sprite_path, sprite));
+        }
+        else
+        {
+            printf("Warning: sprite %d does not have a source data: won't be able to import", sprite.Slot);
+        }
+    }
+}
+
+HError ConvertSpriteForGame(PixelBuffer &image, const SpriteData &sprite, bool verbose)
+{
+    // TODO! check AGS.Native
+    return HError::None();
+}
+
+HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> &sprites, SpriteWriter &writer, bool verbose)
+{
+    PixelFormat px_fmt;
+    RGB pal[256];
+    // TODO: implement loading distinct frame(s) from formats such as GIF
+    PixelBuffer image = ImageFile::LoadImage(src_file, &px_fmt, pal);
+    if (!image)
+    {
+        // In case we output to the spritefile, we must fill all gaps with empty slot entries
+        for (const auto &sprite : sprites)
+        {
+            writer.WriteSprite({}, sprite.Slot);
+        }
+        return new Error(String::FromFormat("Failed to load image file %s", src_file.GetCStr()));
+    }
+
+    for (const auto &sprite : sprites)
+    {
+        PixelBuffer tile = PixelOp::CopyPixelsRegion(image, sprite.ImportOffsetX, sprite.ImportOffsetY, sprite.ImportWidth, sprite.ImportHeight);
+        if (tile)
+        {
+            HError err = ConvertSpriteForGame(tile, sprite, verbose);
+            if (err)
+            {
+                writer.WriteSprite(tile, sprite.Slot);
+            }
+            else
+            {
+                printf("Error: failed to convert the sprite %d for the game:\n", sprite.Slot);
+                printf("%s\n", err->FullMessage().GetCStr());
+            }
+        }
+    }
+    return HError::None();
+}
+
+HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_sprite,
+    SpriteWriter &writer, std::map<sprkey_t, sprkey_t> *out_sprite_order, bool verbose)
+{
+    writer.Begin(source_to_sprite.size() > 0 ? source_to_sprite.size() - 1 : -1);
+    // Multimap stores items ordered by keys, meaning the duplicates will be together.
+    // So lookup for each next key group, collect all sprite indexes from that group,
+    // and pass them into the import as a single collection.
+    std::vector<SpriteData> sprite_group;
+    sprkey_t out_index = 0;
+    for (auto it_spr_src = source_to_sprite.begin(); it_spr_src != source_to_sprite.end();)
+    {
+        sprite_group.clear();
+        const String &this_source = it_spr_src->first;
+        for (; (it_spr_src != source_to_sprite.end()) && (this_source == it_spr_src->first); ++it_spr_src)
+            sprite_group.push_back(it_spr_src->second);
+
+        if (out_sprite_order)
+        {
+            for (const auto s : sprite_group)
+                (*out_sprite_order)[s.Slot] = out_index++;
+        }
+
+        HError err = CutSpritesAndWrite(this_source, sprite_group, writer, verbose);
+        if (!err)
+        {
+            printf("Error: failed to import sprite(s) from source file '%s':\n", this_source.GetCStr());
+            printf("%s\n", err->FullMessage().GetCStr());
+        }
+    }
+    writer.End();
+    return HError::None();
+}
+
+HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_sprite, const String &dst_path, const CommandOptions &opts, bool verbose)
+{
+    // The strategy: because we sort sprites by sources, we might end up having them
+    // in the non-sequential order. While spritefile is supposed to have them strictly
+    // ordered. As a workaround we do a two-step-operation:
+    // Step 1. Write the spritefile into the temporary file, while recording the
+    // order in which the sprites are written there.
+    // Step 2. Write another spritefile into the final file, copying raw chunks
+    // from the temporary file over (simply copy, faster than import itself).
+    std::unique_ptr<Stream> temp_s = File::CreateTempFile();
+    if (!temp_s)
+        return new Error("Failed to open temporary spritefile for writing");
+
+    // As we open a temporary file, it gets deleted as soon as the stream closes.
+    // SpriteFileWriter closes its stream as soon as the pack is finalized.
+    // In order to prevent a temp file closing, here we make a "proxy stream",
+    // which will use the base but not own one, and thus won't close.
+    // TODO: this is a quick and clumsy solution for now, revise this later
+    auto proxy_out = std::make_unique<Stream>(std::make_unique<StreamSection>(temp_s->GetStreamBase(), 0, temp_s->GetStreamBase()->GetLength()));
+    std::unique_ptr<SpriteFileWriter> sf_writer(new SpriteFileWriter(std::move(proxy_out)));
+    SpriteWriter writer(std::move(sf_writer), opts.StorageFlags, opts.Compress, true);
+    std::map<sprkey_t, sprkey_t> out_sprite_order;
+    HError err = ImportSpritesImpl(source_to_sprite, writer, &out_sprite_order, verbose);
+    if (!err)
+        return err;
+
+    std::unique_ptr<Stream> out = File::CreateFile(dst_path);
+    if (!out)
+        return new Error(String::FromFormat("Failed to open destination spritefile for writing: %s", dst_path.GetCStr()));
+
+    SpriteFile spr_reader;
+    temp_s->Seek(0, kSeekBegin);
+    err = spr_reader.OpenFile(std::move(temp_s), {});
+    if (!err)
+        return err;
+
+    SpriteFileWriter spr_writer(std::move(out));
+    SpriteDatHeader hdr;
+    std::vector<uint8_t> data;
+    spr_writer.Begin(opts.StorageFlags, opts.Compress, spr_reader.GetTopmostSprite());
+    sprkey_t last_slot = -1;
+    for (const auto &temp_slot : out_sprite_order)
+    {
+        // Spritefile must have all the gaps filled with "empty slot" entries
+        while (++last_slot < temp_slot.first)
+            spr_writer.WriteEmptySlot();
+        HError err = spr_reader.LoadRawData(temp_slot.second, hdr, data);
+        if (err)
+            spr_writer.WriteRawData(hdr, data);
+        else
+            spr_writer.WriteEmptySlot();
+    }
+    spr_writer.Finalize();
+
+    // Consider index file to be non-obligatory, as the index may be restored from the spritefile
+    if (!opts.IndexFile.IsEmpty())
+    {
+        HError err = SaveSpriteIndex(opts.IndexFile, spr_writer.GetIndex());
+        if (err)
+        {
+            printf("Index file written successfully.\n");
+        }
+        else
+        {
+            printf("Error: failed to write index file (%s):\n", opts.IndexFile.GetCStr());
+            printf("%s\n", err->FullMessage().GetCStr());
+        }
+    }
+    return HError::None();
+}
+
+HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_sprite, const String &dst_path, const CommandOptions &opts, bool verbose)
+{
+    if (!File::IsDirectory(dst_path))
+        return new Error(String::FromFormat("Not a valid directory: %s", dst_path.GetCStr()));
+
+    String image_pattern;
+    if (!ResolveImageFilePattern(opts.ImageFilePattern, image_pattern))
+        return new Error(String::FromFormat("Image file pattern \"%s\" is not a valid pattern.\n", opts.ImageFilePattern.GetCStr()));
+    SpriteWriter writer(dst_path, image_pattern);
+    return ImportSpritesImpl(source_to_sprite, writer, nullptr, verbose);
+}
+
+int Command_Import(const String &src_agf, const String &dst_path, const CommandOptions &opts, bool verbose)
+{
+    std::vector<SpriteData> sprites;
+    HError err = GatherSpriteSpecsFromAgf(src_agf, sprites, verbose);
+    if (!err)
+    {
+        printf("Error: failed to gather sprite specs from '%s':\n", src_agf.GetCStr());
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    // CHECKME: do we need to provide a separate cmd arg for this?
+    const String src_dir = Path::GetParent(src_agf);
+
+    std::multimap<String, SpriteData> source_to_sprite;
+    MapSpritesToSources(src_dir, sprites, source_to_sprite);
+
+    if (opts.OutputToSpritePak)
+        err = ImportToSpritePak(source_to_sprite, dst_path, opts, verbose);
+    else
+        err = ImportToDirectory(source_to_sprite, dst_path, opts, verbose);
+    if (!err)
+    {
+        printf("Error: failed to write imported sprites to their destination:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    printf("Done.\n");
+    return 0;
+}
+
+} // namespace SpriteImport

--- a/Tools/spriteimport/commands.cpp
+++ b/Tools/spriteimport/commands.cpp
@@ -214,7 +214,7 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
         {
             PixelBuffer conv_tile;
             // NOTE: GameColorDepth's values match byte per pixel of a respective color depth type
-            HError err = ConvertSpriteForGame(tile, &pal, conv_tile, game_color_opts, room_cache, sprite);
+            HError err = ConvertSpriteForGame(tile, &pal, conv_tile, game_color_opts, &room_cache, sprite);
             if (err)
             {
                 writer.WriteSprite(conv_tile, sprite.Slot);

--- a/Tools/spriteimport/commands.cpp
+++ b/Tools/spriteimport/commands.cpp
@@ -18,6 +18,7 @@
 #include "data/agfreader.h"
 #include "data/game_utils.h"
 #include "data/sprite_utils.h"
+#include "game/room_file.h"
 #include "gfx/bitmapdata.h"
 #include "gfx/image_file.h"
 #include "util/file.h"
@@ -113,7 +114,8 @@ private:
     int _lastSlot = -1;
 };
 
-HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &sprites, GameColorDepth &game_color_depth, bool verbose)
+HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &sprites, GameColorSettings &game_color_opts,
+    std::vector<std::pair<int, String>> &room_list, bool verbose)
 {
     AGF::AGFReader reader;
     HError err = reader.Open(src_agf.GetCStr());
@@ -121,8 +123,19 @@ HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &
         return new Error(String::FromFormat("Failed to open source AGF '%s':\n", src_agf.GetCStr()), err);
     GameSettings opt;
     AGF::ReadGameSettings(opt, reader.GetGameRoot());
-    game_color_depth = opt.ColorDepth;
+    game_color_opts.ColorDepth = opt.ColorDepth;
     AGF::ReadSpriteList(sprites, reader.GetGameRoot());
+    std::vector<PaletteEntryData> pal_entries(256);
+    AGF::ReadGamePalette(pal_entries, reader.GetGameRoot());
+    for (size_t i = 0; i < pal_entries.size(); ++i)
+    {
+        game_color_opts.Palette[i].r = pal_entries[i].Red;
+        game_color_opts.Palette[i].g = pal_entries[i].Green;
+        game_color_opts.Palette[i].b = pal_entries[i].Blue;
+        game_color_opts.Palette[i].a = 255;
+        game_color_opts.PalUses[i] = pal_entries[i].ColourType;
+    }
+    AGF::ReadRoomList(room_list, reader.GetGameRoot());
     return HError::None();
 }
 
@@ -138,16 +151,50 @@ void MapSpritesToSources(const String &src_dir, const std::vector<SpriteData> &s
         }
         else
         {
-            printf("Warning: sprite %d does not have a source data: won't be able to import", sprite.Slot);
+            printf("Warning: sprite %d does not have a source data: won't be able to import\n", sprite.Slot);
         }
     }
 }
 
-HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> &sprites, const GameColorDepth game_color_depth,
-    SpriteWriter &writer, bool verbose)
+void CacheRoomPalettes(RoomPaletteCache &room_cache, const String &room_dir,
+    const std::vector<std::pair<int, String>> &room_list, const std::vector<SpriteData> &sprites, bool verbose)
+{
+    for (const auto &room_ref : room_list)
+    {
+        const String filepath = Path::ConcatPaths(room_dir, String::FromFormat("room%d.crm", room_ref.first));
+        RoomDataSource src;
+        HRoomFileError err = OpenRoomFile(filepath, src);
+        if (!err)
+        {
+            printf("Error: failed to open room file '%s' for reading:\n", filepath.GetCStr());
+            printf("%s\n", err->FullMessage().GetCStr());
+            continue;
+        }
+        
+        // For the room palette we must read its primary background image
+        // found in the kRoomFblk_Main
+        RoomData room;
+        err = ReadRoomData(&room, nullptr, std::move(src.InputStream), src.DataVersion, {{ kRoomFblk_Main, "" }}, {});
+        if (!err)
+        {
+            printf("Error: failed to read room file '%s':\n", filepath.GetCStr());
+            printf("%s\n", err->FullMessage().GetCStr());
+            continue;
+        }
+
+        std::unique_ptr<Palette> pal = std::make_unique<Palette>();
+        std::copy(room.Palette, room.Palette + PAL_SIZE, pal->data());
+        room_cache[room_ref.first] = std::move(pal);
+        if (verbose)
+            printf("Loaded palette for room %d\n", room_ref.first);
+    }
+}
+
+HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> &sprites, const GameColorSettings &game_color_opts,
+    const RoomPaletteCache &room_cache, SpriteWriter &writer, bool verbose)
 {
     PixelFormat px_fmt;
-    std::array<RGB, 256> pal;
+    Palette pal;
     // TODO: implement loading distinct frame(s) from formats such as GIF
     PixelBuffer image = ImageFile::LoadImage(src_file, &px_fmt, pal.data());
     if (!image)
@@ -167,7 +214,7 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
         {
             PixelBuffer conv_tile;
             // NOTE: GameColorDepth's values match byte per pixel of a respective color depth type
-            HError err = ConvertSpriteForGame(tile, &pal, conv_tile, static_cast<int>(game_color_depth) * 8, sprite);
+            HError err = ConvertSpriteForGame(tile, &pal, conv_tile, game_color_opts, room_cache, sprite);
             if (err)
             {
                 writer.WriteSprite(conv_tile, sprite.Slot);
@@ -182,8 +229,8 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
     return HError::None();
 }
 
-HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
-    SpriteWriter &writer, std::map<sprkey_t, sprkey_t> *out_sprite_order, bool verbose)
+HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorSettings &game_color_opts,
+    const RoomPaletteCache &room_cache, SpriteWriter &writer, std::map<sprkey_t, sprkey_t> *out_sprite_order, bool verbose)
 {
     writer.Begin(source_to_sprite.size() > 0 ? source_to_sprite.size() - 1 : -1);
     // Multimap stores items ordered by keys, meaning the duplicates will be together.
@@ -204,7 +251,7 @@ HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_spri
                 (*out_sprite_order)[s.Slot] = out_index++;
         }
 
-        HError err = CutSpritesAndWrite(this_source, sprite_group, game_color_depth, writer, verbose);
+        HError err = CutSpritesAndWrite(this_source, sprite_group, game_color_opts, room_cache, writer, verbose);
         if (!err)
         {
             printf("Error: failed to import sprite(s) from source file '%s':\n", this_source.GetCStr());
@@ -215,8 +262,8 @@ HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_spri
     return HError::None();
 }
 
-HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
-    const String &dst_path, const CommandOptions &opts, bool verbose)
+HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorSettings &game_color_opts,
+    const RoomPaletteCache &room_cache, const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     // The strategy: because we sort sprites by sources, we might end up having them
     // in the non-sequential order. While spritefile is supposed to have them strictly
@@ -238,7 +285,7 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
     std::unique_ptr<SpriteFileWriter> sf_writer(new SpriteFileWriter(std::move(proxy_out)));
     SpriteWriter writer(std::move(sf_writer), opts.StorageFlags, opts.Compress, true);
     std::map<sprkey_t, sprkey_t> out_sprite_order;
-    HError err = ImportSpritesImpl(source_to_sprite, game_color_depth, writer, &out_sprite_order, verbose);
+    HError err = ImportSpritesImpl(source_to_sprite, game_color_opts, room_cache, writer, &out_sprite_order, verbose);
     if (!err)
         return err;
 
@@ -287,8 +334,8 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
     return HError::None();
 }
 
-HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
-    const String &dst_path, const CommandOptions &opts, bool verbose)
+HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorSettings &game_color_opts,
+    const RoomPaletteCache &room_cache, const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     if (!File::IsDirectory(dst_path))
         return new Error(String::FromFormat("Not a valid directory: %s", dst_path.GetCStr()));
@@ -297,14 +344,15 @@ HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_spri
     if (!ResolveImageFilePattern(opts.ImageFilePattern, image_pattern))
         return new Error(String::FromFormat("Image file pattern \"%s\" is not a valid pattern.\n", opts.ImageFilePattern.GetCStr()));
     SpriteWriter writer(dst_path, image_pattern);
-    return ImportSpritesImpl(source_to_sprite, game_color_depth, writer, nullptr, verbose);
+    return ImportSpritesImpl(source_to_sprite, game_color_opts, room_cache, writer, nullptr, verbose);
 }
 
 int Command_Import(const String &src_agf, const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     std::vector<SpriteData> sprites;
-    GameColorDepth game_color_depth;
-    HError err = GatherSpriteSpecsFromAgf(src_agf, sprites, game_color_depth, verbose);
+    GameColorSettings game_color_opts;
+    std::vector<std::pair<int, String>> room_list;
+    HError err = GatherSpriteSpecsFromAgf(src_agf, sprites, game_color_opts, room_list, verbose);
     if (!err)
     {
         printf("Error: failed to gather sprite specs from '%s':\n", src_agf.GetCStr());
@@ -318,10 +366,22 @@ int Command_Import(const String &src_agf, const String &dst_path, const CommandO
     std::multimap<String, SpriteData> source_to_sprite;
     MapSpritesToSources(src_dir, sprites, source_to_sprite);
 
+    RoomPaletteCache room_cache;
+    if (game_color_opts.ColorDepth == kGameColorDepth_Palette)
+    {
+        String room_dir = !opts.RoomDirectory.IsEmpty() ? opts.RoomDirectory : Path::GetParent(src_agf);
+        CacheRoomPalettes(room_cache, room_dir, room_list, sprites, verbose);
+        if (room_cache.size() < room_list.size())
+        {
+            printf("Warning: failed to precache all the room palettes needed for this 8-bit game. "
+                "The imported 8-bit sprites may have incorrect colors if they were refering room background palette slots.\n");
+        }
+    }
+
     if (opts.OutputToSpritePak)
-        err = ImportToSpritePak(source_to_sprite, game_color_depth, dst_path, opts, verbose);
+        err = ImportToSpritePak(source_to_sprite, game_color_opts, room_cache, dst_path, opts, verbose);
     else
-        err = ImportToDirectory(source_to_sprite, game_color_depth, dst_path, opts, verbose);
+        err = ImportToDirectory(source_to_sprite, game_color_opts, room_cache, dst_path, opts, verbose);
     if (!err)
     {
         printf("Error: failed to write imported sprites to their destination:\n");

--- a/Tools/spriteimport/commands.cpp
+++ b/Tools/spriteimport/commands.cpp
@@ -78,6 +78,7 @@ public:
             for (sprkey_t last_slot = _sfWriter->GetLastWrittenSlot() + 1; last_slot < slot; ++last_slot)
                 _sfWriter->WriteEmptySlot();
 
+            printf("\t+ sprite %d\n", slot);
             if (image)
                 _sfWriter->WriteBitmap(image);
             else
@@ -87,7 +88,11 @@ public:
         else if (image)
         {
             String filename = String::FromFormat(_imagePattern.GetCStr(), slot);
-            if (!ImageFile::SaveImage(image, Path::ConcatPaths(_outDir, filename)))
+            if (ImageFile::SaveImage(image, Path::ConcatPaths(_outDir, filename)))
+            {
+                printf("\t+ %s\n", filename.GetCStr());
+            }
+            else
             {
                 return new Error(String::FromFormat("Failed to save sprite %d as the image file '%s'", slot, filename.GetCStr()));
             }
@@ -207,6 +212,7 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
         return new Error(String::FromFormat("Failed to load image file %s", src_file.GetCStr()));
     }
 
+    printf("> %s\n", src_file.GetCStr());
     for (const auto &sprite : sprites)
     {
         PixelBuffer tile = PixelOp::CopyPixelsRegion(image, sprite.ImportOffsetX, sprite.ImportOffsetY, sprite.ImportWidth, sprite.ImportHeight);
@@ -217,13 +223,21 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
             HError err = ConvertSpriteForGame(tile, &pal, conv_tile, game_color_opts, &room_cache, sprite);
             if (err)
             {
-                writer.WriteSprite(conv_tile, sprite.Slot);
+                err = writer.WriteSprite(conv_tile, sprite.Slot);
+                if (!err)
+                    printf("%s", err->FullMessage().GetCStr());
             }
             else
             {
+                writer.WriteSprite({}, sprite.Slot); // write empty slot to spritefile
                 printf("Error: failed to convert the sprite %d for the game:\n", sprite.Slot);
                 printf("%s\n", err->FullMessage().GetCStr());
             }
+        }
+        else
+        {
+            writer.WriteSprite({}, sprite.Slot); // write empty slot to spritefile
+            printf("Error: failed to cut the sprite's %d tile (%d,%d,%d,%d)\n", sprite.Slot, sprite.ImportOffsetX, sprite.ImportOffsetY, sprite.ImportWidth, sprite.ImportHeight);
         }
     }
     return HError::None();
@@ -281,13 +295,15 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
     // In order to prevent a temp file closing, here we make a "proxy stream",
     // which will use the base but not own one, and thus won't close.
     // TODO: this is a quick and clumsy solution for now, revise this later
-    auto proxy_out = std::make_unique<Stream>(std::make_unique<StreamSection>(temp_s->GetStreamBase(), 0, temp_s->GetStreamBase()->GetLength()));
-    std::unique_ptr<SpriteFileWriter> sf_writer(new SpriteFileWriter(std::move(proxy_out)));
-    SpriteWriter writer(std::move(sf_writer), opts.StorageFlags, opts.Compress, true);
     std::map<sprkey_t, sprkey_t> out_sprite_order;
-    HError err = ImportSpritesImpl(source_to_sprite, game_color_opts, room_cache, writer, &out_sprite_order, verbose);
-    if (!err)
-        return err;
+    {
+        auto proxy_out = std::make_unique<Stream>(std::make_unique<StreamSection>(temp_s->GetStreamBase(), 0, temp_s->GetStreamBase()->GetLength()));
+        std::unique_ptr<SpriteFileWriter> sf_writer(new SpriteFileWriter(std::move(proxy_out)));
+        SpriteWriter writer(std::move(sf_writer), opts.StorageFlags, opts.Compress, true);
+        HError err = ImportSpritesImpl(source_to_sprite, game_color_opts, room_cache, writer, &out_sprite_order, verbose);
+        if (!err)
+            return err;
+    }
 
     std::unique_ptr<Stream> out = File::CreateFile(dst_path);
     if (!out)
@@ -295,7 +311,7 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
 
     SpriteFile spr_reader;
     temp_s->Seek(0, kSeekBegin);
-    err = spr_reader.OpenFile(std::move(temp_s), {});
+    HError err = spr_reader.OpenFile(std::move(temp_s), {});
     if (!err)
         return err;
 
@@ -316,6 +332,7 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
             spr_writer.WriteEmptySlot();
     }
     spr_writer.Finalize();
+    spr_reader.Close();
 
     // Consider index file to be non-obligatory, as the index may be restored from the spritefile
     if (!opts.IndexFile.IsEmpty())

--- a/Tools/spriteimport/commands.cpp
+++ b/Tools/spriteimport/commands.cpp
@@ -113,12 +113,15 @@ private:
     int _lastSlot = -1;
 };
 
-HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &sprites, bool verbose)
+HError GatherSpriteSpecsFromAgf(const String &src_agf, std::vector<SpriteData> &sprites, GameColorDepth &game_color_depth, bool verbose)
 {
     AGF::AGFReader reader;
     HError err = reader.Open(src_agf.GetCStr());
     if (!err)
         return new Error(String::FromFormat("Failed to open source AGF '%s':\n", src_agf.GetCStr()), err);
+    GameSettings opt;
+    AGF::ReadGameSettings(opt, reader.GetGameRoot());
+    game_color_depth = opt.ColorDepth;
     AGF::ReadSpriteList(sprites, reader.GetGameRoot());
     return HError::None();
 }
@@ -140,18 +143,13 @@ void MapSpritesToSources(const String &src_dir, const std::vector<SpriteData> &s
     }
 }
 
-HError ConvertSpriteForGame(PixelBuffer &image, const SpriteData &sprite, bool verbose)
-{
-    // TODO! check AGS.Native
-    return HError::None();
-}
-
-HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> &sprites, SpriteWriter &writer, bool verbose)
+HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> &sprites, const GameColorDepth game_color_depth,
+    SpriteWriter &writer, bool verbose)
 {
     PixelFormat px_fmt;
-    RGB pal[256];
+    std::array<RGB, 256> pal;
     // TODO: implement loading distinct frame(s) from formats such as GIF
-    PixelBuffer image = ImageFile::LoadImage(src_file, &px_fmt, pal);
+    PixelBuffer image = ImageFile::LoadImage(src_file, &px_fmt, pal.data());
     if (!image)
     {
         // In case we output to the spritefile, we must fill all gaps with empty slot entries
@@ -167,10 +165,12 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
         PixelBuffer tile = PixelOp::CopyPixelsRegion(image, sprite.ImportOffsetX, sprite.ImportOffsetY, sprite.ImportWidth, sprite.ImportHeight);
         if (tile)
         {
-            HError err = ConvertSpriteForGame(tile, sprite, verbose);
+            PixelBuffer conv_tile;
+            // NOTE: GameColorDepth's values match byte per pixel of a respective color depth type
+            HError err = ConvertSpriteForGame(tile, &pal, conv_tile, static_cast<int>(game_color_depth) * 8, sprite);
             if (err)
             {
-                writer.WriteSprite(tile, sprite.Slot);
+                writer.WriteSprite(conv_tile, sprite.Slot);
             }
             else
             {
@@ -182,7 +182,7 @@ HError CutSpritesAndWrite(const String &src_file, const std::vector<SpriteData> 
     return HError::None();
 }
 
-HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_sprite,
+HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
     SpriteWriter &writer, std::map<sprkey_t, sprkey_t> *out_sprite_order, bool verbose)
 {
     writer.Begin(source_to_sprite.size() > 0 ? source_to_sprite.size() - 1 : -1);
@@ -204,7 +204,7 @@ HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_spri
                 (*out_sprite_order)[s.Slot] = out_index++;
         }
 
-        HError err = CutSpritesAndWrite(this_source, sprite_group, writer, verbose);
+        HError err = CutSpritesAndWrite(this_source, sprite_group, game_color_depth, writer, verbose);
         if (!err)
         {
             printf("Error: failed to import sprite(s) from source file '%s':\n", this_source.GetCStr());
@@ -215,7 +215,8 @@ HError ImportSpritesImpl(const std::multimap<String, SpriteData> &source_to_spri
     return HError::None();
 }
 
-HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_sprite, const String &dst_path, const CommandOptions &opts, bool verbose)
+HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
+    const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     // The strategy: because we sort sprites by sources, we might end up having them
     // in the non-sequential order. While spritefile is supposed to have them strictly
@@ -237,7 +238,7 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
     std::unique_ptr<SpriteFileWriter> sf_writer(new SpriteFileWriter(std::move(proxy_out)));
     SpriteWriter writer(std::move(sf_writer), opts.StorageFlags, opts.Compress, true);
     std::map<sprkey_t, sprkey_t> out_sprite_order;
-    HError err = ImportSpritesImpl(source_to_sprite, writer, &out_sprite_order, verbose);
+    HError err = ImportSpritesImpl(source_to_sprite, game_color_depth, writer, &out_sprite_order, verbose);
     if (!err)
         return err;
 
@@ -286,7 +287,8 @@ HError ImportToSpritePak(const std::multimap<String, SpriteData> &source_to_spri
     return HError::None();
 }
 
-HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_sprite, const String &dst_path, const CommandOptions &opts, bool verbose)
+HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_sprite, const GameColorDepth game_color_depth,
+    const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     if (!File::IsDirectory(dst_path))
         return new Error(String::FromFormat("Not a valid directory: %s", dst_path.GetCStr()));
@@ -295,13 +297,14 @@ HError ImportToDirectory(const std::multimap<String, SpriteData> &source_to_spri
     if (!ResolveImageFilePattern(opts.ImageFilePattern, image_pattern))
         return new Error(String::FromFormat("Image file pattern \"%s\" is not a valid pattern.\n", opts.ImageFilePattern.GetCStr()));
     SpriteWriter writer(dst_path, image_pattern);
-    return ImportSpritesImpl(source_to_sprite, writer, nullptr, verbose);
+    return ImportSpritesImpl(source_to_sprite, game_color_depth, writer, nullptr, verbose);
 }
 
 int Command_Import(const String &src_agf, const String &dst_path, const CommandOptions &opts, bool verbose)
 {
     std::vector<SpriteData> sprites;
-    HError err = GatherSpriteSpecsFromAgf(src_agf, sprites, verbose);
+    GameColorDepth game_color_depth;
+    HError err = GatherSpriteSpecsFromAgf(src_agf, sprites, game_color_depth, verbose);
     if (!err)
     {
         printf("Error: failed to gather sprite specs from '%s':\n", src_agf.GetCStr());
@@ -316,9 +319,9 @@ int Command_Import(const String &src_agf, const String &dst_path, const CommandO
     MapSpritesToSources(src_dir, sprites, source_to_sprite);
 
     if (opts.OutputToSpritePak)
-        err = ImportToSpritePak(source_to_sprite, dst_path, opts, verbose);
+        err = ImportToSpritePak(source_to_sprite, game_color_depth, dst_path, opts, verbose);
     else
-        err = ImportToDirectory(source_to_sprite, dst_path, opts, verbose);
+        err = ImportToDirectory(source_to_sprite, game_color_depth, dst_path, opts, verbose);
     if (!err)
     {
         printf("Error: failed to write imported sprites to their destination:\n");

--- a/Tools/spriteimport/commands.h
+++ b/Tools/spriteimport/commands.h
@@ -11,12 +11,12 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
-#ifndef __AGS_TOOL_SPRITEPAK__COMMANDS_H
-#define __AGS_TOOL_SPRITEPAK__COMMANDS_H
+#ifndef __AGS_TOOL_SPRITEIMPORT__COMMANDS_H
+#define __AGS_TOOL_SPRITEIMPORT__COMMANDS_H
 
 #include "data/sprite_utils.h"
 
-namespace SpritePak
+namespace SpriteImport
 {
     using String = AGS::Common::String;
     using SpriteStorage = AGS::Common::SpriteStorage;
@@ -24,19 +24,15 @@ namespace SpritePak
 
     struct CommandOptions
     {
+        bool OutputToSpritePak = false;
         String IndexFile;
-        String OutIndexFile;
         String ImageFilePattern;
         SpriteStorage StorageFlags = AGS::Common::kSprStore_OptimizeForSize;
         SpriteCompression Compress = AGS::Common::kSprCompress_Deflate;
     };
 
     void Init();
-    int Command_Create(const String &src_dir, const String &dst_pak, const CommandOptions &opts, bool verbose);
-    int Command_Export(const String &src_pak, const String &dst_dir, const CommandOptions &opts, bool verbose);
-    int Command_Info(const String &src_pak, const CommandOptions &opts);
-    int Command_List(const String &src_pak, const CommandOptions &opts);
-    int Command_Copy(const String &src_pak, const String &dst_pak, const CommandOptions &opts, bool verbose);
+    int Command_Import(const String &src_agf, const String &dst_path, const CommandOptions &opts, bool verbose);
 }
 
-#endif // __AGS_TOOL_SPRITEPAK__COMMANDS_H
+#endif // __AGS_TOOL_SPRITEIMPORT__COMMANDS_H

--- a/Tools/spriteimport/commands.h
+++ b/Tools/spriteimport/commands.h
@@ -29,6 +29,7 @@ namespace SpriteImport
         String ImageFilePattern;
         SpriteStorage StorageFlags = AGS::Common::kSprStore_OptimizeForSize;
         SpriteCompression Compress = AGS::Common::kSprCompress_Deflate;
+        String RoomDirectory;
     };
 
     void Init();

--- a/Tools/spriteimport/main.cpp
+++ b/Tools/spriteimport/main.cpp
@@ -12,49 +12,46 @@
 //
 //=============================================================================
 // 
-// AGS sprite file pack/unpack utility.
+// AGS sprite import utility.
+// Parses Game.agf for game sprite specs. Looks up for the source image files,
+// loads them up, cuts sprites out, converts to AGS compatible format, and
+// optionally either writes individual image files one per sprite into the
+// destination directory, or compiles a spritefile.
 // 
 //=============================================================================
 #include "commands.h"
-#include "data/sprite_utils.h"
 #include "util/cmdlineopts.h"
 #include "util/string.h"
 #include "util/string_utils.h"
 
+using namespace AGS;
 using namespace AGS::Common;
-using namespace AGS::DataUtil;
 
 
-const char *BIN_STRING = "spritepak v0.2.0 - AGS spritefile tool\n"
+const char *BIN_STRING = "spriteimport v0.1.0 - AGS sprite import tool\n"
 "Copyright (c) 2026 AGS Team and contributors\n";
 
 const char *HELP_STRING = "Usage:\n"
 //------------------------------------------------------------------------------|
-"  spritepak <COMMAND> <SPRITEFILE> [<WORK-DIR> | <DEST-SPRITEFILE>] [OPTIONS]\n"
-"      executes an operation regarding the chosen sprite file, a working\n"
-"      directory OR another destination spritefile. Depending on a command\n"
-"      either the spritefile or the directory is an input or an output.\n"
-"      Options may adjust the operation further.\n"
+"  spriteimport <COMMAND> <GAME.AGF> <OUT-PATH> [<COMMAND-OPTIONS>] [<OPTIONS>]\n"
+"      parses the input GAME.AGF file, and writes an output depending on the\n"
+"      command and additional options (see below).\n"
 "\n"
 "Commands:\n"
-"  -c, --create     create a spritefile, gathering the files from the input\n"
-"                   directory.\n"
-"  -e, --export     export (extract) files from the existing spritefile into\n"
-"                   the output directory.\n"
-"  -l, --list       print spritefile's table of contents.\n"
-"  -q, --info       print quick info about spritefile.\n"
-"  -y, --copy       copies spritefile contents over into another spritefile,\n"
-"                   letting to use different storage options.\n"
+"  -c, --out-pak    outputs a compiled spritefile. Additional options '-n', '-s'\n"
+"                   and '-z' modify this command's behavior.\n"
+"  -f, --out-files  outputs sprites as individual image files into the specified\n"
+"                   directory. The files's names and format is determined by\n"
+"                   the pattern option (see '-p'). If not such pattern provided\n"
+"                   then uses \"spr%6N%.png\" by default.\n"
 "\n"
 "Command options:\n"
 "  -n, --index <indexfile>\n"
-"                   specifies the index file to read or write, depending\n"
-"                   respectively on the current command.\n"
-"  --out-index <indexfile>\n"
-"                   when rewriting a spritefile, specifies new index file.\n"
+"                   when output is the spritefile: specifies the accompanying\n"
+"                   sprite index file.\n"
 "  -p, --pattern <name pattern>\n"
-"                   when creating the new spritefile, or extracting one, use the\n"
-"                   given pattern when searching for or creating image files.\n"
+"                   when output is image files: use the given pattern to define\n"
+"                   their naming and image format.\n"
 "                   The pattern may be given with or without file extension.\n"
 "                   The pattern may contain following placeholders:\n"
 "                     * %xN% - sprite number, where 'x' may be any single digit\n"
@@ -63,14 +60,15 @@ const char *HELP_STRING = "Usage:\n"
 "                   If no pattern is provided, the program will use \"spr%6N%\"\n"
 "                   pattern by default. If no extension is specified in the\n"
 "                   pattern, then \".png\" will be used as an extension.\n"
+// -r, --room-dir   RESERVED: input rooms for 8-bit games (need to read palettes)
 "  -s, --storage-flags <flags>\n"
-"                   when creating the new spritefile, use additional storage\n"
+"                   when output is the spritefile: use additional storage\n"
 "                   options, defined using a hexadecimal bitset:\n"
 "                     * 0x01 - optimize storage size when possible;\n"
 "                   e.g. write 16/32-bit images as 8-bit images with palette\n"
-"                   (only when this achieves less space). Default is \"0x01\".\n"
+"                   (only when this achieves less space). Default is \"0x01\"\n"
 "  -z, --compress <type>\n"
-"                   when creating the new spritefile, use compression:\n"
+"                   when output is the spritefile: use compression:\n"
 "                     * none\n"
 "                     * rle\n"
 "                     * lzw\n"
@@ -88,50 +86,31 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
     char command = 0;
     for (const auto &opt : cmdargs.Opt)
     {
-        if (opt == "-c" || opt == "--create")
+        if (opt == "-c" || opt == "--out-pak")
         {
-            command = 'c'; // create
+            command = 'c'; // compile spritefile
             break;
         }
-        if (opt == "-e" || opt == "--export")
+        if (opt == "-f" || opt == "--out-files")
         {
-            command = 'e'; // export
-            break;
-        }
-        if (opt == "-l" || opt == "--list")
-        {
-            command = 'l'; // list
-            break;
-        }
-        if (opt == "-q" || opt == "--info")
-        {
-            command = 'q'; // info
-            break;
-        }
-        if (opt == "-y" || opt == "--copy")
-        {
-            command = 'y'; // copy
+            command = 'f'; // export as image files
             break;
         }
     }
 
     // Fixed pos options
-    const String sprite_file = cmdargs.PosArgs.size() > 0 ? cmdargs.PosArgs[0] : String();
-    const String work_file_or_dir = cmdargs.PosArgs.size() > 1 ? cmdargs.PosArgs[1] : String();
+    const String src_agf = cmdargs.PosArgs.size() > 0 ? cmdargs.PosArgs[0] : String();
+    const String dst_file_or_dir = cmdargs.PosArgs.size() > 1 ? cmdargs.PosArgs[1] : String();
 
     // TODO: easier way to:
     //  - get either short or long named option;
     //  - get option's value without the search loop in the code
-    SpritePak::CommandOptions opts;
+    SpriteImport::CommandOptions opts;
     for (const auto &opt_with_value : cmdargs.OptWithValue)
     {
         if (opt_with_value.first == "-n" || opt_with_value.first == "--index")
         {
             opts.IndexFile = opt_with_value.second;
-        }
-        if (opt_with_value.first == "--out-index")
-        {
-            opts.OutIndexFile = opt_with_value.second;
         }
         else if (opt_with_value.first == "-p" || opt_with_value.first == "--pattern")
         {
@@ -139,50 +118,34 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
         }
         else if (opt_with_value.first == "-s" || opt_with_value.first == "--storage-flags")
         {
-            opts.StorageFlags = static_cast<SpriteStorage>(StrUtil::StringToIntHex(opt_with_value.second));
+            opts.StorageFlags = static_cast<SpriteImport::SpriteStorage>(StrUtil::StringToIntHex(opt_with_value.second));
         }
         else if (opt_with_value.first == "-z" || opt_with_value.first == "--compress")
         {
-            opts.Compress = CompressionFromName(opt_with_value.second);
+            opts.Compress = DataUtil::CompressionFromName(opt_with_value.second);
         }
     }
     const bool verbose = cmdargs.Opt.count("-v") || cmdargs.Opt.count("--verbose");
 
     // Init
-    SpritePak::Init();
+    SpriteImport::Init();
 
     // Run supported commands
     switch (command)
     {
-    case 'c': // create
+    case 'c': // compile spritefile
     {
         if (cmdargs.PosArgs.size() < 2)
             break; // not enough args
-        return SpritePak::Command_Create(work_file_or_dir, sprite_file, opts, verbose);
+        opts.OutputToSpritePak = true;
+        return SpriteImport::Command_Import(src_agf, dst_file_or_dir, opts, verbose);
     }
-    case 'e': // export
+    case 'f': // write as image files
     {
         if (cmdargs.PosArgs.size() < 2)
             break; // not enough args
-        return SpritePak::Command_Export(sprite_file, work_file_or_dir, opts, verbose);
-    }
-    case 'l': // list
-    {
-        if (cmdargs.PosArgs.size() < 1)
-            break; // not enough args
-        return SpritePak::Command_List(sprite_file, opts);
-    }
-    case 'q': // info
-    {
-        if (cmdargs.PosArgs.size() < 1)
-            break; // not enough args
-        return SpritePak::Command_Info(sprite_file, opts);
-    }
-    case 'y': // copy
-    {
-        if (cmdargs.PosArgs.size() < 2)
-            break; // not enough args
-        return SpritePak::Command_Copy(sprite_file, work_file_or_dir, opts, verbose);
+        opts.OutputToSpritePak = false;
+        return SpriteImport::Command_Import(src_agf, dst_file_or_dir, opts, verbose);
     }
     default:
         printf("Error: no valid command is specified\n");
@@ -200,7 +163,7 @@ int main(int argc, char *argv[])
     printf("%s\n", BIN_STRING);
 
     CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv,
-        { "-n", "--index", "-p", "--pattern", "-s", "--storage-flags", "-z", "--compress", "--out-index"});
+        { "-n", "--index", "-p", "--pattern", "-s", "--storage-flags", "-z", "--compress"});
     if (cmdargs.HelpRequested)
     {
         printf("%s\n", HELP_STRING);

--- a/Tools/spriteimport/main.cpp
+++ b/Tools/spriteimport/main.cpp
@@ -60,7 +60,8 @@ const char *HELP_STRING = "Usage:\n"
 "                   If no pattern is provided, the program will use \"spr%6N%\"\n"
 "                   pattern by default. If no extension is specified in the\n"
 "                   pattern, then \".png\" will be used as an extension.\n"
-// -r, --room-dir   RESERVED: input rooms for 8-bit games (need to read palettes)
+"  -r, --room-dir   directory to search for the room files (roomN.crm);\n"
+"                   this is needed for 8-bit games (require room palettes)\n"
 "  -s, --storage-flags <flags>\n"
 "                   when output is the spritefile: use additional storage\n"
 "                   options, defined using a hexadecimal bitset:\n"
@@ -116,6 +117,10 @@ int DoCommand(const CmdLineOpts::ParseResult &cmdargs)
         {
             opts.ImageFilePattern = opt_with_value.second;
         }
+        else if (opt_with_value.first == "-r" || opt_with_value.first == "--room-dir")
+        {
+            opts.RoomDirectory = opt_with_value.second;
+        }
         else if (opt_with_value.first == "-s" || opt_with_value.first == "--storage-flags")
         {
             opts.StorageFlags = static_cast<SpriteImport::SpriteStorage>(StrUtil::StringToIntHex(opt_with_value.second));
@@ -163,7 +168,7 @@ int main(int argc, char *argv[])
     printf("%s\n", BIN_STRING);
 
     CmdLineOpts::ParseResult cmdargs = CmdLineOpts::Parse(argc, argv,
-        { "-n", "--index", "-p", "--pattern", "-s", "--storage-flags", "-z", "--compress"});
+        { "-n", "--index", "-p", "--pattern", "-r", "--room-dir", "-s", "--storage-flags", "-z", "--compress"});
     if (cmdargs.HelpRequested)
     {
         printf("%s\n", HELP_STRING);

--- a/Tools/spritepak/commands.cpp
+++ b/Tools/spritepak/commands.cpp
@@ -14,6 +14,7 @@
 #include "commands.h"
 #include <allegro.h>
 #include "ac/spritefile.h"
+#include "data/sprite_utils.h"
 #include "gfx/image_file.h"
 #include "util/directory.h"
 #include "util/file.h"
@@ -21,93 +22,15 @@
 #include "util/string_utils.h"
 
 using namespace AGS::Common;
+using namespace AGS::DataUtil;
 
 namespace SpritePak
 {
-
-static const String DefaultPattern = "spr%06d";
-static const String DefaultRegexPattern = "spr\\d{6}";
-static const String DefaultExtension = "png";
-static const CstrArr<kNumSprCompressTypes> CompressionNames = {{"none", "rle", "lzw", "deflate"}};
 
 void Init()
 {
     // Init Allegro RGB shifts; necessary for doing color conversions
     set_rgb_shifts(10, 5, 0, 11, 5, 0, 16, 8, 0, 16, 8, 0, 24);
-}
-
-String GetCompressionName(SpriteCompression compress)
-{
-    return String::Wrapper(StrUtil::SelectCStr<kNumSprCompressTypes>(
-        CompressionNames, compress, "unknown"));
-}
-
-SpriteCompression CompressionFromName(const String &compress_name)
-{
-    return StrUtil::ParseEnum<SpriteCompression, kNumSprCompressTypes>(
-        compress_name, CompressionNames, kSprCompress_None);
-}
-
-static bool ResolveImageFilePattern(const String &pattern, String &res_pattern, String &regex_pattern)
-{
-    if (pattern.IsNullOrSpace())
-    {
-        res_pattern = String::FromFormat("%s.%s", DefaultPattern.GetCStr(), DefaultExtension.GetCStr());
-        regex_pattern = String::FromFormat("%s.%s", DefaultRegexPattern.GetCStr(), DefaultExtension.GetCStr());
-        return true;
-    }
-
-    res_pattern = "";
-    regex_pattern = "";
-    bool found_spritenum = false;
-    const auto parts = pattern.Split('%');
-    // Each second part is assumed a placeholder between two '%'
-    for (size_t i = 0; i < parts.size(); ++i)
-    {
-        if (i % 2 == 0)
-        {
-            res_pattern.Append(parts[i]);
-            regex_pattern.Append(parts[i]);
-        }
-        else if (i < parts.size() - 1)
-        {
-            // Resolve placeholder
-            if ((parts[i].GetLast() == 'N' || parts[i].GetLast() == 'n')
-                && (parts[i].GetLength() == 2) && std::isdigit(parts[i][0]))
-            {
-                res_pattern.AppendFmt("%%0%dd", parts[i][0] - '0');
-                regex_pattern.AppendFmt("\\d{%d}", parts[i][0] - '0');
-                found_spritenum = true;
-            }
-            else
-            {
-                res_pattern.Append("_");
-                regex_pattern.Append("_");
-            }
-        }
-    }
-
-    // We cannot export multiple sprites without a sprite number placeholder
-    if (!found_spritenum)
-        return false;
-
-    if (Path::GetFileExtension(res_pattern).IsEmpty())
-    {
-        res_pattern = String::FromFormat("%s.%s", res_pattern.GetCStr(), DefaultExtension.GetCStr());
-        regex_pattern = String::FromFormat("%s.%s", regex_pattern.GetCStr(), DefaultExtension.GetCStr());
-    }
-    return true;
-}
-
-static HError MakeListOfFiles(std::vector<String> &files, const String &asset_dir, const std::regex &regex)
-{
-    for (FindFile ff = FindFile::Open(asset_dir, regex, true, false, 0);
-         !ff.AtEnd(); ff.Next())
-    {
-        String filename = ff.Current();
-        files.push_back(filename);
-    }
-    return HError::None();
 }
 
 static HError OpenSpriteFile(SpriteFile &reader, const String &sprite_file, const String &index_file,

--- a/Tools/test/data_file_writer_test.cpp
+++ b/Tools/test/data_file_writer_test.cpp
@@ -857,9 +857,10 @@ TEST(DataFileWriter, RoundTripFontBlock)
 TEST(DataFileWriter, RoundTripSpriteFlags)
 {
     DataUtil::GameData game;
+
     game.Sprites = {
-        { 1, DataUtil::kSpriteImport_Real, true },
-        { 3, DataUtil::kSpriteImport_HighRes, false }
+        { 1, 0, 0, 0, DataUtil::kSpriteImport_Real, true },
+        { 3, 0, 0, 0, DataUtil::kSpriteImport_HighRes, false }
     };
 
     std::vector<uint8_t> buffer = WriteGameBlock(game,

--- a/Tools/test/gtest_main.cc
+++ b/Tools/test/gtest_main.cc
@@ -1,0 +1,23 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include <stdio.h>
+#include "gtest/gtest.h"
+#include "test/spriteimport_env.h"
+
+GTEST_API_ int main(int argc, char **argv) {
+    printf("Running main() from %s\n", __FILE__);
+    testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment(new SpriteImportEnv());
+    return RUN_ALL_TESTS();
+}

--- a/Tools/test/spriteimport_env.h
+++ b/Tools/test/spriteimport_env.h
@@ -1,0 +1,34 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "gtest/gtest.h"
+#include <allegro.h>
+
+class SpriteImportEnv : public ::testing::Environment
+{
+public:
+    void SetUp() override
+    {
+        // Init Allegro RGB shifts; necessary for doing color conversions
+        set_rgb_shifts(10, 5, 0, 11, 5, 0, 16, 8, 0, 16, 8, 0, 24);
+        // Force internal "bestfit" table to initialize, as our tests may be
+        // run in parallel, having it initialized during the test may cause
+        // race condition.
+        PALETTE dummy;
+        bestfit_color(dummy, 0, 0, 0);
+    }
+
+    void TearDown() override
+    {
+    }
+};

--- a/Tools/test/spriteimport_test.cpp
+++ b/Tools/test/spriteimport_test.cpp
@@ -1,0 +1,820 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-2026 various contributors
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// https://opensource.org/license/artistic-2-0/
+//
+//=============================================================================
+#include "gtest/gtest.h"
+#include "data/sprite_utils.h"
+#include "util/memory_compat.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+
+//-----------------------------------------------------------------------------
+// HELPER FUNCTIONS
+//-----------------------------------------------------------------------------
+
+GameColorSettings GetDefColorSet32()
+{
+    GameColorSettings set;
+    set.ColorDepth = kGameColorDepth_TrueColor;
+    return set;
+}
+
+GameColorSettings GetDefColorSet16()
+{
+    GameColorSettings set;
+    set.ColorDepth = kGameColorDepth_HighColor;
+    return set;
+}
+
+GameColorSettings GetDefColorSet8()
+{
+    GameColorSettings set;
+    set.ColorDepth = kGameColorDepth_Palette;
+    return set;
+}
+
+SpriteData GetDefImport(int width, int height, int color_depth)
+{
+    SpriteData data;
+    data.AlphaChannel = color_depth == 32;
+    data.ColorDepth = color_depth;
+    data.Height = height;
+    data.ImportAlphaChannel = color_depth == 32;
+    data.ImportHeight = height;
+    data.ImportWidth = width;
+    return data;
+}
+
+PixelBuffer GetDefPixels8(Palette &pal)
+{
+    // WARNING: remember that Allegro 4's palette operations
+    // have 64-color-range precision, so all colors must be multiple of 4
+    std::fill(pal.begin(), pal.end(), RGB{0,0,0,0});
+    // palette 0 is a default transparent slot
+    pal[0] = { 0, 0, 0 };
+    pal[1] = { 255, 0, 0 };
+    pal[2] = { 0, 255, 0 };
+    pal[3] = { 0, 0, 255 };
+    pal[4] = { 255, 255, 0 };
+    pal[5] = { 255, 0, 255 };
+    pal[6] = { 0, 255, 255 };
+    pal[7] = { 255, 255, 255 };
+    pal[8] = { 128, 0, 0 };
+    pal[9] = { 0, 128, 0 };
+    pal[10] = { 0, 0, 128 };
+    pal[11] = { 128, 128, 0 };
+    pal[12] = { 128, 0, 128 };
+    pal[13] = { 0, 128, 128 };
+    pal[14] = { 128, 128, 128 };
+    pal[15] = { 64, 64, 64 };
+    pal[16] = { 32, 32, 32 };
+
+    PixelBuffer image(4, 4, kPxFmt_Indexed8);
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image.GetData());
+    pixels[0] = 1; // top-left
+    pixels[1] = 2;
+    pixels[2] = 3;
+    pixels[3] = 4; // top-right
+    pixels[4] = 5;
+    pixels[5] = 0;
+    pixels[6] = 7;
+    pixels[7] = 8;
+    pixels[8] = 9;
+    pixels[9] = 0;
+    pixels[10] = 11;
+    pixels[11] = 12;
+    pixels[12] = 13; // bottom-left
+    pixels[13] = 14;
+    pixels[14] = 15;
+    pixels[15] = 16; // bottom-right
+    return image;
+}
+
+PixelBuffer GetDefPixels16()
+{
+    PixelBuffer image(4, 4, kPxFmt_R5G6B5);
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image.GetData());
+    pixels[0] = 0xFFFF; // top-left
+    pixels[1] = 0x5555;
+    pixels[2] = MASK_COLOR_16;
+    pixels[3] = 0xEEEE; // top-right
+    pixels[4] = 0xFFFF;
+    pixels[5] = 0xEEEE;
+    pixels[6] = 0xDDDD;
+    pixels[7] = MASK_COLOR_16;
+    pixels[8] = 0xDDDD;
+    pixels[9] = 0xEEEE;
+    pixels[10] = 0x7777;
+    pixels[11] = 0xFFFF;
+    pixels[12] = 0xDDDD; // bottom-left
+    pixels[13] = 0xAAAA;
+    pixels[14] = MASK_COLOR_16;
+    pixels[15] = 0xCCCC; // bottom-right
+    return image;
+}
+
+PixelBuffer GetDefPixels32()
+{
+    PixelBuffer image(4, 4, kPxFmt_A8R8G8B8);
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image.GetData());
+    pixels[0] = 0xFFFFFFFF; // top-left
+    pixels[1] = 0x00555555;
+    pixels[2] = MASK_COLOR_32;
+    pixels[3] = 0xFFEEEEEE; // top-right
+    pixels[4] = 0xFFFFFFFF;
+    pixels[5] = 0xFFEEEEEE;
+    pixels[6] = 0xFFDDDDDD;
+    pixels[7] = MASK_COLOR_32;
+    pixels[8] = 0xFFDDDDDD;
+    pixels[9] = 0xFFEEEEEE;
+    pixels[10] = 0x00777777;
+    pixels[11] = 0xFFFFFFFF;
+    pixels[12] = 0xFFDDDDDD; // bottom-left
+    pixels[13] = 0x00AAAAAA;
+    pixels[14] = MASK_COLOR_32;
+    pixels[15] = 0xFFCCCCCC; // bottom-right
+    return image;
+}
+
+void PrintPixelData8(const BitmapData &bm_data1, const BitmapData &bm_data2)
+{
+    for (size_t i = 0; i < bm_data1.GetDataSize(); ++i)
+    {
+        printf("--- %3d : %3d\n", ((uint8_t*)bm_data1.GetData())[i], ((uint8_t*)bm_data2.GetData())[i]);
+    }
+}
+
+void PrintPixelData16(const BitmapData &bm_data1, const BitmapData &bm_data2)
+{
+    for (size_t i = 0; i < bm_data1.GetDataSize() / 2; ++i)
+    {
+        printf("--- %8x : %8x\n", ((uint16_t*)bm_data1.GetData())[i], ((uint16_t*)bm_data2.GetData())[i]);
+    }
+}
+
+void PrintPixelData32(const BitmapData &bm_data1, const BitmapData &bm_data2)
+{
+    for (size_t i = 0; i < bm_data1.GetDataSize() / 4; ++i)
+    {
+        printf("--- %8x : %8x\n", ((uint32_t*)bm_data1.GetData())[i], ((uint32_t*)bm_data2.GetData())[i]);
+    }
+}
+
+template<typename PxType>
+void TestPixelData4x4(const BitmapData &bm_expect, const BitmapData &bm_result)
+{
+    const PxType *expect_p = reinterpret_cast<const PxType *>(bm_expect.GetData());
+    const PxType *result_p = reinterpret_cast<const PxType *>(bm_result.GetData());
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_EQ(expect_p[i], result_p[i]) << "[" << i << "]: expect " << expect_p[i] << " (0x" << std::hex << expect_p[i] << ") got " << std::dec << result_p[i] << std::hex << " (0x" << result_p[i] << ")";
+}
+
+PixelBuffer ImportDefault8Sprite(const GameColorSettings *use_color_set, const RoomPaletteCache *room_pal_cache, int room_to_use,
+    GameColorDepth convert_to_depth = kGameColorDepth_Palette, SpriteImportTransparency trans = kSpriteImport_LeaveAsIs)
+{
+    Palette pal;
+    PixelBuffer image = GetDefPixels8(pal);
+    // If we are going to "import" this 8-bit sprite into 8-bit destination
+    // then we must convert its palette to Allegro 4's 16-bit RGB palette,
+    // otherwise some color algorithms will break (e.g. bestfit_color).
+    if (convert_to_depth == kGameColorDepth_Palette)
+    {
+        for (auto &p : pal)
+        {
+            p.r /= 4;
+            p.g /= 4;
+            p.b /= 4;
+            p.a /= 4;
+        }
+    }
+
+    PixelBuffer dest;
+    GameColorSettings set;
+    if (use_color_set)
+        set = *use_color_set;
+    else
+        set = GetDefColorSet8();
+    set.ColorDepth = convert_to_depth;
+    SpriteData sprite = GetDefImport(4, 4, 8);
+    if (use_color_set)
+        sprite.RemapToGamePalette = true;
+    if (room_pal_cache)
+    {
+        sprite.RemapToRoomPalette = true;
+        sprite.ColoursLockedToRoom = room_to_use;
+    }
+    sprite.TransparentColour = trans;
+    const auto *src_data = image.GetData();
+    HError err = ConvertSpriteForGame(image, &pal, dest, set, room_pal_cache, sprite);
+    EXPECT_TRUE(err);
+    EXPECT_TRUE(dest.GetData() != nullptr);
+    if (convert_to_depth == kGameColorDepth_Palette)
+        EXPECT_EQ(src_data, dest.GetData()); // no format conversion, moved original buffer
+    else
+        EXPECT_NE(src_data, dest.GetData()); // format conversion, created new buffer
+    return dest;
+}
+
+PixelBuffer ImportDefault8Sprite(GameColorDepth convert_to_depth = kGameColorDepth_Palette, SpriteImportTransparency trans = kSpriteImport_LeaveAsIs)
+{
+    return ImportDefault8Sprite(nullptr, nullptr, -1, convert_to_depth, trans);
+}
+
+PixelBuffer ImportDefault16Sprite(GameColorDepth convert_to_depth = kGameColorDepth_HighColor, SpriteImportTransparency trans = kSpriteImport_LeaveAsIs)
+{
+    auto image = GetDefPixels16();
+    PixelBuffer dest;
+    auto set = GetDefColorSet16();
+    set.ColorDepth = convert_to_depth;
+    SpriteData sprite = GetDefImport(4, 4, 16);
+    sprite.TransparentColour = trans;
+    const auto *src_data = image.GetData();
+    HError err = ConvertSpriteForGame(image, nullptr, dest, set, nullptr, sprite);
+    EXPECT_TRUE(err);
+    EXPECT_TRUE(dest.GetData() != nullptr);
+    if (convert_to_depth == kGameColorDepth_HighColor)
+        EXPECT_EQ(src_data, dest.GetData()); // no format conversion, moved original buffer
+    else
+        EXPECT_NE(src_data, dest.GetData()); // format conversion, created new buffer
+    return dest;
+}
+
+PixelBuffer ImportDefault32Sprite(GameColorDepth convert_to_depth = kGameColorDepth_TrueColor, SpriteImportTransparency trans = kSpriteImport_LeaveAsIs)
+{
+    auto image = GetDefPixels32();
+    PixelBuffer dest;
+    auto set = GetDefColorSet32();
+    set.ColorDepth = convert_to_depth;
+    SpriteData sprite = GetDefImport(4, 4, 32);
+    sprite.TransparentColour = trans;
+    const auto *src_data = image.GetData();
+    HError err = ConvertSpriteForGame(image, nullptr, dest, set, nullptr, sprite);
+    EXPECT_TRUE(err);
+    EXPECT_TRUE(dest.GetData() != nullptr);
+    if (convert_to_depth == kGameColorDepth_TrueColor)
+        EXPECT_EQ(src_data, dest.GetData()); // no format conversion, moved original buffer
+    else
+        EXPECT_NE(src_data, dest.GetData()); // format conversion, created new buffer
+    return dest;
+}
+
+//-----------------------------------------------------------------------------
+// TESTS
+//-----------------------------------------------------------------------------
+
+TEST(SpriteImport, DirectImportNoConversion8)
+{
+    auto dest = ImportDefault8Sprite();
+    EXPECT_EQ(4 * 4, dest.GetDataSize());
+}
+
+TEST(SpriteImport, DirectImportNoConversion16)
+{
+    auto dest = ImportDefault16Sprite();
+    EXPECT_EQ(4 * 4 * 2, dest.GetDataSize());
+}
+
+TEST(SpriteImport, DirectImportNoConversion32)
+{
+    auto dest = ImportDefault32Sprite();
+    EXPECT_EQ(4 * 4 * 4, dest.GetDataSize());
+}
+
+TEST(SpriteImport, DirectImportConvert8To16)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_HighColor);
+    EXPECT_EQ(kPxFmt_R5G6B5, dest.GetFormat());
+    EXPECT_EQ(4 * 4 * 2, dest.GetDataSize());
+
+    auto image2 = PixelBuffer(4, 4, kPxFmt_R5G6B5);
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[0] = makecol16(255, 0, 0);
+    pixels[1] = makecol16(0, 255, 0);
+    pixels[2] = makecol16(0, 0, 255);
+    pixels[3] = makecol16(255, 255, 0);
+    pixels[4] = 0xF83F; //(255, 0, 255) => (255, 4, 255) prevent becoming MASK_COLOR_16 (see Convert8BitToHiColor)
+    pixels[5] = MASK_COLOR_16;
+    pixels[6] = makecol16(255, 255, 255);
+    pixels[7] = makecol16(128, 0, 0);
+    pixels[8] = makecol16(0, 128, 0);
+    pixels[9] = MASK_COLOR_16;
+    pixels[10] = makecol16(128, 128, 0);
+    pixels[11] = makecol16(128, 0, 128);
+    pixels[12] = makecol16(0, 128, 128);
+    pixels[13] = makecol16(128, 128, 128);
+    pixels[14] = makecol16(64, 64, 64);
+    pixels[15] = makecol16(32, 32, 32);
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, DirectImportConvert8To32)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_TrueColor);
+    EXPECT_EQ(kPxFmt_A8R8G8B8, dest.GetFormat());
+    EXPECT_EQ(4 * 4 * 4, dest.GetDataSize());
+
+    auto image2 = PixelBuffer(4, 4, kPxFmt_A8R8G8B8);
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[0] = 0xFFFF0000;
+    pixels[1] = 0xFF00FF00;
+    pixels[2] = 0xFF0000FF;
+    pixels[3] = 0xFFFFFF00;
+    pixels[4] = 0xFFFF00FF;
+    pixels[5] = MASK_COLOR_32;
+    pixels[6] = 0xFFFFFFFF;
+    pixels[7] = 0xFF800000;
+    pixels[8] = 0xFF008000;
+    pixels[9] = MASK_COLOR_32;
+    pixels[10] = 0xFF808000;
+    pixels[11] = 0xFF800080;
+    pixels[12] = 0xFF008080;
+    pixels[13] = 0xFF808080;
+    pixels[14] = 0xFF404040;
+    pixels[15] = 0xFF202020;
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, DirectImportConvert16To32)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_TrueColor);
+    EXPECT_EQ(kPxFmt_A8R8G8B8, dest.GetFormat());
+    EXPECT_EQ(4 * 4 * 4, dest.GetDataSize());
+}
+
+TEST(SpriteImport, DirectImportConvert32To16)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_HighColor);
+    EXPECT_EQ(kPxFmt_R5G6B5, dest.GetFormat());
+    EXPECT_EQ(4 * 4 * 2, dest.GetDataSize());
+}
+
+TEST(SpriteImport, Transparency8LeaveAsIs)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_LeaveAsIs);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16LeaveAsIs)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_LeaveAsIs);
+
+    auto image2 = GetDefPixels16();
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32LeaveAsIs)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_LeaveAsIs);
+
+    auto image2 = GetDefPixels32();
+    // Even though the import spec is LeaveAsIs, the conversion replaces
+    // any zero-alpha pixels with the mask color (0x00FF00FF)
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[1]  = MASK_COLOR_32; // 0x00555555 -> MASK_COLOR_32
+    pixels[10] = MASK_COLOR_32; // 0x00777777 -> MASK_COLOR_32
+    pixels[13] = MASK_COLOR_32; // 0x00AAAAAA -> MASK_COLOR_32
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency8NoTransparency)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_NoTransparency);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    // Replace color 0 with 16 (alternate black)
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[5] = 16;
+    pixels[9] = 16;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16NoTransparency)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_NoTransparency);
+
+    auto image2 = GetDefPixels16();
+    // No transparency import replaces mask color pixels with the nearest color
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[2]  = MASK_COLOR_16 - 1;
+    pixels[7]  = MASK_COLOR_16 - 1;
+    pixels[14] = MASK_COLOR_16 - 1;
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32NoTransparency)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_NoTransparency);
+
+    auto image2 = GetDefPixels32();
+    // Zero alpha pixels are first replaced with the mask color
+    // No transparency import replaces any mask color pixels with the nearest color
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[1]  = MASK_COLOR_32 - 1; // 0x00555555 -> MASK_COLOR_32 -> NO TRANS
+    pixels[2]  = MASK_COLOR_32 - 1; // MASK_COLOR_32 -> NO TRANS
+    pixels[7]  = MASK_COLOR_32 - 1; // MASK_COLOR_32 -> NO TRANS
+    pixels[10] = MASK_COLOR_32 - 1; // 0x00777777 -> MASK_COLOR_32 -> NO TRANS
+    pixels[13] = MASK_COLOR_32 - 1; // 0x00AAAAAA -> MASK_COLOR_32 -> NO TRANS
+    pixels[14] = MASK_COLOR_32 - 1; // MASK_COLOR_32 -> NO TRANS
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency8TopLeft)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_TopLeft);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    // Replace top-left pixel values with 0
+    // Replace color 0 with 16 (alternate black)
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[0] = 0;
+    pixels[5] = 16;
+    pixels[9] = 16;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16TopLeft)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_TopLeft);
+
+    auto image2 = GetDefPixels16();
+    // Pick top-left pixel's value and replace all pixels with this value to the mask color
+    // Existing mask color pixels are replaced with zero-alpha black
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[0] = MASK_COLOR_16;
+    pixels[2] = 0;
+    pixels[4] = MASK_COLOR_16;
+    pixels[7] = 0;
+    pixels[11] = MASK_COLOR_16;
+    pixels[14] = 0;
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32TopLeft)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_TopLeft);
+
+    auto image2 = GetDefPixels32();
+    // Pick top-left pixel's value and replace all pixels with this value to the mask color;
+    // Existing mask color pixels (and zero-alpha pixels) are replaced with zero-alpha black
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[0] = MASK_COLOR_32;
+    pixels[1] = 0;
+    pixels[2] = 0;
+    pixels[4] = MASK_COLOR_32;
+    pixels[7] = 0;
+    pixels[10] = 0;
+    pixels[11] = MASK_COLOR_32;
+    pixels[13] = 0;
+    pixels[14] = 0;
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency8TopRight)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_TopRight);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    // Replace top-right pixel values with 0
+    // Replace color 0 with 16 (alternate black)
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[3] = 0;
+    pixels[5] = 16;
+    pixels[9] = 16;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16TopRight)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_TopRight);
+
+    auto image2 = GetDefPixels16();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color
+    // Existing mask color pixels are replaced with zero-alpha black
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[2] = 0;
+    pixels[3] = MASK_COLOR_16; // top-right
+    pixels[5] = MASK_COLOR_16;
+    pixels[7] = 0;
+    pixels[9] = MASK_COLOR_16;
+    pixels[14] = 0;
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32TopRight)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_TopRight);
+
+    auto image2 = GetDefPixels32();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color;
+    // Existing mask color pixels (and zero-alpha pixels) are replaced with zero-alpha black
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[1] = 0;
+    pixels[2] = 0;
+    pixels[3] = MASK_COLOR_32; // top-right
+    pixels[5] = MASK_COLOR_32;
+    pixels[7] = 0;
+    pixels[9] = MASK_COLOR_32;
+    pixels[10] = 0;
+    pixels[13] = 0;
+    pixels[14] = 0;
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency8BottomLeft)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_BottomLeft);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    // Replace bottom-left pixel values with 0
+    // Replace color 0 with 16 (alternate black)
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[5] = 16;
+    pixels[9] = 16;
+    pixels[12] = 0;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16BottomLeft)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_BottomLeft);
+
+    auto image2 = GetDefPixels16();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color
+    // Existing mask color pixels are replaced with zero-alpha black
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[2] = 0;
+    pixels[6] = MASK_COLOR_16;
+    pixels[7] = 0;
+    pixels[8] = MASK_COLOR_16;
+    pixels[12] = MASK_COLOR_16; // bottom-left
+    pixels[14] = 0;
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32BottomLeft)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_BottomLeft);
+
+    auto image2 = GetDefPixels32();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color;
+    // Existing mask color pixels (and zero-alpha pixels) are replaced with zero-alpha black
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[1] = 0;
+    pixels[2] = 0;
+    pixels[6] = MASK_COLOR_32;
+    pixels[7] = 0;
+    pixels[8] = MASK_COLOR_32;
+    pixels[10] = 0;
+    pixels[12] = MASK_COLOR_32;
+    pixels[13] = 0;
+    pixels[14] = 0;
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency8BottomRight)
+{
+    auto dest = ImportDefault8Sprite(kGameColorDepth_Palette, kSpriteImport_BottomRight);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    // Replace bottom-left pixel values with 0
+    // Replace color 0 with 16 (alternate black)
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[5] = 16;
+    pixels[9] = 16;
+    pixels[15] = 0;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency16BottomRight)
+{
+    auto dest = ImportDefault16Sprite(kGameColorDepth_HighColor, kSpriteImport_BottomRight);
+
+    auto image2 = GetDefPixels16();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color
+    // Existing mask color pixels are replaced with zero-alpha black
+    uint16_t *pixels = reinterpret_cast<uint16_t*>(image2.GetData());
+    pixels[2] = 0;
+    pixels[7] = 0;
+    pixels[14] = 0;
+    pixels[15] = MASK_COLOR_16;
+    /* PrintPixelData16(dest, image2); */
+
+    TestPixelData4x4<uint16_t>(image2, dest);
+}
+
+TEST(SpriteImport, Transparency32BottomRight)
+{
+    auto dest = ImportDefault32Sprite(kGameColorDepth_TrueColor, kSpriteImport_BottomRight);
+
+    auto image2 = GetDefPixels32();
+    // Pick top-right pixel's value and replace all pixels with this value to the mask color;
+    // Existing mask color pixels (and zero-alpha pixels) are replaced with zero-alpha black
+    uint32_t *pixels = reinterpret_cast<uint32_t*>(image2.GetData());
+    pixels[1] = 0;
+    pixels[2] = 0;
+    pixels[7] = 0;
+    pixels[10] = 0;
+    pixels[13] = 0;
+    pixels[14] = 0;
+    pixels[15] = MASK_COLOR_32;
+    /* PrintPixelData32(dest, image2); */
+
+    TestPixelData4x4<uint32_t>(image2, dest);
+}
+
+TEST(SpriteImport, Import8RemapToGamePalette)
+{
+    // WARNING: remember that Allegro 4's palette operations
+    // have 64-color-range precision, so all colors must be multiple of 4
+    GameColorSettings color_set;
+    color_set.Palette[0] = { 32, 32, 32 };
+    color_set.Palette[1] = { 64, 64, 64 };
+    color_set.Palette[2] = { 128, 128, 128 };
+    color_set.Palette[3] = { 0, 128, 128 };
+    color_set.Palette[4] = { 128, 0, 128 };
+    color_set.Palette[5] = { 128, 128, 0 };
+    color_set.Palette[6] = { 0, 0, 128 };
+    color_set.Palette[7] = { 0, 128, 0 };
+    color_set.Palette[8] = { 128, 0, 0 };
+    color_set.Palette[9] = { 255, 255, 255 };
+    color_set.Palette[10] = { 0, 255, 255 };
+    color_set.Palette[11] = { 255, 0, 255 };
+    color_set.Palette[12] = { 255, 255, 0 };
+    color_set.Palette[13] = { 0, 0, 255 };
+    color_set.Palette[14] = { 0, 255, 0 };
+    color_set.Palette[15] = { 255, 0, 0 };
+    color_set.Palette[16] = { 0, 0, 0 };
+
+    // Convert to Allegro 4's 16-bit RGB palette
+    for (auto &p : color_set.Palette)
+    {
+        p.r /= 4;
+        p.g /= 4;
+        p.b /= 4;
+        p.a /= 4;
+    }
+
+    auto dest = ImportDefault8Sprite(&color_set, nullptr, -1, kGameColorDepth_Palette, kSpriteImport_LeaveAsIs);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[0] = 15;
+    pixels[1] = 14;
+    pixels[2] = 13;
+    pixels[3] = 12;
+    pixels[4] = 11;
+    pixels[5] = 0;  // transparency is always at 0
+    pixels[6] = 9;
+    pixels[7] = 8;
+    pixels[8] = 7;
+    pixels[9] = 0;  // transparency is always at 0
+    pixels[10] = 5;
+    pixels[11] = 4;
+    pixels[12] = 3;
+    pixels[13] = 2;
+    pixels[14] = 1;
+    pixels[15] = 1;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}
+
+TEST(SpriteImport, Import8RemapToRoomPalette)
+{
+    // WARNING: remember that Allegro 4's palette operations
+    // have 64-color-range precision, so all colors must be multiple of 4
+    GameColorSettings color_set;
+    color_set.Palette[0] = { 32, 32, 32 };
+    color_set.Palette[1] = { 64, 64, 64 };
+    color_set.Palette[2] = { 128, 128, 128 };
+    color_set.Palette[3] = { 0, 128, 128 };
+    color_set.Palette[4] = { 128, 0, 128 };
+    color_set.Palette[5] = { 128, 128, 0 };
+    color_set.Palette[6] = { 0, 0, 128 };
+    color_set.Palette[7] = { 0, 128, 0 };
+    color_set.Palette[8] = { 128, 0, 0 };
+    color_set.Palette[9] = { 255, 255, 255 };
+    color_set.Palette[10] = { 0, 255, 255 };
+    color_set.Palette[11] = { 255, 0, 255 };
+    color_set.Palette[12] = { 255, 255, 0 };
+    color_set.Palette[13] = { 0, 0, 255 };
+    color_set.Palette[14] = { 0, 255, 0 };
+    color_set.Palette[15] = { 255, 0, 0 };
+    color_set.Palette[16] = { 0, 0, 0 };
+    // Give some color slots to the room background
+    for (int i = 10; i < PAL_SIZE; ++i)
+        color_set.PalUses[i] = kPaletteColourType_Background;
+
+    // Convert to Allegro 4's 16-bit RGB palette
+    for (auto &p : color_set.Palette)
+    {
+        p.r /= 4;
+        p.g /= 4;
+        p.b /= 4;
+        p.a /= 4;
+    }
+
+    Palette room_palette;
+    std::fill(room_palette.begin(), room_palette.end(), RGB{0,0,0,0});
+    room_palette[10] = { 0, 0, 0 };
+    room_palette[11] = { 255, 0, 0 };
+    room_palette[12] = { 0, 255, 0 };
+    room_palette[13] = { 0, 0, 255 };
+    room_palette[14] = { 255, 255, 0 };
+    room_palette[15] = { 255, 0, 255 };
+    room_palette[16] = { 0, 255, 255 };
+
+    // Convert to Allegro 4's 16-bit RGB palette
+    for (auto &p : room_palette)
+    {
+        p.r /= 4;
+        p.g /= 4;
+        p.b /= 4;
+        p.a /= 4;
+    }
+
+    RoomPaletteCache cache;
+    cache[5] = std::make_unique<Palette>(std::move(room_palette));
+
+    auto dest = ImportDefault8Sprite(&color_set, &cache, 5, kGameColorDepth_Palette, kSpriteImport_LeaveAsIs);
+
+    Palette pal2;
+    auto image2 = GetDefPixels8(pal2);
+    uint8_t *pixels = reinterpret_cast<uint8_t*>(image2.GetData());
+    pixels[0] = 11;
+    pixels[1] = 12;
+    pixels[2] = 13;
+    pixels[3] = 14;
+    pixels[4] = 15;
+    pixels[5] = 0;  // transparency is always at 0
+    pixels[6] = 9;
+    pixels[7] = 8;
+    pixels[8] = 7;
+    pixels[9] = 0;  // transparency is always at 0
+    pixels[10] = 5;
+    pixels[11] = 4;
+    pixels[12] = 3;
+    pixels[13] = 2;
+    pixels[14] = 1;
+    pixels[15] = 1;
+    /* PrintPixelData8(dest, image2); */
+
+    TestPixelData4x4<uint8_t>(image2, dest);
+}

--- a/Tools/trac/Makefile
+++ b/Tools/trac/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -O2 -g \
 	-Werror=write-strings -Werror=format -Werror=format-security \
 	-DNDEBUG \
 	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	-DALLEGRO_STATICLINK \
 	$(CFLAGS)
 
 CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)

--- a/libsrc/allegro/include/allegro/color.h
+++ b/libsrc/allegro/include/allegro/color.h
@@ -98,6 +98,7 @@ AL_FUNC(void, hsv_to_rgb, (float h, float s, float v, int *r, int *g, int *b));
 AL_FUNC(void, rgb_to_hsv, (int r, int g, int b, float *h, float *s, float *v));
 
 AL_FUNC(int, bestfit_color, (AL_CONST PALETTE pal, int r, int g, int b));
+AL_FUNC(int, replacement_mask_color, (int depth, int mask_color));
 
 AL_FUNC(int, makecol, (int r, int g, int b));
 AL_FUNC(int, makecol8, (int r, int g, int b));

--- a/libsrc/allegro/src/blit.c
+++ b/libsrc/allegro/src/blit.c
@@ -31,23 +31,7 @@
  */
 static int get_replacement_mask_color(BITMAP *bmp)
 {
-   int depth, c, g = 0;
-
-   depth = bitmap_color_depth(bmp);
-
-   if (depth == 8) {
-      if (rgb_map)
-         return rgb_map->data[31][1][31];
-      else
-         return bestfit_color(_current_palette, 63, 1, 63);
-   }
-   else {
-      do
-         c = makecol_depth(depth, 255, ++g, 255);
-      while (c == bitmap_mask_color(bmp));
-
-      return c;
-   }
+   return replacement_mask_color(bitmap_color_depth(bmp), bitmap_mask_color(bmp));
 }
 
 

--- a/libsrc/allegro/src/color.c
+++ b/libsrc/allegro/src/color.c
@@ -394,6 +394,30 @@ int bestfit_color(AL_CONST PALETTE pal, int r, int g, int b)
 
 
 
+/* get_replacement_mask_color:
+ *  Gets a nearest replacement color for the bitmap's mask color.
+ */
+int replacement_mask_color(int depth, int mask_color)
+{
+   int c, g = 0;
+
+   if (depth == 8) {
+      if (rgb_map)
+         return rgb_map->data[31][1][31];
+      else
+         return bestfit_color(_current_palette, 63, 1, 63);
+   }
+   else {
+      do
+         c = makecol_depth(depth, 255, ++g, 255);
+      while (c == mask_color);
+
+      return c;
+   }
+}
+
+
+
 /* makecol8: 
  *  Converts R, G, and B values (ranging 0-255) to an 8 bit paletted color.
  *  If the global rgb_map table is initialised, it uses that, otherwise


### PR DESCRIPTION
Resolve #3029

This implements a "spriteimport" cli tool, which purpose is to import sprites from source images, according to the Game.agf specs, and then either output them as individual image files (one image file per sprite), or compile into the spritefile.

Usage: `spriteimport <COMMAND> <GAME.AGF> <OUT-PATH> [<COMMAND-OPTIONS>] [<OPTIONS>]`

Commands:
* -c, --out-pak - outputs a compiled spritefile. Additional options '-n', '-s' and '-z' modify this command's behavior.
*  -f, --out-files - outputs sprites as individual image files into the specified directory. The files's names and format is determined by  the pattern option (see '-p'). If not such pattern provided then uses "spr%6N%.png" by default.

NOTE: the command options mimic ones used for "spitepak"'s import and export commands.

Command options:
* -n, --index <indexfile> - when output is the spritefile: specifies the accompanying sprite index file.
* -p, --pattern <name pattern> - when output is image files: use the given pattern to define their naming and image format. The pattern may be given with or without file extension. The pattern may contain following placeholders: * %xN% - sprite number, where 'x' may be any single digit integer specifying number of padding zeroes, e.g. "%6N%." If no pattern is provided, the program will use "spr%6N%" pattern by default. If no extension is specified in the pattern, then ".png" will be used as an extension.
* -s, --storage-flags <flags> - when output is the spritefile: use additional storage options, defined using a hexadecimal bitset:
    * 0x01 - optimize storage size when possible; e.g. write 16/32-bit images as 8-bit images with palette (only when this achieves less space). Default is "0x01".
* -z, --compress <type> - when output is the spritefile: use compression:
    * none
    * rle
    * lzw
    * deflate
    Default is "deflate".

Other options:
* -v, --verbose - print operation details

---

Implementation details.
1. This tool optimizes importing tiled sprites. It first gathers a map of all sprite sources and the sprites that originate from them, then loads each source image file only once, cutting all respective sprites out of it in one go.
2. Because of the above, when compiling a spritefile itself, it does so in a non-trivial way. As it processes one source file after another, it compiles a temporary spritefile, where sprites are in a "random" order. After this is done, it starts the new, final spritefile, and copies data between temp and final ones, making the order of sprites correct.
3. If this tool is told to output individual image files, these may be further used by "spritepak" to compile a spritefile if needed.

---

TODO:
1. [DONE] This draft PR does not do any image conversions yet, so transparency option does not work.
3. [DONE] 8-bit images optionally require to sync with the game's or room's palette.
4. Makefile.

WON'T DO IN THIS PR:
1. Other image formats, such as GIF. Less commonly used, will require adding GIF loading support (may port from stb_image). I'd rather do this as a separate task.