### PR TITLE
ci: add linux makefile builds

### DIFF
--- a/.github/workflows/makefile-build.yml
+++ b/.github/workflows/makefile-build.yml
@@ -1,0 +1,99 @@
+name: Makefile Build
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  linux-make-build:
+    name: Linux (ubuntu)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      PREFIX: /opt/agslibs
+      PKG_CONFIG_PATH: /opt/agslibs/lib/pkgconfig
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-01
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config \
+            libarchive-tools \
+            libasound2-dev libdbus-1-dev libegl1-mesa-dev libgl1-mesa-dev \
+            libgles2-mesa-dev libibus-1.0-dev libpulse-dev libsndio-dev libudev-dev libwayland-dev \
+            libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev \
+            libxrandr-dev libxss-dev libxt-dev libxv-dev libxxf86vm-dev
+
+      - name: Cache built libsrc deps
+        id: libsrc-built-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.PREFIX }}
+          key: ${{ runner.os }}-libsrc-built-${{ hashFiles('libsrc/download.sh', 'libsrc/build_install_downloaded.sh') }}
+
+      - name: Cache libsrc downloads
+        if: steps.libsrc-built-cache.outputs.cache-hit != 'true'
+        id: libsrc-download-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ github.workspace }}/libsrc/ogg
+            ${{ github.workspace }}/libsrc/vorbis
+            ${{ github.workspace }}/libsrc/theora
+            ${{ github.workspace }}/libsrc/SDL
+            ${{ github.workspace }}/libsrc/SDL_sound
+          key: ${{ runner.os }}-libsrc-downloads-${{ hashFiles('libsrc/download.sh') }}
+
+      - name: Download deps in libsrc
+        if: steps.libsrc-built-cache.outputs.cache-hit != 'true' && steps.libsrc-download-cache.outputs.cache-hit != 'true'
+        run: |
+          cd libsrc
+          ./download.sh
+
+      - name: Install libsrc downloads
+        if: steps.libsrc-built-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo mkdir -p "$PREFIX"
+          sudo chown -R "$(id -u):$(id -g)" "$PREFIX"
+          cd libsrc
+          ./build_install_downloaded.sh
+
+      - name: Refresh linker cache
+        run: |
+          sudo ldconfig -n "$PREFIX/lib"
+
+      - name: Setup destdir
+        run: |
+          mkdir destdir
+          arch=$(dpkg --print-architecture)
+          ln -s destdir/usr/local/bin bin_$arch
+          echo "ARCH=$arch" >> "$GITHUB_ENV"
+
+      - name: Build Engine
+        run: |
+          make -j4 PREFIX="$(cd destdir && pwd)/usr/local" --directory=Engine install
+
+      - name: Build Compiler
+        run: |
+          make -j4 PREFIX="$(cd destdir && pwd)/usr/local" --directory=Compiler install
+
+      - name: Build Tools
+        run: |
+          find Tools -name Makefile -execdir make -j4 PREFIX="$(cd destdir && pwd)/usr/local" install \;
+
+      - name: Upload binaries artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ubuntu-make-binaries-${{ env.ARCH }}
+          path: bin_*/*
+          if-no-files-found: error

--- a/libsrc/build_install_downloaded.sh
+++ b/libsrc/build_install_downloaded.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+# change to directory where script is located
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+# NOTE: this entire script is linux specific
+# FIX-ME: we can probably put the flags here and other things to make this script work on macOS and maybe MinGW in MSYS2?
+# For now this guards and exits if things are wrong
+case "$(uname -s)" in
+    Linux)
+        ;;
+    *)
+        echo "Only Linux for now..." >&2
+        exit 1
+        ;;
+esac
+
+# TODO: make this a parameter to this script?
+NPROC=4
+
+# NOTE: these config flags are LINUX specific
+# We could have them in a platform switch clause if we want to also include macOS and MinGW someday
+PREFIX="${PREFIX:-/usr/local}"
+SDL2_CMAKE_DIR="$PREFIX/lib/cmake/SDL2"
+SDL_CONFIGURE_FLAGS=(
+	--enable-shared
+	--enable-loadso
+	--enable-pulseaudio-shared
+	--enable-sndio-shared
+	--enable-x11-shared
+	--enable-oss=no
+	--enable-libsamplerate-shared
+	--enable-video-wayland=no
+	--enable-directfb-shared
+	--enable-rpath=no
+)
+
+autotools_build()
+{
+    local dir="$1"
+    shift
+
+    (
+        cd "$dir"
+        ./autogen.sh
+        ./configure "$@"
+        make -j"$NPROC"
+        make install
+    )
+}
+
+# The actual build starts here
+# The order matters because vorbis depends on libogg
+autotools_build ogg --prefix="$PREFIX"
+autotools_build vorbis --prefix="$PREFIX"
+autotools_build theora --disable-encode --disable-examples --disable-oggtest --prefix="$PREFIX"
+
+(
+    cd SDL
+    ./configure --prefix="$PREFIX" "${SDL_CONFIGURE_FLAGS[@]}"
+    make -j"$NPROC"
+    make install
+)
+
+# SDL_sound only builds with CMake
+(
+    cd SDL_sound
+    mkdir -p build
+    cd build
+    cmake -DSDL2_DIR="$SDL2_CMAKE_DIR" -DSDLSOUND_DECODER_MIDI=1 -DCMAKE_INSTALL_PREFIX="$PREFIX" ..
+    cmake --build . --parallel "$NPROC"
+    make install
+)


### PR DESCRIPTION
Hey, I want to add a CI check for building using the Makefiles. I decided to create a separate workflow file for it. 

I made a script to help build the dependencies (ogg, vorbis, theora, SDL2 and SDL_Sound), and use it. The script is so far Linux only. I may eventually do builds with MinGW in Windows (MSYS2) and also just on regular macOS (clang++), and adjust the script accordingly.

I been using make on macOS lately and I find it really quick to run a build and change things with - I have been using it with Sublime Text for zen coding experience. :)

Anyway, since we are maintaining the Makefiles we might as well check them in the CI.

Note that this build doesn't have to succeed to be able to make releases, it's purely for checking things. I am uploading the artifacts on the CI build in case it's useful for checking things, but they aren't meant for releases - in future releases of the tools for non-Windows systems I plan to simply rely on CMake.