### PR TITLE
Common: fix cmdlineopts access missing val in last opt with value

### DIFF
--- a/Common/test/cmdlineopts_test.cpp
+++ b/Common/test/cmdlineopts_test.cpp
@@ -33,6 +33,7 @@ TEST(CmdLineOpts, ParserBasics) {
     ASSERT_TRUE(parseResult.Opt.count("-a"));
     ASSERT_EQ(parseResult.PosArgs.size(),1);
     ASSERT_STREQ(parseResult.PosArgs[0].GetCStr(),"b");
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 
 
     optParamsWithValues = {};
@@ -46,6 +47,7 @@ TEST(CmdLineOpts, ParserBasics) {
     ASSERT_TRUE(parseResult.Opt.count("-a"));
     ASSERT_EQ(parseResult.PosArgs.size(),1);
     ASSERT_STREQ(parseResult.PosArgs[0].GetCStr(),"b");
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 
 
     optParamsWithValues = {};
@@ -63,6 +65,7 @@ TEST(CmdLineOpts, ParserBasics) {
     ASSERT_EQ(parseResult.PosArgs.size(),2);
     ASSERT_STREQ(parseResult.PosArgs[0].GetCStr(),"a");
     ASSERT_STREQ(parseResult.PosArgs[1].GetCStr(),"pos");
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 }
 
 
@@ -81,6 +84,7 @@ TEST(CmdLineOpts, ParserRaisedHelp) {
     ASSERT_TRUE(parseResult.Opt.count("-h"));
     ASSERT_EQ(parseResult.PosArgs.size(),1);
     ASSERT_STREQ(parseResult.PosArgs[0].GetCStr(),"b");
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 
 
     optParamsWithValues = {};
@@ -94,6 +98,7 @@ TEST(CmdLineOpts, ParserRaisedHelp) {
     ASSERT_TRUE(parseResult.Opt.count("--help"));
     ASSERT_EQ(parseResult.PosArgs.size(),1);
     ASSERT_STREQ(parseResult.PosArgs[0].GetCStr(),"b");
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 }
 
 
@@ -113,6 +118,7 @@ TEST(CmdLineOpts, ParserOptWithValues) {
     ASSERT_STREQ(parseResult.OptWithValue[0].first.GetCStr(),"-a");
     ASSERT_STREQ(parseResult.OptWithValue[0].second.GetCStr(),"b");
     ASSERT_EQ(parseResult.PosArgs.size(),0);
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 
 
     optParamsWithValues = {"-a"};
@@ -127,6 +133,7 @@ TEST(CmdLineOpts, ParserOptWithValues) {
     ASSERT_STREQ(parseResult.OptWithValue[0].first.GetCStr(),"-a");
     ASSERT_STREQ(parseResult.OptWithValue[0].second.GetCStr(),"b");
     ASSERT_EQ(parseResult.PosArgs.size(),0);
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 
 
     optParamsWithValues = {"-D"};
@@ -147,6 +154,7 @@ TEST(CmdLineOpts, ParserOptWithValues) {
     ASSERT_STREQ(parseResult.OptWithValue[3].first.GetCStr(),"-D");
     ASSERT_STREQ(parseResult.OptWithValue[3].second.GetCStr(),"eee");
     ASSERT_EQ(parseResult.PosArgs.size(),0);
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
 }
 
 
@@ -154,8 +162,8 @@ TEST(CmdLineOpts, ParserOptWithValuesTrailingEmpty) {
     ParseResult parseResult = {};
     std::set<String> optParamsWithValues;
 
-    optParamsWithValues = { "-a", "-b", "-c"};
-    const char* argv_a[] = { "program","-a","PARAMa","-b","PARAMb","-c","PARAMc","-v"};
+    optParamsWithValues = { "-a", "-b", "-c" };
+    const char* argv_a[] = { "program", "-a", "PARAMa", "-b", "PARAMb", "-c", "PARAMc", "-v" };
     int argc_a = 8;
 
     parseResult = Parse(argc_a, argv_a, optParamsWithValues);
@@ -170,5 +178,28 @@ TEST(CmdLineOpts, ParserOptWithValuesTrailingEmpty) {
     ASSERT_STREQ(parseResult.OptWithValue[1].second.GetCStr(), "PARAMb");
     ASSERT_STREQ(parseResult.OptWithValue[2].first.GetCStr(), "-c");
     ASSERT_STREQ(parseResult.OptWithValue[2].second.GetCStr(), "PARAMc");
+    ASSERT_EQ(parseResult.PosArgs.size(), 0);
+    ASSERT_TRUE(parseResult.OptWithMissingValue.IsEmpty());
+}
+
+TEST(CmdLineOpts, ParserOptWithValuesMissingLast) {
+    ParseResult parseResult = {};
+    std::set<String> optParamsWithValues;
+
+    optParamsWithValues = { "-a", "-b", "-c" };
+    const char* argv_a[] = { "program", "-v", "-a", "PARAMa", "-b", "PARAMb", "-c" };
+    int argc_a = 7;
+
+    parseResult = Parse(argc_a, argv_a, optParamsWithValues);
+
+    ASSERT_EQ(parseResult.HelpRequested, false);
+    ASSERT_EQ(parseResult.Opt.size(), 1);
+    ASSERT_TRUE(parseResult.Opt.count("-v"));
+    ASSERT_EQ(parseResult.OptWithValue.size(), 2);
+    ASSERT_STREQ(parseResult.OptWithValue[0].first.GetCStr(), "-a");
+    ASSERT_STREQ(parseResult.OptWithValue[0].second.GetCStr(), "PARAMa");
+    ASSERT_STREQ(parseResult.OptWithValue[1].first.GetCStr(), "-b");
+    ASSERT_STREQ(parseResult.OptWithValue[1].second.GetCStr(), "PARAMb");
+    ASSERT_STREQ(parseResult.OptWithMissingValue.GetCStr(), "-c");
     ASSERT_EQ(parseResult.PosArgs.size(), 0);
 }

--- a/Common/util/cmdlineopts.cpp
+++ b/Common/util/cmdlineopts.cpp
@@ -78,8 +78,16 @@ ParseResult Parse(int argc, const char *const argv[], const std::set<String> &op
         }
 
         // picks up `--opt Val`
-        parseResult.OptWithValue.emplace_back(arg, args[i + 1]);
-        ++i; // skip next value, it is not a free parameter
+        // we guard agains the last one missing the value, cause we would access an invalid position
+        if (i + 1 < args.size())
+        {
+            parseResult.OptWithValue.emplace_back(arg, args[i + 1]);
+            ++i; // skip next value, it is not a free parameter (it's Val!)
+        }
+        else
+        {
+            parseResult.OptWithMissingValue = arg;
+        }
     }
 
     return parseResult;

--- a/Common/util/cmdlineopts.h
+++ b/Common/util/cmdlineopts.h
@@ -36,6 +36,7 @@ namespace CmdLineOpts
         std::vector<std::pair<String, String>> OptWithValue{};
         std::vector<String> PosArgs;
         std::multiset<String> Opt;
+        String OptWithMissingValue{};
     };
 
     // opt_params_with_values are the options that always take an argument.


### PR DESCRIPTION
Noted that it was possible to access an invalid vector position when looking into a different case, see https://github.com/adventuregamestudio/ags/issues/3033#issuecomment-5173188901