### PR TITLE
agspak: fix printf int64_t portably

### DIFF
--- a/Tools/agspak/commands.cpp
+++ b/Tools/agspak/commands.cpp
@@ -11,6 +11,7 @@
 // https://opensource.org/license/artistic-2-0/
 //
 //=============================================================================
+#include <cinttypes>
 #include "commands.h"
 #include "data/mfl_utils.h"
 #include "data/include_utils.h"
@@ -66,8 +67,8 @@ static HError CopyAssetLibraryIntoFile(const String &pak_file, const String &dst
     if (verbose)
     {
         append ?
-            printf("Info: appended asset pack attachement:\n\t%lld bytes copied over.\n", copy_count) :
-            printf("Info: written new asset pack:\n\t%lld bytes copied over.\n", copy_count);
+            printf("Info: appended asset pack attachement:\n\t%" PRId64 " bytes copied over.\n", copy_count) :
+            printf("Info: written new asset pack:\n\t%" PRId64 " bytes copied over.\n", copy_count);
     }
     if (has_ender)
         MFLUtil::OverwriteEnder(out_lib_offset, lib_version, pak_out.get());
@@ -106,7 +107,7 @@ static HError CutAssetLibrary(const String &pak_file, bool verbose)
         return new Error("Failed to cut existing asset pack attachement.");
     const soff_t new_size = File::GetFileSize(pak_file);
     if (verbose)
-        printf("Info: cut existing asset pack attachement:\n\ttruncated from %lld to %lld, %lld bytes cut.\n", old_size, new_size, old_size - new_size);
+        printf("Info: cut existing asset pack attachement:\n\ttruncated from %" PRId64 " to %" PRId64 ", %" PRId64 " bytes cut.\n", old_size, new_size, old_size - new_size);
     return HError::None();
 }
 
@@ -463,7 +464,7 @@ int Command_List(const String &src_pak)
     // TODO: print more info, but perhaps require cmd arguments for that? (because it's not always useful)
     for (const auto &asset : lib.AssetInfos)
     {
-        printf("* %-40s[%10lld]\n", asset.FileName.GetCStr(), asset.Size);
+        printf("* %-40s[%10" PRId64 "]\n", asset.FileName.GetCStr(), asset.Size);
     }
     printf("Done.\n");
     return 0;


### PR DESCRIPTION
It looks like int64_t is not always long long integer as expected to use the formatting `"%lld"`. This apparently fails in a Linux system somehow - unfortunately it is an ubuntu system, and we do run a build for it in the CI and somehow it didn't error on this?

The documentation I found in https://en.cppreference.com/cpp/types/integer recommends using `PRId64` macro for printing `int64_t` portably. It also has  a not stating that C++ format macros requires a space between them and the `"` to work properly.

> Because C++ interprets a character immediately following a string literal as a [user-defined string literal](https://en.cppreference.com/cpp/language/user_literal), C code such as `printf("%"PRId64"\n",n);` is invalid C++ and requires a space before `PRId64`.

I have no idea if this use of our `soff_t` type (which is a `int64_t`) happens elsewhere in the code, I was playing the tools and the specific error happened when I wanted to compile agspak. Other tools appear to be fine.

I put as a PR to confirm this actually works (builds alright in the CI). I think this format macro should work and is fine, but the cpp reference docs is a bit confusing - the docs state:

> Each of the PRI macros listed here is defined if and only if the implementation defines the corresponding typedef name.

I guess this means if `int64_t` exists, then this macro will exist, but the macro would error if `int64_t` doesn't exist, which I guess would error more things, so the macro looks safe to use.