### PR TITLE
Editor: fix crash in Recent Games when a long game name exists

### DIFF
--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -112,19 +112,39 @@ namespace AGS.Editor.Components
             return name + "     (" + path + ")";
         }
 
-        private string GetRecentGameMenuText(Preferences.RecentGame game, int maxPrintSize)
+        private string GetRecentGameMenuText(Preferences.RecentGame game, int maxPrintSize, int minPrintPathSize)
         {
-            int maxPrintPathSize = maxPrintSize - GetRecentGameText(game.Name, string.Empty).Length;
+            if (minPrintPathSize < 0 )
+            {
+                throw new ArgumentOutOfRangeException("minPrintPathSize cannot be negative");
+            }
+            if (maxPrintSize < 0 )
+            {
+                throw new ArgumentOutOfRangeException("maxPrintSize cannot be negative");
+            }
+
+            string gameName = game.Name;
+            int maxPrintPathSize = maxPrintSize - GetRecentGameText(gameName, string.Empty).Length;
+            if (maxPrintPathSize < minPrintPathSize)
+            {
+                // it looks like the game name is too big, let's truncate the game name
+                // and add some ellipsis so it show a little bit of the game path.
+                int keep = Math.Min(gameName.Length, maxPrintSize - minPrintPathSize);
+                if (keep < gameName.Length)
+                    gameName = gameName.Substring(0, keep) + "...";
+                maxPrintPathSize = maxPrintSize - GetRecentGameText(gameName, string.Empty).Length;
+            }
             string printablePath = game.Path.Length > maxPrintPathSize
                 ? "..." + game.Path.Substring(game.Path.Length - maxPrintPathSize)
                 : game.Path;
 
-            return GetRecentGameText(game.Name, printablePath);
+            return GetRecentGameText(gameName, printablePath);
         }
 
         private List<MenuCommand> GetRecentGamesSubcommands()
         {
             const int maxPrintSize = 80; // Maximum char length for recent games text
+            const int minPrintPathSize = 30; // Minimal char length for recent games dir path
             var subCommands = new List<MenuCommand>();
             
             if(Factory.AGSEditor.Settings.RecentGames.Count <= 1)
@@ -145,7 +165,7 @@ namespace AGS.Editor.Components
                 string projectPath = Path.Combine(game.Path, AGSEditor.GAME_FILE_NAME);
                 if (File.Exists(projectPath))
                 {
-                    string cmdText = GetRecentGameMenuText(game, maxPrintSize);
+                    string cmdText = GetRecentGameMenuText(game, maxPrintSize, minPrintPathSize);
                     MenuCommand cmd = new MenuCommand(OPEN_RECENT_GAME_COMMAND + i.ToString(), cmdText);
                     subCommands.Add(cmd);
                 }


### PR DESCRIPTION
fix #3027

There is no length limit on the Game Name field, so really long game names caused a crash when maxPrintPathSize became negative.

Instead of just clamping, the idea here is to have minimal path size too, and balancing both path size and the game name size, leaving a bit more characters to the game name.

I tested this with a few different game name sizes and then resorted to directly editing the user.config file in the `AppData/Local/AGS/.../3.6.1.12` directory before loading the Editor. It seems to work, and produce results in the recent games menu that look alright while I hope they are still comprehensible by the game author (they can still read enough to find/understand which are their games).

<img width="805" height="207" alt="image" src="https://github.com/user-attachments/assets/84205075-167e-4579-9b1d-ce7f95509e39" />
