### PR TITLE
Editor: remember the time of rebuild all command, don't rebuild newer rooms

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1271,11 +1271,13 @@ namespace AGS.Editor
 
             Utilities.EnsureStandardSubFoldersExist();
 
+            forceRebuild |= NeedsRebuildForDebugMode();
             forceRebuild |= _game.WorkspaceState.RequiresRebuild;
+            DateTime? requiredRebuildTime = forceRebuild ? (DateTime?)_game.WorkspaceState.RequiredRebuildTime : null;
 
             if (PreCompileGame != null)
             {
-				PreCompileGameEventArgs evArgs = new PreCompileGameEventArgs(forceRebuild);
+				PreCompileGameEventArgs evArgs = new PreCompileGameEventArgs(forceRebuild, requiredRebuildTime);
 				evArgs.Errors = errors;
 
                 PreCompileGame(evArgs);

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -168,16 +168,13 @@ namespace AGS.Editor.Components
 
         private void TestGame(bool withDebugger)
         {
-            bool forceRebuild;
-
-            forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
             if (_agsEditor.SaveGameFiles())
             {
-                var messages = _agsEditor.CompileGame(forceRebuild, true);
-                // The user data may have been amended by the building process
-                _agsEditor.SaveUserDataFile();
+                var messages = _agsEditor.CompileGame(false, true);
                 if (!messages.HasErrors)
                 {
+                    // The user data may have been amended by the building process
+                    _agsEditor.SaveUserDataFile();
                     _testGameInProgress = true;
                     _guiController.InteractiveTasks.TestGame(withDebugger);
                     _guiController.ShowLogPanel(true);
@@ -262,12 +259,13 @@ namespace AGS.Editor.Components
 
 		private void CompileGame(bool forceRebuild)
 		{
-			forceRebuild = _agsEditor.NeedsRebuildForDebugMode() || forceRebuild;
-			if (_agsEditor.SaveGameFiles())
+            _agsEditor.CurrentGame.WorkspaceState.RequiredRebuildTime = DateTime.Now;
+            if (_agsEditor.SaveGameFiles())
 			{
                 var messages = _agsEditor.CompileGame(forceRebuild, false);
                 // The user data may have been amended by the building process
-                _agsEditor.SaveUserDataFile();
+                if (!messages.HasErrors)
+                    _agsEditor.SaveUserDataFile();
                 if (messages.Count == 0)
 				{
                     ShowCompileSuccessMessage();

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1621,7 +1621,7 @@ namespace AGS.Editor.Components
 			return false;
 		}
 
-        private bool RecompileAnyRoomsWhereTheScriptHasChanged(CompileMessages errors, bool rebuildAll)
+        private bool RecompileAnyRoomsWhereTheScriptHasChanged(CompileMessages errors, bool rebuildAll, DateTime? mustRebuildSince)
         {
 			List<UnloadedRoom> roomsToRebuild = new List<UnloadedRoom>();
 			List<string> roomFileNamesToRebuild = new List<string>();
@@ -1638,8 +1638,13 @@ namespace AGS.Editor.Components
                     errors.Add(new CompileError("File not found: " + unloadedRoom.FileName + "; If you deleted this file, delete the room from the Project Explorer using a context menu."));
                     success = false;
                 }
-                else if ((rebuildAll) ||
-					(Utilities.DoesFileNeedRecompile(unloadedRoom.ScriptFileName, unloadedRoom.FileName)) ||
+                // If we're told to rebuild all, and no time is provided, then rebuild regardless of the room file's time.
+                // If we're told to rebuild all, and provided with a time anchor, then test if the room's compiled file
+                // does not exist, or is too old.
+                // If we're not told to rebuild all, then test if any relevant scripts have changed since the last build.
+                else if ((rebuildAll && mustRebuildSince == null) ||
+                    (rebuildAll && mustRebuildSince != null && Utilities.DoesFileNeedRecompile(mustRebuildSince.Value, unloadedRoom.FileName)) ||
+                    (Utilities.DoesFileNeedRecompile(unloadedRoom.ScriptFileName, unloadedRoom.FileName)) ||
 					(HaveScriptHeadersBeenUpdatedSinceRoomWasCompiled(unloadedRoom.FileName)))
                 {
 					roomsToRebuild.Add(unloadedRoom);
@@ -1721,7 +1726,7 @@ namespace AGS.Editor.Components
 
             if (evArgs.AllowCompilation)
             {
-				evArgs.AllowCompilation = RecompileAnyRoomsWhereTheScriptHasChanged(evArgs.Errors, evArgs.ForceRebuild);
+				evArgs.AllowCompilation = RecompileAnyRoomsWhereTheScriptHasChanged(evArgs.Errors, evArgs.ForceRebuild, evArgs.ForceRebuildTime);
             }
         }
 

--- a/Editor/AGS.Editor/Entities/PreCompileGameEventArgs.cs
+++ b/Editor/AGS.Editor/Entities/PreCompileGameEventArgs.cs
@@ -8,16 +8,23 @@ namespace AGS.Editor
 	public class PreCompileGameEventArgs
 	{
 		private bool _forceRebuild;
+		private DateTime? _forceRebuildTime;
 
-		public PreCompileGameEventArgs(bool forceRebuild)
+		public PreCompileGameEventArgs(bool forceRebuild, DateTime? dt)
 		{
 			_forceRebuild = forceRebuild;
+			_forceRebuildTime = dt;
 			AllowCompilation = true;
 		}
 
 		public bool ForceRebuild
 		{
 			get { return _forceRebuild; }
+		}
+
+		public DateTime? ForceRebuildTime
+		{
+			get { return _forceRebuildTime; }
 		}
 
 		public bool AllowCompilation;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1087,10 +1087,10 @@ namespace AGS.Editor
             if (_interactiveTasks.LoadGameFromDisk(projectPath))
             {
                 error = false;
-                bool forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
-                var messages = _agsEditor.CompileGame(forceRebuild, false);
-                if (forceRebuild)
-                    _agsEditor.SaveUserDataFile(); // in case pending config is applied
+                var messages = _agsEditor.CompileGame(false, false);
+                // The user data may have been amended by the building process
+                if (!messages.HasErrors)
+                    _agsEditor.SaveUserDataFile();
 
                 _batchProcessShutdown = true;
                 if (!messages.HasErrors)
@@ -1113,10 +1113,10 @@ namespace AGS.Editor
             if (_interactiveTasks.LoadGameFromDisk(projectPath))
             {
                 error = false;
-                bool forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
-                _agsEditor.CompileGame(forceRebuild, false);
-                if (forceRebuild)
-                    _agsEditor.SaveUserDataFile(); // in case pending config is applied
+                var messages = _agsEditor.CompileGame(false, false);
+                // The user data may have been amended by the building process
+                if (!messages.HasErrors)
+                    _agsEditor.SaveUserDataFile();
 
                 _batchProcessShutdown = true;
 
@@ -1319,9 +1319,10 @@ namespace AGS.Editor
                         MessageBoxOnCompile oldMessageBoxSetting = Factory.AGSEditor.Settings.MessageBoxOnCompile;
                         Factory.AGSEditor.Settings.MessageBoxOnCompile = MessageBoxOnCompile.Never;
 
-                        _agsEditor.CompileGame(true, false);
+                        var messages = _agsEditor.CompileGame(true, false);
                         // The user data may have been amended by the building process
-                        _agsEditor.SaveUserDataFile();
+                        if (!messages.HasErrors)
+                            _agsEditor.SaveUserDataFile();
 
                         Factory.AGSEditor.Settings.MessageBoxOnCompile = oldMessageBoxSetting;
                     }

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -373,6 +373,19 @@ namespace AGS.Editor
         }
 
         /// <summary>
+        /// Returns whether the destinationFile is older than the anchorTime,
+        /// or if the destinationFile doesn't exist.
+        /// </summary>
+        public static bool DoesFileNeedRecompile(DateTime anchorTime, string destinationFile)
+        {
+            if (!File.Exists(destinationFile))
+            {
+                return true;
+            }
+            return (anchorTime >= File.GetLastWriteTime(destinationFile));
+        }
+
+        /// <summary>
         /// Attempts to delete file, handling few common exception cases.
         /// 
         /// Exceptions:

--- a/Editor/AGS.Types/WorkspaceState.cs
+++ b/Editor/AGS.Types/WorkspaceState.cs
@@ -11,6 +11,7 @@ namespace AGS.Types
 	{
 		private BuildConfiguration _lastBuildConfiguration = AGS.Types.BuildConfiguration.Unknown;
         private string _lastBuildGameFileName = "";
+        private bool _requiresRebuild = false;
 
         public WorkspaceState()
 		{
@@ -21,7 +22,12 @@ namespace AGS.Types
 		public BuildConfiguration LastBuildConfiguration
 		{
 			get { return _lastBuildConfiguration; }
-			set { _lastBuildConfiguration = value; }
+			set
+            {
+                if (_lastBuildConfiguration != value)
+                    RequiredRebuildTime = DateTime.Now;
+                _lastBuildConfiguration = value;
+            }
 		}
 
         [Browsable(false)]
@@ -32,7 +38,19 @@ namespace AGS.Types
         }
 
         [Browsable(false)]
-        public bool RequiresRebuild { get; set; } = false;
+        public bool RequiresRebuild
+        {
+            get { return _requiresRebuild; }
+            set
+            {
+                _requiresRebuild = value;
+                if (value)
+                    RequiredRebuildTime = DateTime.Now;
+            }
+        }
+
+        [Browsable(false)]
+        public DateTime RequiredRebuildTime { get; set; } = DateTime.MinValue;
 
         // TODO: generic method of serializing key-value list in a string (or other xml element)
         private static string[] StringListSeparators = new string[] { "," };


### PR DESCRIPTION
Fix #2357

When the project is upgraded from the last version it's marked for the full rebuild, so that all scripts take newer features into account. Because project may consist of multiple rooms, we need to let editor skip those that have already been built in the new version. For this - remember the time when the rebuild order is set, and test it against each room's compiled file.

Do the same thing when:
- Switched Debug/Release configuration
- User ordered "Rebuild all..."

