### PR TITLE
4.0: GetLocationType returns eLocationInvItem 

### DIFF
--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -182,9 +182,6 @@ unsigned int load_new_game = 0;
 int load_new_game_restore = -1;
 SaveCmpSelection load_new_game_restore_cmp = kSaveCmp_All;
 
-// TODO: refactor these global vars into function arguments
-int getloctype_index = 0, getloctype_throughgui = 0;
-
 //=============================================================================
 // Audio
 //=============================================================================
@@ -1661,23 +1658,24 @@ void stop_fast_forwarding() {
     }
 }
 
-// allowHotspot0 defines whether Hotspot 0 returns LOCTYPE_HOTSPOT
-// or whether it returns 0
-int __GetLocationType(int x, int y, int allowHotspot0) {
-    getloctype_index = 0;
-    // If it's not in ProcessClick, then return 0 when over a GUI
-    if ((GetGUIAt(x, y, kHit_Interactable) >= 0) && (getloctype_throughgui == 0))
-        return 0;
+int GetLocationTypeImpl(int *locobj_index, int x, int y, bool click_through_gui, bool allow_hotspot0)
+{
+    if (locobj_index)
+        *locobj_index = -1;
 
-    getloctype_throughgui = 0;
+    if (!click_through_gui && (GetGUIAt(x, y, kHit_Interactable) >= 0))
+    {
+        return LOCTYPE_NOTHING;
+    }
 
-    VpPoint vpt = play.ScreenToRoom(x, y);
-    if (vpt.second < 0)
-        return 0;
-    x = vpt.first.X;
-    y = vpt.first.Y;
-    if ((x>=thisroom.Width) || (x<0) || (y<0) || (y>=thisroom.Height))
-        return 0;
+    // Find out if we're inside the room viewport
+    const VpPoint vpt = play.ScreenToRoom(x, y);
+    const Point room_pt = vpt.first;
+    const int view_index = vpt.second;
+    if ((view_index < 0) || (!RectWH(0, 0, thisroom.Width, thisroom.Height).IsInside(room_pt)))
+    {
+        return LOCTYPE_NOTHING;
+    }
 
     // check characters, objects and walkbehinds, work out which is
     // foremost visible to the player
@@ -1686,18 +1684,20 @@ int __GetLocationType(int x, int y, int allowHotspot0) {
     int objat = GetObjectIDAtRoom(x, y, kHit_Interactable);
 
     int wbat = thisroom.WalkBehindMask->GetPixel(x, y);
+    if (wbat <= 0)
+        wbat = 0;
+    else
+        wbat = croom->walkbehind_base[wbat];
 
-    if (wbat <= 0) wbat = 0;
-    else wbat = croom->walkbehind_base[wbat];
-
-    int winner = 0;
+    int winner = LOCTYPE_NOTHING;
     // if it's an Ignore Walkbehinds object, then ignore the walkbehind
     if ((objat >= 0) && ((objs[objat].flags & OBJF_NOWALKBEHINDS) != 0))
         wbat = 0;
     if ((charat >= 0) && ((game.chars[charat].flags & CHF_NOWALKBEHINDS) != 0))
         wbat = 0;
 
-    if ((charat >= 0) && (objat >= 0)) {
+    if ((charat >= 0) && (objat >= 0))
+    {
         if ((wbat > obj_lowest_yp) && (wbat > char_lowest_yp))
             winner = LOCTYPE_HOTSPOT;
         else if (obj_lowest_yp > char_lowest_yp)
@@ -1705,34 +1705,39 @@ int __GetLocationType(int x, int y, int allowHotspot0) {
         else
             winner = LOCTYPE_CHAR;
     }
-    else if (charat >= 0) {
+    else if (charat >= 0)
+    {
         if (wbat > char_lowest_yp)
             winner = LOCTYPE_HOTSPOT;
         else
             winner = LOCTYPE_CHAR;
     }
-    else if (objat >= 0) {
+    else if (objat >= 0)
+    {
         if (wbat > obj_lowest_yp)
             winner = LOCTYPE_HOTSPOT;
         else
             winner = LOCTYPE_OBJ;
     }
 
-    if (winner == 0) {
+    if (winner == 0)
+    {
         if (hsat >= 0)
             winner = LOCTYPE_HOTSPOT;
     }
 
-    if ((winner == LOCTYPE_HOTSPOT) && (!allowHotspot0) && (hsat == 0))
-        winner = 0;
+    if ((winner == LOCTYPE_HOTSPOT) && (!allow_hotspot0) && (hsat == 0))
+        winner = LOCTYPE_NOTHING;
 
-    if (winner == LOCTYPE_HOTSPOT)
-        getloctype_index = hsat;
-    else if (winner == LOCTYPE_CHAR)
-        getloctype_index = charat;
-    else if (winner == LOCTYPE_OBJ)
-        getloctype_index = objat;
-
+    if (locobj_index)
+    {
+        if (winner == LOCTYPE_HOTSPOT)
+            *locobj_index = hsat;
+        else if (winner == LOCTYPE_CHAR)
+            *locobj_index = charat;
+        else if (winner == LOCTYPE_OBJ)
+            *locobj_index = objat;
+    }
     return winner;
 }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -33,6 +33,7 @@
 #include "ac/global_translation.h"
 #include "ac/gui.h"
 #include "ac/hotspot.h"
+#include "ac/inventoryitem.h"
 #include "ac/keycode.h"
 #include "ac/lipsync.h"
 #include "ac/mouse.h"
@@ -1663,9 +1664,21 @@ int GetLocationTypeImpl(int *locobj_index, int x, int y, bool click_through_gui,
     if (locobj_index)
         *locobj_index = -1;
 
-    if (!click_through_gui && (GetGUIAt(x, y, kHit_Interactable) >= 0))
+    if (!click_through_gui)
     {
-        return LOCTYPE_NOTHING;
+        int gui_index = GetGUIAt(x, y, kHit_Interactable);
+        if (gui_index >= 0)
+        {
+            // On GUI, test if we're above an inventory item
+            int invitem_index = GetInvAt(x, y, kHit_Interactable, kHit_Interactable);
+            if (invitem_index >= 0)
+            {
+                if (locobj_index)
+                    *locobj_index = invitem_index;
+                return LOCTYPE_INVITEM;
+            }
+            return LOCTYPE_NOTHING;
+        }
     }
 
     // Find out if we're inside the room viewport

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -182,7 +182,15 @@ bool check_skip_cutscene_gamepad(int gbut);
 void initialize_skippable_cutscene();
 void stop_fast_forwarding();
 
-int __GetLocationType(int xxx,int yyy, int allowHotspot0);
+// Returns location type under the given screen coordinates.
+// click_through_gui defines whether the hit test should be intercepted by a GUI.
+// allow_hotspot0 defines whether Hotspot 0 returns LOCTYPE_HOTSPOT or LOCTYPE_NOTHING.
+// Returns LOCTYPE_NOTHING if either:
+//  - intercepted by GUI;
+//  - outside a room viewport;
+//  - on a hotspot 0 and allow_hotspot0 == false
+// If location type != LOCTYPE_NOTHING, then fills locobj_index with object's or hotspot's index.
+int GetLocationTypeImpl(int *locobj_index, int x, int y, bool click_through_gui = false, bool allow_hotspot0 = false);
 
 // Called whenever game loses input focus
 void display_switch_out();

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -730,8 +730,8 @@ void GamePlayState::ReadFromSavegame(Stream *in, GameDataVersion data_ver, GameS
     rtint_enabled = in->ReadBool();
     in->ReadInt32();// [DEPRECATED]
     skip_until_char_stops = in->ReadInt32();
-    get_loc_name_last_time = in->ReadInt32();
-    get_loc_name_save_cursor = in->ReadInt32();
+    in->ReadInt32(); // was get_loc_name_last_time, should not serialize
+    in->ReadInt32(); // was get_loc_name_save_cursor, should not serialize
     restore_cursor_mode_to = in->ReadInt32();
     restore_cursor_image_to = in->ReadInt32();
     in->ReadInt16(); // legacy music queue
@@ -986,8 +986,8 @@ void GamePlayState::WriteForSavegame(Stream *out) const
     out->WriteBool(rtint_enabled);
     out->WriteInt32( 0);// [DEPRECATED]
     out->WriteInt32( skip_until_char_stops);
-    out->WriteInt32( get_loc_name_last_time);
-    out->WriteInt32( get_loc_name_save_cursor);
+    out->WriteInt32( 0); // was get_loc_name_last_time, should not serialize
+    out->WriteInt32( 0); // was get_loc_name_save_cursor, should not serialize
     out->WriteInt32( restore_cursor_mode_to);
     out->WriteInt32( restore_cursor_image_to);
     out->WriteInt16( 0 ); // legacy music queue

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -51,24 +51,17 @@ struct ScriptViewport;
 struct ScriptCamera;
 struct ScriptOverlay;
 
-// SavedLocationType defines the type of location which
-// was last hovered by the mouse cursor.
-// This value is used as a index base for the respective kind of entity.
-// See GamePlayState::get_loc_name_last_time and get_loc_name_save_cursor
-enum SavedLocationType
+// A location reference, used to remember where the mouse cursor was.
+struct SceneLocationRef
 {
-    // not over a room
-    kSavedLocType_Undefined = -1,
-    // over a empty place in a room
-    kSavedLocType_NoHotspot = 0,
-    // hotspot base index
-    kSavedLocType_Hotspot   = 0,
-    // inv item base index
-    kSavedLocType_InvItem   = 1000,
-    // character base index
-    kSavedLocType_Character = 2000,
-    // room object base index
-    kSavedLocType_Object    = 3000,
+    int LocationType = LOCTYPE_NOTHING;
+    int ObjectIndex = -1;
+
+    SceneLocationRef() = default;
+    SceneLocationRef(int loc_type, int obj_index = -1) : LocationType(loc_type), ObjectIndex(obj_index) {}
+    inline bool IsDefined() const { return LocationType != LOCTYPE_NOTHING && ObjectIndex >= 0; }
+    bool operator ==(const SceneLocationRef &ref) const { return LocationType == ref.LocationType && ObjectIndex == ref.ObjectIndex; }
+    bool operator !=(const SceneLocationRef &ref) const { return LocationType != ref.LocationType || ObjectIndex != ref.ObjectIndex; }
 };
 
 
@@ -227,8 +220,8 @@ struct GamePlayState
     int   rtint_light = 0;
     bool  rtint_enabled = false;
     int   skip_until_char_stops = 0;
-    int   get_loc_name_last_time = kSavedLocType_Undefined;
-    int   get_loc_name_save_cursor = kSavedLocType_Undefined;
+    SceneLocationRef get_loc_name_last_time;
+    SceneLocationRef get_loc_name_save_cursor;
     int   restore_cursor_mode_to = 0;
     int   restore_cursor_image_to = 0;
     short crossfading_out_channel = 0;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -560,32 +560,16 @@ int GetLocationType(int x, int y)
 // returns location's name and "location reference".
 static const char *GetLocationNameAndRef(int x, int y, SceneLocationRef &loc_ref)
 {
+    // If no room loaded yet, then return nothing
     if (displayed_room < 0)
     {
-        loc_ref = SceneLocationRef(LOCTYPE_NOTHING);
-        return ""; // no room loaded yet
-    }
-
-    // Test GUI separately, because we need to detect inventory items in this case
-    if (GetGUIAt(x, y, kHit_Interactable) >= 0)
-    {
-        // On GUI, test if we're above an inventory item
-        int invitem = GetInvAt(x, y, kHit_Interactable, kHit_Interactable);
-        if (invitem > 0)
-        {
-            loc_ref = SceneLocationRef(LOCTYPE_INVITEM, invitem);
-            return game.invinfo[invitem].name.GetCStr();
-        }
-        else
-        {
-            loc_ref = SceneLocationRef(LOCTYPE_NOTHING);
-            return "";
-        }
+        loc_ref = {};
+        return "";
     }
 
     int getloctype_index = -1;
     // GetLocationType takes screen coords
-    const int loctype = GetLocationTypeImpl(&getloctype_index, x, y, true /* ignore gui */, true /* allow hotspot0 */);
+    const int loctype = GetLocationTypeImpl(&getloctype_index, x, y, false /* dont ignore gui */, true /* allow hotspot0 */);
     loc_ref = SceneLocationRef(loctype, getloctype_index);
     if (loctype == LOCTYPE_NOTHING)
     {
@@ -599,14 +583,21 @@ static const char *GetLocationNameAndRef(int x, int y, SceneLocationRef &loc_ref
         return game.chars[getloctype_index].name.GetCStr();
     }
     // on object
-    if (loctype == LOCTYPE_OBJ)
+    else if (loctype == LOCTYPE_OBJ)
     {
         return croom->obj[getloctype_index].name.GetCStr();
     }
-    // on hotspot
-    if (getloctype_index > 0)
+    // on hotspot (except hotspot 0 which means "empty space")
+    else if (loctype == LOCTYPE_HOTSPOT)
     {
-        return croom->hotspot[getloctype_index].Name.GetCStr();
+        if (getloctype_index > 0)
+        {
+            return croom->hotspot[getloctype_index].Name.GetCStr();
+        }
+    }
+    else if (loctype == LOCTYPE_INVITEM)
+    {
+        return game.invinfo[getloctype_index].name.GetCStr();
     }
     return "";
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -78,7 +78,6 @@ extern GameSetupStruct game;
 extern std::vector<ViewStruct> views;
 extern RoomStatus*croom;
 extern RoomStruct thisroom;
-extern int getloctype_index;
 extern IGraphicsDriver *gfxDriver;
 extern RGB palette[256];
 
@@ -552,10 +551,9 @@ void ShowInputBoxImpl(const char*msg, char *bufr, size_t buf_len) {
     restore_after_dialog();
 }
 
-// GetLocationType exported function - just call through
-// to the main function with default 0
-int GetLocationType(int xxx,int yyy) {
-    return __GetLocationType(xxx, yyy, 0);
+int GetLocationType(int x, int y)
+{
+    return GetLocationTypeImpl(nullptr, x, y, false /* dont click-through gui */, false /* not allow hotspot0 */);
 }
 
 // Finds out what is located under the cursor;
@@ -584,7 +582,9 @@ static const char *GetLocationNameAndIndex(int x, int y, int &loc_index)
         }
     }
 
-    const int loctype = GetLocationType(x, y); // GetLocationType takes screen coords
+    int getloctype_index = -1;
+    // GetLocationType takes screen coords
+    const int loctype = GetLocationTypeImpl(&getloctype_index, x, y);
     // Find out if we're inside the room viewport
     const VpPoint vpt = play.ScreenToRoom(x, y);
     const Point room_pt = vpt.first;
@@ -596,7 +596,7 @@ static const char *GetLocationNameAndIndex(int x, int y, int &loc_index)
     }
 
     // Get if we're above any interactable location
-    const int onhs = getloctype_index; // FIXME: stop using global variable
+    const int onhs = getloctype_index;
     if (loctype == 0)
     {
         loc_index = kSavedLocType_NoHotspot;
@@ -746,11 +746,10 @@ void SetMultitasking (int mode) {
     }
 }
 
-extern int getloctype_throughgui, getloctype_index;
-
-void RoomProcessClick(int xx,int yy,int mood) {
-    getloctype_throughgui = 1;
-    int loctype = GetLocationType (xx, yy);
+void RoomProcessClick(int xx, int yy,int mood)
+{
+    int getloctype_index = -1;
+    int loctype = GetLocationTypeImpl(&getloctype_index, xx, yy, true /* ignore gui */, false /* not allow hotspot0 */);
     VpPoint vpt = play.ScreenToRoom(xx, yy);
     if (vpt.second < 0)
         return;
@@ -788,9 +787,10 @@ void RoomProcessClick(int xx,int yy,int mood) {
         RunHotspotInteraction (getloctype_index, mood);
 }
 
-int IsInteractionAvailable (int xx,int yy,int mood) {
-    getloctype_throughgui = 1;
-    int loctype = GetLocationType (xx, yy);
+int IsInteractionAvailable (int xx, int yy, int mood)
+{
+    int getloctype_index = -1;
+    int loctype = GetLocationTypeImpl(&getloctype_index, xx, yy, true /* ignore gui */, false /* not allow hotspot0 */);
     VpPoint vpt = play.ScreenToRoom(xx, yy);
     if (vpt.second < 0)
         return 0;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -557,84 +557,71 @@ int GetLocationType(int x, int y)
 }
 
 // Finds out what is located under the cursor;
-// returns location's name and "location index" using respective SavedLocationType index base.
-static const char *GetLocationNameAndIndex(int x, int y, int &loc_index)
+// returns location's name and "location reference".
+static const char *GetLocationNameAndRef(int x, int y, SceneLocationRef &loc_ref)
 {
     if (displayed_room < 0)
     {
-        loc_index = kSavedLocType_Undefined;
+        loc_ref = SceneLocationRef(LOCTYPE_NOTHING);
         return ""; // no room loaded yet
     }
 
+    // Test GUI separately, because we need to detect inventory items in this case
     if (GetGUIAt(x, y, kHit_Interactable) >= 0)
     {
         // On GUI, test if we're above an inventory item
         int invitem = GetInvAt(x, y, kHit_Interactable, kHit_Interactable);
         if (invitem > 0)
         {
-            loc_index = kSavedLocType_InvItem + invitem;
+            loc_ref = SceneLocationRef(LOCTYPE_INVITEM, invitem);
             return game.invinfo[invitem].name.GetCStr();
         }
         else
         {
-            loc_index = kSavedLocType_Undefined;
+            loc_ref = SceneLocationRef(LOCTYPE_NOTHING);
             return "";
         }
     }
 
     int getloctype_index = -1;
     // GetLocationType takes screen coords
-    const int loctype = GetLocationTypeImpl(&getloctype_index, x, y);
-    // Find out if we're inside the room viewport
-    const VpPoint vpt = play.ScreenToRoom(x, y);
-    const Point room_pt = vpt.first;
-    const int view_index = vpt.second;
-    if ((view_index < 0) || (!RectWH(0, 0, thisroom.Width, thisroom.Height).IsInside(room_pt)))
+    const int loctype = GetLocationTypeImpl(&getloctype_index, x, y, true /* ignore gui */, true /* allow hotspot0 */);
+    loc_ref = SceneLocationRef(loctype, getloctype_index);
+    if (loctype == LOCTYPE_NOTHING)
     {
-        loc_index = kSavedLocType_Undefined;
         return "";
     }
 
     // Get if we're above any interactable location
-    const int onhs = getloctype_index;
-    if (loctype == 0)
-    {
-        loc_index = kSavedLocType_NoHotspot;
-        return "";
-    }
-
     // on character
     if (loctype == LOCTYPE_CHAR)
     {
-        loc_index = kSavedLocType_Character + onhs;
-        return game.chars[onhs].name.GetCStr();
+        return game.chars[getloctype_index].name.GetCStr();
     }
     // on object
     if (loctype == LOCTYPE_OBJ)
     {
-        loc_index = kSavedLocType_Object + onhs;
-        return croom->obj[onhs].name.GetCStr();
+        return croom->obj[getloctype_index].name.GetCStr();
     }
     // on hotspot
-    if (onhs > 0)
+    if (getloctype_index > 0)
     {
-        loc_index = kSavedLocType_Hotspot + onhs;
-        return croom->hotspot[onhs].Name.GetCStr();
+        return croom->hotspot[getloctype_index].Name.GetCStr();
     }
     return "";
 }
 
 const char *GetLocationName(int x, int y)
 {
-    int loc_index;
-    const char *loc_name = GetLocationNameAndIndex(x, y, loc_index);
+    SceneLocationRef loc_ref;
+    const char *loc_name = GetLocationNameAndRef(x, y, loc_ref);
 
     // If it's a new location, different from the last time we checked,
     // then update "@OVERHOTSPOT@" label(s), and save the last index
-    if (play.get_loc_name_last_time != loc_index)
+    if (play.get_loc_name_last_time != loc_ref)
     {
         GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
-        play.get_loc_name_last_time = loc_index;
+        play.get_loc_name_last_time = loc_ref;
     }
 
     return loc_name;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -743,8 +743,8 @@ void engine_init_game_settings()
     play.anim_background_speed = 0;
     play.mouse_cursor_hidden = 0;
     play.skip_until_char_stops = -1;
-    play.get_loc_name_last_time = kSavedLocType_Undefined;
-    play.get_loc_name_save_cursor = kSavedLocType_Undefined;
+    play.get_loc_name_last_time = {};
+    play.get_loc_name_save_cursor = {};
     play.restore_cursor_mode_to = -1;
     play.restore_cursor_image_to = -1;
     play.ground_level_areas_disabled = 0;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -81,7 +81,6 @@ extern ScriptSystem scsystem;
 extern GameSetupStruct game;
 extern RoomStruct thisroom;
 extern int game_paused;
-extern int getloctype_index;
 extern bool in_enters_screen;
 extern bool done_as_error;
 extern int in_leaves_screen;
@@ -1129,11 +1128,10 @@ static void update_cursor_over_location(int mwasatx, int mwasaty)
         (offsetxWas != offsetx) || (offsetyWas != offsety))) 
     {
         // mouse moves over hotspot
-        if (__GetLocationType(mousex, mousey, 1) == LOCTYPE_HOTSPOT)
+        int getloctype_index = -1;
+        if (GetLocationTypeImpl(&getloctype_index, mousex, mousey, false /* dont click-through gui */, true /* allow hotspot0 */) == LOCTYPE_HOTSPOT)
         {
-            int onhs = getloctype_index;
-
-            setevent(AGSEvent_Object(kObjEventType_Hotspot, onhs, kHotspotEvent_MouseOver));
+            setevent(AGSEvent_Object(kObjEventType_Hotspot, getloctype_index, kHotspotEvent_MouseOver));
         }
     }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -1053,12 +1053,12 @@ static void UpdateSavedCursorOverLocation()
     // so it may be not necessary here.
     GetLocationName(mousex, mousey);
 
-    if ((play.get_loc_name_save_cursor >= 0) &&
+    if ((play.get_loc_name_save_cursor.IsDefined()) &&
         (play.get_loc_name_save_cursor != play.get_loc_name_last_time) &&
         (mouse_on_iface < 0) && (ifacepopped < 0)) {
         // we have saved the cursor, but the mouse location has changed
         // and it's time to restore it
-        play.get_loc_name_save_cursor = kSavedLocType_Undefined;
+        play.get_loc_name_save_cursor = {};
         set_cursor_mode(play.restore_cursor_mode_to);
 
         if (cur_mode == play.restore_cursor_mode_to)


### PR DESCRIPTION
Made this a PR, because I'd like to know if there exist any counter-arguments for this.

Recently i've added `eLocationInvItem` to use in `unhandled_event`, and a user asked me why it's not returned from `GetLocationType` too. I cannot see a reason not to really. Because `GetLocationName` (now it's called `GetDisplayNameAt`) returns inventory item names, so why not also return the type? It's difficult to imagine a scenario in which a user would like GetLocationType to skip through the inventory gui and return some room object below it (and then, there's always GetAtScreenXY, and other tricks).

The PR contains couple of refactor commits which are also suitable for backporting to ags3.