### PR TITLE
Engine: VS Solution copies SDL2.dll

### DIFF
--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -1070,4 +1070,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemGroup>
+    <None Include="$(AGS_SDL_DLL)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Solutions/sdl2.props
+++ b/Solutions/sdl2.props
@@ -22,4 +22,11 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
+  <PropertyGroup Condition="'$(Platform)'=='Win32'">
+    <AGS_SDL_DLL>$(AGS_SDL_LIB)\SDL2.dll</AGS_SDL_DLL>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
+    <AGS_SDL_DLL>$(AGS_SDL_LIB)\..\x64\SDL2.dll</AGS_SDL_DLL>
+    <AGS_SDL_DLL Condition="'$(AGS_SDL_LIB_X64)'!=''">$(AGS_SDL_LIB_X64)\SDL2.dll</AGS_SDL_DLL>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
let's see how this works in the CI first. Locally this appears to copy correctly with the correct bitness when varying between Win32 and x64 in VS.

Info on `None`: https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=visualstudio&viewFallbackFrom=vs-2019#none

I think for our usecase `None` and `Content` may be used interchangeably, afaict their differences are more significant in a ASP .NET usecase.

I looked into this sometime ago and found it weird there wasn't some default way of linking a .dll library to a C++ project in a way its reference gets copied, but I am really ignorant of this. If I recall even in CMake, if it is dynamically linked you need a weird manual copy command too. Edit: [found the docs I had in mind](https://learn.microsoft.com/en-us/cpp/build/adding-references-in-visual-cpp-projects?view=msvc-170#dynamic-link-libraries), it gives no explanation on how to copy the dlls.

This PR will appear in VS itself like below

<img width="642" height="255" alt="image" src="https://github.com/user-attachments/assets/5d843bfb-9bc4-4523-9d92-b6116ec33690" />

Without it, it doesn't copy the SDL2.dll and the project in VS looks like this

<img width="203" height="141" alt="image" src="https://github.com/user-attachments/assets/571a4730-e704-460f-b87e-393ae61147a6" />

For the sdl2.props file, in terms of organization of the text, I can also instead group the Win32 (x86) stuff on top, and then the x64 on the bottom.