### PR TITLE
Engine: fix location type not using room coords

### DIFF
--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1662,6 +1662,8 @@ int GetLocationTypeImpl(int *locobj_index, int x, int y, int hit_options, bool c
 
     // check characters, objects and walkbehinds, work out which is
     // foremost visible to the player
+    x = room_pt.X;
+    y = room_pt.Y;
     int charat = GetCharIDAtRoom(x, y, hit_options);
     int hsat = GetHotspotIDAtRoom(x, y, hit_options);
     int objat = GetObjectIDAtRoom(x, y, hit_options);


### PR DESCRIPTION
I am unsure, but reading the commit https://github.com/adventuregamestudio/ags/commit/d34426de52cc3f3056a19f471ae67744b3cb8e96 I think there is an issue with the resulting coordinates. I am trying to decipher why clicking in cHologram in Tumbleweed room2 is not possible and the only thing I could come up with is that room scrolls.

Feel free to discard this PR if this is incorrect or the fix is wrong, because I will be away from my computer for a little while.

Also, I think the commit of the refactor was originally in ags4 , so there is a chance something broke there too.