### PR TITLE
CMakeLists: add spriteimport to the list of tools

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -202,7 +202,7 @@ set_target_properties(crmpak PROPERTIES
         )
 target_link_libraries(crmpak PUBLIC libtools)
 
-#----- spritepak -------------------------------------------------
+#----- spriteimport -------------------------------------------------
 add_executable(spriteimport spriteimport/main.cpp
         spriteimport/commands.h
         spriteimport/commands.cpp
@@ -238,6 +238,7 @@ list(APPEND TOOLS_TARGETS
         agfexport
         agspak
         crmpak
+        spriteimport
         spritepak
         trac
         )


### PR DESCRIPTION
It appears that I forgot to do this in #3030