### PR TITLE
Engine: do not auto-translate values of get/set properties in script

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -134,6 +134,9 @@ Expanded Color properties for GUI Controls. TextBox's TextAlignment.
 Character blocking rectangle set up at design time.
 3.6.3.10:
 Updated inventory behavior; don't secretly disable all Labels on startup.
+3.6.3.14:
+Do not auto-translate text properties which are set or get in script
+(by principle, only translate texts that are about to be displayed on screen).
 */
 
 enum GameDataVersion
@@ -198,7 +201,8 @@ enum GameDataVersion
     kGameVersion_363_06         = 3060306,
     kGameVersion_363_08         = 3060308,
     kGameVersion_363_10         = 3060310,
-    kGameVersion_Current        = kGameVersion_363_10
+    kGameVersion_363_14         = 3060314,
+    kGameVersion_Current        = kGameVersion_363_14
 };
 
 #endif // __AGS_CN_AC__GAMEVERSION_H

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -108,7 +108,7 @@ void Button_GetText(GUIButton *butt, char *buffer) {
 }
 
 void Button_SetText(GUIButton *butt, const char *newtx) {
-    newtx = get_translation(newtx);
+    newtx = get_compat_prop_translation(newtx);
 
     if (butt->GetText() != newtx) {
         butt->SetText(newtx);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -172,7 +172,7 @@ const char *Dialog_GetOptionText(ScriptDialog *sd, int option)
 
     option--; // option id is 1-based in script, and 0 is entry point
 
-    return CreateNewScriptString(get_translation(dialog[sd->id].Options[option].Text.GetCStr()));
+    return CreateNewScriptString(get_compat_prop_translation(dialog[sd->id].Options[option].Text.GetCStr()));
 }
 
 void Dialog_SetOptionText(ScriptDialog *sd, int option, const char *text)
@@ -450,7 +450,7 @@ int run_dialog_script(int dialogID, int offse, int optionIndex)
             param1 = game.playercharacter;
 
           if (param1 == DCHAR_NARRATOR)
-            Display(get_translation(old_speech_lines[param2].GetCStr()));
+            Display(old_speech_lines[param2].GetCStr()); // translated inside Display
           else
             DisplaySpeech(get_translation(old_speech_lines[param2].GetCStr()), param1);
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1012,7 +1012,10 @@ const char* Game_GetGlobalMessages(int index) {
         return nullptr;
     }
     char buffer[STD_BUFFER_SIZE];
-    replace_tokens(get_translation(get_global_message(index)), buffer, STD_BUFFER_SIZE);
+    // Must translate here, as it's potentially a formatted string with macros.
+    // FIXME: get_global_message() already does get_translation(), but IMO that's wrong,
+    // and should be refactored. Instead call get_translation() after getting a message text.
+    replace_tokens(get_global_message(index), buffer, STD_BUFFER_SIZE);
     return CreateNewScriptString(buffer);
 }
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -44,6 +44,7 @@ std::array<const char*, kNum_RBS> RBSwitchNames =
     "smooth_walk",                  // kRBO_SmoothWalkTransition
     "gui_text_direction",           // kRBO_ApplyGUITextDirection
     "dialog_opt_text_alignment",    // kRBO_ApplyDialogOptionTextAlignment
+    "no_textprop_autotranslate",    // kRBO_NoTextPropertyAutoTranslate
 }};
 
 GamePlayState::GamePlayState()

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -768,7 +768,7 @@ static const char *GetLocationNameAndRef(SceneLocationRef &loc_ref, int x, int y
         if (invitem > 0)
         {
             loc_ref = SceneLocationRef(LOCTYPE_INVITEM, invitem);
-            return get_translation(game.invinfo[invitem].name.GetCStr());
+            return get_compat_prop_translation(game.invinfo[invitem].name.GetCStr());
         }
         else
         {
@@ -790,12 +790,12 @@ static const char *GetLocationNameAndRef(SceneLocationRef &loc_ref, int x, int y
     // on character
     if (loctype == LOCTYPE_CHAR)
     {
-        return get_translation(game.chars2[getloctype_index].name_new.GetCStr());
+        return get_compat_prop_translation(game.chars2[getloctype_index].name_new.GetCStr());
     }
     // on object
     if (loctype == LOCTYPE_OBJ)
     {
-        const char *out_name = get_translation(croom->obj[getloctype_index].name.GetCStr());
+        const char *out_name = get_compat_prop_translation(croom->obj[getloctype_index].name.GetCStr());
         // Compatibility: < 3.1.1 games returned space for nameless object
         // (presumably was a bug, but fixing it affected certain games behavior)
         if (loaded_game_file_version < kGameVersion_311 && out_name[0] == 0)
@@ -807,7 +807,7 @@ static const char *GetLocationNameAndRef(SceneLocationRef &loc_ref, int x, int y
     // on hotspot
     if (getloctype_index > 0)
     {
-        return get_translation(croom->hotspot[getloctype_index].Name.GetCStr());
+        return get_compat_prop_translation(croom->hotspot[getloctype_index].Name.GetCStr());
     }
     return "";
 }

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -92,7 +92,7 @@ void GetHotspotName(int hotspot, char *buffer) {
     if ((hotspot < 0) || (hotspot >= MAX_ROOM_HOTSPOTS))
         quit("!GetHotspotName: invalid hotspot number");
 
-    snprintf(buffer, MAX_MAXSTRLEN, "%s", get_translation(croom->hotspot[hotspot].Name.GetCStr()));
+    snprintf(buffer, MAX_MAXSTRLEN, "%s", get_compat_prop_translation(croom->hotspot[hotspot].Name.GetCStr()));
 }
 
 void RunHotspotInteraction (int hotspothere, int mood) {

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -131,7 +131,7 @@ void GetInvName(int indx, char*buff)
     VALIDATE_STRING(buff);
     if (!ValidateInventoryItem("GetInvName", indx))
         return;
-    snprintf(buff, MAX_MAXSTRLEN, "%s", get_translation(game.invinfo[indx].name.GetCStr()));
+    snprintf(buff, MAX_MAXSTRLEN, "%s", get_compat_prop_translation(game.invinfo[indx].name.GetCStr()));
 }
 
 int GetInvGraphic(int indx)

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -412,7 +412,7 @@ void GetObjectName(int obj, char *buffer) {
     if (!is_valid_object(obj))
         quit("!GetObjectName: invalid object number");
 
-    snprintf(buffer, MAX_MAXSTRLEN, "%s", get_translation(croom->obj[obj].name.GetCStr()));
+    snprintf(buffer, MAX_MAXSTRLEN, "%s", get_compat_prop_translation(croom->obj[obj].name.GetCStr()));
 }
 
 void MoveObject(int objj,int xx,int yy,int spp) {

--- a/Engine/ac/global_translation.cpp
+++ b/Engine/ac/global_translation.cpp
@@ -26,10 +26,11 @@ using namespace AGS::Common::Memory;
 
 extern AGSPlatformDriver *platform;
 
-const char *get_translation (const char *text) {
-    if (text == nullptr)
-        quit("!Null string supplied to CheckForTranslations");
-
+const char *get_translation(const char *text)
+{
+    if (!text)
+        text = "";
+    // FIXME: dont use global variable, remake into the function parameter!
     source_text_length = GetTextDisplayLength(text);
     if (text[0] == 0)
         return ""; // don't try translating an empty line
@@ -46,6 +47,14 @@ const char *get_translation (const char *text) {
         return it->second.GetCStr();
     // return the original text
     return text;
+}
+
+const char *get_compat_prop_translation(const char *text)
+{
+    if (play.GetRBSwitches()[kRBO_NoTextPropertyAutoTranslate])
+        return text;
+    else
+        return get_translation(text);
 }
 
 int IsTranslationAvailable () {

--- a/Engine/ac/global_translation.h
+++ b/Engine/ac/global_translation.h
@@ -18,11 +18,18 @@
 #ifndef __AGS_EE_AC__GLOBALTRANSLATION_H
 #define __AGS_EE_AC__GLOBALTRANSLATION_H
 
-// WARNING: get_translation returns original char* if no translation is found;
+// Use the provided text as a key and returns the mapped translation.
+// Returns the original text back if no matching translation found.
+// WARNING: get_translation returns original char* ptr if no translation is found;
 // for that reason make sure that you don't pass temporary buffer there, unless
 // you use returned value immediately or save it in another buffer.
-const char *get_translation (const char *text);
-int IsTranslationAvailable ();
+const char *get_translation(const char *text);
+// A backwards compatible translation of the script property values.
+// For 3.6.3+ games it does NO translation and always returns original string.
+// For < 3.6.3 games it acts like get_translation(), unless
+// kRBO_NoTextPropertyAutoTranslate behavior switch is set by config.
+const char *get_compat_prop_translation(const char *text);
+int IsTranslationAvailable();
 // GetTranslationName assumes a string buffer of MAX_MAXSTRLEN
 int GetTranslationName(char *buffer);
 

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -98,7 +98,7 @@ void Hotspot_GetName(ScriptHotspot *hss, char *buffer) {
 const char* Hotspot_GetName_New(ScriptHotspot *hss) {
     if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
         quit("!Hotspot.Name: invalid hotspot number");
-    return CreateNewScriptString(get_translation(croom->hotspot[hss->id].Name.GetCStr()));
+    return CreateNewScriptString(get_compat_prop_translation(croom->hotspot[hss->id].Name.GetCStr()));
 }
 
 void Hotspot_SetName(ScriptHotspot *hss, const char *newName) {

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -122,7 +122,7 @@ void InventoryItem_GetName(ScriptInvItem *iitem, char *buff) {
 }
 
 const char* InventoryItem_GetName_New(ScriptInvItem *invitem) {
-  return CreateNewScriptString(get_translation(game.invinfo[invitem->id].name.GetCStr()));
+  return CreateNewScriptString(get_compat_prop_translation(game.invinfo[invitem->id].name.GetCStr()));
 }
 
 int InventoryItem_GetGraphic(ScriptInvItem *iitem) {

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -34,7 +34,7 @@ void Label_GetText(GUILabel *labl, char *buffer) {
 }
 
 void Label_SetText(GUILabel *labl, const char *newtx) {
-    newtx = get_translation(newtx);
+    newtx = get_compat_prop_translation(newtx);
 
     if (labl->GetText() != newtx) {
         labl->SetText(newtx);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -320,7 +320,7 @@ const char* Object_GetName_New(ScriptObject *objj) {
     if (!is_valid_object(objj->id))
         quit("!Object.Name: invalid object number");
 
-    return CreateNewScriptString(get_translation(croom->obj[objj->id].name.GetCStr()));
+    return CreateNewScriptString(get_compat_prop_translation(croom->obj[objj->id].name.GetCStr()));
 }
 
 void Object_SetName(ScriptObject *objj, const char *newName) {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -220,6 +220,7 @@ const char* Room_GetMessages(int index) {
         return nullptr;
     }
     char buffer[STD_BUFFER_SIZE];
+    // Must translate here, as it's potentially a formatted string with macros.
     replace_tokens(get_translation(thisroom.Messages[index].GetCStr()), buffer, STD_BUFFER_SIZE);
     return CreateNewScriptString(buffer);
 }

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -308,6 +308,8 @@ enum RuntimeBehaviorSwitch
     kRBO_ApplyGUITextDirection,
     // Apply text alignment for dialog options (and auto-switch when translation changes)
     kRBO_ApplyDialogOptionTextAlignment,
+    // Do not auto-translate values of text properties; only translate displayed text
+    kRBO_NoTextPropertyAutoTranslate,
     kNum_RBS
 };
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -602,6 +602,7 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
     rbo[kRBO_SmoothWalkTransition] = (loaded_game_file_version >= kGameVersion_361);
     rbo[kRBO_ApplyGUITextDirection] = (loaded_game_file_version >= kGameVersion_361);
     rbo[kRBO_ApplyDialogOptionTextAlignment]= (loaded_game_file_version >= kGameVersion_363);
+    rbo[kRBO_NoTextPropertyAutoTranslate]= (loaded_game_file_version >= kGameVersion_363_14);
 
     // Now apply overrides from config, *BUT* these only enable disabled options,
     // and never disable enabled ones (because that might break or "downgrade" modern games).

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -149,9 +149,10 @@ Locations of two latter files differ between running platforms:
   game looks.
   * new_key_mode = \[0; 1\] - enforce new key handling mode, where each button is firing separate event, and button codes do not depend on the keyboard layout. WARNING: may cause script errors in certain old games.
 * **\[override_behavior\]** - options, overriding backwards-compatible engine behavior. When running old games, the engine tries to emulate old behavior as close as possible. This may include various restrictions and inconveniences. These options allow to enable *modern* behavior on a per-case basis. NOTE: you can only enable new behavior in old games, you won't be able to disable modern behavior in games where it is a standard.
-  * smooth_walk = \[0; 1\] - enable seamless transition between consecutive walk commands. WARNING: may cause script errors in certain old games.
-  * gui_text_direction = \[0; 1\] - enable applying text direction on gui controls other than labels (labels support it always).
   * dialog_opt_text_alignment = \[0; 1\] - enable applying text alignment in dialog options.
+  * gui_text_direction = \[0; 1\] - enable applying text direction on gui controls other than labels (labels support it always).
+  * no_textprop_autotranslate = \[0; 1\] - disable auto-translation of text property values that are get or set in script.
+  * smooth_walk = \[0; 1\] - enable seamless transition between consecutive walk commands. WARNING: may cause logical errors in certain old games.
 * **\[disabled\]** - special instructions for the setup program hinting to disable particular options or lock some in the certain state. Ignored by the engine.
   * gfxdrivers = \[0; 1\] - tells to lock "Graphics driver" selection in a default state;
   * \<gfxdriver id\> = \[0; 1\] - tells to remove particular graphics driver from the selection list;


### PR DESCRIPTION
This fixes problem #1940 in 3.6.3 branch. Previously I fixed it in ags4, being reluctant of changing this behavior in 3.x, but now it seems like this may be wanted in 3.x as well, because the inconsistent behavior causes annoying issues when translating the game, and especially when trying to translate old games.

This removes inconsistent translation of game texts when they are either assigned to object properties or retrieved from ones. The principle to follow is this: properties set and get untranslated strings, the text is only automatically translated when displayed or drawn somewhere. Note: user still has an option to explicitly translate anything using GetTranslation function.

Affected script properties and functions:
* Button.Text (setting)
* Label.Text (setting)
* Dialog.GetOptionText()
* Hotspot.Name (getting)
* InventoryItem.Name (getting)
* Object.Name (getting)
* Game.GetLocationName()

Did not change:
* Game.GlobalMessages[] (getting)
* Room.Messages[] (getting)

The latter two cannot be changed, because these "messages" are potentially format strings with macros, and must be translated before replacing macros with values. The returned strings may be already modified, and cannot be used as translation keys later on.

**For backwards compatibility**, introduced kRBO_NoTextPropertyAutoTranslate behavior switch, and get_compat_prop_translation() function, which returns same text always for the 3.6.3+ games, or when kRBO_NoTextPropertyAutoTranslate switch is set in config. Otherwise returns translated string. User may add following in config to force "new" behavior in the old game:
```
[override_behavior]
no_textprop_autotranslate=1
```
