### PR TITLE
ci: add tools to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -862,7 +862,7 @@ jobs:
 
       - name: Install bsdtar
         run: sudo apt-get update -y && sudo apt-get install -y libarchive-tools
-        
+
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4
         with:
@@ -874,13 +874,13 @@ jobs:
         run: |
           TAG_NAME=${{ env.BASE_BRANCH }}-${{ matrix.platform.arch }}
           IMAGE="ghcr.io/${{ github.repository_owner }}/ags-linux-builder-image:$TAG_NAME"
-  
+
           docker run --rm \
             -v "$PWD:/workspace" \
             -w /workspace \
             "$IMAGE" \
             bash -c 'find Tools -name Makefile -execdir make -j4 PREFIX=/workspace/dist-tools/usr/local install \; && make -j4 --directory=Compiler PREFIX=/workspace/dist-tools/usr/local install'
-    
+
       - name: Create Linux Tools archive ${{ matrix.platform.archname }}
         run: |
           bsdtar -f "linux-tools-${{ matrix.platform.archname }}.tar.gz" -cvzC dist-tools/usr/local/bin .
@@ -963,7 +963,7 @@ jobs:
         with:
           name: tools-linux-archive
           include-hidden-files: true
-          path: AGS-Tools-*-Linux.tar.gz  
+          path: AGS-Tools-*-Linux.tar.gz
 
   windows-packaging:
     name: Windows Packaging
@@ -1120,6 +1120,7 @@ jobs:
       - build-android-bundle
       - build-linux-bundle
       - windows-packaging
+      - package-tools-archives
       - package-pdbs
     steps:
       - uses: actions/checkout@v6
@@ -1206,6 +1207,18 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: ags-bundle-android
+          path: /tmp/github_release
+
+      - name: Download Windows Tools archive
+        uses: actions/download-artifact@v8
+        with:
+          name: tools-windows-archive
+          path: /tmp/github_release
+
+      - name: Download Linux Tools archive
+        uses: actions/download-artifact@v8
+        with:
+          name: tools-linux-archive
           path: /tmp/github_release
 
       - name: Generate SHA-256 checksums


### PR DESCRIPTION
fix #3061

Initially my idea is to just add the Windows Tools to release. Note that the archive currently has both the x86 and x64 tools, and I am not sure that is the best way to go. I think we can make one version of the tools for release and later change the shape of the archives as we understand better how to work with them. I imagine we may change again if at some point the tools are added along the Editor.

I added also makefile builds of the tools for Linux and macOS, Linux build is also added to the release.

I didn't add the macOS tools to the release since they will require using `xattr -dr com.apple.quarantine *` on them after they are downloaded since I am not signing and notarizing them - afaict as I can tell this would require a paid license, and the license is tied to a specific dev and not a software, so this means changes by someone else in the ags codebase that apple doesn't like could make I and not ags lose the account.

~~Keeping as a draft until #3057  is merged~~

Merged so it is now for review.