### PR TITLE
ci,Editor: add nunit3 transform template to Tests directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -629,11 +629,10 @@ jobs:
       - name: Run NUnit tests (Debug)
         shell: cmd
         run: |
-          curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
           pushd Solutions\packages\NUnit.ConsoleRunner.3.*
           set RUNNER="%CD%\tools\nunit3-console.exe"
           popd
-          cmd /v:on /c "!RUNNER! Solutions\.test\x86\Debug\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
+          cmd /v:on /c "!RUNNER! Solutions\.test\x86\Debug\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=Editor\AGS.Editor.Tests\nunit3-junit.xslt"
 
       - name: Build Editor (Release)
         shell: cmd
@@ -644,11 +643,10 @@ jobs:
       - name: Run NUnit tests (Release)
         shell: cmd
         run: |
-          curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
           pushd Solutions\packages\NUnit.ConsoleRunner.3.*
           set RUNNER="%CD%\tools\nunit3-console.exe"
           popd
-          cmd /v:on /c "!RUNNER! Solutions\.test\x86\Release\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
+          cmd /v:on /c "!RUNNER! Solutions\.test\x86\Release\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=Editor\AGS.Editor.Tests\nunit3-junit.xslt"
 
       - name: Upload test results
         if: always()

--- a/Editor/AGS.Editor.Tests/nunit3-junit.xslt
+++ b/Editor/AGS.Editor.Tests/nunit3-junit.xslt
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="/test-run">
+    <testsuites tests="{@testcasecount}" failures="{@failed}" disabled="{@skipped}" time="{@duration}">
+      <xsl:apply-templates/>
+    </testsuites>
+  </xsl:template>
+
+  <xsl:template match="test-suite">
+    <xsl:if test="test-case">
+      <testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed}" failures="{@failed}" skipped="{@skipped}" timestamp="{@start-time}">
+        <xsl:attribute name="name">
+          <xsl:for-each select="ancestor-or-self::test-suite[@type='TestSuite']/@name">
+            <xsl:value-of select="concat(., '.')"/>
+          </xsl:for-each>
+        </xsl:attribute>
+        <xsl:apply-templates select="test-case"/>
+      </testsuite>
+      <xsl:apply-templates select="test-suite"/>
+    </xsl:if>
+    <xsl:if test="not(test-case)">
+      <xsl:apply-templates/>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="test-case">
+    <testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
+      <xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored'">
+        <skipped/>
+      </xsl:if>
+      
+      <xsl:apply-templates/>
+    </testcase>
+  </xsl:template>
+
+  <xsl:template match="command-line"/>
+  <xsl:template match="settings"/>
+  <xsl:template match="filter"/>
+
+  <xsl:template match="output">
+    <system-out>
+      <xsl:value-of select="."/>
+    </system-out>
+  </xsl:template>
+
+  <xsl:template match="stack-trace">
+  </xsl:template>
+
+  <xsl:template match="test-case/failure">
+    <failure message="{./message}">
+      <xsl:value-of select="./stack-trace"/>
+    </failure>
+  </xsl:template>
+
+  <xsl:template match="test-suite/failure"/>
+
+  <xsl:template match="test-case/reason">
+    <xsl:if test="./message != null">
+      <skipped message="{./message}"/>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="test-case/assertions">
+  </xsl:template>
+
+  <xsl:template match="test-suite/reason"/>
+
+  <xsl:template match="properties"/>
+</xsl:stylesheet>
+


### PR DESCRIPTION
removes one possible download failure from CI. I think I got this failure before, but I got a specific download failure here: https://github.com/adventuregamestudio/ags/actions/runs/33309134700/job/99250946082

I don't remember why we do such transform, since this was ported from the previous Cirrus CI run.

They do make the uploaded test result more readable but I don't remember to have to actually download them to read when having a failure in the CI.

Waiting for the CI to run.