### PR TITLE
Engine: fix fatal error on a stale character loop after room change

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -319,6 +319,21 @@ void Character_ChangeRoomSetLoop(CharacterInfo *chaa, int room, int x, int y, in
 }
 
 
+// Internal: set the character's active view directly, without changing
+// their default view. Does not validate the view number, and expects
+// it to be 0-based.
+void Character_SetViewDirect(CharacterInfo *chap, int vii, bool is_walk_view) {
+    // if the idle animation is playing we should release the view
+    stop_character_idling(chap);
+    chap->view = vii;
+    stop_character_anim(chap);
+    chap->frame = 0;
+    chap->wait = 0;
+    chap->walkwait = 0;
+    charextra[chap->index_id].animwait = 0;
+    FindReasonableLoopForCharacter(chap, is_walk_view);
+}
+
 void Character_ChangeView(CharacterInfo *chap, int vii) {
     vii--;
 
@@ -329,18 +344,9 @@ void Character_ChangeView(CharacterInfo *chap, int vii) {
     if ((chap->flags & CHF_FIXVIEW) && (chap->idleleft >= 0))
         debug_script_warn("Warning: ChangeCharacterView was used while the view was fixed - call ReleaseCharView first");
 
-    // if the idle animation is playing we should release the view
-    stop_character_idling(chap);
-
     debug_script_log("%s: Change view to %d", chap->scrname, vii+1);
     chap->defview = vii;
-    chap->view = vii;
-    stop_character_anim(chap);
-    chap->frame = 0;
-    chap->wait = 0;
-    chap->walkwait = 0;
-    charextra[chap->index_id].animwait = 0;
-    FindReasonableLoopForCharacter(chap, true);
+    Character_SetViewDirect(chap, vii, true);
 }
 
 enum DirectionalLoop
@@ -2576,8 +2582,10 @@ void update_character_scale(int charid)
     }
     if (chin.loop >= views[chin.view].numLoops)
     {
-        quitprintf("!The character '%s' could not be displayed because there was no loop %d of view %d.",
+        // a stale loop can survive a view change, re-select a valid loop
+        debug_script_warn("WARNING: The character '%s' was to be displayed with loop %d of view %d, which does not exist; resetting to a valid loop.",
             chin.scrname, chin.loop, chin.view + 1);
+        FindReasonableLoopForCharacter(&chin);
     }
     // If frame is too high -- fallback to the frame 0;
     // there's always at least 1 dummy frame at index 0

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -39,6 +39,7 @@ void    Character_ChangeRoomAutoPosition(CharacterInfo *chaa, int room, int newP
 void    Character_ChangeRoom(CharacterInfo *chaa, int room, int x, int y);
 void    Character_ChangeRoomSetLoop(CharacterInfo *chaa, int room, int x, int y, int direction);
 void    Character_ChangeView(CharacterInfo *chap, int vii);
+void    Character_SetViewDirect(CharacterInfo *chap, int vii, bool is_walk_view);
 void    Character_FaceDirection(CharacterInfo *char1, int direction, int blockingStyle);
 void    Character_FaceCharacter(CharacterInfo *char1, CharacterInfo *char2, int blockingStyle);
 void    Character_FaceLocation(CharacterInfo *char1, int xx, int yy, int blockingStyle);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -967,9 +967,8 @@ void load_new_room(int newnum, CharacterInfo *forchar)
             play.temporarily_turned_off_character = game.playercharacter;
         }
         if (forchar->flags & CHF_FIXVIEW) ;
-        else if (thisroom.Options.PlayerView==0) forchar->view=forchar->defview;
-        else forchar->view=thisroom.Options.PlayerView-1;
-        forchar->frame=0;   // make him standing
+        else if (thisroom.Options.PlayerView==0) Character_SetViewDirect(forchar, forchar->defview, true);
+        else Character_SetViewDirect(forchar, thisroom.Options.PlayerView-1, true);
     }
     color_map = nullptr;
 


### PR DESCRIPTION
Fixes #3071.

Short version: load_new_room() reassigns the player character's view on room entry and resets the frame but not the loop, so a loop from the previous room can survive into a view that doesn't have it, and update_character_scale() then quits with a fatal "no loop X of view Y" error. Full analysis and repro in #3071.

The change:

- room.cpp: the room-entry view assignment now goes through the new internal Character_SetViewDirect(), which sets the active view without touching defview and stops idling and the current animation, resets the frame and re-selects a valid loop with FindReasonableLoopForCharacter(). Character_ChangeView() is refactored to call it after its own defview assignment, so the logic is not duplicated. When the view is locked (CHF_FIXVIEW) nothing is touched anymore, frame included.
- character.h: declaration of Character_SetViewDirect.
- character.cpp: if an out-of-range loop still reaches update_character_scale(), log a warning and re-select a valid loop with FindReasonableLoopForCharacter() instead of ending the game -- the same thing this function already does for an out-of-range frame a few lines below. A view with no loops at all stays fatal.

Tested on hardware: I built the previous revision for aarch64 and ran it on a R36S handheld with an Endacopia port based on 3.6.3.13. The transition that used to kill the engine every time (entering the hub while facing up-right on the analog stick) works now, both playing fresh and after restoring a save. Happy to rebuild and re-test this revision on the device before merge.

The patch also applies and compiles against current master (gcc 14, Linux).