### PR TITLE
Common: in fonts, fix possible null pointer access 

### DIFF
--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -336,7 +336,7 @@ int get_text_width_outlined(const char *text, int font_number)
 
 int get_text_height(const char *text, int font_number)
 {
-    if (!assert_font_number(font_number))
+    if (!assert_font_renderer(font_number))
         return 0;
     return fonts[font_number].Renderer->GetTextHeight(text, font_number);
 }


### PR DESCRIPTION
so, recently in the forums of an error: https://www.adventuregamestudio.co.uk/forums/beginners-technical-questions/audio-functions-stopped-working/msg636691713/#msg636691713

> An exception 0xC0000005 occurred in ACWIN.EXE ae EIP = 0x00495D1F; program pointer is +78, engine version 3.6.3.12 gtags (0,15)

So, deciphering this I got it was something in GUI 0, in the control 15, and found out that program pointer 78 is 

https://github.com/adventuregamestudio/ags/blob/059d6ef7a198919daf358b63f24b0434000795af/Engine/main/game_run.cpp#L1418

The person also mentioned a GUI for entering text, so I guessed it should also include a TextBox. The `0xC0000005` exception I remembered I had seen before so I googled an found the MS Learn article: https://learn.microsoft.com/en-us/shows/inside/c0000005 , which suggests a null pointer access.

With all this information, I asked Claude Opus on low to find me a possible null pointer access giving these conditions and it returned pointing me to this spot as a possibility. I checked and the commit is there since 3.6.3.1, https://github.com/adventuregamestudio/ags/commit/c21b0bbce2364bd6c2569e596de80bfe3d9722a0, and I have had no issue, but the other things that use the renderer around it use a different assert, so I am copying the code around it (see get_text_width).

What I have no idea is how the renderer could be null after a project upgrade (I guess it would have to be failing silently before). This also possibly has nothing to do with what the person reported, since I don't have the game I don't know how to reproduce.