### PR TITLE
4.0: deprecate ASCII mode, old speech file naming, old key mode

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -87,7 +87,7 @@
 #define OPT_CUSTOMENGINETAG    51 // custom engine tag (for overriding behavior)
 #define OPT_SCALECHAROFFSETS   52 // apply character scaling to the sprite offsets (z, locked offs)
 #define OPT_SAVESCREENSHOTLAYER 53 // which render layers to include into savegame screenshot
-#define OPT_VOICECLIPNAMERULE  54 // which rule to use for a voice clip name based on character's name (old/new)
+#define OPT_VOICECLIPNAMERULE  54 // which rule to use for a voice clip name based on character's name
 #define OPT_SAVECOMPONENTSIGNORE 55 // ignore these savegame components (flag mask)
 #define OPT_GAMEFPS            56 // game speed (frame per seconds)
 #define OPT_GUICONTROLMOUSEBUT 57 // whether common gui controls should react only to LMB (0 - any, 1 - LMB)

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -83,7 +83,7 @@
 #define OPT_OBSOLETE_WALKSPEEDABSOLUTE 47 // if movement speeds are independent of walkable mask resolution
 #define OPT_CLIPGUICONTROLS    48 // clip drawn gui control contents to the control's rectangle
 #define OPT_GAMETEXTENCODING   49 // how the text in the game data should be interpreted
-#define OPT_KEYHANDLEAPI       50 // key handling mode (old/new)
+#define OPT_KEYHANDLEAPI       50 // key handling mode version
 #define OPT_CUSTOMENGINETAG    51 // custom engine tag (for overriding behavior)
 #define OPT_SCALECHAROFFSETS   52 // apply character scaling to the sprite offsets (z, locked offs)
 #define OPT_SAVESCREENSHOTLAYER 53 // which render layers to include into savegame screenshot

--- a/Common/ac/keycode.h
+++ b/Common/ac/keycode.h
@@ -292,6 +292,8 @@ struct KeyInput
     eAGSKeyCode Key = eAGSKeyCodeNone;
     // Key code combined with mods, old-style (e.g. eAGSKeyCodeCtrlA)
     // may be used when comparing with the variables set from script.
+    // NOTE: this may be removed only if script API allows to set mod+key
+    // combos as two separate variables everywhere.
     eAGSKeyCode CompatKey = eAGSKeyCodeNone;
     // Key modifiers (see eAGSKeyMod)
     int         Mod = 0;

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -284,7 +284,7 @@ void GUIListBox::RemoveItem(int index)
 
 void GUIListBox::SortItems(bool nocase, bool locale_aware, bool ascending)
 {
-    auto str_less = StrUtil::GetStrLessAutoFor(get_uformat() == U_UTF8, nocase, locale_aware ? GUI::Context.TextLocaleName.GetCStr() : nullptr);
+    auto str_less = StrUtil::GetStrLessAutoFor(true, nocase, locale_aware ? GUI::Context.TextLocaleName.GetCStr() : nullptr);
     if (ascending)
         std::sort(_items.begin(), _items.end(), str_less);
     else

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -68,16 +68,9 @@ void GUITextBox::Draw(Bitmap *ds, int x, int y)
 // TODO: a shared utility function
 static void Backspace(String &text)
 {
-    if (get_uformat() == U_UTF8)
-    {// Find where the last utf8 char begins
-        const char *ptr_end = text.GetCStr() + text.GetLength();
-        const char *ptr_prev = Utf8::BackOneChar(ptr_end, text.GetCStr());
-        text.ClipRight(ptr_end - ptr_prev);
-    }
-    else
-    {
-        text.ClipRight(1);
-    }
+    const char *ptr_end = text.GetCStr() + text.GetLength();
+    const char *ptr_prev = Utf8::BackOneChar(ptr_end, text.GetCStr());
+    text.ClipRight(ptr_end - ptr_prev);
 }
 
 bool GUITextBox::OnKeyPress(const KeyInput &ki)
@@ -97,12 +90,7 @@ bool GUITextBox::OnKeyPress(const KeyInput &ki)
     if (ki.UChar == 0)
         return false; // not a textual event, don't handle
 
-    if (get_uformat() == U_UTF8)
-        _text.Append(ki.Text); // proper unicode char
-    else if (ki.UChar < 256)
-        _text.AppendChar(static_cast<uint8_t>(ki.UChar)); // ascii/ansi-range char in ascii mode
-    else
-        return true; // char from an unsupported range, don't print but still report as handled
+    _text.Append(ki.Text);
     // if the new string is too long, remove the new character
     if (get_text_width(_text.GetCStr(), _font) > (_width - (6 + 5)))
         Backspace(_text);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1563,6 +1563,9 @@ namespace AGS.Editor
             return true;
         }
 
+        // TODO: implement passing IWorkProgress into SaveGameFiles, and counting progress there.
+        // This will also require passing it along with PreSaveGameEventArgs, and using everywhere
+        // where PreSaveGame event is handled.
         public bool SaveGameFiles()
         {
             if (!TestIfCanSaveNow())

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Entities\UpgradeGame\UpgradeGameRoomsOpenFormatTask.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameRoomsOptionalTask.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameUtils.cs" />
+    <Compile Include="Entities\UpgradeGame\UpgradeGameVoiceClipsTask.cs" />
     <Compile Include="Enums\AdjustMaskOptions.cs" />
     <Compile Include="GUI\AdjustMasksDialog.cs">
       <SubType>Form</SubType>
@@ -280,6 +281,12 @@
     </Compile>
     <Compile Include="GUI\UpgradeGameWizard\UpgradeGameIntroPage.Designer.cs">
       <DependentUpon>UpgradeGameIntroPage.cs</DependentUpon>
+    </Compile>
+    <Compile Include="GUI\UpgradeGameWizard\UpgradeGameVoiceClipsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="GUI\UpgradeGameWizard\UpgradeGameVoiceClipsPage.Designer.cs">
+      <DependentUpon>UpgradeGameVoiceClipsPage.cs</DependentUpon>
     </Compile>
     <Compile Include="GUI\UpgradeGameWizard\UpgradeGameWizardPage.cs">
       <SubType>UserControl</SubType>
@@ -569,6 +576,12 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\UpgradeGameWizard\UpgradeGameIntroPage.resx">
       <DependentUpon>UpgradeGameIntroPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\UpgradeGameWizard\UpgradeGameVoiceClipsPage.resx">
+      <DependentUpon>UpgradeGameVoiceClipsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\UpgradeGameWizard\UpgradeGameWizardPage.resx">
+      <DependentUpon>UpgradeGameWizardPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\WatchVariablesPanel.resx">
       <DependentUpon>WatchVariablesPanel.cs</DependentUpon>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Components\SpriteManagerComponent.cs" />
     <Compile Include="Components\TextParserComponent.cs" />
     <Compile Include="Components\ViewsComponent.cs" />
+    <Compile Include="Entities\GameTextEncodingChangedArgs.cs" />
     <Compile Include="Entities\IAppSettings.cs" />
     <Compile Include="Config\ConfigUtils.cs" />
     <Compile Include="Entities\CharacterDescriptionChangedEventArgs.cs" />
@@ -182,6 +183,7 @@
     <Compile Include="Entities\ScriptModuleDef.cs" />
     <Compile Include="Entities\GenericMessagesArgs.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameCommonTask.cs" />
+    <Compile Include="Entities\UpgradeGame\UpgradeGameTextEncodingTask.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameEventArgs.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameFontsToFontFilesTask.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameIntroAndBackupTask.cs" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Entities\ScriptModuleDef.cs" />
     <Compile Include="Entities\GenericMessagesArgs.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameCommonTask.cs" />
+    <Compile Include="Entities\UpgradeGame\UpgradeGameTaskBase.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameTextEncodingTask.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameEventArgs.cs" />
     <Compile Include="Entities\UpgradeGame\UpgradeGameFontsToFontFilesTask.cs" />

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -106,6 +106,7 @@ namespace AGS.Editor.Components
 			_agsEditor.PreDeleteSprite += AGSEditor_PreDeleteSprite;
             Factory.Events.GamePrepareUpgrade += Events_GamePrepareUpgrade;
             Factory.Events.GamePostLoad += Events_GamePostLoad;
+            Factory.Events.GameTextEncodingChanged += Events_GameTextEncodingChanged;
             _modifiedChangedHandler = _loadedRoom_RoomModifiedChanged;
             RePopulateTreeView();
         }
@@ -1943,6 +1944,28 @@ namespace AGS.Editor.Components
             if (IsRoomUpgradeNecessary(game))
             {
                 game.WorkspaceState.RequiresRebuild = true;
+            }
+        }
+
+        private void Events_GameTextEncodingChanged(GameTextEncodingChangedArgs evArgs)
+        {
+            // Load and re-save (using new encoding) every room room script
+            // NOTE: there's no need to resave room documents as we always have them saved with UTF-8
+            IWorkProgress progress = evArgs.Progress;
+            int total = Factory.AGSEditor.CurrentGame.Rooms.Count;
+            int current = 0;
+            foreach (var room in Factory.AGSEditor.CurrentGame.Rooms)
+            {
+                Script.TextEncoding = evArgs.OldEncoding;
+                room.LoadScript();
+                Script.TextEncoding = evArgs.Game.TextEncoding;
+                room.Script.Modified = true;
+                room.Script.SaveToDisk();
+                room.UnloadScript();
+
+                if (progress != null)
+                    progress.SetProgress(total, current, $"Room scripts: {current} / {total}", false);
+                current++;
             }
         }
 

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -1,15 +1,12 @@
+using AGS.Editor.Preferences;
+using AGS.Editor.Utils;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
-using System.Xml;
-using AGS.Editor.Preferences;
-using AGS.Editor.Utils;
-using AGS.Types;
-using WeifenLuo.WinFormsUI.Docking;
 
 namespace AGS.Editor.Components
 {
@@ -76,6 +73,7 @@ namespace AGS.Editor.Components
             _guiController.ProjectTree.OnAfterLabelEdit += ProjectTree_OnAfterLabelEdit;
 
             Factory.Events.GamePostLoad += Events_GamePostLoad;
+            Factory.Events.GameTextEncodingChanged += Events_GameTextEncodingChanged;
         }
 
         private void _guiController_OnGetScriptEditorControl(GetScriptEditorControlEventArgs evArgs)
@@ -959,6 +957,31 @@ namespace AGS.Editor.Components
                     // CHECKME: do not save the script here, in case user made a mistake opening this in a newer editor
                     // and closes project without saving after upgrade? Upgrade process is not well defined...
                 }
+            }
+        }
+
+        private void Events_GameTextEncodingChanged(GameTextEncodingChangedArgs evArgs)
+        {
+            // Convert all scripts
+            IWorkProgress progress = evArgs.Progress;
+            int total = Factory.AGSEditor.CurrentGame.ScriptsAndHeaders.Count;
+            int current = 0;
+            foreach (var script in Factory.AGSEditor.CurrentGame.ScriptsAndHeaders)
+            {
+                // TODO: this is ugly, make TextEncoding non-static per script property?
+                // or pass into Load/Save method (but some more changes are necessary)
+                Script.TextEncoding = evArgs.OldEncoding;
+                script.Header.LoadFromDisk();
+                script.Script.LoadFromDisk();
+                Script.TextEncoding = evArgs.Game.TextEncoding;
+                script.Header.Modified = true;
+                script.Header.SaveToDisk();
+                script.Script.Modified = true;
+                script.Script.SaveToDisk();
+
+                if (progress != null)
+                    progress.SetProgress(total, current, $"Game scripts: {current} / {total}", false);
+                current++;
             }
         }
     }

--- a/Editor/AGS.Editor/Components/SettingsComponent.cs
+++ b/Editor/AGS.Editor/Components/SettingsComponent.cs
@@ -22,6 +22,7 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("iconsett.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, "GeneralSettings", "General Settings", ICON_KEY);
 
+            Factory.Events.GamePrepareUpgrade += Events_GamePrepareUpgrade;
             Factory.Events.GamePostLoad += Events_GamePostLoad;
             Factory.Events.GameSettingsChanged += Events_GameSettingsChanged;
         }
@@ -98,6 +99,11 @@ namespace AGS.Editor.Components
             _agsEditor.CurrentGame.Settings.DialogOptionsGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.DialogOptionsGUI, oldID, gui.ID, false);
             _agsEditor.CurrentGame.Settings.ThoughtGUI = UpdatePropertyOnGuiMove(_agsEditor.CurrentGame.Settings.ThoughtGUI, oldID, gui.ID, false);
             _settingsPane.RefreshData();
+        }
+
+        private void Events_GamePrepareUpgrade(UpgradeGameEventArgs args)
+        {
+            args.Tasks.Add(new UpgradeGameTextEncodingTask());
         }
 
         private void Events_GamePostLoad(Game game)

--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -1,3 +1,5 @@
+using AGS.CScript.Compiler;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -5,11 +7,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Messaging;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web.Security;
 using System.Windows.Forms;
 using System.Xml;
-using AGS.Types;
 
 namespace AGS.Editor.Components
 {
@@ -40,6 +43,12 @@ namespace AGS.Editor.Components
         {
             _agsEditor.ExtraCompilationStep += _agsEditor_ExtraCompilationStep;
             _agsEditor.ExtraOutputCreationStep += _agsEditor_ExtraOutputCreationStep;
+            Factory.Events.GamePrepareUpgrade += Events_GamePrepareUpgrade;
+        }
+
+        private void Events_GamePrepareUpgrade(UpgradeGameEventArgs args)
+        {
+            args.Tasks.Add(new UpgradeGameVoiceClipsTask(ConvertVoiceClipsToNewNamingStyle));
         }
 
         private void _agsEditor_ExtraCompilationStep(CompilationStepArgs args)
@@ -135,27 +144,71 @@ namespace AGS.Editor.Components
         /// </summary>
         private void CheckSpeechFilesForConsistency(string dir, CompileMessages messages)
         {
-            string[] audioClipList = ConstructFileListForSpeechVOX(dir, true);
+            // TODO: perhaps test if there are any files not matching supported format / naming convention?
+            //string[] audioClipList = ConstructFileListForSpeechVOX(dir, true);
+        }
 
-            if (_agsEditor.CurrentGame.Settings.UseOldVoiceClipNaming)
+        private void ConvertVoiceClipsToNewNamingStyle(Game game, IWorkProgress progress, CompileMessages messages)
+        {
+            var dirs = Directory.GetDirectories(SPEECH_DIRECTORY).ToList();
+            dirs.Insert(0, SPEECH_DIRECTORY);
+            progress.SetProgress(dirs.Count, 0, "Upgrading speech files", autoFormatProgress: false);
+
+            int progressCount = 0;
+            int renamedCount = 0;
+            foreach (string dir in dirs)
             {
-                var regNewStyle = new Regex(@"^\w+\.\d+\.\w+");
-                foreach (string clipFile in audioClipList)
-                {
-                    if (regNewStyle.IsMatch(Path.GetFileName(clipFile)))
-                    {
-                        messages.Add(new CompileWarning($"Speech file \"{clipFile}\" matches the new voice clip naming rule, but the game is set to use the old rule (see General Settings)."));
-                    }
-                }
+                ConvertVoiceClipsToNewNamingStyle(game, dir, messages, ref renamedCount);
+                progress.SetProgress(dirs.Count, progressCount, $"Upgrading speech files: {progressCount} of {dirs.Count} directories", autoFormatProgress: false);
+                progressCount++;
             }
-            else
+            messages.Add(new CompileInformation($"Converted {renamedCount} speech-related files to new style naming format"));
+        }
+
+        /// <summary>
+        /// Scan the given speech directory, find any files in old-style names,
+        /// and rename them to respective new-style names.
+        /// </summary>
+        private void ConvertVoiceClipsToNewNamingStyle(Game game, string dir, CompileMessages messages, ref int renamedCount)
+        {
+            string[] audioClipList = ConstructFileListForSpeechVOX(dir, true);
+            var regOldStyle = new Regex(@"^(\w{1,4})(\d+)\.(\w+)");
+            foreach (string clipFile in audioClipList)
             {
-                var regOldStyle = new Regex(@"^\w{1,4}\d+\.\w+");
-                foreach (string clipFile in audioClipList)
+                var match = regOldStyle.Match(Path.GetFileName(clipFile));
+                // 4 groups total, because group 0 is full string
+                if (match.Success && match.Groups.Count == 4)
                 {
-                    if (regOldStyle.IsMatch(Path.GetFileName(clipFile)))
+                    var charNameShort = match.Groups[1].Value;
+                    var cue = match.Groups[2].Value;
+                    var ext = match.Groups[3].Value;
+                    string charNameFull = null;
+                    // Find first character whose script name's first 4 letters (without first 'c') match the clip's name
+                    foreach (var character in game.Characters)
                     {
-                        messages.Add(new CompileWarning($"Speech file \"{clipFile}\" matches the old voice clip naming rule, but the game is set to use the new rule (see General Settings)."));
+                        if (!string.IsNullOrEmpty(character.ScriptName))
+                        {
+                            var nameWithoutC = character.ScriptName.StartsWith("c") ? character.ScriptName.Substring(1) : character.ScriptName;
+                            if (string.Compare(charNameShort, nameWithoutC.Substring(0, 4), true) == 0)
+                            {
+                                charNameFull = nameWithoutC;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (charNameFull != null)
+                    {
+                        var newClipFile = Path.Combine(dir, $"{charNameFull}.{cue}.{ext}");
+                        try
+                        {
+                            File.Move(clipFile, newClipFile);
+                            renamedCount++;
+                        }
+                        catch (Exception e)
+                        {
+                            messages.Add(new CompileError($"Failed to rename speech file {Path.GetFileName(clipFile)} to {Path.GetFileName(newClipFile)}", e));
+                        }
                     }
                 }
             }
@@ -356,6 +409,9 @@ namespace AGS.Editor.Components
 
         private string[] ConstructFileListForSpeechVOX(string sourceDir, bool audioOnly = false)
         {
+            // TODO: only gather voice files that match the naming style?
+            // var regNewStyle = new Regex(@"^\w+\.\d+\.\w+");
+
             List<string> files = new List<string>();
             if (!audioOnly)
                 Utilities.AddAllMatchingFiles(files, sourceDir, LIP_SYNC_DATA_OUTPUT, true);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -538,9 +538,9 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_RENDERATSCREENRES] = (int)game.Settings.RenderAtScreenResolution;
             options[NativeConstants.GameOptions.OPT_CLIPGUICONTROLS] = (game.Settings.ClipGUIControls ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_GAMETEXTENCODING] = game.TextEncoding.CodePage;
-            options[NativeConstants.GameOptions.OPT_KEYHANDLEAPI] = (game.Settings.UseOldKeyboardHandling ? 0 : 1); // inverted, 0 for old
+            options[NativeConstants.GameOptions.OPT_KEYHANDLEAPI] = 1; // always use new one
             options[NativeConstants.GameOptions.OPT_SCALECHAROFFSETS] = (game.Settings.ScaleCharacterSpriteOffsets ? 1 : 0);
-            options[NativeConstants.GameOptions.OPT_VOICECLIPNAMERULE] = (game.Settings.UseOldVoiceClipNaming ? 0 : 1); // inverted, 0 for old
+            options[NativeConstants.GameOptions.OPT_VOICECLIPNAMERULE] = 1; // always use new one
             options[NativeConstants.GameOptions.OPT_GAMEFPS] = game.Settings.GameFPS;
             options[NativeConstants.GameOptions.OPT_GUICONTROLMOUSEBUT] = (game.Settings.GUIHandleOnlyLeftMouseButton ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_DISPLAYSINGLEDIALOGOPTION] = (game.Settings.DisplaySingleDialogOption ? 1 : 0);

--- a/Editor/AGS.Editor/EditorEvents.cs
+++ b/Editor/AGS.Editor/EditorEvents.cs
@@ -17,6 +17,8 @@ namespace AGS.Editor
         public event GamePrepareUpgradeHandler GamePrepareUpgrade;
         public delegate void GamePostLoadHandler(Game game);
         public event GamePostLoadHandler GamePostLoad;
+        public delegate void GameTextEncodingChangedHandler(GameTextEncodingChangedArgs evArgs);
+        public event GameTextEncodingChangedHandler GameTextEncodingChanged;
         public delegate void SavingGameHandler(XmlTextWriter writer);
         public event SavingGameHandler SavingGame;
         public delegate void SavingUserDataHandler(XmlTextWriter writer);
@@ -65,6 +67,11 @@ namespace AGS.Editor
             {
                 GamePostLoad(game);
             }
+        }
+
+        public void OnGameTextEncodingChanged(GameTextEncodingChangedArgs args)
+        {
+            GameTextEncodingChanged?.Invoke(args);
         }
 
         public void OnSavingGame(XmlTextWriter writer)

--- a/Editor/AGS.Editor/Entities/GameTextEncodingChangedArgs.cs
+++ b/Editor/AGS.Editor/Entities/GameTextEncodingChangedArgs.cs
@@ -1,0 +1,23 @@
+﻿using AGS.CScript.Compiler;
+using AGS.Types;
+using System;
+using System.Text;
+
+namespace AGS.Editor
+{
+    public class GameTextEncodingChangedArgs
+    {
+        public GameTextEncodingChangedArgs(Game game, Encoding oldEnc, IWorkProgress progress, CompileMessages errors)
+        {
+            Game = game;
+            OldEncoding = oldEnc;
+            Progress = progress;
+            Errors = errors;
+        }
+
+        public Game Game { get; private set; }
+        public Encoding OldEncoding { get; private set; }
+        public IWorkProgress Progress { get; private set; }
+        public CompileMessages Errors { get; private set; }
+    }
+}

--- a/Editor/AGS.Editor/Entities/UpgradeGame/IUpgradeGameTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/IUpgradeGameTask.cs
@@ -5,6 +5,16 @@ using AGS.Types;
 namespace AGS.Editor
 {
     /// <summary>
+    /// Defines which stage a task has to be run on.
+    /// </summary>
+    public enum UpgradeGameTaskStage
+    {
+        None,
+        PreStage,
+        PostStage
+    }
+
+    /// <summary>
     /// IUpgradeGameTask represents a single step operation in the game upgrade
     /// process. The operation itself may include multiple adjustments to the
     /// game's data. A distinct upgrade task is required when particular changes
@@ -68,6 +78,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this task had errors.
         /// </summary>
         bool RequestConfirmationOnErrors { get; }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        UpgradeGameTaskStage Stage { get; }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/IUpgradeGameTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/IUpgradeGameTask.cs
@@ -75,6 +75,12 @@ namespace AGS.Editor
         bool Enabled { get; set; }
 
         /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        bool ShouldApplyToGame(Game game);
+
+        /// <summary>
         /// Provides WizardPage control(s) used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
@@ -72,6 +72,15 @@ namespace AGS.Editor
         public bool Enabled { get; set; }
 
         /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        public bool ShouldApplyToGame(Game game)
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Provides WizardPage control(s) used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
@@ -65,6 +65,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this task had errors.
         /// </summary>
         public bool RequestConfirmationOnErrors { get { return false; } }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameCommonTask.cs
@@ -13,92 +13,16 @@ namespace AGS.Editor
     /// that do not require user's attention. This task is run implicitly
     /// whenever AGS Editor loads an older project.
     /// </summary>
-    public class UpgradeGameCommonTask : IUpgradeGameTask
+    public class UpgradeGameCommonTask : UpgradeGameTaskBase
     {
-        public UpgradeGameCommonTask()
+        public UpgradeGameCommonTask() : base("UpgradeGameCommon")
         {
+            Title = "Update Game to the new version";
+            Implicit = true; // executed unconditionally
+            Optional = false;
+            AllowToSkipIfHadErrors = true; // ignore, but will report errors after
+            RequestConfirmationOnErrors = false;
             Enabled = true;
-        }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade task.
-        /// </summary>
-        public string ID { get { return "UpgradeGameCommon"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this task when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Update Game to the new version"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description { get { return ""; } }
-        /// <summary>
-        /// A game project version that introduced this upgrade task.
-        /// If a loaded game has a less project version, then this task
-        /// must be applied, otherwise it should not.
-        /// Returns null if should be applied regardless of the game version
-        /// (but the execution process may still have version checks inside).
-        /// </summary>
-        public System.Version GameVersion { get { return null; /* any version */ } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return null; /* any version */ } }
-        /// <summary>
-        /// Tells whether this upgrade task is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return true; } }
-        /// <summary>
-        /// Tells whether this upgrade task may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return false; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// task had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return true; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this task had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return false; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
-
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Tells whether this task should be applied to this game.
-        /// This method can have additional conditions, besides the default version check.
-        /// </summary>
-        public bool ShouldApplyToGame(Game game)
-        {
-            return true;
-        }
-
-        /// <summary>
-        /// Provides WizardPage control(s) used to represent this upgrade task.
-        /// The page implementation may have this IUpgradeGameTask passed into
-        /// constructor in order to assign settings right into it.
-        /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
-        {
-            return null;
-        }
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-            // does not have any options
         }
 
         struct CursorDefinition
@@ -121,7 +45,7 @@ namespace AGS.Editor
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
 #pragma warning disable 0612, 0618
             int xmlVersionIndex = 0;

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
@@ -81,6 +81,15 @@ namespace AGS.Editor
         public bool Enabled { get; set; }
 
         /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        public bool ShouldApplyToGame(Game game)
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Provides WizardPage controls used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
@@ -74,6 +74,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this task had errors.
         /// </summary>
         public bool RequestConfirmationOnErrors { get { return false; } }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameFontsToFontFilesTask.cs
@@ -4,7 +4,7 @@ using AGS.Types;
 
 namespace AGS.Editor
 {
-    public class UpgradeGameFontsToFontFilesTask : IUpgradeGameTask
+    public class UpgradeGameFontsToFontFilesTask : UpgradeGameTaskBase
     {
         // TODO: revise this later.
         // The conversion process is run via a delegate here, because at the time
@@ -15,82 +15,21 @@ namespace AGS.Editor
         public delegate void ConvertFonts(Game game, IWorkProgress progress, CompileMessages errors);
         private ConvertFonts _convertFonts;
 
-        public UpgradeGameFontsToFontFilesTask(ConvertFonts convertFonts)
+        public UpgradeGameFontsToFontFilesTask(ConvertFonts convertFonts) : base("UpgradeGameFontsToFontFiles")
         {
-            _convertFonts = convertFonts;
-            Enabled = true;
-        }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade task.
-        /// </summary>
-        public string ID { get { return "UpgradeGameFontsToFontFiles"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this task when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Separate Fonts into Font Files and Fonts"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description
-        {
-            get
-            {
-                return "In AGS 4.0 there's a distinction between Font Files and Fonts. Previously you had to add a new font file to your project whenever you needed a font of different size. In 4.0 you can import a single font file, and then create multiple Fonts from it, each with different settings." +
+            Title = "Separate Fonts into Font Files and Fonts";
+            Description = "In AGS 4.0 there's a distinction between Font Files and Fonts. Previously you had to add a new font file to your project whenever you needed a font of different size. In 4.0 you can import a single font file, and then create multiple Fonts from it, each with different settings." +
                     Environment.NewLine + Environment.NewLine +
                     "During this upgrade step your project's font files will be moved to a \"Fonts\" folder, and there will be respective Font Files and Font items created in the project tree.";
-            }
-        }
-        /// <summary>
-        /// A game project version that introduced this upgrade task.
-        /// If a loaded game has a less project version, then this task
-        /// must be applied, otherwise it should not.
-        /// Returns null if should be applied regardless of the game version
-        /// (but the execution process may still have version checks inside).
-        /// </summary>
-        public System.Version GameVersion { get { return new System.Version(AGSEditor.FIRST_XML_VERSION_USING_INDEX); } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_FONT_SOURCES; } }
-        /// <summary>
-        /// Tells whether this upgrade task is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade task may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return false; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// task had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return false; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this task had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return false; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
+            GameVersion = new System.Version(AGSEditor.FIRST_XML_VERSION_USING_INDEX);
+            GameVersionIndex = AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_FONT_SOURCES;
+            Implicit = false;
+            Optional = false;
+            AllowToSkipIfHadErrors = false;
+            RequestConfirmationOnErrors = false;
+            Enabled = true;
 
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Tells whether this task should be applied to this game.
-        /// This method can have additional conditions, besides the default version check.
-        /// </summary>
-        public bool ShouldApplyToGame(Game game)
-        {
-            return true;
+            _convertFonts = convertFonts;
         }
 
         /// <summary>
@@ -98,22 +37,15 @@ namespace AGS.Editor
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             return new UpgradeGameWizardPage[] { new UpdateGameGenericInfoPage(game, this) };
-        }
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-            // does not have any options
         }
         /// <summary>
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             _convertFonts(game, progress, errors);
         }

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameIntroAndBackupTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameIntroAndBackupTask.cs
@@ -60,6 +60,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this step had errors.
         /// </summary>
         public bool RequestConfirmationOnErrors { get { return true; } }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.PreStage; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameIntroAndBackupTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameIntroAndBackupTask.cs
@@ -10,65 +10,18 @@ namespace AGS.Editor
     /// UpgradeGameIntroAndBackupTask performs an optional project backup;
     /// is supposed to be executed prior to any other upgrade tasks.
     /// </summary>
-    public class UpgradeGameIntroAndBackupTask : IUpgradeGameTask
+    public class UpgradeGameIntroAndBackupTask : UpgradeGameTaskBase
     {
-        public UpgradeGameIntroAndBackupTask()
+        public UpgradeGameIntroAndBackupTask() : base("UpgradeGameIntroAndBackup")
         {
+            Title = "Backup project files";
+            Implicit = false;
+            Optional = true;
+            AllowToSkipIfHadErrors = true; // well, not good, but allow this
+            RequestConfirmationOnErrors = true; // still must ask user if they like to skip backup
+            Stage = UpgradeGameTaskStage.PreStage; // must be complete before any changes done to project
             Enabled = true;
         }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade step.
-        /// </summary>
-        public string ID { get { return "UpgradeGameIntroAndBackup"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this step when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Backup project files"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description { get { return ""; /* TODO? */ } }
-        /// <summary>
-        /// A game project version that introduced this upgrade step.
-        /// If a loaded game has a less project version, then this step
-        /// must be applied, otherwise it should not.
-        /// </summary>
-        public System.Version GameVersion { get { return null; /* any version where needed */ } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return null; } }
-        /// <summary>
-        /// Tells whether this upgrade step is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade step may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return true; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// step had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return true; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this step had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return true; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.PreStage; } }
-
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
 
         /// <summary>
         /// A directory to copy backup files to.
@@ -76,35 +29,19 @@ namespace AGS.Editor
         public string BackupPath { get; set; }
 
         /// <summary>
-        /// Tells whether this task should be applied to this game.
-        /// This method can have additional conditions, besides the default version check.
-        /// </summary>
-        public bool ShouldApplyToGame(Game game)
-        {
-            return true;
-        }
-
-        /// <summary>
         /// Provides WizardPage controls used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             return new UpgradeGameWizardPage[] { new UpgradeGameIntroPage(game, this) };
-        }
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-
         }
         /// <summary>
         /// Execute the upgrade step over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             if (string.IsNullOrEmpty(BackupPath))
             {

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOpenFormatTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOpenFormatTask.cs
@@ -83,6 +83,15 @@ namespace AGS.Editor
         public bool Enabled { get; set; }
 
         /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        public bool ShouldApplyToGame(Game game)
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Provides WizardPage controls used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOpenFormatTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOpenFormatTask.cs
@@ -4,7 +4,7 @@ using AGS.Types;
 
 namespace AGS.Editor
 {
-    public class UpgradeGameRoomsOpenFormatTask : IUpgradeGameTask
+    public class UpgradeGameRoomsOpenFormatTask : UpgradeGameTaskBase
     {
         // TODO: revise this later.
         // The conversion process is run via a delegate here, because at the time
@@ -15,84 +15,24 @@ namespace AGS.Editor
         public delegate void ConvertRooms(Game game, IWorkProgress progress, CompileMessages errors);
         private ConvertRooms _convertRooms;
 
-        public UpgradeGameRoomsOpenFormatTask(ConvertRooms convertRooms)
+        public UpgradeGameRoomsOpenFormatTask(ConvertRooms convertRooms) : base("UpgradeGameRoomsOpenFormat")
         {
-            _convertRooms = convertRooms;
             Enabled = true;
-        }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade task.
-        /// </summary>
-        public string ID { get { return "UpgradeGameRoomsOpenFormat"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this task when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Upgrade Rooms to the new open format"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description
-        {
-            get
-            {
-                return "In AGS 4.0 the Rooms will now be stored in a \"open\" format, where each Room has a subfolder inside the \"Rooms\" folder, and each room component is saved as a separate file: properties are saved as XML, backgrounds and masks as PNG files, and so forth." +
+            Title = "Upgrade Rooms to the new open format";
+            Description = "In AGS 4.0 the Rooms will now be stored in a \"open\" format, where each Room has a subfolder inside the \"Rooms\" folder, and each room component is saved as a separate file: properties are saved as XML, backgrounds and masks as PNG files, and so forth." +
                     Environment.NewLine + Environment.NewLine +
                     "During this upgrade step every one of your \"room*.crm\" files will be converted into this open format representation." +
                     Environment.NewLine + Environment.NewLine +
                     "After this upgrade the \"room*.crm\" files will become purely output files, created as a result of the game compilation. They no longer need to be kept in the project folder. You may even delete them when e.g. sending your game sources to a co-developer in order to save disk space, and ignore them when adding your project under a source control.";
-            }
-        }
-        /// <summary>
-        /// A game project version that introduced this upgrade task.
-        /// If a loaded game has a less project version, then this task
-        /// must be applied, otherwise it should not.
-        /// Returns null if should be applied regardless of the game version
-        /// (but the execution process may still have version checks inside).
-        /// </summary>
-        public System.Version GameVersion { get { return new System.Version(AGSEditor.FIRST_XML_VERSION_USING_INDEX); } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_OPEN_ROOMS; } }
-        /// <summary>
-        /// Tells whether this upgrade task is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade task may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return false; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// task had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return false; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this task had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return false; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
+            GameVersion = new System.Version(AGSEditor.FIRST_XML_VERSION_USING_INDEX);
+            GameVersionIndex = AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_OPEN_ROOMS;
+            Implicit = false;
+            Optional = false;
+            AllowToSkipIfHadErrors = false;
+            RequestConfirmationOnErrors = false;
 
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
 
-        /// <summary>
-        /// Tells whether this task should be applied to this game.
-        /// This method can have additional conditions, besides the default version check.
-        /// </summary>
-        public bool ShouldApplyToGame(Game game)
-        {
-            return true;
+            _convertRooms = convertRooms;
         }
 
         /// <summary>
@@ -100,22 +40,15 @@ namespace AGS.Editor
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             return new UpgradeGameWizardPage[] { new UpdateGameGenericInfoPage(game, this) };
-        }
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-            // does not have any options
         }
         /// <summary>
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             _convertRooms(game, progress, errors);
         }

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
@@ -69,6 +69,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this task had errors.
         /// </summary>
         public bool RequestConfirmationOnErrors { get { return true; } }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
@@ -75,6 +75,15 @@ namespace AGS.Editor
         /// </summary>
         public bool Enabled { get; set; }
 
+        /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        public bool ShouldApplyToGame(Game game)
+        {
+            return true;
+        }
+
         internal RoomsComponent.UpgradeOptions Options
         {
             get { return _options; }

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameRoomsOptionalTask.cs
@@ -9,85 +9,26 @@ namespace AGS.Editor
     /// Performs an optional all-rooms update, according to the user
     /// selection (made in related game wizard pages).
     /// </summary>
-    public class UpgradeGameRoomsOptionalTask : IUpgradeGameTask
+    public class UpgradeGameRoomsOptionalTask : UpgradeGameTaskBase
     {
         internal delegate void ProcessRooms(Game game, RoomsComponent.UpgradeOptions options, IWorkProgress progress, CompileMessages errors);
         private ProcessRooms _processRooms;
         private RoomsComponent.UpgradeOptions _options = new RoomsComponent.UpgradeOptions();
 
-        internal UpgradeGameRoomsOptionalTask(ProcessRooms processRooms)
+        internal UpgradeGameRoomsOptionalTask(ProcessRooms processRooms) : base("UpgradeGameRoomsOptional")
         {
-            _processRooms = processRooms;
+            Title = "Update Rooms (optional section)";
+            GameVersion = new System.Version(AGSEditor.FIRST_USER_DATA_VERSION_WITHOUT_INDEX);
+            Implicit = false;
+            Optional = true;
+            AllowToSkipIfHadErrors = true;
+            RequestConfirmationOnErrors = true;
             Enabled = true;
+
+            _processRooms = processRooms;
         }
 
-        /// <summary>
-        /// A unique string identifier of this upgrade task.
-        /// </summary>
-        public string ID { get { return "UpgradeGameRoomsOptional"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this task when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Update Rooms (optional section)"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description
-        {
-            get { return ""; }
-        }
-        /// <summary>
-        /// A game project version that introduced this upgrade task.
-        /// If a loaded game has a less project version, then this task
-        /// must be applied, otherwise it should not.
-        /// Returns null if should be applied regardless of the game version
-        /// (but the execution process may still have version checks inside).
-        /// </summary>
-        public System.Version GameVersion { get { return new System.Version(AGSEditor.FIRST_USER_DATA_VERSION_WITHOUT_INDEX); } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return null; } }
-        /// <summary>
-        /// Tells whether this upgrade task is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade task may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return true; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// task had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return true; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this task had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return true; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
-
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Tells whether this task should be applied to this game.
-        /// This method can have additional conditions, besides the default version check.
-        /// </summary>
-        public bool ShouldApplyToGame(Game game)
-        {
-            return true;
-        }
-
+        // TODO: can we alternatively (optionally) use IUpgradeGameTask.ApplyOptions ?
         internal RoomsComponent.UpgradeOptions Options
         {
             get { return _options; }
@@ -99,7 +40,7 @@ namespace AGS.Editor
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             // NOTE: we may use game.SavedXmlVersion to decide which pages
             // and/or options to display! Return null if none are necessary.
@@ -115,17 +56,10 @@ namespace AGS.Editor
             return pages.ToArray();
         }
         /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-            // does not have any options
-        }
-        /// <summary>
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             // Check if any option is enabled, prevents from unnecessary loading every room
             if (!_options.AdjustObjectsBy1YPixel)

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTaskBase.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTaskBase.cs
@@ -1,0 +1,106 @@
+﻿using AGS.Types;
+using System;
+using System.Collections.Generic;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// An abstract implementation of IUpgradeGameTask.
+    /// Lets its descendants assign interface's properties in constructor instead of implementing them.
+    /// Descendant class is only oblidged to implement Execute() method, everything else is optional.
+    /// </summary>
+    public abstract class UpgradeGameTaskBase : IUpgradeGameTask
+    {
+        private string _id;
+
+        public UpgradeGameTaskBase(string id)
+        {
+            _id = id;
+        }
+
+        /// <summary>
+        /// A unique string identifier of this upgrade task.
+        /// </summary>
+        public string ID { get { return _id; } }
+        /// <summary>
+        /// An arbitrary title, used to identify this task when
+        /// presenting to a user.
+        /// </summary>
+        public string Title { get; protected set; }
+        /// <summary>
+        /// An arbitrary description, may contain any amount of text.
+        /// </summary>
+        public string Description { get; protected set; }
+        /// <summary>
+        /// A game project version that introduced this upgrade task.
+        /// If a loaded game has a less project version, then this task
+        /// must be applied, otherwise it should not.
+        /// Returns null if should be applied regardless of the game version
+        /// (but the execution process may still have version checks inside).
+        /// </summary>
+        public System.Version GameVersion { get; protected set; }
+        /// <summary>
+        /// A game project version in form of a numeric index, for the projects
+        /// which used these.
+        /// </summary>
+        public int? GameVersionIndex { get; protected set; }
+        /// <summary>
+        /// Tells whether this upgrade task is to be executed unconditionally,
+        /// without warning user about it.
+        /// </summary>
+        public bool Implicit { get; protected set; }
+        /// <summary>
+        /// Tells whether this upgrade task may be disabled by user's choice.
+        /// </summary>
+        public bool Optional { get; protected set; }
+        /// <summary>
+        /// Tells whether the upgrade process is allowed to continue if this
+        /// task had errors.
+        /// </summary>
+        public bool AllowToSkipIfHadErrors { get; protected set; }
+        /// <summary>
+        /// Tells whether user should be asked for a confirmation in order to
+        /// continue the upgrade process in case this task had errors.
+        /// </summary>
+        public bool RequestConfirmationOnErrors { get; protected set; }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get; protected set; }
+
+        /// <summary>
+        /// Whether this task is enabled, otherwise should be skipped.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Tells whether this task should be applied to this game.
+        /// This method can have additional conditions, besides the default version check.
+        /// </summary>
+        public virtual bool ShouldApplyToGame(Game game)
+        {
+            return true;
+        }
+        /// <summary>
+        /// Provides WizardPage control(s) used to represent this upgrade task.
+        /// The page implementation may have this IUpgradeGameTask passed into
+        /// constructor in order to assign settings right into it.
+        /// </summary>
+        public virtual UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        {
+            return null;
+        }
+        /// <summary>
+        /// Apply task options reading them from the dictionary of key-values.
+        /// </summary>
+        public virtual void ApplyOptions(Dictionary<string, string> options)
+        {
+            // does not have any options
+        }
+        /// <summary>
+        /// Execute the upgrade task over the given Game project.
+        /// Fills any errors or warnings into the provided "errors" collection.
+        /// </summary>
+        public abstract void Execute(Game game, IWorkProgress progress, CompileMessages errors);
+    }
+}

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTextEncodingTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTextEncodingTask.cs
@@ -1,35 +1,29 @@
-﻿using System;
+﻿using AGS.Types;
+using System;
 using System.Collections.Generic;
-using AGS.Types;
+using System.Text;
 
 namespace AGS.Editor
 {
-    public class UpgradeGameRoomsOpenFormatTask : IUpgradeGameTask
+    /// <summary>
+    /// UpgradeGameTextEncodingTask enforces UTF-8 encoding.
+    /// </summary>
+    public class UpgradeGameTextEncodingTask : IUpgradeGameTask
     {
-        // TODO: revise this later.
-        // The conversion process is run via a delegate here, because at the time
-        // I was not certain if it should remain in RoomComponent or not.
-        // It sort of makes sense, conceptually.
-        // Also, the conversion calls a number of private methods from RoomComponent,
-        // therefore this seemed to be the most trivial way to proceed.
-        public delegate void ConvertRooms(Game game, IWorkProgress progress, CompileMessages errors);
-        private ConvertRooms _convertRooms;
-
-        public UpgradeGameRoomsOpenFormatTask(ConvertRooms convertRooms)
+        public UpgradeGameTextEncodingTask()
         {
-            _convertRooms = convertRooms;
             Enabled = true;
         }
 
         /// <summary>
         /// A unique string identifier of this upgrade task.
         /// </summary>
-        public string ID { get { return "UpgradeGameRoomsOpenFormat"; } }
+        public string ID { get { return "UpgradeGameTextEncodingTask"; } }
         /// <summary>
         /// An arbitrary title, used to identify this task when
         /// presenting to a user.
         /// </summary>
-        public string Title { get { return "Upgrade Rooms to the new open format"; } }
+        public string Title { get { return "Convert game to UTF-8 encoding"; } }
         /// <summary>
         /// An arbitrary description, may contain any amount of text.
         /// </summary>
@@ -37,11 +31,10 @@ namespace AGS.Editor
         {
             get
             {
-                return "In AGS 4.0 the Rooms will now be stored in a \"open\" format, where each Room has a subfolder inside the \"Rooms\" folder, and each room component is saved as a separate file: properties are saved as XML, backgrounds and masks as PNG files, and so forth." +
+                return "In AGS 4.0 the ASCII game text encoding is no longer supported. Your game will be converted to UTF-8 format; this will affect game scripts and all the text properties." +
                     Environment.NewLine + Environment.NewLine +
-                    "During this upgrade step every one of your \"room*.crm\" files will be converted into this open format representation." +
-                    Environment.NewLine + Environment.NewLine +
-                    "After this upgrade the \"room*.crm\" files will become purely output files, created as a result of the game compilation. They no longer need to be kept in the project folder. You may even delete them when e.g. sending your game sources to a co-developer in order to save disk space, and ignore them when adding your project under a source control.";
+                    "If your game has only English texts, then everything will remain as it were." + Environment.NewLine +
+                    "If you were using any language(s) other than English in your game, then likely you have ANSI-compatible fonts. In this case the texts in non-English languages will appear \"broken\" in game. This can be fixed by replacing ANSI fonts with Unicode-compatible fonts. This is something that AGS cannot do on its own; you will have to find suitable fonts yourself and import them into the game, replacing existing ones.";
             }
         }
         /// <summary>
@@ -51,12 +44,12 @@ namespace AGS.Editor
         /// Returns null if should be applied regardless of the game version
         /// (but the execution process may still have version checks inside).
         /// </summary>
-        public System.Version GameVersion { get { return new System.Version(AGSEditor.FIRST_XML_VERSION_USING_INDEX); } }
+        public System.Version GameVersion { get { return null; } }
         /// <summary>
         /// A game project version in form of a numeric index, for the projects
         /// which used these.
         /// </summary>
-        public int? GameVersionIndex { get { return AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_OPEN_ROOMS; } }
+        public int? GameVersionIndex { get { return null; } }
         /// <summary>
         /// Tells whether this upgrade task is to be executed unconditionally,
         /// without warning user about it.
@@ -79,7 +72,7 @@ namespace AGS.Editor
         /// <summary>
         /// Tells which stage should this task be run on.
         /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.PostStage; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.
@@ -92,11 +85,11 @@ namespace AGS.Editor
         /// </summary>
         public bool ShouldApplyToGame(Game game)
         {
-            return true;
+            return game.Settings.GameTextEncoding != Encoding.UTF8.WebName;
         }
 
         /// <summary>
-        /// Provides WizardPage controls used to represent this upgrade task.
+        /// Provides WizardPage control(s) used to represent this upgrade task.
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
@@ -104,20 +97,28 @@ namespace AGS.Editor
         {
             return new UpgradeGameWizardPage[] { new UpdateGameGenericInfoPage(game, this) };
         }
+
         /// <summary>
         /// Apply task options reading them from the dictionary of key-values.
         /// </summary>
         public void ApplyOptions(Dictionary<string, string> options)
         {
-            // does not have any options
+            // do nothing
         }
+
         /// <summary>
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
         public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
-            _convertRooms(game, progress, errors);
+            var oldEncoding = game.TextEncoding;
+            game.Settings.GameTextEncoding = Encoding.UTF8.WebName;
+            Factory.AGSEditor.Tasks.ConvertAllGameTextsNoSaveGame(game,
+                            oldEncoding,
+                            progress,
+                            errors);
+            errors.Add(new CompileInformation($"Converted game to UTF-8 text format"));
         }
     }
 }

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTextEncodingTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameTextEncodingTask.cs
@@ -8,82 +8,28 @@ namespace AGS.Editor
     /// <summary>
     /// UpgradeGameTextEncodingTask enforces UTF-8 encoding.
     /// </summary>
-    public class UpgradeGameTextEncodingTask : IUpgradeGameTask
+    public class UpgradeGameTextEncodingTask : UpgradeGameTaskBase
     {
-        public UpgradeGameTextEncodingTask()
+        public UpgradeGameTextEncodingTask() : base("UpgradeGameTextEncodingTask")
         {
-            Enabled = true;
-        }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade task.
-        /// </summary>
-        public string ID { get { return "UpgradeGameTextEncodingTask"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this task when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Convert game to UTF-8 encoding"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description
-        {
-            get
-            {
-                return "In AGS 4.0 the ASCII game text encoding is no longer supported. Your game will be converted to UTF-8 format; this will affect game scripts and all the text properties." +
+            Title = "Convert game to UTF-8 encoding";
+            Description = "In AGS 4.0 the ASCII game text encoding is no longer supported. Your game will be converted to UTF-8 format; this will affect game scripts and all the text properties." +
                     Environment.NewLine + Environment.NewLine +
                     "If your game has only English texts, then everything will remain as it were." + Environment.NewLine +
                     "If you were using any language(s) other than English in your game, then likely you have ANSI-compatible fonts. In this case the texts in non-English languages will appear \"broken\" in game. This can be fixed by replacing ANSI fonts with Unicode-compatible fonts. This is something that AGS cannot do on its own; you will have to find suitable fonts yourself and import them into the game, replacing existing ones.";
-            }
+            Implicit = false;
+            Optional = false;
+            AllowToSkipIfHadErrors = false;
+            RequestConfirmationOnErrors = false;
+            Stage = UpgradeGameTaskStage.PostStage; // should do this after any project format conversions
+            Enabled = true;
         }
-        /// <summary>
-        /// A game project version that introduced this upgrade task.
-        /// If a loaded game has a less project version, then this task
-        /// must be applied, otherwise it should not.
-        /// Returns null if should be applied regardless of the game version
-        /// (but the execution process may still have version checks inside).
-        /// </summary>
-        public System.Version GameVersion { get { return null; } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return null; } }
-        /// <summary>
-        /// Tells whether this upgrade task is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade task may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return false; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// task had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return false; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this task had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return false; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.PostStage; } }
-
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
 
         /// <summary>
         /// Tells whether this task should be applied to this game.
         /// This method can have additional conditions, besides the default version check.
         /// </summary>
-        public bool ShouldApplyToGame(Game game)
+        public override bool ShouldApplyToGame(Game game)
         {
             return game.Settings.GameTextEncoding != Encoding.UTF8.WebName;
         }
@@ -93,24 +39,16 @@ namespace AGS.Editor
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             return new UpgradeGameWizardPage[] { new UpdateGameGenericInfoPage(game, this) };
-        }
-
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-            // do nothing
         }
 
         /// <summary>
         /// Execute the upgrade task over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             var oldEncoding = game.TextEncoding;
             game.Settings.GameTextEncoding = Encoding.UTF8.WebName;

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
@@ -62,6 +62,10 @@ namespace AGS.Editor
         /// continue the upgrade process in case this step had errors.
         /// </summary>
         public bool RequestConfirmationOnErrors { get { return true; } }
+        /// <summary>
+        /// Tells which stage should this task be run on.
+        /// </summary>
+        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
 
         /// <summary>
         /// Whether this task is enabled, otherwise should be skipped.

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
@@ -1,31 +1,33 @@
-﻿using System;
+﻿using AGS.Types;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using AGS.Editor.Components;
-using AGS.Types;
 
 namespace AGS.Editor
 {
     /// <summary>
-    /// UpgradeGameIntroAndBackupTask performs an optional project backup;
-    /// is supposed to be executed prior to any other upgrade tasks.
+    /// UpgradeGameVoiceClips renames old-style voice clips to new-style format.
     /// </summary>
-    public class UpgradeGameIntroAndBackupTask : IUpgradeGameTask
+    public class UpgradeGameVoiceClipsTask : IUpgradeGameTask
     {
-        public UpgradeGameIntroAndBackupTask()
+        internal delegate void ProcessSpeechFiles(Game game, IWorkProgress progress, CompileMessages errors);
+        private ProcessSpeechFiles _procSpeechFiles;
+
+        internal UpgradeGameVoiceClipsTask(ProcessSpeechFiles proc)
         {
+            _procSpeechFiles = proc;
             Enabled = true;
         }
 
         /// <summary>
         /// A unique string identifier of this upgrade step.
         /// </summary>
-        public string ID { get { return "UpgradeGameIntroAndBackup"; } }
+        public string ID { get { return "UpgradeGameVoiceClips"; } }
         /// <summary>
         /// An arbitrary title, used to identify this step when
         /// presenting to a user.
         /// </summary>
-        public string Title { get { return "Backup project files"; } }
+        public string Title { get { return "Convert old-style voice clips"; } }
         /// <summary>
         /// An arbitrary description, may contain any amount of text.
         /// </summary>
@@ -35,12 +37,12 @@ namespace AGS.Editor
         /// If a loaded game has a less project version, then this step
         /// must be applied, otherwise it should not.
         /// </summary>
-        public System.Version GameVersion { get { return null; /* any version where needed */ } }
+        public System.Version GameVersion { get { return new System.Version("4.0.0.33"); } }
         /// <summary>
         /// A game project version in form of a numeric index, for the projects
         /// which used these.
         /// </summary>
-        public int? GameVersionIndex { get { return null; } }
+        public int? GameVersionIndex { get { return 4000033; } }
         /// <summary>
         /// Tells whether this upgrade step is to be executed unconditionally,
         /// without warning user about it.
@@ -67,17 +69,14 @@ namespace AGS.Editor
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// A directory to copy backup files to.
-        /// </summary>
-        public string BackupPath { get; set; }
-
-        /// <summary>
         /// Tells whether this task should be applied to this game.
         /// This method can have additional conditions, besides the default version check.
         /// </summary>
         public bool ShouldApplyToGame(Game game)
         {
-            return true;
+#pragma warning disable 0612
+            return game.Settings.UseOldVoiceClipNaming;
+#pragma warning restore 0612
         }
 
         /// <summary>
@@ -87,7 +86,7 @@ namespace AGS.Editor
         /// </summary>
         public UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
-            return new UpgradeGameWizardPage[] { new UpgradeGameIntroPage(game, this) };
+            return new UpgradeGameWizardPage[] { new UpgradeGameVoiceClipsPage(game, this) };
         }
         /// <summary>
         /// Apply task options reading them from the dictionary of key-values.
@@ -102,31 +101,7 @@ namespace AGS.Editor
         /// </summary>
         public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
-            if (string.IsNullOrEmpty(BackupPath))
-            {
-                errors.Add(new CompileError("Invalid backup location"));
-                return;
-            }
-
-            // CHECKME: not sure if we should backup media resources here
-            string[] patternStr = AGSEditor.Instance.Tasks.GetPatternsForStandardGameFiles(game, mediaResources: true);
-            var patterns = IncludeUtils.CreatePatternList(patternStr, IncludeUtils.MatchOption.CaseInsensitive);
-            string[] filesToBackup = Utilities.GetDirectoryFileList(game.DirectoryPath, "*", SearchOption.AllDirectories, relativePaths: true);
-            filesToBackup = IncludeUtils.FilterItemList(filesToBackup, patterns, IncludeUtils.MatchOption.CaseInsensitive);
-
-            foreach (string file in filesToBackup)
-            {
-                string relativeFile = Utilities.GetRelativeToProjectPath(file);
-                string destinationFile = Path.Combine(BackupPath, relativeFile);
-                string destinationDirectory = Path.GetDirectoryName(destinationFile);
-                if (!Directory.Exists(destinationDirectory))
-                {
-                    Directory.CreateDirectory(destinationDirectory);
-                }
-                File.Copy(file, destinationFile);
-            }
-
-            errors.Add(new CompileInformation($"Original game files are backed up in {BackupPath}"));
+            _procSpeechFiles(game, progress, errors);
         }
     }
 }

--- a/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
+++ b/Editor/AGS.Editor/Entities/UpgradeGame/UpgradeGameVoiceClipsTask.cs
@@ -8,75 +8,30 @@ namespace AGS.Editor
     /// <summary>
     /// UpgradeGameVoiceClips renames old-style voice clips to new-style format.
     /// </summary>
-    public class UpgradeGameVoiceClipsTask : IUpgradeGameTask
+    public class UpgradeGameVoiceClipsTask : UpgradeGameTaskBase
     {
         internal delegate void ProcessSpeechFiles(Game game, IWorkProgress progress, CompileMessages errors);
         private ProcessSpeechFiles _procSpeechFiles;
 
-        internal UpgradeGameVoiceClipsTask(ProcessSpeechFiles proc)
+        internal UpgradeGameVoiceClipsTask(ProcessSpeechFiles proc) : base("UpgradeGameVoiceClips")
         {
-            _procSpeechFiles = proc;
+            Title = "Convert old-style voice clips";
+            GameVersion = new System.Version("4.0.0.33");
+            GameVersionIndex = 4000033;
+            Implicit = false;
+            Optional = true;
+            AllowToSkipIfHadErrors = true;
+            RequestConfirmationOnErrors = true;
             Enabled = true;
+
+            _procSpeechFiles = proc;
         }
-
-        /// <summary>
-        /// A unique string identifier of this upgrade step.
-        /// </summary>
-        public string ID { get { return "UpgradeGameVoiceClips"; } }
-        /// <summary>
-        /// An arbitrary title, used to identify this step when
-        /// presenting to a user.
-        /// </summary>
-        public string Title { get { return "Convert old-style voice clips"; } }
-        /// <summary>
-        /// An arbitrary description, may contain any amount of text.
-        /// </summary>
-        public string Description { get { return ""; /* TODO? */ } }
-        /// <summary>
-        /// A game project version that introduced this upgrade step.
-        /// If a loaded game has a less project version, then this step
-        /// must be applied, otherwise it should not.
-        /// </summary>
-        public System.Version GameVersion { get { return new System.Version("4.0.0.33"); } }
-        /// <summary>
-        /// A game project version in form of a numeric index, for the projects
-        /// which used these.
-        /// </summary>
-        public int? GameVersionIndex { get { return 4000033; } }
-        /// <summary>
-        /// Tells whether this upgrade step is to be executed unconditionally,
-        /// without warning user about it.
-        /// </summary>
-        public bool Implicit { get { return false; } }
-        /// <summary>
-        /// Tells whether this upgrade step may be disabled by user's choice.
-        /// </summary>
-        public bool Optional { get { return true; } }
-        /// <summary>
-        /// Tells whether the upgrade process is allowed to continue if this
-        /// step had errors.
-        /// </summary>
-        public bool AllowToSkipIfHadErrors { get { return true; } }
-        /// <summary>
-        /// Tells whether user should be asked for a confirmation in order to
-        /// continue the upgrade process in case this step had errors.
-        /// </summary>
-        public bool RequestConfirmationOnErrors { get { return true; } }
-        /// <summary>
-        /// Tells which stage should this task be run on.
-        /// </summary>
-        public UpgradeGameTaskStage Stage { get { return UpgradeGameTaskStage.None; } }
-
-        /// <summary>
-        /// Whether this task is enabled, otherwise should be skipped.
-        /// </summary>
-        public bool Enabled { get; set; }
 
         /// <summary>
         /// Tells whether this task should be applied to this game.
         /// This method can have additional conditions, besides the default version check.
         /// </summary>
-        public bool ShouldApplyToGame(Game game)
+        public override bool ShouldApplyToGame(Game game)
         {
 #pragma warning disable 0612
             return game.Settings.UseOldVoiceClipNaming;
@@ -88,22 +43,15 @@ namespace AGS.Editor
         /// The page implementation may have this IUpgradeGameTask passed into
         /// constructor in order to assign settings right into it.
         /// </summary>
-        public UpgradeGameWizardPage[] CreateWizardPages(Game game)
+        public override UpgradeGameWizardPage[] CreateWizardPages(Game game)
         {
             return new UpgradeGameWizardPage[] { new UpgradeGameVoiceClipsPage(game, this) };
-        }
-        /// <summary>
-        /// Apply task options reading them from the dictionary of key-values.
-        /// </summary>
-        public void ApplyOptions(Dictionary<string, string> options)
-        {
-
         }
         /// <summary>
         /// Execute the upgrade step over the given Game project.
         /// Fills any errors or warnings into the provided "errors" collection.
         /// </summary>
-        public void Execute(Game game, IWorkProgress progress, CompileMessages errors)
+        public override void Execute(Game game, IWorkProgress progress, CompileMessages errors)
         {
             _procSpeechFiles(game, progress, errors);
         }

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpdateGameGenericInfoPage.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpdateGameGenericInfoPage.cs
@@ -15,11 +15,6 @@ namespace AGS.Editor
             richDescription.Text = task.Description;
         }
 
-        public override string TitleText
-        {
-            get { return Task.Title; }
-        }
-
         private void InitializeComponent()
         {
             this.richDescription = new AGS.Controls.ReadOnlyRichTextBox();
@@ -44,7 +39,7 @@ namespace AGS.Editor
             this.MinimumSize = new System.Drawing.Size(640, 320);
             this.Name = "UpdateGameGenericInfoPage";
             this.Padding = new System.Windows.Forms.Padding(13);
-            this.Size = new System.Drawing.Size(1358, 677);
+            this.Size = new System.Drawing.Size(1523, 582);
             this.ResumeLayout(false);
 
         }

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpdateGameRoomsOptionalPage.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpdateGameRoomsOptionalPage.cs
@@ -23,11 +23,6 @@ namespace AGS.Editor
             _roomsOptionalTask = task as UpgradeGameRoomsOptionalTask;
         }
 
-        public override string TitleText
-        {
-            get { return Task.Title; }
-        }
-
         public override bool NextButtonPressed()
         {
             RoomsComponent.UpgradeOptions options = new RoomsComponent.UpgradeOptions();
@@ -112,7 +107,7 @@ namespace AGS.Editor
             this.MinimumSize = new System.Drawing.Size(640, 320);
             this.Name = "UpdateGameRoomsOptionalPage";
             this.Padding = new System.Windows.Forms.Padding(13);
-            this.Size = new System.Drawing.Size(1193, 715);
+            this.Size = new System.Drawing.Size(1523, 582);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameIntroPage.Designer.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameIntroPage.Designer.cs
@@ -128,7 +128,7 @@ namespace AGS.Editor
             this.MinimumSize = new System.Drawing.Size(640, 320);
             this.Name = "UpgradeGameIntroPage";
             this.Padding = new System.Windows.Forms.Padding(13);
-            this.Size = new System.Drawing.Size(1193, 575);
+            this.Size = new System.Drawing.Size(1523, 582);
             this.Load += new System.EventHandler(this.UpgradeGameIntroPage_Load);
             this.VisibleChanged += new System.EventHandler(this.UpgradeGameIntroPage_VisibleChanged);
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.Designer.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.Designer.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AGS.Editor
+{
+    partial class UpgradeGameVoiceClipsPage
+    {
+        private Controls.ReadOnlyRichTextBox richDescription;
+        private System.Windows.Forms.CheckBox chkRenameVoiceClips;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Panel panel1;
+
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UpgradeGameVoiceClipsPage));
+            this.richDescription = new AGS.Controls.ReadOnlyRichTextBox();
+            this.chkRenameVoiceClips = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // richDescription
+            // 
+            this.richDescription.BackColor = System.Drawing.SystemColors.Control;
+            this.richDescription.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.richDescription.Cursor = System.Windows.Forms.Cursors.Default;
+            this.richDescription.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.richDescription.Location = new System.Drawing.Point(3, 3);
+            this.richDescription.Name = "richDescription";
+            this.richDescription.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.richDescription.Size = new System.Drawing.Size(515, 103);
+            this.richDescription.TabIndex = 0;
+            this.richDescription.Text = resources.GetString("richDescription.Text");
+            // 
+            // chkRenameVoiceClips
+            // 
+            this.chkRenameVoiceClips.AutoSize = true;
+            this.chkRenameVoiceClips.Checked = true;
+            this.chkRenameVoiceClips.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkRenameVoiceClips.Location = new System.Drawing.Point(18, 13);
+            this.chkRenameVoiceClips.Name = "chkRenameVoiceClips";
+            this.chkRenameVoiceClips.Size = new System.Drawing.Size(228, 17);
+            this.chkRenameVoiceClips.TabIndex = 4;
+            this.chkRenameVoiceClips.Text = "Rename voice clips to the new style format";
+            this.chkRenameVoiceClips.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.richDescription, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(16, 16);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(572, 340);
+            this.tableLayoutPanel1.TabIndex = 7;
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.chkRenameVoiceClips);
+            this.panel1.Location = new System.Drawing.Point(3, 122);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(515, 40);
+            this.panel1.TabIndex = 7;
+            // 
+            // UpgradeGameVoiceClipsPage
+            // 
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Name = "UpgradeGameVoiceClipsPage";
+            this.Size = new System.Drawing.Size(1523, 582);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.cs
@@ -1,0 +1,25 @@
+﻿using AGS.Editor.Components;
+using AGS.Types;
+using System;
+
+namespace AGS.Editor
+{
+    public partial class UpgradeGameVoiceClipsPage : UpgradeGameWizardPage
+    {
+        private UpgradeGameVoiceClipsTask _task;
+
+        public UpgradeGameVoiceClipsPage(Game game, UpgradeGameVoiceClipsTask task)
+            : base(game, task)
+        {
+            InitializeComponent();
+            _task = task;
+            chkRenameVoiceClips.Checked = _task.Enabled;
+        }
+
+        public override bool NextButtonPressed()
+        {
+            _task.Enabled = chkRenameVoiceClips.Checked;
+            return true;
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.resx
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameVoiceClipsPage.resx
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="richDescription.Text" xml:space="preserve">
+    <value>The classic naming convention for the speech voice files was "CHARNNNN.ext". AGS 3.6.2 introduced new naming convention for the speech voice clips: "CharacterName.Number.ext". The 3.x version branch kept support for the old and new conventions simultaneously, but in AGS 4 we have the old one discontinued and new style enforced.
+
+If you have voice files in Speech folder, we suggest to rename these following the new convention. This may be done during the project upgrade, or you may decide to keep the old files and do renaming yourself later.</value>
+  </data>
+</root>

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameWizardPage.cs
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameWizardPage.cs
@@ -25,5 +25,21 @@ namespace AGS.Editor
             _game = game;
             _upgradeTask = task;
         }
+
+        public override string TitleText
+        {
+            get { return Task != null ? Task.Title : string.Empty; }
+        }
+
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // UpgradeGameWizardPage
+            // 
+            this.Name = "UpgradeGameWizardPage";
+            this.Size = new System.Drawing.Size(1523, 582);
+            this.ResumeLayout(false);
+        }
     }
 }

--- a/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameWizardPage.resx
+++ b/Editor/AGS.Editor/GUI/UpgradeGameWizard/UpgradeGameWizardPage.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -121,13 +121,13 @@ namespace AGS.Editor
             return _native.GetFontValidCharacters(fontNum);
         }
 
-        public void DrawFont(IntPtr hdc, int fontNum, bool ansi_mode, bool only_valid_chars,
+        public void DrawFont(IntPtr hdc, int fontNum, bool only_valid_chars,
                 int dc_atx, int dc_aty, int draw_atx, int draw_aty,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y,
                 int col_count, int row_count, int first_cell,
                 float scaling)
         {
-            _native.DrawFont((int)hdc, fontNum, ansi_mode, only_valid_chars,
+            _native.DrawFont((int)hdc, fontNum, only_valid_chars,
                 dc_atx, dc_aty, draw_atx, draw_aty,
                 cell_w, cell_h, cell_space_x, cell_space_y,
                 col_count, row_count, first_cell, scaling);

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -31,19 +31,15 @@ namespace AGS.Editor
             this.currentItemGroupBox = new System.Windows.Forms.GroupBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.chkRTL = new System.Windows.Forms.CheckBox();
             this.tbTextPreview = new System.Windows.Forms.TextBox();
             this.textPreviewPanel = new AGS.Editor.BufferedPanel();
-            this.rbPreviewAuto = new System.Windows.Forms.RadioButton();
-            this.rbANSI = new System.Windows.Forms.RadioButton();
-            this.rbUnicode = new System.Windows.Forms.RadioButton();
-            this.label2 = new System.Windows.Forms.Label();
             this.chkDisplayCodes = new System.Windows.Forms.CheckBox();
             this.btnGotoChar = new System.Windows.Forms.Button();
             this.tbCharInput = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.udCharCode = new System.Windows.Forms.NumericUpDown();
             this.lblCharCode = new System.Windows.Forms.Label();
-            this.chkRTL = new System.Windows.Forms.CheckBox();
             this.fontViewPanel = new AGS.Editor.FontPreviewGrid();
             this.label1 = new System.Windows.Forms.Label();
             this.currentItemGroupBox.SuspendLayout();
@@ -100,10 +96,6 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.rbPreviewAuto);
-            this.splitContainer1.Panel2.Controls.Add(this.rbANSI);
-            this.splitContainer1.Panel2.Controls.Add(this.rbUnicode);
-            this.splitContainer1.Panel2.Controls.Add(this.label2);
             this.splitContainer1.Panel2.Controls.Add(this.chkDisplayCodes);
             this.splitContainer1.Panel2.Controls.Add(this.btnGotoChar);
             this.splitContainer1.Panel2.Controls.Add(this.tbCharInput);
@@ -118,6 +110,18 @@ namespace AGS.Editor
             this.splitContainer1.TabIndex = 0;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
             this.splitContainer1.Resize += new System.EventHandler(this.splitContainer1_Resize);
+            // 
+            // chkRTL
+            // 
+            this.chkRTL.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.chkRTL.AutoSize = true;
+            this.chkRTL.Location = new System.Drawing.Point(10, 128);
+            this.chkRTL.Name = "chkRTL";
+            this.chkRTL.Size = new System.Drawing.Size(140, 17);
+            this.chkRTL.TabIndex = 2;
+            this.chkRTL.Text = "Right-to-left text preview";
+            this.chkRTL.UseVisualStyleBackColor = true;
+            this.chkRTL.CheckedChanged += new System.EventHandler(this.chkRTL_CheckedChanged);
             // 
             // tbTextPreview
             // 
@@ -145,56 +149,10 @@ namespace AGS.Editor
             this.textPreviewPanel.SizeChanged += new System.EventHandler(this.textPreviewPanel_SizeChanged);
             this.textPreviewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.textPreviewPanel_Paint);
             // 
-            // rbPreviewAuto
-            // 
-            this.rbPreviewAuto.AutoSize = true;
-            this.rbPreviewAuto.Checked = true;
-            this.rbPreviewAuto.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.rbPreviewAuto.Location = new System.Drawing.Point(91, 6);
-            this.rbPreviewAuto.Name = "rbPreviewAuto";
-            this.rbPreviewAuto.Size = new System.Drawing.Size(138, 17);
-            this.rbPreviewAuto.TabIndex = 10;
-            this.rbPreviewAuto.TabStop = true;
-            this.rbPreviewAuto.Text = "Auto (use Game setting)";
-            this.rbPreviewAuto.UseVisualStyleBackColor = true;
-            this.rbPreviewAuto.CheckedChanged += new System.EventHandler(this.rbPreviewAuto_CheckedChanged);
-            // 
-            // rbANSI
-            // 
-            this.rbANSI.AutoSize = true;
-            this.rbANSI.Location = new System.Drawing.Point(306, 6);
-            this.rbANSI.Name = "rbANSI";
-            this.rbANSI.Size = new System.Drawing.Size(88, 17);
-            this.rbANSI.TabIndex = 2;
-            this.rbANSI.Text = "ASCII / ANSI";
-            this.rbANSI.UseVisualStyleBackColor = true;
-            this.rbANSI.CheckedChanged += new System.EventHandler(this.rbANSI_CheckedChanged);
-            // 
-            // rbUnicode
-            // 
-            this.rbUnicode.AutoSize = true;
-            this.rbUnicode.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.rbUnicode.Location = new System.Drawing.Point(235, 6);
-            this.rbUnicode.Name = "rbUnicode";
-            this.rbUnicode.Size = new System.Drawing.Size(65, 17);
-            this.rbUnicode.TabIndex = 1;
-            this.rbUnicode.Text = "Unicode";
-            this.rbUnicode.UseVisualStyleBackColor = true;
-            this.rbUnicode.CheckedChanged += new System.EventHandler(this.rbUnicode_CheckedChanged);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 7);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(77, 13);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Preview mode:";
-            // 
             // chkDisplayCodes
             // 
             this.chkDisplayCodes.AutoSize = true;
-            this.chkDisplayCodes.Location = new System.Drawing.Point(408, 33);
+            this.chkDisplayCodes.Location = new System.Drawing.Point(408, 11);
             this.chkDisplayCodes.Name = "chkDisplayCodes";
             this.chkDisplayCodes.Size = new System.Drawing.Size(92, 17);
             this.chkDisplayCodes.TabIndex = 8;
@@ -204,7 +162,7 @@ namespace AGS.Editor
             // 
             // btnGotoChar
             // 
-            this.btnGotoChar.Location = new System.Drawing.Point(313, 29);
+            this.btnGotoChar.Location = new System.Drawing.Point(313, 7);
             this.btnGotoChar.Name = "btnGotoChar";
             this.btnGotoChar.Size = new System.Drawing.Size(75, 23);
             this.btnGotoChar.TabIndex = 7;
@@ -214,7 +172,7 @@ namespace AGS.Editor
             // 
             // tbCharInput
             // 
-            this.tbCharInput.Location = new System.Drawing.Point(231, 31);
+            this.tbCharInput.Location = new System.Drawing.Point(231, 9);
             this.tbCharInput.MaxLength = 1;
             this.tbCharInput.Name = "tbCharInput";
             this.tbCharInput.Size = new System.Drawing.Size(60, 20);
@@ -225,7 +183,7 @@ namespace AGS.Editor
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(169, 34);
+            this.label3.Location = new System.Drawing.Point(169, 12);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(56, 13);
             this.label3.TabIndex = 5;
@@ -234,7 +192,7 @@ namespace AGS.Editor
             // udCharCode
             // 
             this.udCharCode.Hexadecimal = true;
-            this.udCharCode.Location = new System.Drawing.Point(65, 30);
+            this.udCharCode.Location = new System.Drawing.Point(63, 9);
             this.udCharCode.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -249,38 +207,26 @@ namespace AGS.Editor
             // lblCharCode
             // 
             this.lblCharCode.AutoSize = true;
-            this.lblCharCode.Location = new System.Drawing.Point(11, 34);
+            this.lblCharCode.Location = new System.Drawing.Point(11, 12);
             this.lblCharCode.Name = "lblCharCode";
             this.lblCharCode.Size = new System.Drawing.Size(52, 13);
             this.lblCharCode.TabIndex = 3;
             this.lblCharCode.Text = "Code: U+";
             // 
-            // chkRTL
-            // 
-            this.chkRTL.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.chkRTL.AutoSize = true;
-            this.chkRTL.Location = new System.Drawing.Point(10, 128);
-            this.chkRTL.Name = "chkRTL";
-            this.chkRTL.Size = new System.Drawing.Size(140, 17);
-            this.chkRTL.TabIndex = 2;
-            this.chkRTL.Text = "Right-to-left text preview";
-            this.chkRTL.UseVisualStyleBackColor = true;
-            this.chkRTL.CheckedChanged += new System.EventHandler(this.chkRTL_CheckedChanged);
             // fontViewPanel
             // 
             this.fontViewPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fontViewPanel.ANSIMode = false;
             this.fontViewPanel.AutoScroll = true;
             this.fontViewPanel.DisplayCodes = false;
             this.fontViewPanel.GameFont = null;
             this.fontViewPanel.HideMissingCharacters = true;
-            this.fontViewPanel.Location = new System.Drawing.Point(6, 57);
+            this.fontViewPanel.Location = new System.Drawing.Point(6, 36);
             this.fontViewPanel.Name = "fontViewPanel";
             this.fontViewPanel.Scaling = 1F;
             this.fontViewPanel.SelectedCharCode = -1;
-            this.fontViewPanel.Size = new System.Drawing.Size(520, 234);
+            this.fontViewPanel.Size = new System.Drawing.Size(520, 255);
             this.fontViewPanel.TabIndex = 9;
             this.fontViewPanel.TabStop = true;
             // 
@@ -330,10 +276,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblCharCode;
         private System.Windows.Forms.Button btnGotoChar;
         private System.Windows.Forms.CheckBox chkDisplayCodes;
-        private System.Windows.Forms.RadioButton rbANSI;
-        private System.Windows.Forms.RadioButton rbUnicode;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.RadioButton rbPreviewAuto;
         private System.Windows.Forms.CheckBox chkRTL;
     }
 }

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -58,7 +58,7 @@ namespace AGS.Editor
 
         public void OnTextFormatUpdated()
         {
-            SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
+            SetFontPreviewMode();
         }
 
         public void UpdatePreviewScaling()
@@ -140,36 +140,12 @@ namespace AGS.Editor
             textPreviewPanel.Invalidate();
         }
 
-        private void SetFontPreviewMode(bool unicodeMode)
+        private void SetFontPreviewMode()
         {
-            if (unicodeMode)
-            {
-                fontViewPanel.ANSIMode = false;
-                lblCharCode.Text = "Code: U+";
-                udCharCode.Hexadecimal = true;
-            }
-            else
-            {
-                fontViewPanel.ANSIMode = true;
-                lblCharCode.Text = "Code:";
-                udCharCode.Hexadecimal = false;
-            }
+            lblCharCode.Text = "Code: U+";
+            udCharCode.Hexadecimal = true;
         }
 
-        private void rbPreviewAuto_CheckedChanged(object sender, EventArgs e)
-        {
-            SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
-        }
-
-        private void rbUnicode_CheckedChanged(object sender, EventArgs e)
-        {
-            SetFontPreviewMode(true);
-        }
-
-        private void rbANSI_CheckedChanged(object sender, EventArgs e)
-        {
-            SetFontPreviewMode(false);
-        }
         private void fontViewPanel_CharacterSelected(object sender, FontPreviewGrid.CharacterSelectedEventArgs args)
         {
             udCharCode.Value = args.CharacterCode;
@@ -183,15 +159,7 @@ namespace AGS.Editor
                 int code = 0;
                 if (tbCharInput.Text.Length > 0)
                 {
-                    if (fontViewPanel.ANSIMode)
-                    {
-                        var ansiBytes = Encoding.Default.GetBytes(tbCharInput.Text);
-                        code = ansiBytes[0];
-                    }
-                    else
-                    {
-                        code = tbCharInput.Text[0];
-                    }
+                    code = tbCharInput.Text[0];
                 }
                 udCharCode.Value = (code >= udCharCode.Minimum && code <= udCharCode.Maximum) ? code : 0;
 
@@ -287,7 +255,7 @@ namespace AGS.Editor
             if (!DesignMode)
             {
                 Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
-                SetFontPreviewMode(Factory.AGSEditor.CurrentGame.UnicodeMode);
+                SetFontPreviewMode();
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
+++ b/Editor/AGS.Editor/Panes/FontPreviewGrid.cs
@@ -15,9 +15,7 @@ namespace AGS.Editor
         private int[] _charCodes;
         // Character code to preview index lookup table
         private Dictionary<int, int> _charcodeToCellIndex;
-        private int _lastANSICharCodeIndex = -1;
         private float _scaling = 1.0f;
-        private bool _ansiMode = false;
         private bool _hideMissingChars = true;
         private int _selectedChar = -1;
         private bool _displayCodes = false;
@@ -65,19 +63,6 @@ namespace AGS.Editor
                     throw new ArgumentOutOfRangeException();
 
                 _scaling = value;
-                if (!DesignMode)
-                {
-                    UpdateAndRepaint(false);
-                }
-            }
-        }
-
-        public bool ANSIMode
-        {
-            get { return _ansiMode; }
-            set
-            {
-                _ansiMode = value;
                 if (!DesignMode)
                 {
                     UpdateAndRepaint(false);
@@ -200,8 +185,6 @@ namespace AGS.Editor
                     for (int i = 0; i < _charCodes.Length; ++i)
                     {
                         _charcodeToCellIndex.Add(_charCodes[i], i);
-                        if (_charCodes[i] < 256)
-                            _lastANSICharCodeIndex = i;
                     }
                 }
             }
@@ -210,7 +193,6 @@ namespace AGS.Editor
                 _fontMetrics = FontMetrics.Empty;
                 _charCodes = null;
                 _charcodeToCellIndex = null;
-                _lastANSICharCodeIndex = -1;
             }
 
             PrecalculatePreviewGrid();
@@ -249,17 +231,13 @@ namespace AGS.Editor
             {
                 if (_charCodes.Length > 0)
                 {
-                    char_count = ANSIMode ?
-                        _lastANSICharCodeIndex + 1 :
-                        _charCodes.Length;
+                    char_count = _charCodes.Length;
                 }
             }
             else
             {
                 int first_char = 0;
                 int last_char = _fontMetrics.LastCharCode;
-                if (ANSIMode)
-                    last_char = Math.Min(last_char, 255);
                 char_count = (last_char - first_char + 1);
             }
 
@@ -497,7 +475,7 @@ namespace AGS.Editor
             {
                 int firstRowDrawPos = _grid.CellSpaceY + firstVisibleRow * (_grid.CellHeight + _grid.CellSpaceY)
                     - scroll_y;
-                Factory.NativeProxy.DrawFont(g.GetHdc(), _font.ID, ANSIMode, HideMissingCharacters,
+                Factory.NativeProxy.DrawFont(g.GetHdc(), _font.ID, HideMissingCharacters,
                     0, 0, _grid.CellSpaceX, firstRowDrawPos,
                     _grid.CellWidth, _grid.CellHeight, _grid.CellSpaceX, _grid.CellSpaceY,
                     _grid.CharsPerRow, lastVisibleRow - firstVisibleRow + 1, firstVisibleCell,
@@ -530,8 +508,6 @@ namespace AGS.Editor
             if (DisplayCodes)
             {
                 int lastCharCode = _fontMetrics.LastCharCode;
-                if (ANSIMode)
-                    lastCharCode = Math.Min(lastCharCode, 255);
                 for (int cell = firstVisibleCell, row = firstVisibleRow; row <= lastVisibleRow && cell <= lastVisibleCell; ++row)
                 {
                     for (int col = 0; col < _grid.CharsPerRow && cell <= lastVisibleCell; ++col, ++cell)
@@ -545,10 +521,7 @@ namespace AGS.Editor
                         Rectangle pos = new Rectangle(cellLeftBottom.X, cellLeftBottom.Y - _codeCue.Height,
                             _codeCue.Width, _codeCue.Height);
                         g.FillRectangle(Brushes.LightGray, pos);
-                        if (ANSIMode)
-                            g.DrawString(code.ToString(), _codeCue.Font, Brushes.Black, pos.X + 1, pos.Y + 1);
-                        else
-                            g.DrawString(code.ToString("X4"), _codeCue.Font, Brushes.Black, pos.X + 1, pos.Y + 1);
+                        g.DrawString(code.ToString("X4"), _codeCue.Font, Brushes.Black, pos.X + 1, pos.Y + 1);
                     }
                 }
             }

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -69,7 +69,8 @@ namespace AGS.Editor
                     (IWorkProgress progress, object o) => {
                         Factory.AGSEditor.Tasks.ConvertAllGameTexts(
                             Types.Utilities.EncodingFromName(oldFormat),
-                            Types.Utilities.EncodingFromName(newFormat));
+                            Types.Utilities.EncodingFromName(newFormat),
+                            progress);
                         return null;
                     }, null);
             }

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -1145,33 +1145,17 @@ namespace AGS.Editor
         /// </summary>
         /// <param name="oldEnc"></param>
         /// <param name="newEnc"></param>
-        public void ConvertAllGameTexts(Encoding oldEnc, Encoding newEnc)
+        /// <param name="progress"></param>
+        public void ConvertAllGameTexts(Encoding oldEnc, Encoding newEnc, IWorkProgress progress)
         {
-            // Convert all scripts
-            foreach (var script in Factory.AGSEditor.CurrentGame.ScriptsAndHeaders)
-            {
-                // TODO: this is ugly, make TextEncoding non-static per script property?
-                // or pass into Load/Save method (but some more changes are necessary)
-                Script.TextEncoding = oldEnc;
-                script.Header.LoadFromDisk();
-                script.Script.LoadFromDisk();
-                Script.TextEncoding = newEnc;
-                script.Header.Modified = true;
-                script.Header.SaveToDisk();
-                script.Script.Modified = true;
-                script.Script.SaveToDisk();
-            }
-            // Convert all room scripts
-            foreach (var room in Factory.AGSEditor.CurrentGame.Rooms)
-            {
-                Script.TextEncoding = oldEnc;
-                room.LoadScript();
-                Script.TextEncoding = newEnc;
-                room.Script.Modified = true;
-                room.Script.SaveToDisk();
-                room.UnloadScript();
-            }
+            // TODO: have these messages passed into the function, and used in outer code
+            CompileMessages messages = new CompileMessages();
+            GameTextEncodingChangedArgs evArgs = new GameTextEncodingChangedArgs(Factory.AGSEditor.CurrentGame, oldEnc, progress, messages);
+            Factory.Events.OnGameTextEncodingChanged(evArgs);
+
             // Save game with a new encoding
+            // TODO: implement passing IWorkProgress and CompileMessages into SaveGameFiles, and counting progress there
+            progress.SetProgress(0, 0, "Saving game files...", false);
             if (Factory.GUIController.InvokeRequired)
             {
                 Factory.GUIController.Invoke(new Func<bool>(Factory.AGSEditor.SaveGameFiles));
@@ -1180,6 +1164,22 @@ namespace AGS.Editor
             {
                 Factory.AGSEditor.SaveGameFiles();
             }
+        }
+
+        /// <summary>
+        /// Converts all separate game files which may contain text from one encoding
+        /// to another. This is done by loading and resaving them, and may take time
+        /// depending on the size of the project.
+        /// This variant of the operation does not save game itself, only separate
+        /// components such as scripts.
+        /// </summary>
+        /// <param name="game"></param>
+        /// <param name="oldEnc"></param>
+        /// <param name="progress"></param>
+        public void ConvertAllGameTextsNoSaveGame(Game game, Encoding oldEnc, IWorkProgress progress, CompileMessages messages)
+        {
+            GameTextEncodingChangedArgs evArgs = new GameTextEncodingChangedArgs(game, oldEnc, progress, messages);
+            Factory.Events.OnGameTextEncodingChanged(evArgs);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/UpgradeGameManager.cs
+++ b/Editor/AGS.Editor/UpgradeGameManager.cs
@@ -33,17 +33,20 @@ namespace AGS.Editor
             return tasks.ToArray();
         }
 
-        private static IUpgradeGameTask[] GetTasksForGameVersion(System.Version gameVersion, int? gameVersionIndex)
+        private static IUpgradeGameTask[] GetTasksForGame(Game game)
         {
             var allTasks = GetAllTasks();
 
             List<IUpgradeGameTask> tasks = new List<IUpgradeGameTask>();
+            var gameVersion = game.SavedXmlVersion;
+            var gameVersionIndex = game.SavedXmlVersionIndex;
             bool needBackup = false;
             foreach (var task in allTasks)
             {
-                if ((task.GameVersion == null) || // if no version is defined, then run always
+                if (((task.GameVersion == null) || // if no version is defined, then run always
                     (gameVersion < task.GameVersion) ||
                     (task.GameVersionIndex.HasValue && gameVersionIndex.HasValue && gameVersionIndex < task.GameVersionIndex))
+                    && task.ShouldApplyToGame(game))
                 {
                     tasks.Add(task);
                     // We request Backup task whenever there's a non-implicit upgrade task
@@ -202,7 +205,7 @@ namespace AGS.Editor
 
         public static bool UpgradeWithoutWizard(Game game, Dictionary<string, string> options, CompileMessages errors, out UpgradeGameResult result)
         {
-            var tasks = GetTasksForGameVersion(game.SavedXmlVersion, game.SavedXmlVersionIndex);
+            var tasks = GetTasksForGame(game);
             bool hasExplicitTasks = tasks.FirstOrDefault(task => !task.Implicit) != null;
             // TODO: apply options to Tasks
             var execData = new ExecuteTasksData(game, tasks, errors);
@@ -213,7 +216,7 @@ namespace AGS.Editor
 
         public static bool UpgradeWithWizard(Game game, CompileMessages errors, out UpgradeGameResult result)
         {
-            var tasks = GetTasksForGameVersion(game.SavedXmlVersion, game.SavedXmlVersionIndex);
+            var tasks = GetTasksForGame(game);
             // No tasks counts as auto-success, where we skip upgrading and end opening the project
             if (tasks.Length == 0)
             {

--- a/Editor/AGS.Editor/UpgradeGameManager.cs
+++ b/Editor/AGS.Editor/UpgradeGameManager.cs
@@ -38,6 +38,8 @@ namespace AGS.Editor
             var allTasks = GetAllTasks();
 
             List<IUpgradeGameTask> tasks = new List<IUpgradeGameTask>();
+            List<IUpgradeGameTask> preTasks = new List<IUpgradeGameTask>();
+            List<IUpgradeGameTask> postTasks = new List<IUpgradeGameTask>();
             var gameVersion = game.SavedXmlVersion;
             var gameVersionIndex = game.SavedXmlVersionIndex;
             bool needBackup = false;
@@ -48,11 +50,25 @@ namespace AGS.Editor
                     (task.GameVersionIndex.HasValue && gameVersionIndex.HasValue && gameVersionIndex < task.GameVersionIndex))
                     && task.ShouldApplyToGame(game))
                 {
-                    tasks.Add(task);
-                    // We request Backup task whenever there's a non-implicit upgrade task
+                    switch (task.Stage)
+                    {
+                        case UpgradeGameTaskStage.PreStage: preTasks.Add(task); break;
+                        case UpgradeGameTaskStage.PostStage: postTasks.Add(task); break;
+                        default: tasks.Add(task); break;
+                    }
+                    
+                    // We request Backup task whenever there's a non-implicit upgrade task;
+                    // the reasoning here is that explicit tasks define sensitive updates
+                    // that either changes project format, or may potentially alter the game's behavior.
                     needBackup |= !task.Implicit;
                 }
             }
+
+            // Insert pre- post- tasks either at the beginning or end of the main task list
+            foreach (var task in preTasks)
+                tasks.Insert(0, task);
+            foreach (var task in postTasks)
+                tasks.Add(task);
 
             // If need a project backup task, always insert one at the beginning of the list
             if (needBackup)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -59,7 +59,7 @@ extern bool measure_font_height(const AGSString &filename, int pixel_height, int
 extern void GetFontMetrics(int fontnum, int &last_charcode, Rect &char_bbox);
 extern void GetFontValidCharacters(int fontnum, std::vector<int> &char_codes);
 // Draws font char sheet on the provided context
-extern void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
+extern void DrawFontAt(HDC hdc, int fontnum, bool only_valid_chars,
     int dc_atx, int dc_aty, int draw_atx, int draw_aty,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y,
     int col_count, int row_count, int first_cell,
@@ -368,13 +368,13 @@ namespace AGS
             return arr;
         }
 
-        void NativeMethods::DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
+        void NativeMethods::DrawFont(int hDC, int fontNum, bool only_valid_chars,
             int dc_atx, int dc_aty, int draw_atx, int draw_aty,
             int cell_w, int cell_h, int cell_space_x, int cell_space_y,
             int col_count, int row_count, int first_cell,
             float scaling)
         {
-            return DrawFontAt((HDC)hDC, fontNum, ansi_mode, only_valid_chars,
+            return DrawFontAt((HDC)hDC, fontNum, only_valid_chars,
                 dc_atx, dc_aty, draw_atx, draw_aty,
                 cell_w, cell_h, cell_space_x, cell_space_y,
                 col_count, row_count, first_cell, scaling);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -56,7 +56,7 @@ namespace Native
             FontMetrics ^GetFontMetrics(int fontNum);
             cli::array<int> ^GetFontValidCharacters(int fontNum);
             // Draws font char sheet on the provided context
-            void DrawFont(int hDC, int fontNum, bool ansi_mode, bool only_valid_chars,
+            void DrawFont(int hDC, int fontNum, bool only_valid_chars,
                 int dc_atx, int dc_aty, int draw_atx, int draw_aty,
                 int cell_w, int cell_h, int cell_space_x, int cell_space_y,
                 int col_count, int row_count, int first_cell,

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -687,7 +687,7 @@ void GetFontValidCharacters(int fontnum, std::vector<int> &char_codes)
         char_codes = *codes;
 }
 
-void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
+void DrawFontAt(HDC hdc, int fontnum, bool only_valid_chars,
     int dc_atx, int dc_aty, int draw_atx, int draw_aty,
     int cell_w, int cell_h, int cell_space_x, int cell_space_y,
     int col_count, int row_count, int first_cell,
@@ -730,9 +730,7 @@ void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
     else
     {
         int first_char = 0;
-        int last_char = ansi_mode ?
-            std::min(255, get_font_topmost_char_code(fontnum)) :
-            get_font_topmost_char_code(fontnum);
+        int last_char = get_font_topmost_char_code(fontnum);
         char_count = last_char - first_char + 1;
     }
 
@@ -742,48 +740,20 @@ void DrawFontAt(HDC hdc, int fontnum, bool ansi_mode, bool only_valid_chars,
     tempblock->Fill(0);
     const color_t text_color = tempblock->GetCompatibleColor(15); // fixed white color
     const int old_uformat = get_uformat();
-    const int want_uformat = ansi_mode ? U_ASCII : U_UTF8;
+    const int want_uformat = U_UTF8;
     if (old_uformat != want_uformat)
         set_uformat(want_uformat);
-    if (want_uformat == U_ASCII)
+    for (int i = first_cell; i < char_count; ++i)
     {
-        // ASCII / ANSI variant
-        for (int i = first_cell; i < char_count; ++i)
-        {
-            int c;
-            if (only_valid_chars)
-            {
-                c = (*char_codes)[i];
-                if (c > 255)
-                    break; // in ansi mode do not print characters above code 255
-            }
-            else
-            {
-                c = i;
-            }
-            const int char_col = ((i - first_cell) % col_count);
-            const int char_row = ((i - first_cell) / col_count);
-            woutprintf(tempblock.get(),
-                       draw_atx + char_col * (cell_w + cell_space_x) + char_off.X,
-                       draw_aty + char_row * (cell_h + cell_space_y) + char_off.Y,
-                       fontnum, text_color, "%c", c);
-        }
-    }
-    else if (want_uformat == U_UTF8)
-    {
-        // UTF-8 variant
-        for (int i = first_cell; i < char_count; ++i)
-        {
-            const int c = only_valid_chars ? (*char_codes)[i] : i;
-            char uchar[Utf8::UtfSz + 1];
-            uchar[Utf8::SetChar(c, uchar, sizeof(uchar))] = 0;
-            const int char_col = ((i - first_cell) % col_count);
-            const int char_row = ((i - first_cell) / col_count);
-            wouttextxy(tempblock.get(),
-                       draw_atx + char_col * (cell_w + cell_space_x) + char_off.X,
-                       draw_aty + char_row * (cell_h + cell_space_y) + char_off.Y,
-                       fontnum, text_color, uchar);
-        }
+        const int c = only_valid_chars ? (*char_codes)[i] : i;
+        char uchar[Utf8::UtfSz + 1];
+        uchar[Utf8::SetChar(c, uchar, sizeof(uchar))] = 0;
+        const int char_col = ((i - first_cell) % col_count);
+        const int char_row = ((i - first_cell) / col_count);
+        wouttextxy(tempblock.get(),
+            draw_atx + char_col * (cell_w + cell_space_x) + char_off.X,
+            draw_aty + char_row * (cell_h + cell_space_y) + char_off.Y,
+            fontnum, text_color, uchar);
     }
     if (old_uformat != want_uformat)
         set_uformat(old_uformat);
@@ -1712,7 +1682,7 @@ void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
 
 void GameUpdated(Game ^game, bool forceUpdate)
 {
-  set_uformat(game->UnicodeMode ? U_UTF8 : U_ASCII);
+  set_uformat(U_UTF8);
   // TODO: this function may get called when only one item is added/removed or edited;
   // probably it would be best to split it up into several callbacks at some point.
   thisgame.color_depth = (int)game->Settings->ColorDepth;

--- a/Editor/AGS.Types/PropertyGridExtras/TextEncodingTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/TextEncodingTypeConverter.cs
@@ -12,10 +12,8 @@ namespace AGS.Types
         static TextEncodingTypeConverter()
         {
             _values = new Dictionary<string, string>();
-            // For the time being, add only one "generic" value for ASCII/ANSI;
-            // it is possible to add exact ansi page names later, if necessary
+            // We do not support anything besides UTF-8 now in AGS 4.x
             _values.Add(Encoding.UTF8.WebName, "Unicode (UTF-8)");
-            _values.Add("ANSI", "ASCII / ANSI");
         }
 
         protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -77,8 +77,6 @@ namespace AGS.Types
         private ScriptAPIVersion _scriptCompatLevel = ScriptAPIVersion.Highest;
         private ScriptAPIVersion _scriptAPIVersionReal = Utilities.GetActualAPI(ScriptAPIVersion.Highest);
         private ScriptAPIVersion _scriptCompatLevelReal = Utilities.GetActualAPI(ScriptAPIVersion.Highest);
-        private bool _oldKeyHandling = false;
-        private bool _oldVoiceClipNaming = false;
         private bool _scaleCharacterSpriteOffsets = true;
         private float _faceDirectionRatio = 1.0f;
         private int _dialogOptionsGUI = 0;
@@ -733,25 +731,13 @@ namespace AGS.Types
         [Browsable(false)]
         public bool UseOldCustomDialogOptionsAPI { get { return false; } }
 
-        [DisplayName("Use old-style keyboard handling")]
-        [Description("Use pre-unicode mode key codes in 'on_key_press' function, where regular keys were merged with Ctrl and Alt modifiers.")]
-        [Category("Backwards Compatibility")]
-        [DefaultValue(false)]
-        public bool UseOldKeyboardHandling
-        {
-            get { return _oldKeyHandling; }
-            set { _oldKeyHandling = value; }
-        }
-        
-        [DisplayName("Use old-style voice clip naming rule")]
-        [Description("Define voice clip name using only the first 4 letters from a Character's script name.")]
-        [Category("Backwards Compatibility")]
-        [DefaultValue(false)]
-        public bool UseOldVoiceClipNaming
-        {
-            get { return _oldVoiceClipNaming; }
-            set { _oldVoiceClipNaming = value; }
-        }
+        [Obsolete]
+        [Browsable(false)]
+        public bool UseOldKeyboardHandling { get; set; }
+
+        [Obsolete]
+        [Browsable(false)]
+        public bool UseOldVoiceClipNaming { get; set; }
 
         [Obsolete]
         [Browsable(false)]

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1429,8 +1429,6 @@ bool DialogOptions::RunControls()
 
 bool DialogOptions::RunKey(const KeyInput &ki)
 {
-    const bool old_keyhandle = game.options[OPT_KEYHANDLEAPI] == 0;
-
     const eAGSKeyCode agskey = ki.Key;
     if (parserInput)
     {
@@ -1462,20 +1460,20 @@ bool DialogOptions::RunKey(const KeyInput &ki)
     }
     else if (newCustomRender)
     {
-        if (old_keyhandle || (ki.UChar == 0))
+        if (ki.UChar == 0)
         { // "dialog_options_key_press"
             runDialogOptionKeyPressHandlerFunc.Params[0].SetScriptObject(ccDialogOptionsRendering, ccDialogOptionsRendering);
             runDialogOptionKeyPressHandlerFunc.Params[1].SetInt32(AGSKeyToScriptKey(ki.Key));
             runDialogOptionKeyPressHandlerFunc.Params[2].SetInt32(ki.Mod);
             run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
         }
-        if (!old_keyhandle && (ki.UChar > 0))
+        if (ki.UChar > 0)
         { // "dialog_options_text_input"
             runDialogOptionTextInputHandlerFunc.Params[0].SetScriptObject(ccDialogOptionsRendering, ccDialogOptionsRendering);
             runDialogOptionTextInputHandlerFunc.Params[1].SetInt32(ki.UChar);
             run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
         }
-        return (old_keyhandle || (ki.UChar == 0)) || (!old_keyhandle && (ki.UChar > 0));
+        return ki.UChar >= 0;
     }
     // Allow selection of options by keyboard shortcuts
     else if (game.options[OPT_DIALOGNUMBERED] >= kDlgOptKeysOnly &&

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -157,8 +157,8 @@ void FillDirList(std::vector<String> &files, const String &pattern, ScriptFileSo
         return;
 
     std::vector<FileEntry> fileents;
-    const FileEntryCmpByNameAuto fileent_name_less(StrUtil::GetStrCmpImplFor(get_uformat() == U_UTF8, true, play.GetTextLocaleName().GetCStr()));
-    const FileEntryEqByNameAuto fileent_name_eq(StrUtil::GetStrCmpImplFor(get_uformat() == U_UTF8, true, play.GetTextLocaleName().GetCStr()));
+    const FileEntryCmpByNameAuto fileent_name_less(StrUtil::GetStrCmpImplFor(true, true, play.GetTextLocaleName().GetCStr()));
+    const FileEntryEqByNameAuto fileent_name_eq(StrUtil::GetStrCmpImplFor(true, true, play.GetTextLocaleName().GetCStr()));
 
     if (rp.AssetMgr)
     {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1111,7 +1111,6 @@ ScriptCamera* Game_GetAnyCamera(int index)
 
 void Game_SimulateKeyPress(int key, int mod)
 {
-    const bool old_key_mode = game.options[OPT_KEYHANDLEAPI] == 0;
     eAGSKeyCode modkey = eAGSKeyCodeNone;
     eAGSKeyMod mod_ex = eAGSModNone;
     // Support combo-keys, split them into key + mod and pass as separate events.
@@ -1132,12 +1131,12 @@ void Game_SimulateKeyPress(int key, int mod)
     if (modkey > 0)
     {
         ags_simulate_keydown(modkey);
-        ags_simulate_keypress(static_cast<eAGSKeyCode>(key), static_cast<eAGSKeyMod>(mod | mod_ex), old_key_mode);
+        ags_simulate_keypress(static_cast<eAGSKeyCode>(key), static_cast<eAGSKeyMod>(mod | mod_ex));
         ags_simulate_keyup(modkey);
     }
     else
     {
-        ags_simulate_keypress(static_cast<eAGSKeyCode>(key), static_cast<eAGSKeyMod>(mod), old_key_mode);
+        ags_simulate_keypress(static_cast<eAGSKeyCode>(key), static_cast<eAGSKeyMod>(mod));
     }
 }
 

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -70,7 +70,6 @@ struct OverrideGameConfig
     int8_t Multitasking     = -1; // -1 for none, 0 or 1 to lock in the on/off mode (TODO: make enum)
     bool  NoPlugins         = false; // disable loading plugins
     bool  UpscaleResolution = false; // whether upscale old games that supported that
-    bool  NewKeyHandling    = false; // force new keyhandling mode
     // Optional keys for calling built-in save/restore dialogs;
     // primarily meant for the test runs of the games where save functionality
     // is not implemented (or does not work correctly).

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -54,14 +54,7 @@ GamePlayState::GamePlayState()
 void GamePlayState::SetGameTextLanguage(const String &language)
 {
     _gameTextLanguage = language;
-    if (get_uformat() == U_UTF8)
-    {
-        _localeNameUTF8 = StrUtil::FindCompatibleUTF8LocaleName(language.GetCStr());
-    }
-    else
-    {
-        _localeNameUTF8 = "";
-    }
+    _localeNameUTF8 = StrUtil::FindCompatibleUTF8LocaleName(language.GetCStr());
     GUI::Context.TextLocaleName = _localeNameUTF8;
     Debug::Printf("Set game text language: %s", _gameTextLanguage.GetCStr());
     Debug::Printf("Set locale: %s", _localeNameUTF8.GetCStr());

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -59,25 +59,21 @@ int IsMusicVoxAvailable () {
 extern ScriptAudioChannel scrAudioChannel[MAX_GAME_CHANNELS];
 
 // Construct an asset name for the voice-over clip for the given character and cue id
-static String get_cue_filename(int charid, int sndid, bool old_style)
+static String get_cue_filename(int charid, int sndid)
 {
     // Clip name generation rule:
     // Cut a small case 'c' prefix from the character's script name,
     // this is a ugly hack, but is still done, because in AGS
     // characters were traditionally named as 'cEgo'.
-    // New-style: use full script name (past the prefix),
+    // Naming format: use full script name (past the prefix),
     //            clip number (X) is separated by a dot:
     //            "CHARNAME.X"
-    // Old-style: use only first 4 characters (past the prefix).
-    //            clip number (X) is not separated:
-    //            "CHARX"
     const char *charname = (charid >= 0) ? game.chars[charid].scrname.GetCStr()
         : "narrator";
     size_t from = (charname[0] == 'c') ? 1 : 0u;
-    size_t len = old_style ? 4 : SIZE_MAX;
-    String charname_fix(charname + from, len);
+    String charname_fix(charname + from, SIZE_MAX);
     
-    const char *fmt_str = old_style ? "%s%d" : "%s.%d";
+    const char *fmt_str = "%s.%d";
     String asset_filename = String::FromFormat(fmt_str, charname_fix.GetCStr(), sndid);
     return Path::ConcatPaths(get_voice_assetpath(), asset_filename);
 }
@@ -165,7 +161,7 @@ bool play_voice_speech(int charid, int sndid)
     if (!play.ShouldPlayVoiceSpeech())
         return false;
 
-    String voice_file = get_cue_filename(charid, sndid, !game.options[OPT_VOICECLIPNAMERULE]);
+    String voice_file = get_cue_filename(charid, sndid);
     if (!play_voice_clip_impl(voice_file, true, true))
         return false;
 
@@ -201,7 +197,7 @@ bool play_voice_nonblocking(int charid, int sndid, bool as_speech)
     if (as_speech && play.IsBlockingVoiceSpeech())
         return false;
 
-    String voice_file = get_cue_filename(charid, sndid, !game.options[OPT_VOICECLIPNAMERULE]);
+    String voice_file = get_cue_filename(charid, sndid);
     return play_voice_clip_impl(voice_file, as_speech, false);
 }
 
@@ -211,7 +207,7 @@ const ScriptAudioChannel *play_voice_clip_as_type(int charid, int sndid, int typ
     if (!play.ShouldPlayVoiceSpeechNonBlocking())
         return nullptr;
 
-    String voice_file = get_cue_filename(charid, sndid, !game.options[OPT_VOICECLIPNAMERULE]);
+    String voice_file = get_cue_filename(charid, sndid);
     AssetPath apath = find_voice_clip(voice_file);
     if (!apath)
         return nullptr;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -233,7 +233,7 @@ static void SortSaveList(std::vector<SaveListItem> &saves, ScriptSaveGameSortSty
         break;
     case kScSaveGameSort_Description:
     {
-        SaveItemCmpByDesc cmp_by_desc(StrUtil::GetStrCmpImplFor(get_uformat() == U_UTF8, false, play.GetTextLocaleName().GetCStr()));
+        SaveItemCmpByDesc cmp_by_desc(StrUtil::GetStrCmpImplFor(true, false, play.GetTextLocaleName().GetCStr()));
         if (ascending)
             std::sort(saves.begin(), saves.end(), cmp_by_desc);
         else

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -15,7 +15,6 @@
 // Containers script API.
 //
 //=============================================================================
-#include <allegro.h> // get_uformat
 #include "ac/game.h"
 #include "ac/gamestate.h"
 #include "ac/string.h"
@@ -47,41 +46,21 @@ ScriptDictBase *Dict_CreateImpl(ScriptSortStyle sort_style, ScriptStringComparis
     ScriptDictBase *dic;
     if (sorted)
     {
-        if (get_uformat() == U_UTF8)
-        {
-            if (case_sensitive)
-                dic = locale_aware ?
-                    (ScriptDictBase*)new ScriptDictLocaleAware(LexographicalStrLess(play.GetTextLocaleName().GetCStr()))
-                    : new ScriptDict();
-            else
-                dic = locale_aware ?
-                    (ScriptDictBase*)new ScriptDictLocaleAwareCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()))
-                    : new ScriptDictUtf8CI();
-        }
+        if (case_sensitive)
+            dic = locale_aware ?
+            (ScriptDictBase*)new ScriptDictLocaleAware(LexographicalStrLess(play.GetTextLocaleName().GetCStr()))
+            : new ScriptDict();
         else
-        {
-            if (case_sensitive)
-                dic = new ScriptDict();
-            else
-                dic = new ScriptDictCI();
-        }
+            dic = locale_aware ?
+            (ScriptDictBase*)new ScriptDictLocaleAwareCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()))
+            : new ScriptDictUtf8CI();
     }
     else
     {
-        if (get_uformat() == U_UTF8)
-        {
-            if (case_sensitive)
-                dic = new ScriptHashDict();
-            else
-                dic = new ScriptHashDictUtf8CI();
-        }
+        if (case_sensitive)
+            dic = new ScriptHashDict();
         else
-        {
-            if (case_sensitive)
-                dic = new ScriptHashDict();
-            else
-                dic = new ScriptHashDictCI();
-        }
+            dic = new ScriptHashDictUtf8CI();
     }
     return dic;
 }
@@ -239,41 +218,21 @@ ScriptSetBase *Set_CreateImpl(ScriptSortStyle sort_style, ScriptStringComparison
     ScriptSetBase *set;
     if (sorted)
     {
-        if (get_uformat() == U_UTF8)
-        {
-            if (case_sensitive)
-                set = locale_aware ?
-                    (ScriptSetBase*)new ScriptSetLocaleAware(LexographicalStrLess(play.GetTextLocaleName().GetCStr()))
-                    : new ScriptSet();
-            else
-                set = locale_aware ?
-                    (ScriptSetBase*)new ScriptSetLocaleAwareCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()))
-                    : new ScriptSetUtf8CI();
-        }
+        if (case_sensitive)
+            set = locale_aware ?
+            (ScriptSetBase*)new ScriptSetLocaleAware(LexographicalStrLess(play.GetTextLocaleName().GetCStr()))
+            : new ScriptSet();
         else
-        {
-            if (case_sensitive)
-                set = new ScriptSet();
-            else
-                set = new ScriptSetCI();
-        }
+            set = locale_aware ?
+            (ScriptSetBase*)new ScriptSetLocaleAwareCI(LexographicalStrLessNoCase(play.GetTextLocaleName().GetCStr()))
+            : new ScriptSetUtf8CI();
     }
     else
     {
-        if (get_uformat() == U_UTF8)
-        {
-            if (case_sensitive)
-                set = new ScriptHashSet();
-            else
-                set = new ScriptHashSetUtf8CI();
-        }
+        if (case_sensitive)
+            set = new ScriptHashSet();
         else
-        {
-            if (case_sensitive)
-                set = new ScriptHashSet();
-            else
-                set = new ScriptHashSetCI();
-        }
+            set = new ScriptHashSetUtf8CI();
     }
     return set;
 }

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -61,11 +61,6 @@ size_t GetStringCharOff(const char *thisString, int index)
 {
     auto &header = ScriptString::GetHeader((void*)thisString);
     assert((index >= 0) && (static_cast<uint32_t>(index) < header.ULength));
-    // No need to calculate anything or save last results in ASCII mode
-    if (get_uformat() == U_ASCII)
-    {
-        return index;
-    }
 
     int off;
     if (header.LastCharIdx <= index)
@@ -208,31 +203,20 @@ const char* String_Truncate(const char *thisString, int length) {
     return CreateNewScriptString(std::move(buf));
 }
 
-const char * TrimFront(const char *front, const char *back) {
-    if (get_uformat() == U_UTF8) {
-        for (int c = ugetc(front); front != back && uisspace(c);) {
-            front += ucwidth(c);
-            c = ugetc(front);
-        }
-    }
-    else {
-        for (; front != back && std::isspace(*front); ++front);
+const char *TrimFront(const char *front, const char *back) {
+    for (int c = ugetc(front); front != back && uisspace(c);) {
+        front += ucwidth(c);
+        c = ugetc(front);
     }
     return front;
 }
 
-const char * TrimBack(const char *front, const char *back) {
-    if (get_uformat() == U_UTF8) {
-        const char* prev = Utf8::BackOneChar(back, front);
-        for (int c = ugetc(prev); prev != front && uisspace(c); ) {
-            back = prev;
-            prev = Utf8::BackOneChar(prev, front);
-            c = ugetc(prev);
-        }
-    }
-    else {
-        for (--back; back != front && std::isspace(*back); --back);
-        ++back;
+const char *TrimBack(const char *front, const char *back) {
+    const char* prev = Utf8::BackOneChar(back, front);
+    for (int c = ugetc(prev); prev != front && uisspace(c); ) {
+        back = prev;
+        prev = Utf8::BackOneChar(prev, front);
+        c = ugetc(prev);
     }
     return back;
 }
@@ -282,7 +266,7 @@ int String_CompareTo(const char *thisString, const char *otherString, int compar
 {
     compare_style = ValidateStringComparison("String.CompareTo", compare_style);
     const bool case_sensitive = (compare_style & kScCaseSensitiveFlag) != 0;
-    const bool locale_aware = ((compare_style & kScLocaleAwareFlag) != 0) && (get_uformat() == U_UTF8);
+    const bool locale_aware = (compare_style & kScLocaleAwareFlag) != 0;
     if (locale_aware)
     {
         if (case_sensitive)
@@ -559,16 +543,8 @@ size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLi
     bool rtl_mode = game.options[OPT_RIGHTLEFTWRITE] != 0;
     if (apply_direction)
     {
-        if (get_uformat() == U_UTF8)
-        {
-            for (size_t rr = 0; rr < lines.Count(); rr++)
-                lines[rr] = StrUtil::ApplyTextDirection(lines[rr], rtl_mode);
-        }
-        else if (rtl_mode)
-        {
-            for (size_t rr = 0; rr < lines.Count(); rr++)
-                lines[rr].Reverse();
-        }
+        for (size_t rr = 0; rr < lines.Count(); rr++)
+            lines[rr] = StrUtil::ApplyTextDirection(lines[rr], rtl_mode);
     }
     // Calculate the longest line
     for (size_t rr = 0; rr < lines.Count(); rr++)

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -50,28 +50,29 @@ int sdl_mod_to_ags_mod(const Uint16 mod)
     return ags_mod;
 }
 
-eAGSKeyCode sdl_key_to_ags_key(const SDL_Keycode sym, const SDL_Scancode scancode, const Uint16 mod, bool old_keyhandle)
+static eAGSKeyCode sdl_key_to_ags_key(const SDL_Keycode sym, const SDL_Scancode scancode, const Uint16 mod, bool combo_keys)
 {
     // NOTE: keycodes such as SDLK_EXCLAIM ('!') may be misleading, as they are NOT
     // received when user presses for example Shift + 1 on regular keyboard, but only on
     // systems where single keypress can produce that symbol.
 
-    // Old mode: Ctrl and Alt combinations realign the letter code to certain offset
-    if (old_keyhandle && (sym >= SDLK_a && sym <= SDLK_z))
+    // Combo key request: Ctrl and Alt combinations realign the letter code to certain offset
+    if (combo_keys && (sym >= SDLK_a && sym <= SDLK_z))
     {
         if ((mod & KMOD_CTRL) != 0) // align letters to code 1
             return static_cast<eAGSKeyCode>( 0 + (sym - SDLK_a) + 1 );
         else if ((mod & KMOD_ALT) != 0) // align letters to code 301
             return static_cast<eAGSKeyCode>( AGS_EXT_KEY_SHIFT + (sym - SDLK_a) + 1 );
     }
-    // New mode: also handle common key range
-    else if (!old_keyhandle && (sym >= SDLK_SPACE && sym <= SDLK_z))
+
+    // Handle common key range
+    if (sym >= SDLK_SPACE && sym <= SDLK_z)
     {
         return static_cast<eAGSKeyCode>(sym);
     }
 
     // NumPad with NumLock on
-    if (!old_keyhandle && (sym >= SDLK_KP_1 && sym <= SDLK_KP_PERIOD) && (mod & KMOD_NUM) != 0)
+    if ((sym >= SDLK_KP_1 && sym <= SDLK_KP_PERIOD) && (mod & KMOD_NUM) != 0)
     {
         switch (sym)
         {
@@ -158,9 +159,9 @@ eAGSKeyCode sdl_key_to_ags_key(const SDL_Keycode key, const SDL_Scancode scancod
     return sdl_key_to_ags_key(key, scancode, mod, false);
 }
 
-eAGSKeyCode sdl_key_to_ags_key(const SDL_Keysym &key, bool old_keyhandle)
+static eAGSKeyCode sdl_key_to_ags_key(const SDL_Keysym &key, bool combo_keys)
 {
-    return sdl_key_to_ags_key(key.sym, key.scancode, key.mod, old_keyhandle);
+    return sdl_key_to_ags_key(key.sym, key.scancode, key.mod, combo_keys);
 }
 
 // Converts ags key to SDL key scans (up to 3 values, because this is not a 1:1 match);
@@ -272,38 +273,19 @@ int ags_mod_to_sdl_mod(eAGSKeyMod mod)
 }
 
 // Converts SDL scan and key codes to the ags keycode
-KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event, bool old_keyhandle)
+KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event)
 {
     KeyInput ki;
-    // Normally SDL_TEXTINPUT is meant for handling the printable characters,
-    // and not the actual key presses.
-    // But in the "old key handle" mode we use it also to get the full range
-    // of key codes corresponding to chars, including combos (SHIFT + 3 = #).
-    // TODO: find out if it's feasible to just convert keydown + SHIFT combos
-    // ourselves: then we can utilize SDL_KEYDOWN for both modes and leave
-    // TEXTINPUT for char print only.
     switch (event.type)
     {
     case SDL_TEXTINPUT:
-        if (old_keyhandle)
-        {
-            char ascii[sizeof(SDL_TextInputEvent::text)];
-            StrUtil::ConvertUtf8ToAscii(event.text.text, "C", &ascii[0], sizeof(ascii));
-            if (ascii[0] >= 32)
-            {
-                ki.Key = static_cast<eAGSKeyCode>(ascii[0]);
-                ki.CompatKey = ki.Key;
-            }
-        }
         ags_strncpy_s(ki.Text, KeyInput::UTF8_ARR_SIZE, event.text.text, KeyInput::UTF8_ARR_SIZE - 1);
         Utf8::GetChar(event.text.text, sizeof(SDL_TextInputEvent::text), &ki.UChar);
         return ki;
     case SDL_KEYDOWN:
         ki.Mod = sdl_mod_to_ags_mod(event.key.keysym.mod);
-        ki.Key = sdl_key_to_ags_key(event.key.keysym, old_keyhandle);
+        ki.Key = sdl_key_to_ags_key(event.key.keysym, false);
         ki.CompatKey = sdl_key_to_ags_key(event.key.keysym, true);
-        if (!old_keyhandle && (ki.CompatKey == eAGSKeyCodeNone))
-            ki.CompatKey = ki.Key; // in the new mode also assign letter-range keys
         return ki;
     default:
         return ki;
@@ -392,13 +374,6 @@ void ags_drop_next_inputevent()
 
 bool ags_iskeydown(eAGSKeyCode ags_key)
 {
-    // old input handling: update key state in realtime
-    // left only in case if necessary for some ancient game, but
-    // this really may only be required if there's a key waiting loop in
-    // script without Wait(1) to let engine poll events in a natural way.
-    if (gl_SysConfig.OldStyleKeyHandling)
-        SDL_PumpEvents();
-
     const Uint8 *state = SDL_GetKeyboardState(NULL);
     SDL_Scancode scan[3];
     if (!ags_key_to_sdl_scan(ags_key, scan))
@@ -416,7 +391,7 @@ const std::vector<SDL_Keysym> &ags_getkeysdown()
     return sys_keysdown;
 }
 
-void ags_simulate_keypress(eAGSKeyCode ags_key, eAGSKeyMod mod, bool old_keyhandle)
+void ags_simulate_keypress(eAGSKeyCode ags_key, eAGSKeyMod mod)
 {
     SDL_Scancode scan[3];
     if (!ags_key_to_sdl_scan(ags_key, scan))
@@ -429,14 +404,6 @@ void ags_simulate_keypress(eAGSKeyCode ags_key, eAGSKeyMod mod, bool old_keyhand
     sdlevent.key.keysym.scancode = scan[0];
     sdlevent.key.keysym.mod = ags_mod_to_sdl_mod(mod) | SDL_GetModState();
     SDL_PushEvent(&sdlevent);
-    // Push a text input event for ascii printable characters;
-    // in case of "old key handling mode" this instead will trigger on_key_press for them.
-    if (old_keyhandle && (key_sym >= SDLK_SPACE && key_sym <= SDLK_z))
-    {
-        sdlevent.type = SDL_TEXTINPUT;
-        sdlevent.text.text[0] = static_cast<char>(key_sym);
-        SDL_PushEvent(&sdlevent);
-    }
     sdlevent.type = SDL_KEYUP;
     SDL_PushEvent(&sdlevent);
 }

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -50,8 +50,7 @@ enum AGS_SDLUserEvents
 //
 // Converts SDL key data to eAGSKeyCode, which may be also directly used as an ASCII char
 // if it is in proper range, see comments to eAGSKeyCode for details.
-// Optionally works in bacward compatible mode (old_keyhandle)
-KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event, bool old_keyhandle);
+KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event);
 // Converts eAGSKeyCode to SDL key scans (up to 3 values, because this is not a 1:1 match);
 // NOTE: fails at Ctrl+ or Alt+ AGS keys, or any unknown key codes.
 bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3]);
@@ -116,7 +115,7 @@ bool ags_isanykeydown();
 // Returns a list of keys that are currently down
 const std::vector<SDL_Keysym> &ags_getkeysdown();
 // Simulates key press with the given AGS key (sends key down, then key up event)
-void ags_simulate_keypress(eAGSKeyCode ags_key, eAGSKeyMod mod, bool old_keyhandle);
+void ags_simulate_keypress(eAGSKeyCode ags_key, eAGSKeyMod mod);
 // Simulates key down event with the given AGS key
 void ags_simulate_keydown(eAGSKeyCode ags_key);
 // Simulates key up event with the given AGS key

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -89,13 +89,8 @@ void close_translation()
     trans_name = "";
     trans_filename = "";
 
-    // Return back to default game's encoding
-    if (game.options[OPT_GAMETEXTENCODING] == 65001) // utf-8 codepage number
-        set_uformat(U_UTF8);
-    else
-        set_uformat(U_ASCII);
     play.SetGameTextLanguage(game.GameTextLanguage);
-    SetTranslationTextParser(CreateTextParser(game.dict.get(), get_uformat() == U_UTF8, play.GetTextLocaleName()));
+    SetTranslationTextParser(CreateTextParser(game.dict.get(), true, play.GetTextLocaleName()));
 }
 
 bool init_translation(const String &lang, const String &fallback_lang)
@@ -164,44 +159,11 @@ bool init_translation(const String &lang, const String &fallback_lang)
 
     // Setup a text encoding mode depending on the translation data hint
     String encoding = trans.StrOptions["encoding"];
-    if (encoding.CompareNoCase("utf-8") == 0)
-        set_uformat(U_UTF8);
-    else
-        set_uformat(U_ASCII);
     String language = trans.StrOptions["language"];
-
     String encoding_msg = !encoding.IsEmpty() ? encoding : "presume ASCII";
     Debug::Printf("Translation's encoding: %s, language: %s", encoding_msg.GetCStr(), language.GetCStr());
-
-    // Mixed encoding support: 
-    // original text unfortunately may contain extended ASCII chars (> 127);
-    // if translation is UTF-8 but game is extended ASCII, then the translation
-    // dictionary keys won't match. With that assumption we must convert
-    // dictionary keys into ASCII using provided locale hint.
-    int game_codepage = game.options[OPT_GAMETEXTENCODING];
-    if ((get_uformat() == U_UTF8) && (game_codepage != 65001))
-    {
-        String key_enc = (game_codepage > 0) ?
-            String::FromFormat(".%d", game_codepage) :
-            trans.StrOptions["gameencoding"];
-        Debug::Printf("Game's source encoding hint: own: %d, from TRA: %s", game_codepage, trans.StrOptions["gameencoding"].GetCStr());
-        if (!key_enc.IsEmpty())
-        {
-            StringMap conv_map;
-            std::vector<char> ascii; // ascii buffer
-            Debug::Printf("Converting UTF-8 TRA keys to the game's encoding (%s)", key_enc.GetCStr());
-            for (const auto &item : trans.Dict)
-            {
-                StrUtil::ConvertUtf8ToAscii(item.first.GetCStr(), key_enc.GetCStr(), ascii);
-                conv_map.insert(std::make_pair(ascii.data(), item.second));
-            }
-            trans.Dict = conv_map;
-        }
-        else
-        {
-            Debug::Printf(kDbgMsg_Warn, "WARNING: UTF-8 translation in the ASCII/ANSI game, but no encoding hint for TRA keys conversion");
-        }
-    }
+    if (encoding.CompareNoCase("utf-8") != 0)
+        Debug::Printf(kDbgMsg_Warn, "WARNING: translation's text encoding is not UTF-8, and may be displayed incorrectly");
 
     play.SetGameTextLanguage(language);
     if (trans.ParserDict.GetWords().size() > 0)
@@ -210,11 +172,11 @@ bool init_translation(const String &lang, const String &fallback_lang)
         // found in the translated dict, then add base ones directly there.
         if (game.dict.get())
             MergeParserDictionary(&trans.ParserDict, game.dict.get());
-        SetTranslationTextParser(CreateTextParser(&trans.ParserDict, get_uformat() == U_UTF8, play.GetTextLocaleName()));
+        SetTranslationTextParser(CreateTextParser(&trans.ParserDict, true, play.GetTextLocaleName()));
     }
     else
     {
-        SetTranslationTextParser(CreateTextParser(game.dict.get(), get_uformat() == U_UTF8, play.GetTextLocaleName()));
+        SetTranslationTextParser(CreateTextParser(game.dict.get(), true, play.GetTextLocaleName()));
     }
 
     Debug::Printf(kDbgMsg_Info, "Translation initialized: %s (format: %s)", trans_name.GetCStr(), encoding_msg.GetCStr());

--- a/Engine/ac/utils_script.cpp
+++ b/Engine/ac/utils_script.cpp
@@ -54,7 +54,7 @@ void Utils_SortStrings(void* arrobj, int compare_style, int sort_dir)
     }
 
     compare_style = ValidateStringComparison("Utils.SortStrings", compare_style);
-    DynStrCmpAuto dynstr_less(StrUtil::GetStrCmpImplFor(get_uformat() == U_UTF8, (compare_style & kScCaseSensitiveFlag) == 0,
+    DynStrCmpAuto dynstr_less(StrUtil::GetStrCmpImplFor(true, (compare_style & kScCaseSensitiveFlag) == 0,
         (compare_style & kScLocaleAwareFlag) != 0 ? play.GetTextLocaleName().GetCStr() : nullptr));
     if (scsort_dir == kScSortAscending)
         std::sort(string_objs.begin(), string_objs.end(), dynstr_less);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -464,8 +464,8 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     play.std_gui_textheight = get_font_height_outlined(0) + 1;
     play.enable_antialiasing = usetup.AntialiasSprites;
     play.SetGameTextLanguage(game.GameTextLanguage);
-    SetBaseTextParser(CreateTextParser(game.dict.get(), get_uformat() == U_UTF8, play.GetTextLocaleName()));
-    SetTranslationTextParser(CreateTextParser(game.dict.get(), get_uformat() == U_UTF8, play.GetTextLocaleName()));
+    SetBaseTextParser(CreateTextParser(game.dict.get(), true, play.GetTextLocaleName()));
+    SetTranslationTextParser(CreateTextParser(game.dict.get(), true, play.GetTextLocaleName()));
 
     //
     // 5. Initialize runtime state of certain game objects

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -566,11 +566,6 @@ void ApplyBehaviorOptions(GameSetupStruct &game, GamePlayState &play, const Game
     }
     play.SetRBSwitches(rbo);
 
-    if (setup.Override.NewKeyHandling)
-    {
-        game.options[OPT_KEYHANDLEAPI] = 1;
-    }
-
     GUI::Options.ApplyTextDirection = play.GetRBSwitches()[kRBO_ApplyGUITextDirection];
 }
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -66,17 +66,7 @@ namespace Common
 String GUI::ApplyTextDirection(const String &text)
 {
     const bool rtl_mode = game.options[OPT_RIGHTLEFTWRITE] != 0;
-    if (get_uformat() == U_UTF8)
-    {
-        return StrUtil::ApplyTextDirection(text, rtl_mode);
-    }
-    else if (rtl_mode)
-    {
-        String res_text = text;
-        res_text.Reverse();
-        return res_text;
-    }
-    return text;
+    return StrUtil::ApplyTextDirection(text, rtl_mode);
 }
 
 String GUI::TransformTextForDrawing(const String &text, bool translate, bool apply_direction)

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -344,7 +344,6 @@ void apply_config(const ConfigTree &cfg, GameSetup &setup)
     String override_os = CfgReadString(cfg, "override", "os");
     setup.Override.ScriptOS = StrUtil::ParseEnum<eScriptSystemOSID>(override_os,
         CstrArr<eNumOS>{"", "dos", "win", "linux", "mac", "android", "ios", "psp", "web", "freebsd"}, eOS_Unknown);
-    setup.Override.NewKeyHandling = CfgReadBoolInt(cfg, "override", "new_key_mode", setup.Override.NewKeyHandling);
     setup.Override.KeySaveGame = CfgReadInt(cfg, "override", "save_game_key", 0);
     setup.Override.KeyRestoreGame = CfgReadInt(cfg, "override", "restore_game_key", 0);
     setup.Override.MaxSaveSlot = CfgReadInt(cfg, "override", "max_save", 0);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -634,14 +634,18 @@ void engine_init_game_settings()
         play.separate_music_lib = false;
     }
 
-    // Setup a text encoding mode depending on the game data hint
+    // Since 4.0 AGS engine always works in UTF-8 mode
+    set_uformat(U_UTF8);
+    String game_encoding;
     if (game.options[OPT_GAMETEXTENCODING] == 65001) // utf-8 codepage number
-        set_uformat(U_UTF8);
+        game_encoding = "UTF-8";
     else
-        set_uformat(U_ASCII);
+        game_encoding = "ASCII";
     Debug::Printf("Game text encoding: %s, text language: %s",
-        get_uformat() == U_UTF8 ? "UTF-8" : "ASCII",
+        game_encoding.GetCStr(),
         game.GameTextLanguage.IsEmpty() ? "not set" : game.GameTextLanguage.GetCStr());
+    if (game.options[OPT_GAMETEXTENCODING] != 65001)
+        Debug::Printf(kDbgMsg_Warn, "WARNING: game's text encoding is not UTF-8, and may be displayed incorrectly");
 
     int ee;
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -150,7 +150,6 @@ void engine_setup_window()
     SystemConfig sys_cfg;
     sys_cfg.DisplayMode = static_cast<Size>(gfxDriver->GetDisplayMode());
     sys_cfg.MouseEnabled = usetup.MouseEnabled;
-    sys_cfg.OldStyleKeyHandling = game.options[OPT_KEYHANDLEAPI] == 0;
     sys_set_config(sys_cfg);
     sys_evt_set_quit_callback(winclosehook);
     set_our_eip(-197);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -468,7 +468,6 @@ bool run_service_key_controls(KeyInput &out_key)
     if (ags_inputevent_ready() != kInputKeyboard)
         return false; // there was no key event
 
-    const bool old_keyhandle = (game.options[OPT_KEYHANDLEAPI] == 0);
     const SDL_Event key_evt = ags_get_next_inputevent();
     bool handled = false;
 
@@ -529,10 +528,10 @@ bool run_service_key_controls(KeyInput &out_key)
     sys_modkeys_fired = sys_modkeys_fired && (cur_mod != 0);
 
     // If mods are handled, or is in backward input mode, then stop here
-    if (handled || (old_keyhandle && is_only_mod_key))
+    if (handled)
         return false;
 
-    KeyInput ki = sdl_keyevt_to_ags_key(key_evt, old_keyhandle);
+    KeyInput ki = sdl_keyevt_to_ags_key(key_evt);
     if ((ki.Key == eAGSKeyCodeNone) && (ki.UChar == 0))
         return false; // should skip this key event
 
@@ -623,7 +622,6 @@ bool run_service_key_controls(KeyInput &out_key)
 // Runs default keyboard handling
 static void check_keyboard_controls()
 {
-    const bool old_keyhandle = game.options[OPT_KEYHANDLEAPI] == 0;
     // First check for service engine's combinations (mouse lock, display mode switch, and so forth)
     KeyInput ki;
     if (!run_service_key_controls(ki)) {
@@ -721,13 +719,13 @@ static void check_keyboard_controls()
     }
 
     // Pass the key event to the script.
-    if (old_keyhandle || (ki.UChar == 0))
+    if (ki.UChar == 0)
     {
         const int agskeymod = ki.Mod;
         debug_script_log("Running on_key_press keycode %d, mod %d", agskey, agskeymod);
         setevent(AGSEvent_Script(kTS_KeyPress, agskey, agskeymod));
     }
-    if (!old_keyhandle && (ki.UChar > 0))
+    if (ki.UChar > 0)
     {
         debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);
         setevent(AGSEvent_Script(kTS_TextInput, ki.UChar));

--- a/Engine/platform/base/sys_main.h
+++ b/Engine/platform/base/sys_main.h
@@ -34,7 +34,6 @@ struct SystemConfig
     // (moving, resizing, closing), only mouse interaction within the
     // game window.
     bool MouseEnabled = true;
-    bool OldStyleKeyHandling = false; // CLNUP: remove in AGS 4
     // Used to tell the current display mode
     Size DisplayMode;
 };


### PR DESCRIPTION
Resolves #2553

This deprecates:
* ASCII mode (all games and translations must be in utf-8);
* Old key handling mode;
* Old speech file naming.

Adds game upgrade task & wizard page for converting imported ASCII game to UTF-8.
The fonts are impossible to get converted, so made a warning for user that they might require to change fonts to Unicode-compatible ones if their game contains non-English language(s).

Adds game upgrade task & wizard page for renaming speech files if imported game has "old voice clip naming" setting (the file rename is made optional and may be disabled by user).

Removed ASCII/Unicode switch from the Font preview pane.

Removed text format checking in the engine, assume UTF-8 in game texts always. (Utility functions may still have this distinction where it's passed as parameter, and i decided to keep this just in case.)