### PR TITLE
Editor: fix 64-bit Scintilla malfunction

### DIFF
--- a/Editor/AGS.Controls/ScintillaNET/LineCollection.cs
+++ b/Editor/AGS.Controls/ScintillaNET/LineCollection.cs
@@ -341,10 +341,10 @@ namespace ScintillaNET
 
             // Fake an insert notification
             var scn = new NativeMethods.SCNotification();
-            scn.linesAdded = scintilla.DirectMessage(NativeMethods.SCI_GETLINECOUNT).ToInt32() - 1;
-            scn.position = 0;
-            scn.length = scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH).ToInt32();
-            scn.text = scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, new IntPtr(scn.position), new IntPtr(scn.length));
+            scn.linesAdded = new IntPtr(scintilla.DirectMessage(NativeMethods.SCI_GETLINECOUNT).ToInt32() - 1);
+            scn.position = IntPtr.Zero;
+            scn.length = scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH);
+            scn.text = scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, scn.position, scn.length);
             TrackInsertText(scn);
         }
 
@@ -374,11 +374,11 @@ namespace ScintillaNET
 
         private void TrackDeleteText(NativeMethods.SCNotification scn)
         {
-            var startLine = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(scn.position)).ToInt32();
-            if (scn.linesAdded == 0)
+            var startLine = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
+            if (scn.linesAdded == IntPtr.Zero)
             {
                 // That was easy
-                var delta = GetCharCount(scn.text, scn.length, scintilla.Encoding);
+                var delta = GetCharCount(scn.text, scn.length.ToInt32(), scintilla.Encoding);
                 AdjustLineLength(startLine, delta * -1);
             }
             else
@@ -388,7 +388,7 @@ namespace ScintillaNET
                 var lineByteLength = scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
                 AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
 
-                var linesRemoved = scn.linesAdded * -1;
+                var linesRemoved = scn.linesAdded.ToInt32() * -1;
                 for (int i = 0; i < linesRemoved; i++)
                 {
                     // Deleted line
@@ -399,11 +399,11 @@ namespace ScintillaNET
 
         private void TrackInsertText(NativeMethods.SCNotification scn)
         {
-            var startLine = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(scn.position)).ToInt32();
-            if (scn.linesAdded == 0)
+            var startLine = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
+            if (scn.linesAdded == IntPtr.Zero)
             {
                 // That was easy
-                var delta = GetCharCount(scn.position, scn.length);
+                var delta = GetCharCount(scn.position.ToInt32(), scn.length.ToInt32());
                 AdjustLineLength(startLine, delta);
             }
             else
@@ -416,7 +416,7 @@ namespace ScintillaNET
                 lineByteLength = scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
                 AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
 
-                for (int i = 1; i <= scn.linesAdded; i++)
+                for (int i = 1; i <= scn.linesAdded.ToInt32(); i++)
                 {
                     var line = startLine + i;
 

--- a/Editor/AGS.Controls/ScintillaNET/NativeMethods.cs
+++ b/Editor/AGS.Controls/ScintillaNET/NativeMethods.cs
@@ -1836,17 +1836,17 @@ namespace ScintillaNET
         public struct SCNotification
         {
             public Sci_NotifyHeader nmhdr;
-            public int position;
+            public IntPtr position;
             public int ch;
             public int modifiers;
             public int modificationType;
             public IntPtr text;
-            public int length;
-            public int linesAdded;
+            public IntPtr length;
+            public IntPtr linesAdded;
             public int message;
             public IntPtr wParam;
             public IntPtr lParam;
-            public int line;
+            public IntPtr line;
             public int foldLevelNow;
             public int foldLevelPrev;
             public int margin;
@@ -1854,9 +1854,10 @@ namespace ScintillaNET
             public int x;
             public int y;
             public int token;
-            public int annotationLinesAdded;
+            public IntPtr annotationLinesAdded;
             public int updated;
             public int listCompletionMethod;
+            public int characterSource;
         }
 
         #endregion Structures

--- a/Editor/AGS.Controls/ScintillaNET/Scintilla.cs
+++ b/Editor/AGS.Controls/ScintillaNET/Scintilla.cs
@@ -2036,14 +2036,14 @@ namespace ScintillaNET
         private void ScnDoubleClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new DoubleClickEventArgs(this, keys, scn.position, scn.line);
+            var eventArgs = new DoubleClickEventArgs(this, keys, scn.position.ToInt32(), scn.line.ToInt32());
             OnDoubleClick(eventArgs);
         }
 
         private void ScnHotspotClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new HotspotClickEventArgs(this, keys, scn.position);
+            var eventArgs = new HotspotClickEventArgs(this, keys, scn.position.ToInt32());
             switch (scn.nmhdr.code)
             {
                 case NativeMethods.SCN_HOTSPOTCLICK:
@@ -2066,11 +2066,11 @@ namespace ScintillaNET
             {
                 case NativeMethods.SCN_INDICATORCLICK:
                     var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-                    OnIndicatorClick(new IndicatorClickEventArgs(this, keys, scn.position));
+                    OnIndicatorClick(new IndicatorClickEventArgs(this, keys, scn.position.ToInt32()));
                     break;
 
                 case NativeMethods.SCN_INDICATORRELEASE:
-                    OnIndicatorRelease(new IndicatorReleaseEventArgs(this, scn.position));
+                    OnIndicatorRelease(new IndicatorReleaseEventArgs(this, scn.position.ToInt32()));
                     break;
             }
         }
@@ -2078,7 +2078,7 @@ namespace ScintillaNET
         private void ScnMarginClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new MarginClickEventArgs(this, keys, scn.position, scn.margin);
+            var eventArgs = new MarginClickEventArgs(this, keys, scn.position.ToInt32(), scn.margin);
 
             if (scn.nmhdr.code == NativeMethods.SCN_MARGINCLICK)
                 OnMarginClick(eventArgs);
@@ -2094,7 +2094,7 @@ namespace ScintillaNET
 
             if ((scn.modificationType & NativeMethods.SC_MOD_INSERTCHECK) > 0)
             {
-                var eventArgs = new InsertCheckEventArgs(this, scn.position, scn.length, scn.text);
+                var eventArgs = new InsertCheckEventArgs(this, scn.position.ToInt32(), scn.length.ToInt32(), scn.text);
                 OnInsertCheck(eventArgs);
 
                 cachedPosition = eventArgs.CachedPosition;
@@ -2106,7 +2106,7 @@ namespace ScintillaNET
             if ((scn.modificationType & (NativeMethods.SC_MOD_BEFOREDELETE | NativeMethods.SC_MOD_BEFOREINSERT)) > 0)
             {
                 var source = (ModificationSource)(scn.modificationType & sourceMask);
-                var eventArgs = new BeforeModificationEventArgs(this, source, scn.position, scn.length, scn.text);
+                var eventArgs = new BeforeModificationEventArgs(this, source, scn.position.ToInt32(), scn.length.ToInt32(), scn.text);
 
                 eventArgs.CachedPosition = cachedPosition;
                 eventArgs.CachedText = cachedText;
@@ -2127,7 +2127,7 @@ namespace ScintillaNET
             if ((scn.modificationType & (NativeMethods.SC_MOD_DELETETEXT | NativeMethods.SC_MOD_INSERTTEXT)) > 0)
             {
                 var source = (ModificationSource)(scn.modificationType & sourceMask);
-                var eventArgs = new ModificationEventArgs(this, source, scn.position, scn.length, scn.text, scn.linesAdded);
+                var eventArgs = new ModificationEventArgs(this, source, scn.position.ToInt32(), scn.length.ToInt32(), scn.text, scn.linesAdded.ToInt32());
 
                 eventArgs.CachedPosition = cachedPosition;
                 eventArgs.CachedText = cachedText;
@@ -2152,7 +2152,7 @@ namespace ScintillaNET
 
             if ((scn.modificationType & NativeMethods.SC_MOD_CHANGEANNOTATION) > 0)
             {
-                var eventArgs = new ChangeAnnotationEventArgs(scn.line);
+                var eventArgs = new ChangeAnnotationEventArgs(scn.line.ToInt32());
                 OnChangeAnnotation(eventArgs);
             }
         }
@@ -2724,7 +2724,7 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_STYLENEEDED:
-                        OnStyleNeeded(new StyleNeededEventArgs(this, scn.position));
+                        OnStyleNeeded(new StyleNeededEventArgs(this, scn.position.ToInt32()));
                         break;
 
                     case NativeMethods.SCN_SAVEPOINTLEFT:
@@ -2749,11 +2749,11 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_AUTOCSELECTION:
-                        OnAutoCSelection(new AutoCSelectionEventArgs(this, scn.position, scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
+                        OnAutoCSelection(new AutoCSelectionEventArgs(this, scn.position.ToInt32(), scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
                         break;
 
                     case NativeMethods.SCN_AUTOCCOMPLETED:
-                        OnAutoCCompleted(new AutoCSelectionEventArgs(this, scn.position, scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
+                        OnAutoCCompleted(new AutoCSelectionEventArgs(this, scn.position.ToInt32(), scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
                         break;
 
                     case NativeMethods.SCN_AUTOCCANCELLED:
@@ -2765,11 +2765,11 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_DWELLSTART:
-                        OnDwellStart(new DwellEventArgs(this, scn.position, scn.x, scn.y));
+                        OnDwellStart(new DwellEventArgs(this, scn.position.ToInt32(), scn.x, scn.y));
                         break;
 
                     case NativeMethods.SCN_DWELLEND:
-                        OnDwellEnd(new DwellEventArgs(this, scn.position, scn.x, scn.y));
+                        OnDwellEnd(new DwellEventArgs(this, scn.position.ToInt32(), scn.x, scn.y));
                         break;
 
                     case NativeMethods.SCN_DOUBLECLICK:
@@ -2777,7 +2777,7 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_NEEDSHOWN:
-                        OnNeedShown(new NeedShownEventArgs(this, scn.position, scn.length));
+                        OnNeedShown(new NeedShownEventArgs(this, scn.position.ToInt32(), scn.length.ToInt32()));
                         break;
 
                     case NativeMethods.SCN_HOTSPOTCLICK:

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -395,6 +395,14 @@ copy "$(TargetPath)" "$(SolutionDir)..\Editor\References\x64"</Command>
   <ItemGroup>
     <ClInclude Include="..\Native\ac\actiontype.h" />
     <ClInclude Include="..\Native\ac\scriptmodule.h" />
+    <ClInclude Include="..\scintilla\include\Compat.h" />
+    <ClInclude Include="..\scintilla\include\ILexer.h" />
+    <ClInclude Include="..\scintilla\include\ILoader.h" />
+    <ClInclude Include="..\scintilla\include\Platform.h" />
+    <ClInclude Include="..\scintilla\include\SciLexer.h" />
+    <ClInclude Include="..\scintilla\include\Scintilla.h" />
+    <ClInclude Include="..\scintilla\include\ScintillaWidget.h" />
+    <ClInclude Include="..\scintilla\include\Sci_Position.h" />
     <ClInclude Include="agsnative.h" />
     <ClInclude Include="IScriptCompiler.h" />
     <ClInclude Include="NativeMethods.h" />

--- a/Editor/AGS.Native/NativeDLL.vcxproj.filters
+++ b/Editor/AGS.Native/NativeDLL.vcxproj.filters
@@ -38,6 +38,9 @@
     <Filter Include="Scintilla\win32">
       <UniqueIdentifier>{da98ad13-ce0a-4516-acea-168c64b051f3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Scintilla\include">
+      <UniqueIdentifier>{0649598e-6343-466a-aee8-45d2d0434f40}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Native\acgui_agsnative.cpp">
@@ -233,6 +236,30 @@
     </ClInclude>
     <ClInclude Include="CompiledScript.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\Compat.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\ILexer.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\ILoader.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\Platform.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\Sci_Position.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\SciLexer.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\Scintilla.h">
+      <Filter>Scintilla\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scintilla\include\ScintillaWidget.h">
+      <Filter>Scintilla\include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
fix #3076 

I applied the changes to the SCNotification cs so it matched the C++ counterpart in the spirit from the PR in https://github.com/jacobslusser/ScintillaNET/pull/447 (which fixes the upstream https://github.com/jacobslusser/ScintillaNET/issues/488), then I just adjust each build error due to type mismatch until it built in VS and got pretty much the same code changes from the PR - except one missing member at the end of the struct that I added.

It looks like I don't reproduce the reported issue in the Editor Debug x64 build.