### PR TITLE
Uniform object and character assertions in script functions

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -321,6 +321,11 @@ Engine:
    translate the GUI text property values).
  - Engine does not quit with error when DrawImage is called with a non-existant sprite, only logs
    a warning.
+ - Engine now defines certain mistakes in script function use as "serious mistake" (such as trying
+   to call a function for a non-existing object). When such mistake is met, engine will only print
+   a message to the log if the game was compiled in Release mode, or quit the game with a error
+   popup if the game was compiled in Debug mode. The former is done to let player continue playing
+   the game despite the error, while the latter brings immediate attention of the game developer.
  - Fixed inventory cursor not updated immediately if OPT_FIXEDINVCURSOR option is set.
  - Fixed InventoryWindow not getting redrawn immediately if one of the item's has a dynamic sprite
    assigned as a graphic and that dynamic sprite gets edited (like, drawn upon).
@@ -337,6 +342,9 @@ Engine:
    diagonal loops" setting).
  - Fixed Debug(0) script command that gives all inventory items reducing inventory quantity to 1.
    Now it should keep whatever amount player character have had, if it's higher than 1.
+ - Fixed potential crash which could occur if script is trying to access certain Room Object's
+   properties via 'object[]' array in a Room that has no objects or does not have this specific
+   object.
 
 Compatibility:
  - Let restore a save from game_start() in pre-2.7 games.
@@ -4127,7 +4135,7 @@ VERSION 3.2, June 2010
  - The Restart Point save file (AGSSAVE.999) is no longer deleted when you quit the game, 
    to fix a problem where RestartGame didn't work if you started the game by double-clicking
    an Enhanced Save Game file in explorer
- - Disallowed accented characters like й in script names in the editor, because they
+ - Disallowed accented characters like 'Г ' in script names in the editor, because they
    wouldn't compile
  - Dynamic sprite deletion warning is now only displayed on exit if Debug Mode is turned on
  - Fixed sprite entry getting duplicated if you dragged a sprite to the end of the list
@@ -4372,7 +4380,7 @@ VERSION 3.1, October 2008
    help newbies who are using it by accident instead of the Change button.
  - Added option for AGS Editor to pop up a message every X days reminding you to back
    up your game
- - GUI Text Box now allows the user to type in extended chars like йнс when the
+ - GUI Text Box now allows the user to type in extended chars like 'Г ' when the
    textbox is using a TTF font
  - D3D driver now automatically tries 640x400 if your monitor doesn't support 320x200,
    like the DX5 driver already did

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -107,11 +107,6 @@ int numLipLines = 0, curLipLine = -1, curLipLinePhoneme = 0;
 
 // **** CHARACTER: FUNCTIONS ****
 
-bool is_valid_character(int char_id)
-{
-    return ((char_id >= 0) && (char_id < game.numcharacters));
-}
-
 // Checks if character is currently playing idle anim, and reset it
 void stop_character_idling(CharacterInfo *chi)
 {
@@ -127,6 +122,11 @@ void reset_character_idling_time(CharacterInfo *chi)
 {
     chi->idleleft = chi->idledelay;
     charextra[chi->index_id].process_idle_this_time = 1;
+}
+
+bool IsValidCharacter(int char_id)
+{
+    return ((char_id >= 0) && (char_id < game.numcharacters));
 }
 
 bool AssertCharacter(const char *apiname, int char_id)
@@ -2728,8 +2728,8 @@ void DisplayThoughtCore(int chid, const char *displbuf) {
 
 void display_speech(const char *texx, int aschar, int xx, int yy, int widd, bool auto_position, bool is_thought)
 {
-    if (!is_valid_character(aschar))
-        quit("!DisplaySpeech: invalid character");
+    if (!AssertCharacter("DisplaySpeech", aschar))
+        return;
 
     CharacterInfo *speakingChar = &game.chars[aschar];
     if ((speakingChar->view < 0) || (speakingChar->view >= game.numviews))

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -133,7 +133,7 @@ bool AssertCharacter(const char *apiname, int char_id)
 {
     if ((char_id >= 0) && (char_id < game.numcharacters))
         return true;
-    debug_script_warn("%s: invalid character id %d (range is 0..%d)", apiname, char_id, game.numcharacters > 0 ? game.numcharacters - 1 : 0);
+    debug_script_error("%s: invalid character id %d (range is 0..%d)", apiname, char_id, game.numcharacters > 0 ? game.numcharacters - 1 : 0);
     return false;
 }
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -133,7 +133,7 @@ bool AssertCharacter(const char *apiname, int char_id)
 {
     if ((char_id >= 0) && (char_id < game.numcharacters))
         return true;
-    debug_script_warn("%s: invalid character id %d (range is 0..%d)", apiname, char_id, game.numcharacters - 1);
+    debug_script_warn("%s: invalid character id %d (range is 0..%d)", apiname, char_id, game.numcharacters > 0 ? game.numcharacters - 1 : 0);
     return false;
 }
 

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -25,7 +25,8 @@
 
 // **** CHARACTER: FUNCTIONS ****
 
-bool    is_valid_character(int char_id);
+// Tells if the character ID is valid
+bool    IsValidCharacter(int char_id);
 // Asserts the character ID is valid,
 // if not then prints a warning to the log; returns assertion result
 bool    AssertCharacter(const char *apiname, int char_id);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -491,7 +491,7 @@ void *DrawingSurface_GetPixelsCopyImpl(ScriptDrawingSurface *sds, int x, int y, 
 
     if (dest_elem_size != sizeof(uint8_t) && dest_elem_size != ds->GetBPP())
     {
-        debug_script_warn("DrawingSurface.GetPixelsCopy: invalid destination array type for %d-bit image", ds->GetColorDepth());
+        debug_script_error("DrawingSurface.GetPixelsCopy: invalid destination array type for %d-bit image", ds->GetColorDepth());
         return nullptr;
     }
     if (x < 0 || y < 0 || x >= ds->GetWidth() || y >= ds->GetHeight())
@@ -542,7 +542,7 @@ void DrawingSurface_SetPixelsImpl(ScriptDrawingSurface *sds, void *arrobj, int x
 
     if (dest_elem_size != sizeof(uint8_t) && dest_elem_size != ds->GetBPP())
     {
-        debug_script_warn("DrawingSurface.SetPixels: invalid source array type for %d-bit image", ds->GetColorDepth());
+        debug_script_error("DrawingSurface.SetPixels: invalid source array type for %d-bit image", ds->GetColorDepth());
         return;
     }
     if (x < 0 || y < 0 || x >= ds->GetWidth() || y >= ds->GetHeight())

--- a/Engine/ac/dynobj/scriptgame.cpp
+++ b/Engine/ac/dynobj/scriptgame.cpp
@@ -146,7 +146,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 58:  // play.inv_numdisp
     case 59:  // play.inv_numorder
     case 60:  // play.inv_numinline
-        debug_script_warn("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
+        debug_script_error("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
         break;
     case 61:  
         if (usetup.Access.TextReadSpeed <= 0)
@@ -180,7 +180,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 84: // play.fast_forward;
     case 85: // play.room_width;
     case 86: // play.room_height;
-        debug_script_warn("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
+        debug_script_error("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
         break;
     case 87:  play.game_speed_modifier = val; break;
     case 88:  play.score_sound = val; break;
@@ -215,7 +215,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 117: // play.fade_to_red;
     case 118: // play.fade_to_green;
     case 119: // play.fade_to_blue;
-        debug_script_warn("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
+        debug_script_error("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
         break;
     case 120:
         play.show_single_dialog_option = val;

--- a/Engine/ac/dynobj/scriptmouse.cpp
+++ b/Engine/ac/dynobj/scriptmouse.cpp
@@ -33,7 +33,7 @@ void ScriptMouse::WriteInt32(void *address, intptr_t offset, int32_t val)
     {
     case 0:
     case 4:
-        debug_script_warn("ScriptMouse: attempt to write in readonly variable at offset %d, value", offset, val);
+        debug_script_error("ScriptMouse: attempt to write in readonly variable at offset %d, value", offset, val);
         break;
     default:
         cc_error("ScriptMouse: unsupported variable offset %d", offset);

--- a/Engine/ac/dynobj/scriptsystem.cpp
+++ b/Engine/ac/dynobj/scriptsystem.cpp
@@ -46,7 +46,7 @@ void ScriptSystem::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 4:
     case 6:
     case 7:
-        debug_script_warn("ScriptSystem: attempt to write in readonly variable at offset %d, value %d", offset, val);
+        debug_script_error("ScriptSystem: attempt to write in readonly variable at offset %d, value %d", offset, val);
         break;
     case 5: vsync = val; break;
     default:

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -175,7 +175,7 @@ bool AssertAudioType(const char *api_name, int audio_type)
 {
     if ((audio_type < 0) || ((size_t)audio_type >= game.audioClipTypes.size()))
     {
-        debug_script_warn("%s: invalid audio type: %d, valid range is 0..%d", api_name, audio_type, static_cast<int>(game.audioClipTypes.size()) - 1);
+        debug_script_error("%s: invalid audio type: %d, valid range is 0..%d", api_name, audio_type, static_cast<int>(game.audioClipTypes.size()) - 1);
         return false;
     }
     return true;

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -63,22 +63,22 @@ void StopMoving(int chaa) {
 }
 
 void ReleaseCharacterView(int chat) {
-    if (!is_valid_character(chat))
-        quit("!ReleaseCahracterView: invalid character supplied");
+    if (!AssertCharacter("ReleaseCahracterView", chat))
+        return;
 
     Character_UnlockView(&game.chars[chat]);
 }
 
 void MoveToWalkableArea(int charid) {
-    if (!is_valid_character(charid))
-        quit("!MoveToWalkableArea: invalid character specified");
+    if (!AssertCharacter("MoveToWalkableArea", charid))
+        return;
 
     Character_PlaceOnWalkableArea(&game.chars[charid]);
 }
 
 int FaceLocation(int cha, int xx, int yy) {
-    if (!is_valid_character(cha))
-        quit("!FaceLocation: Invalid character specified");
+    if (!AssertCharacter("FaceLocation", cha))
+        return 0;
 
     const int old_loop = game.chars[cha].loop;
     Character_FaceLocation(&game.chars[cha], xx, yy, BLOCKING);
@@ -91,10 +91,10 @@ int FaceLocation(int cha, int xx, int yy) {
 }
 
 int FaceCharacter(int cha,int toface) {
-    if (!is_valid_character(cha))
-        quit("!FaceCharacter: Invalid character specified");
-    if (!is_valid_character(toface)) 
-        quit("!FaceCharacter: invalid character specified");
+    if (!AssertCharacter("FaceCharacter", cha))
+        return 0;
+    if (!AssertCharacter("FaceCharacter", toface))
+        return 0;
 
     const int old_loop = game.chars[cha].loop;
     Character_FaceCharacter(&game.chars[cha], &game.chars[toface], BLOCKING);
@@ -108,8 +108,8 @@ int FaceCharacter(int cha,int toface) {
 
 
 void SetCharacterIdle(int who, int iview, int itime) {
-    if (!is_valid_character(who))
-        quit("!SetCharacterIdle: Invalid character specified");
+    if (!AssertCharacter("SetCharacterIdle", who))
+        return;
 
     Character_SetIdleView(&game.chars[who], iview, itime);
 }
@@ -159,15 +159,16 @@ int GetCharacterHeight(int charid) {
 
 
 void SetCharacterBaseline (int obn, int basel) {
-    if (!is_valid_character(obn)) quit("!SetCharacterBaseline: invalid object number specified");
+    if (!AssertCharacter("SetCharacterBaseline", obn))
+        return;
 
     Character_SetBaseline(&game.chars[obn], basel);
 }
 
 // pass trans=0 for fully solid, trans=100 for fully transparent
 void SetCharacterTransparency(int obn,int trans) {
-    if (!is_valid_character(obn))
-        quit("!SetCharTransparent: invalid character number specified");
+    if (!AssertCharacter("SetCharTransparent", obn))
+        return;
 
     Character_SetTransparency(&game.chars[obn], trans);
 }
@@ -177,27 +178,27 @@ void AnimateCharacter4(int chh, int loopn, int sppd, int rept) {
 }
 
 void AnimateCharacter6(int chh, int loopn, int sppd, int rept, int direction, int blocking) {
-    if (!is_valid_character(chh))
-        quit("AnimateCharacter: invalid character");
+    if (!AssertCharacter("AnimateCharacter", chh))
+        return;
 
     Character_Animate5(&game.chars[chh], loopn, sppd, rept, blocking, direction);
 }
 
 void SetPlayerCharacter(int newchar) {
-    if (!is_valid_character(newchar))
-        quit("!SetPlayerCharacter: Invalid character specified");
+    if (!AssertCharacter("SetPlayerCharacter", newchar))
+        return;
 
     Character_SetAsPlayer(&game.chars[newchar]);
 }
 
 void FollowCharacterEx(int who, int tofollow, int distaway, int eagerness) {
-    if (!is_valid_character(who))
-        quit("!FollowCharacter: Invalid character specified");
+    if (!AssertCharacter("FollowCharacter", who))
+        return;
     CharacterInfo *chtofollow = nullptr;
     if (tofollow != -1)
     {
-        if (!is_valid_character(tofollow))
-            quit("!FollowCharacterEx: invalid character to follow");
+        if (!AssertCharacter("FollowCharacter", tofollow))
+            return;
         else
             chtofollow = &game.chars[tofollow];
     }
@@ -210,16 +211,16 @@ void FollowCharacter(int who, int tofollow) {
 }
 
 void SetCharacterIgnoreLight (int who, int yesorno) {
-    if (!is_valid_character(who))
-        quit("!SetCharacterIgnoreLight: Invalid character specified");
+    if (!AssertCharacter("SetCharacterIgnoreLight", who))
+        return;
 
     Character_SetIgnoreLighting(&game.chars[who], yesorno);
 }
 
 void MoveCharacter(int cc,int x, int y)
 {
-    if (!is_valid_character(cc))
-        quit("!MoveCharacter: invalid character specified");
+    if (!AssertCharacter("MoveCharacter", cc))
+        return;
 
     Character_DoMove(&game.chars[cc], "MoveCharacter", x, y,
                      false /* not straight */, IN_BACKGROUND, WALKABLE_AREAS, true /* animate */);
@@ -227,8 +228,8 @@ void MoveCharacter(int cc,int x, int y)
 
 void MoveCharacterDirect(int cc, int x, int y)
 {
-    if (!is_valid_character(cc))
-        quit("!MoveCharacterDirect: invalid character specified");
+    if (!AssertCharacter("MoveCharacterDirect", cc))
+        return;
 
     Character_DoMove(&game.chars[cc], "MoveCharacterDirect", x, y,
                      false /* not straight */, IN_BACKGROUND, ANYWHERE, true /* animate */);
@@ -236,8 +237,8 @@ void MoveCharacterDirect(int cc, int x, int y)
 
 void MoveCharacterStraight(int cc,int x, int y)
 {
-    if (!is_valid_character(cc))
-        quit("!MoveCharacterStraight: invalid character specified");
+    if (!AssertCharacter("MoveCharacterStraight", cc))
+        return;
 
     Character_DoMove(&game.chars[cc], "MoveCharacterStraight", x, y,
                      true /* straight */, IN_BACKGROUND, WALKABLE_AREAS, true /* animate */);
@@ -246,8 +247,8 @@ void MoveCharacterStraight(int cc,int x, int y)
 // Append to character path
 void MoveCharacterPath(int chac, int tox, int toy)
 {
-    if (!is_valid_character(chac))
-        quit("!MoveCharacterPath: invalid character specified");
+    if (!AssertCharacter("MoveCharacterPath", chac))
+        return;
 
     Character_AddWaypoint(&game.chars[chac], tox, toy);
 }
@@ -258,8 +259,8 @@ int GetPlayerCharacter() {
 }
 
 void SetCharacterSpeedEx(int chaa, int xspeed, int yspeed) {
-    if (!is_valid_character(chaa))
-        quit("!SetCharacterSpeedEx: invalid character");
+    if (!AssertCharacter("SetCharacterSpeedEx", chaa))
+        return;
 
     Character_SetSpeed(&game.chars[chaa], xspeed, yspeed);
 
@@ -270,29 +271,30 @@ void SetCharacterSpeed(int chaa,int nspeed) {
 }
 
 void SetTalkingColor(int chaa,int ncol) {
-    if (!is_valid_character(chaa)) quit("!SetTalkingColor: invalid character");
+    if (!AssertCharacter("SetTalkingColor", chaa))
+        return;
 
     Character_SetSpeechColor(&game.chars[chaa], ncol);
 }
 
 void SetCharacterSpeechView (int chaa, int vii) {
-    if (!is_valid_character(chaa))
-        quit("!SetCharacterSpeechView: invalid character specified");
+    if (!AssertCharacter("SetCharacterSpeechView", chaa))
+        return;
 
     Character_SetSpeechView(&game.chars[chaa], vii);
 }
 
 void SetCharacterBlinkView (int chaa, int vii, int intrv) {
-    if (!is_valid_character(chaa))
-        quit("!SetCharacterBlinkView: invalid character specified");
+    if (!AssertCharacter("SetCharacterBlinkView", chaa))
+        return;
 
     Character_SetBlinkView(&game.chars[chaa], vii);
     Character_SetBlinkInterval(&game.chars[chaa], intrv);
 }
 
 void SetCharacterView(int chaa,int vii) {
-    if (!is_valid_character(chaa))
-        quit("!SetCharacterView: invalid character specified");
+    if (!AssertCharacter("SetCharacterView", chaa))
+        return;
 
     Character_LockView(&game.chars[chaa], vii);
 }
@@ -315,15 +317,15 @@ void SetCharacterViewOffset (int chaa, int vii, int xoffs, int yoffs) {
 
 
 void ChangeCharacterView(int chaa,int vii) {
-    if (!is_valid_character(chaa))
-        quit("!ChangeCharacterView: invalid character specified");
+    if (!AssertCharacter("ChangeCharacterView", chaa))
+        return;
 
     Character_ChangeView(&game.chars[chaa], vii);
 }
 
 void SetCharacterClickable (int cha, int clik) {
-    if (!is_valid_character(cha))
-        quit("!SetCharacterClickable: Invalid character specified");
+    if (!AssertCharacter("SetCharacterClickable", cha))
+        return;
     // make the character clicklabe (reset "No interaction" bit)
     game.chars[cha].flags&=~CHF_NOINTERACT;
     // if they don't want it clickable, set the relevant bit
@@ -332,8 +334,8 @@ void SetCharacterClickable (int cha, int clik) {
 }
 
 void SetCharacterIgnoreWalkbehinds (int cha, int clik) {
-    if (!is_valid_character(cha))
-        quit("!SetCharacterIgnoreWalkbehinds: Invalid character specified");
+    if (!AssertCharacter("SetCharacterIgnoreWalkbehinds", cha))
+        return;
 
     Character_SetIgnoreWalkbehinds(&game.chars[cha], clik);
 }
@@ -343,7 +345,7 @@ void MoveCharacterToObject(int chaa,int obbj)
 {
     // invalid object, do nothing
     // this allows MoveCharacterToObject(EGO, GetObjectAt(...));
-    if (!is_valid_object(obbj))
+    if (!AssertObject("MoveCharacterToObject", obbj))
         return;
 
     // NOTE: yep, it was using a hardcoded +5,+6 relative position...
@@ -364,8 +366,8 @@ void MoveCharacterToHotspot(int chaa, int hotsp)
 
 int MoveCharacterBlocking(int chaa, int x, int y, int ignwal)
 {
-    if (!is_valid_character (chaa))
-        quit("!MoveCharacterBlocking: invalid character");
+    if (!AssertCharacter("MoveCharacterBlocking", chaa))
+        return 0;
 
     Character_DoMove(&game.chars[chaa], "MoveCharacterBlocking", x, y,
                      false /* not straight */, BLOCKING, ignwal, true /* animate */);
@@ -387,8 +389,8 @@ int GetCharacterSpeechAnimationDelay(CharacterInfo *cha)
 }
 
 void RunCharacterInteraction (int cc, int mood) {
-    if (!is_valid_character(cc))
-        quit("!RunCharacterInteraction: invalid character");
+    if (!AssertCharacter("RunCharacterInteraction", cc))
+        return;
 
     // convert cursor mode to event index (in character event table)
     // TODO: probably move this conversion table elsewhere? should be a global info
@@ -431,32 +433,32 @@ void RunCharacterInteraction (int cc, int mood) {
 }
 
 int AreCharObjColliding(int charid,int objid) {
-    if (!is_valid_character(charid))
-        quit("!AreCharObjColliding: invalid character");
-    if (!is_valid_object(objid))
-        quit("!AreCharObjColliding: invalid object number");
+    if (!AssertCharacter("AreCharObjColliding", charid))
+        return 0;
+    if (!AssertObject("AreCharObjColliding", objid))
+        return 0;
 
     return Character_IsCollidingWithObject(&game.chars[charid], &scrObj[objid]);
 }
 
 int AreCharactersColliding(int cchar1,int cchar2) {
-    if (!is_valid_character(cchar1))
-        quit("!AreCharactersColliding: invalid char1");
-    if (!is_valid_character(cchar2))
-        quit("!AreCharactersColliding: invalid char2");
+    if (!AssertCharacter("AreCharactersColliding", cchar1))
+        return 0;
+    if (!AssertCharacter("AreCharactersColliding", cchar2))
+        return 0;
 
     return Character_IsCollidingWithChar(&game.chars[cchar1], &game.chars[cchar2]);
 }
 
 int GetCharacterProperty (int cha, const char *property) {
-    if (!is_valid_character(cha))
-        quit("!GetCharacterProperty: invalid character");
+    if (!AssertCharacter("GetCharacterProperty", cha))
+        return 0;
     return get_int_property (game.charProps[cha], play.charProps[cha], property);
 }
 
 void SetCharacterProperty (int who, int flag, int yesorno) {
-    if (!is_valid_character(who))
-        quit("!SetCharacterProperty: Invalid character specified");
+    if (!AssertCharacter("SetCharacterProperty", who))
+        return;
 
     Character_SetOption(&game.chars[who], flag, yesorno);
 }
@@ -535,8 +537,8 @@ void lose_inventory(int inum)
 }
 
 void AddInventoryToCharacter(int charid, int inum) {
-    if (!is_valid_character(charid))
-        quit("!AddInventoryToCharacter: invalid character specified");
+    if (!AssertCharacter("AddInventoryToCharacter", charid))
+        return;
     if ((inum < 1) || (inum >= game.numinvitems))
         quit("!AddInventory: invalid inv item specified");
 
@@ -544,8 +546,8 @@ void AddInventoryToCharacter(int charid, int inum) {
 }
 
 void LoseInventoryFromCharacter(int charid, int inum) {
-    if (!is_valid_character(charid))
-        quit("!LoseInventoryFromCharacter: invalid character specified");
+    if (!AssertCharacter("LoseInventoryFromCharacter", charid))
+        return;
     if ((inum < 1) || (inum >= game.numinvitems))
         quit("!AddInventory: invalid inv item specified");
 

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -46,7 +46,7 @@ int32_t FileOpenCMode(const char*fnmm, const char* cmode)
 int32_t FileOpen(const char *fnmm, FileOpenMode open_mode, StreamMode work_mode)
 {
   
-  debug_script_print(kDbgMsg_Debug, "FileOpen: request: %s, mode: %s",
+  debug_script_message(kDbgMsg_Debug, "FileOpen: request: %s, mode: %s",
                      fnmm, File::GetCMode(open_mode, work_mode).GetCStr());
   std::unique_ptr<Stream> s(ResolveScriptPathAndOpen(fnmm, open_mode, work_mode));
   if (!s)
@@ -54,7 +54,7 @@ int32_t FileOpen(const char *fnmm, FileOpenMode open_mode, StreamMode work_mode)
 
   String res_path = s->GetPath();
   int32_t handle = add_file_stream(std::move(s), "FileOpen");
-  debug_script_print(kDbgMsg_Info, "FileOpen: success, handle %d, path: %s", handle, res_path.GetCStr());
+  debug_script_message(kDbgMsg_Info, "FileOpen: success, handle %d, path: %s", handle, res_path.GetCStr());
   return handle;
 }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -553,7 +553,7 @@ int SetGameOption (int opt, int newval)
 {
     if (((opt < OPT_DEBUGMODE) || (opt > OPT_HIGHESTOPTION)) && (opt != OPT_LIPSYNCTEXT))
     {
-        debug_script_warn("SetGameOption: invalid option specified: %d", opt);
+        debug_script_error("SetGameOption: invalid option specified: %d", opt);
         return 0;
     }
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -643,8 +643,8 @@ int GetGameOption (int opt) {
 }
 
 void SkipUntilCharacterStops(int cc) {
-    if (!is_valid_character(cc))
-        quit("!SkipUntilCharacterStops: invalid character specified");
+    if (!AssertCharacter("SkipUntilCharacterStops", cc))
+        return;
     if (game.chars[cc].room!=displayed_room)
         quitprintf("!SkipUntilCharacterStops: character %s is not in current room %d (it is in room %d)",
             game.chars[cc].scrname, displayed_room, game.chars[cc].room);

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -43,7 +43,7 @@ bool ValidateInventoryItem(const char *api_name, int invitem)
     // Inventory Item 0 is a "dummy" slot in AGS historically (idk why)
     if ((invitem < 1) || (invitem >= game.numinvitems))
     {
-        debug_script_warn("%s: invalid inventory item specified, id %d, valid range is 1..%d", api_name, invitem, game.numinvitems - 1);
+        debug_script_error("%s: invalid inventory item specified, id %d, valid range is 1..%d", api_name, invitem, game.numinvitems - 1);
         return false;
     }
     return true;

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -121,8 +121,8 @@ void SetObjectTint(int obj, int red, int green, int blue, int opacity, int lumin
         (luminance < 0) || (luminance > 100))
         quit("!SetObjectTint: invalid parameter. R,G,B must be 0-255, opacity & luminance 0-100");
 
-    if (!is_valid_object(obj))
-        quit("!SetObjectTint: invalid object number specified");
+    if (!AssertObject("SetObjectTint", obj))
+        return;
 
     debug_script_log("Set object %d tint RGB(%d,%d,%d) %d%%", obj, red, green, blue, opacity);
 
@@ -136,8 +136,8 @@ void SetObjectTint(int obj, int red, int green, int blue, int opacity, int lumin
 }
 
 void RemoveObjectTint(int obj) {
-    if (!is_valid_object(obj))
-        quit("!RemoveObjectTint: invalid object");
+    if (!AssertObject("RemoveObjectTint", obj))
+        return;
 
     if (objs[obj].flags & (OBJF_HASTINT | OBJF_HASLIGHT)) {
         debug_script_log("Un-tint object %d", obj);
@@ -155,8 +155,8 @@ void SetObjectView(int obn, int vii) {
 }
 
 bool SetObjectFrameSimple(int obn, int viw, int lop, int fra) {
-    if (!is_valid_object(obn))
-        quitprintf("!SetObjectFrame: invalid object number specified (%d, range is 0 - %d)", obn, 0, croom->numobj);
+    if (!AssertObject("SetObjectFrame", obn))
+        return false;
     viw--;
     AssertViewHasLoops("SetObjectFrame", thisroom.Objects[obn].ScriptName.GetCStr(), viw);
 
@@ -211,7 +211,8 @@ void SetObjectFrame(int obn, int viw, int lop, int fra) {
 
 // pass trans=0 for fully solid, trans=100 for fully transparent
 void SetObjectTransparency(int obn,int trans) {
-    if (!is_valid_object(obn)) quit("!SetObjectTransparent: invalid object number specified");
+    if (!AssertObject("SetObjectTransparent", obn))
+        return;
     if ((trans < 0) || (trans > 100)) quit("!SetObjectTransparent: transparency value must be between 0 and 100");
 
     objs[obn].transparent = GfxDef::Trans100ToLegacyTrans255(trans);
@@ -220,7 +221,8 @@ void SetObjectTransparency(int obn,int trans) {
 
 
 void SetObjectBaseline (int obn, int basel) {
-    if (!is_valid_object(obn)) quit("!SetObjectBaseline: invalid object number specified");
+    if (!AssertObject("SetObjectBaseline", obn))
+        return;
     // baseline has changed, invalidate the cache
     if (objs[obn].baseline != basel) {
         objs[obn].baseline = basel;
@@ -229,7 +231,8 @@ void SetObjectBaseline (int obn, int basel) {
 }
 
 int GetObjectBaseline(int obn) {
-    if (!is_valid_object(obn)) quit("!GetObjectBaseline: invalid object number specified");
+    if (!AssertObject("GetObjectBaseline", obn))
+        return 0;
 
     if (objs[obn].baseline < 1)
         return 0;
@@ -240,8 +243,8 @@ int GetObjectBaseline(int obn) {
 void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking,
     int sframe, int volume)
 {
-    if (!is_valid_object(obn))
-        quit("!AnimateObject: invalid object number specified");
+    if (!AssertObject("AnimateObject", obn))
+        return;
 
     const RoomObjectInfo &obji = thisroom.Objects[obn];
     RoomObject &obj = objs[obn];
@@ -300,7 +303,8 @@ void AnimateObject4(int obn, int loopn, int spdd, int rept) {
 }
 
 void MergeObject(int obn) {
-    if (!is_valid_object(obn)) quit("!MergeObject: invalid object specified");
+    if (!AssertObject("MergeObject", obn))
+        return;
 
     update_object_scale(obn); // make sure sprite transform is up to date
     construct_object_gfx(obn, true);
@@ -324,15 +328,16 @@ void MergeObject(int obn) {
 }
 
 void StopObjectMoving(int objj) {
-    if (!is_valid_object(objj))
-        quit("!StopObjectMoving: invalid object number");
+    if (!AssertObject("StopObjectMoving", objj))
+        return;
     objs[objj].moving = 0;
 
     debug_script_log("Object %d stop moving", objj);
 }
 
 void ObjectOff(int obn) {
-    if (!is_valid_object(obn)) quit("!ObjectOff: invalid object specified");
+    if (!AssertObject("ObjectOff", obn))
+        return;
     // don't change it if on == 2 (merged)
     if (objs[obn].on == OBJ_STATE_ENABLED) {
         objs[obn].on = OBJ_STATE_DISABLED;
@@ -342,7 +347,8 @@ void ObjectOff(int obn) {
 }
 
 void ObjectOn(int obn) {
-    if (!is_valid_object(obn)) quit("!ObjectOn: invalid object specified");
+    if (!AssertObject("ObjectOn", obn))
+        return;
     if (objs[obn].on == OBJ_STATE_DISABLED) {
         objs[obn].on = OBJ_STATE_ENABLED;
         debug_script_log("Object %d turned on", obn);
@@ -350,7 +356,8 @@ void ObjectOn(int obn) {
 }
 
 int IsObjectOn (int objj) {
-    if (!is_valid_object(objj)) quit("!IsObjectOn: invalid object number");
+    if (!AssertObject("IsObjectOn", objj))
+        return 0;
 
     if (objs[objj].on == OBJ_STATE_ENABLED)
         return 1;
@@ -359,7 +366,8 @@ int IsObjectOn (int objj) {
 }
 
 void SetObjectGraphic(int obn,int slott) {
-    if (!is_valid_object(obn)) quit("!SetObjectGraphic: invalid object specified");
+    if (!AssertObject("SetObjectGraphic", obn))
+        return;
 
     if (objs[obn].num != slott) {
         objs[obn].num = Math::InRangeOrDef<uint16_t>(slott, 0);
@@ -374,28 +382,32 @@ void SetObjectGraphic(int obn,int slott) {
 }
 
 int GetObjectGraphic(int obn) {
-    if (!is_valid_object(obn)) quit("!GetObjectGraphic: invalid object specified");
+    if (!AssertObject("GetObjectGraphic", obn))
+        return 0;
     return objs[obn].num;
 }
 
 int GetObjectY (int objj) {
-    if (!is_valid_object(objj)) quit("!GetObjectY: invalid object number");
+    if (!AssertObject("GetObjectY", objj))
+        return 0;
     return objs[objj].y;
 }
 
 int IsObjectAnimating(int objj) {
-    if (!is_valid_object(objj)) quit("!IsObjectAnimating: invalid object number");
+    if (!AssertObject("IsObjectAnimating", objj))
+        return 0;
     return (objs[objj].cycling != 0) ? 1 : 0;
 }
 
 int IsObjectMoving(int objj) {
-    if (!is_valid_object(objj)) quit("!IsObjectMoving: invalid object number");
+    if (!AssertObject("IsObjectMoving", objj))
+        return 0;
     return (objs[objj].moving > 0) ? 1 : 0;
 }
 
 void SetObjectPosition(int objj, int tox, int toy) {
-    if (!is_valid_object(objj))
-        quit("!SetObjectPosition: invalid object number");
+    if (!AssertObject("SetObjectPosition", objj))
+        return;
 
     if (objs[objj].moving > 0)
     {
@@ -409,8 +421,8 @@ void SetObjectPosition(int objj, int tox, int toy) {
 
 void GetObjectName(int obj, char *buffer) {
     VALIDATE_STRING(buffer);
-    if (!is_valid_object(obj))
-        quit("!GetObjectName: invalid object number");
+    if (!AssertObject("GetObjectName", obj))
+        return;
 
     snprintf(buffer, MAX_MAXSTRLEN, "%s", get_compat_prop_translation(croom->obj[obj].name.GetCStr()));
 }
@@ -423,16 +435,16 @@ void MoveObjectDirect(int objj,int xx,int yy,int spp) {
 }
 
 void SetObjectClickable (int cha, int clik) {
-    if (!is_valid_object(cha))
-        quit("!SetObjectClickable: Invalid object specified");
+    if (!AssertObject("SetObjectClickable", cha))
+        return;
     objs[cha].flags&=~OBJF_NOINTERACT;
     if (clik == 0)
         objs[cha].flags|=OBJF_NOINTERACT;
 }
 
 void SetObjectIgnoreWalkbehinds (int cha, int clik) {
-    if (!is_valid_object(cha))
-        quit("!SetObjectIgnoreWalkbehinds: Invalid object specified");
+    if (!AssertObject("SetObjectIgnoreWalkbehinds", cha))
+        return;
     if (game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v350)
         debug_script_warn("IgnoreWalkbehinds is not recommended for use, consider other solutions");
     objs[cha].flags&=~OBJF_NOWALKBEHINDS;
@@ -442,8 +454,8 @@ void SetObjectIgnoreWalkbehinds (int cha, int clik) {
 }
 
 void RunObjectInteraction (int aa, int mood) {
-    if (!is_valid_object(aa))
-        quit("!RunObjectInteraction: invalid object number for current room");
+    if (!AssertObject("RunObjectInteraction", aa))
+        return;
 
     // convert cursor mode to event index (in character event table)
     // TODO: probably move this conversion table elsewhere? should be a global info
@@ -486,15 +498,15 @@ void RunObjectInteraction (int aa, int mood) {
 }
 
 int AreObjectsColliding(int obj1,int obj2) {
-    if (!is_valid_object(obj1) || !is_valid_object(obj2))
-        quit("!AreObjectsColliding: invalid object specified");
+    if (!AssertObject("AreObjectsColliding", obj1) || !AssertObject("AreObjectsColliding", obj2))
+        return 0;
 
     return (AreThingsOverlapping(obj1 + OVERLAPPING_OBJECT, obj2 + OVERLAPPING_OBJECT)) ? 1 : 0;
 }
 
 static int GetThingRect(int thing, Rect *rect)
 {
-    if (is_valid_character(thing))
+    if (IsValidCharacter(thing))
     {
         if (game.chars[thing].room != displayed_room)
             return 0;
@@ -506,7 +518,7 @@ static int GetThingRect(int thing, Rect *rect)
             charextra[thing].GetEffectiveY(&game.chars[thing]) - charh + 1,
             charw, charh);
     }
-    else if (is_valid_object(thing - OVERLAPPING_OBJECT))
+    else if (IsValidObject(thing - OVERLAPPING_OBJECT))
     {
         int objid = thing - OVERLAPPING_OBJECT;
         if (objs[objid].on != OBJ_STATE_ENABLED)
@@ -556,8 +568,8 @@ int AreThingsOverlapping(int thing1, int thing2)
 
 int GetObjectProperty (int hss, const char *property)
 {
-    if (!is_valid_object(hss))
-        quit("!GetObjectProperty: invalid object");
+    if (!AssertObject("GetObjectProperty", hss))
+        return 0;
     return get_int_property(thisroom.Objects[hss].Properties, croom->objProps[hss], property);
 }
 

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -132,8 +132,8 @@ void NewRoomEx(int nrnum,int newx,int newy) {
 }
 
 void NewRoomNPC(int charid, int nrnum, int newx, int newy) {
-    if (!is_valid_character(charid))
-        quit("!NewRoomNPC: invalid character");
+    if (!AssertCharacter("NewRoomNPC", charid))
+        return;
     if (charid == game.playercharacter)
         quit("!NewRoomNPC: use NewRoomEx with the player character");
 

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -195,7 +195,7 @@ void GetRoomPropertyText (const char *property, char *bufer)
 void SetBackgroundFrame(int frnum) {
     if ((frnum < -1) || (frnum != -1 && (size_t)frnum >= thisroom.BgFrameCount))
     {
-        debug_script_warn("SetBackgrondFrame: invalid background number specified: %d, valid range in this room is 0..%u", thisroom.BgFrameCount - 1);
+        debug_script_error("SetBackgrondFrame: invalid background number specified: %d, valid range in this room is 0..%u", thisroom.BgFrameCount - 1);
         return;
     }
 

--- a/Engine/ac/global_timer.cpp
+++ b/Engine/ac/global_timer.cpp
@@ -21,7 +21,7 @@ bool AssertTimerID(const char *api_name, int tnum)
 {
     if (tnum < 0)
     {
-        debug_script_warn("%s: invalid timer id %d, must be a number >= 0", api_name, tnum);
+        debug_script_error("%s: invalid timer id %d, must be a number >= 0", api_name, tnum);
         return false;
     }
     return true;

--- a/Engine/ac/global_walkbehind.cpp
+++ b/Engine/ac/global_walkbehind.cpp
@@ -26,7 +26,7 @@ void SetWalkBehindBase(int wa,int bl)
 {
     if ((wa < 1) || (wa >= MAX_WALK_BEHINDS))
     {
-        debug_script_warn("SetWalkBehindBase: invalid walk-behind area specified: %d, range is 1..%d", wa, MAX_WALK_BEHINDS - 1);
+        debug_script_error("SetWalkBehindBase: invalid walk-behind area specified: %d, range is 1..%d", wa, MAX_WALK_BEHINDS - 1);
         return;
     }
 
@@ -42,7 +42,7 @@ int GetWalkBehindBase(int wa)
 {
     if ((wa < 1) || (wa >= MAX_WALK_BEHINDS))
     {
-        debug_script_warn("SetWalkBehindBase: invalid walk-behind area specified: %d, range is 1..%d", wa, MAX_WALK_BEHINDS - 1);
+        debug_script_error("SetWalkBehindBase: invalid walk-behind area specified: %d, range is 1..%d", wa, MAX_WALK_BEHINDS - 1);
         return 0;
     }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -64,7 +64,7 @@ bool AssertObject(const char *apiname, int obj_id)
 {
     if ((obj_id >= 0) && (static_cast<uint32_t>(obj_id) < croom->numobj))
         return true;
-    debug_script_warn("%s: invalid object id %d (range is 0..%d)", apiname, obj_id, croom->numobj - 1);
+    debug_script_warn("%s: invalid object id %d (range is 0..%d)", apiname, obj_id, croom->numobj > 0 ? croom->numobj - 1 : 0);
     return false;
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -64,7 +64,7 @@ bool AssertObject(const char *apiname, int obj_id)
 {
     if ((obj_id >= 0) && (static_cast<uint32_t>(obj_id) < croom->numobj))
         return true;
-    debug_script_warn("%s: invalid object id %d (range is 0..%d)", apiname, obj_id, croom->numobj > 0 ? croom->numobj - 1 : 0);
+    debug_script_error("%s: invalid object id %d (range is 0..%d)", apiname, obj_id, croom->numobj > 0 ? croom->numobj - 1 : 0);
     return false;
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -55,9 +55,9 @@ extern IGraphicsDriver *gfxDriver;
 extern CCObject ccDynamicObject;
 
 
-bool is_valid_object(int obj_id)
+bool IsValidObject(int obj_id)
 {
-    return (obj_id >= 0) && (static_cast<uint32_t>(obj_id) < croom->numobj);
+    return ((obj_id >= 0) && (static_cast<uint32_t>(obj_id) < croom->numobj));
 }
 
 bool AssertObject(const char *apiname, int obj_id)
@@ -68,7 +68,8 @@ bool AssertObject(const char *apiname, int obj_id)
     return false;
 }
 
-int Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2) {
+int Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2)
+{
     return AreObjectsColliding(objj->id, obj2->id);
 }
 
@@ -114,8 +115,8 @@ void Object_SetTransparency(ScriptObject *objj, int trans) {
 }
 
 int Object_GetTransparency(ScriptObject *objj) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.Transparent: invalid object number specified");
+    if (!AssertObject("Object.Transparent", objj->id))
+        return 0;
 
     return GfxDef::LegacyTrans255ToTrans100(objs[objj->id].transparent);
 }
@@ -137,7 +138,6 @@ int Object_GetAudioSpeed(ScriptObject *objj)
 
 void Object_SetAudioSpeed(ScriptObject *objj, int newval)
 {
-
     objs[objj->id].audio_speed = newval;
 }
 
@@ -148,7 +148,6 @@ int Object_GetAudioVolume(ScriptObject *objj)
 
 void Object_SetAudioVolume(ScriptObject *objj, int newval)
 {
-
     objs[objj->id].audio_volume = Math::Clamp(newval, 0, 100);
 }
 
@@ -174,8 +173,8 @@ void Object_Animate6(ScriptObject *objj, int loop, int delay, int repeat, int bl
 }
 
 void Object_StopAnimating(ScriptObject *objj) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.StopAnimating: invalid object number");
+    if (!AssertObject("Object.StopAnimating", objj->id))
+        return;
 
     if (objs[objj->id].cycling) {
         objs[objj->id].cycling = 0;
@@ -229,7 +228,8 @@ int Object_GetGraphic(ScriptObject *objj) {
 }
 
 int GetObjectX (int objj) {
-    if (!is_valid_object(objj)) quit("!GetObjectX: invalid object number");
+    if (!AssertObject("GetObjectX", objj))
+        return 0;
     return objs[objj].x;
 }
 
@@ -266,10 +266,10 @@ int Object_GetLightLevel(ScriptObject *obj)
 
 void Object_SetLightLevel(ScriptObject *objj, int light_level)
 {
-    int obj = objj->id;
-    if (!is_valid_object(obj))
-        quit("!SetObjectTint: invalid object number specified");
+    if (!AssertObject("Object.LightLevel", objj->id))
+        return;
 
+    int obj = objj->id;
     objs[obj].tint_light = light_level;
     objs[obj].flags &= ~OBJF_HASTINT;
     objs[obj].flags |= OBJF_HASLIGHT;
@@ -317,15 +317,15 @@ void Object_GetName(ScriptObject *objj, char *buffer) {
 }
 
 const char* Object_GetName_New(ScriptObject *objj) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.Name: invalid object number");
+    if (!AssertObject("Object.Name", objj->id))
+        return nullptr;
 
     return CreateNewScriptString(get_compat_prop_translation(croom->obj[objj->id].name.GetCStr()));
 }
 
 void Object_SetName(ScriptObject *objj, const char *newName) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.Name: invalid object number");
+    if (!AssertObject("Object.Name", objj->id))
+        return;
     croom->obj[objj->id].name = newName;
     GUIE::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
@@ -354,8 +354,8 @@ void Object_SetClickable(ScriptObject *objj, int clik) {
 }
 
 int Object_GetClickable(ScriptObject *objj) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.Clickable: Invalid object specified");
+    if (!AssertObject("Object.Clickable", objj->id))
+        return 0;
 
     if (objs[objj->id].flags & OBJF_NOINTERACT)
         return 0;
@@ -364,8 +364,8 @@ int Object_GetClickable(ScriptObject *objj) {
 
 int Object_GetDestinationX(ScriptObject *objj)
 {
-    if (!is_valid_object(objj->id))
-        quit("!Object.DestionationX: Invalid object specified");
+    if (!AssertObject("Object.DestinationX", objj->id))
+        return 0;
 
     if (objs[objj->id].moving)
     {
@@ -377,8 +377,8 @@ int Object_GetDestinationX(ScriptObject *objj)
 
 int Object_GetDestinationY(ScriptObject *objj)
 {
-    if (!is_valid_object(objj->id))
-        quit("!Object.DestionationX: Invalid object specified");
+    if (!AssertObject("Object.DestinationY", objj->id))
+        return 0;
 
     if (objs[objj->id].moving)
     {
@@ -397,16 +397,16 @@ void Object_SetManualScaling(ScriptObject *objj, bool on)
 }
 
 void Object_SetIgnoreScaling(ScriptObject *objj, int newval) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.IgnoreScaling: Invalid object specified");
+    if (!AssertObject("Object.IgnoreScaling", objj->id))
+        return;
     if (newval)
         objs[objj->id].zoom = 100; // compatibility, for before manual scaling existed
     Object_SetManualScaling(objj, newval != 0);
 }
 
 int Object_GetIgnoreScaling(ScriptObject *objj) {
-    if (!is_valid_object(objj->id))
-        quit("!Object.IgnoreScaling: Invalid object specified");
+    if (!AssertObject("Object.IgnoreScaling", objj->id))
+        return 0;
 
     if (objs[objj->id].flags & OBJF_USEROOMSCALING)
         return 0;
@@ -487,19 +487,19 @@ void Object_SetIgnoreWalkbehinds(ScriptObject *chaa, int clik) {
     SetObjectIgnoreWalkbehinds(chaa->id, clik);
 }
 
-int Object_GetIgnoreWalkbehinds(ScriptObject *chaa) {
-    if (!is_valid_object(chaa->id))
-        quit("!Object.IgnoreWalkbehinds: Invalid object specified");
+int Object_GetIgnoreWalkbehinds(ScriptObject *objj) {
+    if (!AssertObject("Object.IgnoreWalkbehinds", objj->id))
+        return 0;
 
-    if (objs[chaa->id].flags & OBJF_NOWALKBEHINDS)
+    if (objs[objj->id].flags & OBJF_NOWALKBEHINDS)
         return 1;
     return 0;
 }
 
 void move_object(int objj, int tox, int toy, int speed, int ignwal) {
 
-    if (!is_valid_object(objj))
-        quit("!MoveObject: invalid object number");
+    if (!AssertObject("MoveObject", objj))
+        return;
 
     auto &obj = objs[objj];
     // AGS <= 2.61 uses MoveObject with spp=-1 internally instead of SetObjectPosition

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -123,31 +123,43 @@ int Object_GetTransparency(ScriptObject *objj) {
 
 int Object_GetAudioPanning(ScriptObject *objj)
 {
+    if (!AssertObject("Object.AudioPanning", objj->id))
+        return 0;
     return objs[objj->id].audio_panning;
 }
 
 void Object_SetAudioPanning(ScriptObject *objj, int newval)
 {
+    if (!AssertObject("Object.AudioPanning", objj->id))
+        return;
     objs[objj->id].audio_panning = Math::Clamp(newval, -100, 100);
 }
 
 int Object_GetAudioSpeed(ScriptObject *objj)
 {
+    if (!AssertObject("Object.AudioSpeed", objj->id))
+        return 0;
     return objs[objj->id].audio_speed;
 }
 
 void Object_SetAudioSpeed(ScriptObject *objj, int newval)
 {
+    if (!AssertObject("Object.AudioSpeed", objj->id))
+        return;
     objs[objj->id].audio_speed = newval;
 }
 
 int Object_GetAudioVolume(ScriptObject *objj)
 {
+    if (!AssertObject("Object.AudioVolume", objj->id))
+        return 0;
     return objs[objj->id].audio_volume;
 }
 
 void Object_SetAudioVolume(ScriptObject *objj, int newval)
 {
+    if (!AssertObject("Object.AudioVolume", objj->id))
+        return;
     objs[objj->id].audio_volume = Math::Clamp(newval, 0, 100);
 }
 
@@ -198,18 +210,24 @@ void Object_SetVisible(ScriptObject *objj, int onoroff) {
 }
 
 int Object_GetView(ScriptObject *objj) {
+    if (!AssertObject("Object.View", objj->id))
+        return 0;
     if (objs[objj->id].view == RoomObject::NoView)
         return 0;
     return objs[objj->id].view + 1;
 }
 
 int Object_GetLoop(ScriptObject *objj) {
+    if (!AssertObject("Object.Loop", objj->id))
+        return 0;
     if (objs[objj->id].view == RoomObject::NoView)
         return 0;
     return objs[objj->id].loop;
 }
 
 int Object_GetFrame(ScriptObject *objj) {
+    if (!AssertObject("Object.Frame", objj->id))
+        return 0;
     if (objs[objj->id].view == RoomObject::NoView)
         return 0;
     return objs[objj->id].frame;
@@ -251,16 +269,22 @@ int Object_GetMoving(ScriptObject *objj) {
 
 bool Object_HasExplicitLight(ScriptObject *obj)
 {
+    if (!AssertObject("Object.HasExplicitLight", obj->id))
+        return false;
     return objs[obj->id].has_explicit_light();
 }
 
 bool Object_HasExplicitTint(ScriptObject *obj)
 {
+    if (!AssertObject("Object.HasExplicitTint", obj->id))
+        return false;
     return objs[obj->id].has_explicit_tint();
 }
 
 int Object_GetLightLevel(ScriptObject *obj)
 {
+    if (!AssertObject("Object.LightLevel", obj->id))
+        return 0;
     return objs[obj->id].has_explicit_light() ? objs[obj->id].tint_light : 0;
 }
 
@@ -277,26 +301,36 @@ void Object_SetLightLevel(ScriptObject *objj, int light_level)
 
 int Object_GetTintRed(ScriptObject *obj)
 {
+    if (!AssertObject("Object.TintRed", obj->id))
+        return 0;
     return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_r : 0;
 }
 
 int Object_GetTintGreen(ScriptObject *obj)
 {
+    if (!AssertObject("Object.TintGreen", obj->id))
+        return 0;
     return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_g : 0;
 }
 
 int Object_GetTintBlue(ScriptObject *obj)
 {
+    if (!AssertObject("Object.TintBlue", obj->id))
+        return 0;
     return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_b : 0;
 }
 
 int Object_GetTintSaturation(ScriptObject *obj)
 {
+    if (!AssertObject("Object.TintSaturation", obj->id))
+        return 0;
      return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_level : 0;
 }
 
 int Object_GetTintLuminance(ScriptObject *obj)
 {
+    if (!AssertObject("Object.TintLuminance", obj->id))
+        return 0;
     return objs[obj->id].has_explicit_tint() ? ((objs[obj->id].tint_light * 10) / 25) : 0;
 }
 
@@ -334,13 +368,15 @@ bool Object_IsInteractionAvailable(ScriptObject *oobj, int mood) {
 
     play.check_interaction_only = 1;
     RunObjectInteraction(oobj->id, mood);
-    int ciwas = play.check_interaction_only;
+    int ciwas = play.check_interaction_only; // FIXME: reimplement returning check result without this hack!
     play.check_interaction_only = 0;
     return (ciwas == 2);
 }
 
 void Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int ignwal)
 {
+    if (!AssertObject("Object.Move", objj->id))
+        return;
     ValidateMoveParams("Object.Move", blocking, ignwal);
 
     move_object(objj->id, x, y, speed, ignwal);
@@ -390,6 +426,8 @@ int Object_GetDestinationY(ScriptObject *objj)
 
 void Object_SetManualScaling(ScriptObject *objj, bool on)
 {
+    if (!AssertObject("Object.ManualScaling", objj->id))
+        return;
     if (on) objs[objj->id].flags &= ~OBJF_USEROOMSCALING;
     else objs[objj->id].flags |= OBJF_USEROOMSCALING;
     // clear the cache
@@ -414,10 +452,14 @@ int Object_GetIgnoreScaling(ScriptObject *objj) {
 }
 
 int Object_GetScaling(ScriptObject *objj) {
+    if (!AssertObject("Object.Scaling", objj->id))
+        return 0;
     return objs[objj->id].zoom;
 }
 
 void Object_SetScaling(ScriptObject *objj, int zoomlevel) {
+    if (!AssertObject("Object.Scaling", objj->id))
+        return;
     if ((objs[objj->id].flags & OBJF_USEROOMSCALING) != 0)
     {
         debug_script_warn("Object.Scaling: cannot set property unless ManualScaling is enabled");
@@ -431,46 +473,66 @@ void Object_SetScaling(ScriptObject *objj, int zoomlevel) {
 }
 
 void Object_SetSolid(ScriptObject *objj, int solid) {
+    if (!AssertObject("Object.Solid", objj->id))
+        return;
     objs[objj->id].flags &= ~OBJF_SOLID;
     if (solid)
       objs[objj->id].flags |= OBJF_SOLID;
 }
 
 int Object_GetSolid(ScriptObject *objj) {
+    if (!AssertObject("Object.Solid", objj->id))
+        return 0;
     if (objs[objj->id].flags & OBJF_SOLID)
         return 1;
     return 0;
 }
 
 void Object_SetBlockingWidth(ScriptObject *objj, int bwid) {
+    if (!AssertObject("Object.BlockingWidth", objj->id))
+        return;
     objs[objj->id].blocking_width = static_cast<int16_t>(bwid);
 }
 
 int Object_GetBlockingWidth(ScriptObject *objj) {
+    if (!AssertObject("Object.BlockingWidth", objj->id))
+        return 0;
     return objs[objj->id].blocking_width;
 }
 
 void Object_SetBlockingHeight(ScriptObject *objj, int bhit) {
+    if (!AssertObject("Object.BlockingHeight", objj->id))
+        return;
     objs[objj->id].blocking_height = static_cast<int16_t>(bhit);
 }
 
 int Object_GetBlockingHeight(ScriptObject *objj) {
+    if (!AssertObject("Object.BlockingHeight", objj->id))
+        return 0;
     return objs[objj->id].blocking_height;
 }
 
 int Object_GetBlockingRectX(ScriptObject *objj) {
+    if (!AssertObject("Object.BlockingRectX", objj->id))
+        return 0;
     return objs[objj->id].blocking_x;
 }
 
 void Object_SetBlockingRectX(ScriptObject *objj, int x) {
+    if (!AssertObject("Object.BlockingRectX", objj->id))
+        return;
     objs[objj->id].blocking_x = static_cast<int16_t>(x);
 }
 
 int Object_GetBlockingRectY(ScriptObject *objj) {
+    if (!AssertObject("Object.BlockingRectY", objj->id))
+        return 0;
     return objs[objj->id].blocking_y;
 }
 
 void Object_SetBlockingRectY(ScriptObject *objj, int y) {
+    if (!AssertObject("Object.BlockingRectY", objj->id))
+        return;
     objs[objj->id].blocking_y = static_cast<int16_t>(y);
 }
 

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -27,12 +27,12 @@
 namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 
-bool    is_valid_object(int obj_id);
+// Tells if the object ID is valid (in the current room)
+bool    IsValidObject(int obj_id);
 // Asserts the object ID is valid in the current room,
 // if not then prints a warning to the log; returns assertion result
 bool    AssertObject(const char *apiname, int obj_id);
 int     Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2);
-ScriptObject *GetObjectAtScreen(int xx, int yy);
 void    Object_Tint(ScriptObject *objj, int red, int green, int blue, int saturation, int luminance);
 void    Object_RemoveTint(ScriptObject *objj);
 void    Object_SetView(ScriptObject *objj, int view, int loop, int frame);

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -238,7 +238,7 @@ int System_GetEngineInteger(int value_id, int index)
 {
     int value = 0;
     if (!GetEngineInteger(value, static_cast<EngineValueID>(value_id), index))
-        debug_script_warn("System.GetEngineInteger: undefined engine value %d (#%d), or not an integer value", value_id, index);
+        debug_script_error("System.GetEngineInteger: undefined engine value %d (#%d), or not an integer value", value_id, index);
     return value;
 }
 
@@ -246,7 +246,7 @@ const char* System_GetEngineString(int value_id, int index)
 {
     String value;
     if (!GetEngineString(value, static_cast<EngineValueID>(value_id), index))
-        debug_script_warn("System.GetEngineString: undefined engine value %d (#%d)", value_id, index);
+        debug_script_error("System.GetEngineString: undefined engine value %d (#%d)", value_id, index);
     return CreateNewScriptString(value.GetCStr());
 }
 

--- a/Engine/ac/utils_script.cpp
+++ b/Engine/ac/utils_script.cpp
@@ -49,7 +49,7 @@ void Utils_SortStrings(void* arrobj, int compare_style, int sort_dir)
     std::vector<DynObjectRef> string_objs;
     if (!DynamicArrayHelpers::ResolvePointerArray(arrobj, string_objs))
     {
-        debug_script_warn("Utils.SortStrings: internal error: provided array is not a pointer array?");
+        debug_script_error("Utils.SortStrings: internal error: provided array is not a pointer array?");
         return;
     }
 

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -403,6 +403,15 @@ void debug_script_warn(const char *msg, ...)
     debug_script_print_impl(full_msg, kDbgMsg_Warn);
 }
 
+void debug_script_error(const char *msg, ...)
+{
+    va_list ap;
+    va_start(ap, msg);
+    String full_msg = String::FromFormatV(msg, ap);
+    va_end(ap);
+    debug_script_print_impl(full_msg, kDbgMsg_Error);
+}
+
 void debug_script_log(const char *msg, ...)
 {
     va_list ap;

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -371,9 +371,9 @@ void shutdown_debug()
     DbgMgr.UnregisterAll();
 }
 
-// Prepends message text with current room number and running script info, then logs result
-static void debug_script_print_impl(const String &msg, MessageType mt)
+void debug_script_event(MessageType mt, const String &msg)
 {
+    // Generate the full log message, prepending current script location
     String script_ref;
     ccInstance *curinst = ccInstance::GetCurrentInstance();
     if (curinst != nullptr)
@@ -383,42 +383,17 @@ static void debug_script_print_impl(const String &msg, MessageType mt)
     }
 
     Debug::Printf(kDbgGroup_Game, mt, "(room:%d) %s%s", displayed_room, script_ref.GetCStr(), msg.GetCStr());
-}
 
-void debug_script_print(MessageType mt, const char *msg, ...)
-{
-    va_list ap;
-    va_start(ap, msg);
-    String full_msg = String::FromFormatV(msg, ap);
-    va_end(ap);
-    debug_script_print_impl(full_msg, mt);
-}
-
-void debug_script_warn(const char *msg, ...)
-{
-    va_list ap;
-    va_start(ap, msg);
-    String full_msg = String::FromFormatV(msg, ap);
-    va_end(ap);
-    debug_script_print_impl(full_msg, kDbgMsg_Warn);
-}
-
-void debug_script_error(const char *msg, ...)
-{
-    va_list ap;
-    va_start(ap, msg);
-    String full_msg = String::FromFormatV(msg, ap);
-    va_end(ap);
-    debug_script_print_impl(full_msg, kDbgMsg_Error);
-}
-
-void debug_script_log(const char *msg, ...)
-{
-    va_list ap;
-    va_start(ap, msg);
-    String full_msg = String::FromFormatV(msg, ap);
-    va_end(ap);
-    debug_script_print_impl(full_msg, kDbgMsg_Debug);
+    // A (possibly) temporary solution to making script errors stand out more to the game developer or testers:
+    // if the game is compiled in debug mode, then quit on script error events.
+    if (game.options[OPT_DEBUGMODE])
+    {
+        if (mt == kDbgMsg_Error || mt == kDbgMsg_Fatal)
+        {
+            // Report as a game error (using '!')
+            quitprintf("!%s", msg.GetCStr());
+        }
+    }
 }
 
 

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -31,6 +31,9 @@ void debug_script_print(AGS::Common::MessageType mt, const char *msg, ...);
 // prints formatted debug warnings tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
 void debug_script_warn(const char *msg, ...);
+// prints formatted debug errors tagged with kDbgGroup_Game,
+// prepending it with current room number and script position info
+void debug_script_error(const char *msg, ...);
 // prints formatted debug message tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
 void debug_script_log(const char *msg, ...);

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -14,6 +14,7 @@
 #ifndef __AC_DEBUG_LOG_H
 #define __AC_DEBUG_LOG_H
 
+#include <cstdarg>
 #include "ac/runtime_defines.h"
 #include "debug/out.h"
 #include "util/ini_util.h"
@@ -25,18 +26,32 @@ void init_debug(const AGS::Common::ConfigTree &cfg, bool stderr_only);
 void apply_debug_config(const AGS::Common::ConfigTree &cfg, bool finalize);
 void shutdown_debug();
 
+void debug_script_event(AGS::Common::MessageType mt, const AGS::Common::String &msg);
+template<typename... Args>
+void debug_script_event(AGS::Common::MessageType mt, const char *msg, Args ...args)
+{
+    debug_script_event(mt, AGS::Common::String::FromFormat(msg, std::forward<Args>(args)...));
+}
 // prints debug messages of given type tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
-void debug_script_print(AGS::Common::MessageType mt, const char *msg, ...);
+template<typename... Args>
+void debug_script_message(AGS::Common::MessageType mt, const char *msg, Args ...args)
+    { debug_script_event(mt, msg, std::forward<Args>(args)...); }
 // prints formatted debug warnings tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
-void debug_script_warn(const char *msg, ...);
+template<typename... Args>
+void debug_script_warn(const char *msg, Args ...args)
+    { debug_script_event(AGS::Common::kDbgMsg_Warn, msg, std::forward<Args>(args)...); }
 // prints formatted debug errors tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
-void debug_script_error(const char *msg, ...);
+template<typename... Args>
+void debug_script_error(const char *msg, Args ...args)
+    { debug_script_event(AGS::Common::kDbgMsg_Error, msg, std::forward<Args>(args)...); }
 // prints formatted debug message tagged with kDbgGroup_Game,
 // prepending it with current room number and script position info
-void debug_script_log(const char *msg, ...);
+template<typename... Args>
+void debug_script_log(const char *msg, Args ...args)
+    { debug_script_event(AGS::Common::kDbgMsg_Debug, msg, std::forward<Args>(args)...); }
 
 // Same as quit(), but with message formatting
 void quitprintf(const char *texx, ...);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -1369,7 +1369,7 @@ int SaveInfo_GetGUIControlCount(ScriptRestoredSaveInfo *info, int index)
 {
     if (index < 0 || static_cast<uint32_t>(index) >= info->GetCounts().GUIControls.size())
     {
-        debug_script_warn("RestoredSaveInfo::GUIControlCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().GUIs);
+        debug_script_error("RestoredSaveInfo::GUIControlCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().GUIs);
         return 0;
     }
     return info->GetCounts().GUIControls[index];
@@ -1394,7 +1394,7 @@ int SaveInfo_GetViewLoopCount(ScriptRestoredSaveInfo *info, int index)
 {
     if (index < 0 || static_cast<uint32_t>(index) >= info->GetCounts().ViewLoops.size())
     {
-        debug_script_warn("RestoredSaveInfo::ViewLoopCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().Views);
+        debug_script_error("RestoredSaveInfo::ViewLoopCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().Views);
         return 0;
     }
     return info->GetCounts().ViewLoops[index];
@@ -1404,7 +1404,7 @@ int SaveInfo_GetViewFrameCount(ScriptRestoredSaveInfo *info, int index)
 {
     if (index < 0 || static_cast<uint32_t>(index) >= info->GetCounts().ViewFrames.size())
     {
-        debug_script_warn("RestoredSaveInfo::ViewFrameCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().Views);
+        debug_script_error("RestoredSaveInfo::ViewFrameCount: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().Views);
         return 0;
     }
     return info->GetCounts().ViewFrames[index];
@@ -1424,7 +1424,7 @@ const char *SaveInfo_GetScriptModuleNames(ScriptRestoredSaveInfo *info, int inde
 {
     if (index < 0 || static_cast<uint32_t>(index) >= info->GetCounts().ScriptModuleDataSz.size())
     {
-        debug_script_warn("RestoredSaveInfo::ScriptModuleNames: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().ScriptModules);
+        debug_script_error("RestoredSaveInfo::ScriptModuleNames: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().ScriptModules);
         return 0;
     }
     return CreateNewScriptString(info->GetCounts().ScriptModuleNames[index]);
@@ -1434,7 +1434,7 @@ int SaveInfo_GetScriptModuleDataSizes(ScriptRestoredSaveInfo *info, int index)
 {
     if (index < 0 || static_cast<uint32_t>(index) >= info->GetCounts().ScriptModuleDataSz.size())
     {
-        debug_script_warn("RestoredSaveInfo::ScriptModuleDataSize: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().ScriptModules);
+        debug_script_error("RestoredSaveInfo::ScriptModuleDataSize: index %d out of bounds (%d..%d)", index, 0, info->GetCounts().ScriptModules);
         return 0;
     }
     return info->GetCounts().ScriptModuleDataSz[index];

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -1002,8 +1002,8 @@ int run_interaction_commandlist(const ObjectEvent &obj_evt, InteractionCommandLi
             NewRoomEx (IPARAM1, IPARAM2, IPARAM3);
             return -1;
         case 26: // Move NPC to different room
-            if (!is_valid_character(IPARAM1))
-                quit("!Move NPC to different room: invalid character specified");
+            if (!AssertCharacter("Move NPC to different room", IPARAM1))
+                break;
             game.chars[IPARAM1].room = IPARAM2;
             break;
         case 27: // Set character view

--- a/Engine/test/scsprintf_test.cpp
+++ b/Engine/test/scsprintf_test.cpp
@@ -23,7 +23,7 @@ void cc_error(const char *, ...)
     // do nothing
 }
 
-void debug_script_warn(const char *msg, ...)
+void debug_script_event(MessageType mt, const String &msg)
 {
     // do nothing
 }


### PR DESCRIPTION
Enforce that Object and Character script functions use same Assertxxx function that tests if the object is valid and prints to the log instead of quitting. If assertion fails, the function returns immediately with default result.

Added similar assertions to all the object functions that missed them.
This fixes the multiple potential crashes which could happen if game script tries to get/set object's properties using `object[N]` object access, in a room that does not have a object at particular index.